### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/learn/function-calling/notebooks_firefunction_openai/fw_autogen_stock_chart.ipynb
+++ b/learn/function-calling/notebooks_firefunction_openai/fw_autogen_stock_chart.ipynb
@@ -31,21 +31,21 @@
           "name": "stdout",
           "output_type": "stream",
           "text": [
-            "Requirement already satisfied: pyautogen in /Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages (0.3.1)\n",
+            "Requirement already satisfied: ag2 in /Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages (0.3.1)\n",
             "Requirement already satisfied: openai in /Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages (1.47.0)\n",
             "Requirement already satisfied: fireworks-ai in /Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages (0.15.3)\n",
             "Requirement already satisfied: matplotlib in /Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages (3.9.2)\n",
             "Requirement already satisfied: opencv-python in /Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages (4.10.0.84)\n",
             "Requirement already satisfied: yfinance in /Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages (0.2.40)\n",
-            "Requirement already satisfied: diskcache in /Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages (from pyautogen) (5.6.3)\n",
-            "Requirement already satisfied: docker in /Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages (from pyautogen) (7.1.0)\n",
-            "Requirement already satisfied: flaml in /Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages (from pyautogen) (2.3.2)\n",
-            "Requirement already satisfied: numpy<2,>=1.17.0 in /Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages (from pyautogen) (1.26.4)\n",
-            "Requirement already satisfied: packaging in /Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages (from pyautogen) (23.2)\n",
-            "Requirement already satisfied: pydantic!=2.6.0,<3,>=1.10 in /Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages (from pyautogen) (2.9.2)\n",
-            "Requirement already satisfied: python-dotenv in /Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages (from pyautogen) (1.0.1)\n",
-            "Requirement already satisfied: termcolor in /Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages (from pyautogen) (2.5.0)\n",
-            "Requirement already satisfied: tiktoken in /Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages (from pyautogen) (0.7.0)\n",
+            "Requirement already satisfied: diskcache in /Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages (from ag2) (5.6.3)\n",
+            "Requirement already satisfied: docker in /Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages (from ag2) (7.1.0)\n",
+            "Requirement already satisfied: flaml in /Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages (from ag2) (2.3.2)\n",
+            "Requirement already satisfied: numpy<2,>=1.17.0 in /Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages (from ag2) (1.26.4)\n",
+            "Requirement already satisfied: packaging in /Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages (from ag2) (23.2)\n",
+            "Requirement already satisfied: pydantic!=2.6.0,<3,>=1.10 in /Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages (from ag2) (2.9.2)\n",
+            "Requirement already satisfied: python-dotenv in /Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages (from ag2) (1.0.1)\n",
+            "Requirement already satisfied: termcolor in /Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages (from ag2) (2.5.0)\n",
+            "Requirement already satisfied: tiktoken in /Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages (from ag2) (0.7.0)\n",
             "Requirement already satisfied: anyio<5,>=3.5.0 in /Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages (from openai) (4.6.0)\n",
             "Requirement already satisfied: distro<2,>=1.7.0 in /Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages (from openai) (1.9.0)\n",
             "Requirement already satisfied: httpx<1,>=0.23.0 in /Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages (from openai) (0.27.2)\n",
@@ -79,11 +79,11 @@
             "Requirement already satisfied: httpcore==1.* in /Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages (from httpx<1,>=0.23.0->openai) (1.0.5)\n",
             "Requirement already satisfied: h11<0.15,>=0.13 in /Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages (from httpcore==1.*->httpx<1,>=0.23.0->openai) (0.14.0)\n",
             "Requirement already satisfied: tzdata>=2022.7 in /Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages (from pandas>=1.3.0->yfinance) (2024.1)\n",
-            "Requirement already satisfied: annotated-types>=0.6.0 in /Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages (from pydantic!=2.6.0,<3,>=1.10->pyautogen) (0.7.0)\n",
-            "Requirement already satisfied: pydantic-core==2.23.4 in /Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages (from pydantic!=2.6.0,<3,>=1.10->pyautogen) (2.23.4)\n",
+            "Requirement already satisfied: annotated-types>=0.6.0 in /Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages (from pydantic!=2.6.0,<3,>=1.10->ag2) (0.7.0)\n",
+            "Requirement already satisfied: pydantic-core==2.23.4 in /Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages (from pydantic!=2.6.0,<3,>=1.10->ag2) (2.23.4)\n",
             "Requirement already satisfied: charset-normalizer<4,>=2 in /Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages (from requests>=2.31->yfinance) (3.3.2)\n",
             "Requirement already satisfied: urllib3<3,>=1.21.1 in /Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages (from requests>=2.31->yfinance) (2.2.3)\n",
-            "Requirement already satisfied: regex>=2022.1.18 in /Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages (from tiktoken->pyautogen) (2023.12.25)\n",
+            "Requirement already satisfied: regex>=2022.1.18 in /Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages (from tiktoken->ag2) (2023.12.25)\n",
             "\n",
             "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m24.2\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m24.3.1\u001b[0m\n",
             "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpip3 install --upgrade pip\u001b[0m\n"
@@ -91,7 +91,7 @@
         }
       ],
       "source": [
-        "!pip3 install pyautogen openai fireworks-ai matplotlib opencv-python yfinance"
+        "!pip3 install ag2 openai fireworks-ai matplotlib opencv-python yfinance"
       ]
     },
     {


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using AG2! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
