### PR TITLE
feat: add Kimi K2.5 long-context SFT example with eval pipeline

### DIFF
--- a/training/recipes/sft_loop.py
+++ b/training/recipes/sft_loop.py
@@ -68,8 +68,21 @@ class Config:
     max_seq_len: int | None = None
     max_examples: int | None = None
     lora_rank: int = 0
+    output_model: str | None = None
+    """Model name for the promoted checkpoint (e.g. ``my-sft-model``).
+    When set, the final inference checkpoint is promoted to a model under
+    the current account so it can be used for inference."""
 
-    dcp_save_interval: int = 0  # save DCP checkpoint every N steps (0 = off)
+    dcp_save_interval: int = 0
+    """Save DCP checkpoint every N steps (0 = off, unless auto-derived from checkpoint_pct)."""
+    infer_save_interval: int = 0
+    """Save inference checkpoint every N steps (0 = off, unless auto-derived from checkpoint_pct)."""
+    checkpoint_pct: int = 0
+    """Auto-checkpoint every N% of total steps. Set to 0 to disable.
+    Only takes effect when both dcp_save_interval and infer_save_interval are 0."""
+    auto_checkpoint_min_steps: int = 10
+    """Minimum total optimizer steps required to enable percentage-based
+    auto-checkpointing. Prevents excessive saves on tiny runs."""
 
     infra: InfraConfig = field(default_factory=InfraConfig)
     wandb: WandBConfig = field(default_factory=lambda: WandBConfig(project="sft-tinker"))
@@ -197,11 +210,32 @@ def main(
         step_offset, _ = setup_resume(client, cfg.resume)
         adam_params = tinker.AdamParams(learning_rate=cfg.learning_rate, **DEFAULT_ADAM)
 
-        # -- Training loop (batched) -------------------------------------------
+        # -- Compute checkpoint intervals ----------------------------------
 
         batch_size = cfg.batch_size
         step = step_offset
         total_steps = len(training_data) * cfg.epochs // (cfg.grad_accum * batch_size)
+
+        dcp_interval = cfg.dcp_save_interval
+        infer_interval = cfg.infer_save_interval
+
+        if dcp_interval == 0 and infer_interval == 0 and cfg.checkpoint_pct > 0:
+            if total_steps >= cfg.auto_checkpoint_min_steps:
+                auto_interval = max(1, total_steps * cfg.checkpoint_pct // 100)
+                dcp_interval = auto_interval
+                infer_interval = auto_interval
+                logger.info(
+                    "Auto-checkpoint enabled: every %d steps (%d%% of %d total steps)",
+                    auto_interval, cfg.checkpoint_pct, total_steps,
+                )
+            else:
+                logger.info(
+                    "Auto-checkpoint skipped: total_steps=%d < min=%d",
+                    total_steps, cfg.auto_checkpoint_min_steps,
+                )
+
+        # -- Training loop (batched) ---------------------------------------
+
         accum = 0
         agg_loss_sum = 0.0
         agg_resp_tokens = 0
@@ -236,10 +270,17 @@ def main(
                 step += 1
                 accum = 0
 
-                if cfg.dcp_save_interval > 0 and step % cfg.dcp_save_interval == 0:
+                if dcp_interval > 0 and step % dcp_interval == 0:
                     with timer("dcp_save"):
                         logger.info("Saving DCP checkpoint at step %d", step)
                         client.inner.save_state(f"step-{step}")
+
+                if infer_interval > 0 and step % infer_interval == 0:
+                    with timer("infer_save"):
+                        logger.info("Saving inference checkpoint at step %d", step)
+                        client.inner.save_weights_for_sampler_ext(
+                            f"step-{step}", checkpoint_type="base"
+                        )
 
                 step_metrics: Dict[str, Any] = flush_timing()
 
@@ -285,20 +326,51 @@ def main(
             client.optim_step(adam_params)
             step += 1
 
-        # -- Final checkpoint --------------------------------------------------
+        # -- Final checkpoint ----------------------------------------------
 
+        final_snapshot = None
         if step > step_offset:
-            logger.info("Saving final DCP checkpoint (step %d)...", step)
-            client.inner.save_state(f"final-step-{step}")
+            if dcp_interval > 0:
+                logger.info("Saving final DCP checkpoint (step %d)...", step)
+                client.inner.save_state(f"final-step-{step}")
 
-            logger.info("Saving final base checkpoint (step %d)...", step)
-            result = client.inner.save_weights_for_sampler_ext(
-                f"final-step-{step}", checkpoint_type="base"
-            )
-            logger.info("Final base checkpoint saved: %s", result.path)
+            logger.info("Saving final inference checkpoint (step %d)...", step)
+            with timer("final_infer_save"):
+                result = client.inner.save_weights_for_sampler_ext(
+                    f"final-step-{step}", checkpoint_type="base"
+                )
+                final_snapshot = result.path
+            logger.info("Final inference checkpoint saved: %s", final_snapshot)
+
+        # -- Promote to model ----------------------------------------------
+
+        promoted_model = None
+        if cfg.output_model and final_snapshot:
+            try:
+                checkpoints = rlor_mgr.list_checkpoints(job_id)
+                if checkpoints:
+                    last_ckpt = checkpoints[-1]
+                    ckpt_name = last_ckpt.get("name", "")
+                    logger.info("Promoting checkpoint %s -> %s", ckpt_name, cfg.output_model)
+                    promo_result = rlor_mgr.promote_checkpoint(
+                        job_id=job_id,
+                        checkpoint_name=ckpt_name,
+                        output_model=cfg.output_model,
+                    )
+                    promoted_model = promo_result.get("model", {}).get("name")
+                    logger.info("Model promoted: %s", promoted_model)
+                else:
+                    logger.warning("No checkpoints found for job %s, skipping promotion", job_id)
+            except Exception as e:
+                logger.error("Failed to promote checkpoint: %s", e)
 
         logger.info("Training complete: %d optimizer steps", step)
-        return {"steps": step, "job_id": job_id}
+        return {
+            "steps": step,
+            "job_id": job_id,
+            "final_snapshot": final_snapshot,
+            "promoted_model": promoted_model,
+        }
     finally:
         wandb_finish()
         try:
@@ -315,6 +387,7 @@ if __name__ == "__main__":
         tokenizer_model="Qwen/Qwen3-8B",
         max_seq_len=4096,
         max_examples=10,
+        output_model="my-sft-model",
         infra=InfraConfig(
             training_shape_id="your-training-shape",
         ),

--- a/training/utils/client.py
+++ b/training/utils/client.py
@@ -13,6 +13,7 @@ cleanly and resume from the last DCP checkpoint.
 from __future__ import annotations
 
 import logging
+import time
 
 from fireworks.training.sdk.client import FiretitanServiceClient, FiretitanTrainingClient
 from fireworks.training.sdk.trainer import TrainerJobManager, TrainerServiceEndpoint
@@ -86,25 +87,41 @@ class ReconnectableClient:
         return self._job_id
 
     def forward(self, data, loss_fn):
-        return self._client.forward(data, loss_fn).result(
+        t0 = time.monotonic()
+        result = self._client.forward(data, loss_fn).result(
             timeout=self._default_timeout,
         )
+        logger.debug("[client_timing] forward: %.2fs", time.monotonic() - t0)
+        return result
 
     def forward_backward_custom(self, data, loss_fn):
-        return self._client.forward_backward_custom(data, loss_fn).result(
+        t0 = time.monotonic()
+        result = self._client.forward_backward_custom(data, loss_fn).result(
             timeout=self._default_timeout,
         )
+        elapsed = time.monotonic() - t0
+        logger.info("[client_timing] fwd_bwd: %.2fs", elapsed)
+        return result
 
     def optim_step(self, params):
-        return self._client.optim_step(params).result(
+        t0 = time.monotonic()
+        result = self._client.optim_step(params).result(
             timeout=self._default_timeout,
         )
+        logger.info("[client_timing] optim_step: %.2fs", time.monotonic() - t0)
+        return result
 
     def save_state(self, name: str, timeout: int = DCP_TIMEOUT_S):
-        return self._client.save_state(name).result(timeout=timeout)
+        t0 = time.monotonic()
+        result = self._client.save_state(name).result(timeout=timeout)
+        logger.info("[client_timing] save_state(%s): %.2fs", name, time.monotonic() - t0)
+        return result
 
     def load_state_with_optimizer(self, path: str, timeout: int = DCP_TIMEOUT_S):
-        return self._client.load_state_with_optimizer(path).result(timeout=timeout)
+        t0 = time.monotonic()
+        result = self._client.load_state_with_optimizer(path).result(timeout=timeout)
+        logger.info("[client_timing] load_state(%s): %.2fs", path, time.monotonic() - t0)
+        return result
 
     def resolve_checkpoint_path(self, name: str, source_job_id: str | None = None) -> str:
         return self.inner.resolve_checkpoint_path(name, source_job_id=source_job_id)


### PR DESCRIPTION
## Summary

- Add customer-facing **Kimi K2.5 SFT training + evaluation** example under `training/examples/kimi_k2p5_sft/`
  - `train.py`: LoRA SFT with 88K context, periodic checkpoint promotion via `rft-kimi-k2p5-2n-b200` training shape
  - `eval.py`: Reference-based multi-turn evaluation using LLM-as-judge — deploys each model (base + LoRA checkpoints) via `rft-kimi-k2p5-v2` deployment shape, scores against ground truth from training data (content coverage, style alignment, non-repetition)
  - `README.md`: End-to-end customer guide covering prerequisites, dataset format, training params, and eval workflow
- Supporting library changes:
  - `sft_loop.py`: auto-checkpoint intervals from `checkpoint_pct`, conditional final DCP save, optional model promotion to return promoted model name
  - `config.py`: new `checkpoint_pct` and `auto_checkpoint_min_steps` fields on `HotloadConfig`
  - `client.py`: timing instrumentation for `fwd_bwd`, `optim_step`, and `save_state` operations

## Context

This is for Doximity's long-context multi-turn SFT use case on Kimi K2.5. The training pipeline uses 2-node (16x B200) LoRA training with EP=8 + CP=2 parallelism, and the eval pipeline deploys each checkpoint sequentially on 8x B200 via the public `rft-kimi-k2p5-v2` shape. Validated end-to-end.

## Test plan

- [x] Training script validated end-to-end with DCP + inference checkpoints
- [x] Eval script validated end-to-end with deployment creation/deletion lifecycle
- [x] Reference-based scoring produces meaningful differentiation between base and SFT models
- [ ] Verify cookbook CI passes (imports, linting)

Made with [Cursor](https://cursor.com)