### PR TITLE
refactor(training): two-path shape override contract

### DIFF
--- a/training/README.md
+++ b/training/README.md
@@ -141,7 +141,7 @@ All recipes expect JSONL files with OpenAI chat format:
 
 All recipes use composable dataclass configs:
 
-- **`InfraConfig`** -- region, accelerators, training shapes. When `training_shape_id` is set, `max_seq_len` and GPU config are auto-derived.
+- **`InfraConfig`** -- region, accelerators, training shapes. When `training_shape_id` is set, `max_seq_len` and GPU config are auto-derived; use `skip_validations=True` only if you intentionally want explicit accelerator overrides to win.
 - **`DeployConfig`** -- inference deployment for RL rollouts. Set `deployment_id` to reuse an existing deployment, or omit to auto-create.
 - **`HotloadConfig`** -- weight sync cadence and checkpoint settings.
 - **`WandBConfig`** -- optional Weights & Biases logging.

--- a/training/pyproject.toml
+++ b/training/pyproject.toml
@@ -7,8 +7,8 @@ name = "fireworks-training-cookbook"
 version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [
-    "fireworks-ai>=1.0.0a38,<2",
-    "tinker-cookbook @ git+https://github.com/thinking-machines-lab/tinker-cookbook.git@41cc57642f6373f342151ad95d418349d85512c5",
+    "fireworks-ai>=1.0.0a39,<2",
+    "tinker-cookbook @ git+https://github.com/thinking-machines-lab/tinker-cookbook.git@934f0d9b2f53c3edff02cbf23ec6da8682047fa5",
     "eval-protocol>=0.3.23",
     "tqdm",
     "torch",

--- a/training/tests/unit/test_orpo_loop.py
+++ b/training/tests/unit/test_orpo_loop.py
@@ -54,20 +54,18 @@ def test_main_uses_profile_and_trains_pairs(monkeypatch):
         def forward_backward_custom(self, batch, loss_fn):
             events["forward_batches"].append((list(batch), loss_fn))
             return SimpleNamespace(
-                result=lambda: SimpleNamespace(
-                    metrics={
-                        "orpo_loss": 1.2,
-                        "sft_loss": 0.7,
-                        "or_loss": 0.5,
-                        "log_odds_ratio": 0.1,
-                        "accuracy": 0.75,
-                    }
-                )
+                metrics={
+                    "orpo_loss": 1.2,
+                    "sft_loss": 0.7,
+                    "or_loss": 0.5,
+                    "log_odds_ratio": 0.1,
+                    "accuracy": 0.75,
+                }
             )
 
         def optim_step(self, _params):
             events["optim_steps"] += 1
-            return SimpleNamespace(result=lambda: SimpleNamespace())
+            return SimpleNamespace()
 
     pair_outputs = iter(
         [

--- a/training/tests/unit/test_sdk_compat.py
+++ b/training/tests/unit/test_sdk_compat.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import training.utils.config as config_module
+from fireworks.training.sdk.deployment import DeploymentConfig
+
+
+def test_to_deployment_config_includes_extra_values():
+    deploy_cfg = config_module.DeployConfig(
+        deployment_id="dep-123",
+        deployment_region="US_OHIO_1",
+        extra_values={"priorityClass": "deployment"},
+    )
+
+    deployment_config = deploy_cfg.to_deployment_config(
+        "accounts/test/models/qwen3-4b",
+        config_module.InfraConfig(),
+    )
+
+    assert isinstance(deployment_config, DeploymentConfig)
+    assert deployment_config.deployment_id == "dep-123"
+    assert deployment_config.region == "US_OHIO_1"
+    assert deployment_config.disable_speculative_decoding is True
+    assert deployment_config.extra_values == {"priorityClass": "deployment"}

--- a/training/tests/unit/test_shape_override_paths.py
+++ b/training/tests/unit/test_shape_override_paths.py
@@ -1,0 +1,329 @@
+"""Smoke tests for the three training-shape launch paths.
+
+Exercises the full stack from cookbook ``create_trainer_job`` through
+SDK ``TrainerJobManager._create`` payload serialization for a Qwen 1.7B
+model, verifying that each path produces the correct TrainerJobConfig
+fields *and* REST payload shape.
+
+Three paths tested:
+  1. Validated shape (training_shape_id, no skip_validations)
+  2. Override shape  (training_shape_id + skip_validations=True)
+  3. Manual          (no training_shape_id)
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import training.utils.infra as infra_module
+from training.utils.config import InfraConfig
+from fireworks.training.sdk.trainer import (
+    TrainerJobConfig,
+    TrainerJobManager,
+    TrainingShapeProfile,
+)
+
+BASE_MODEL = "accounts/fireworks/models/qwen3-1p7b"
+
+PROFILE = TrainingShapeProfile(
+    training_shape_version="accounts/fw/trainingShapes/ts-qwen3-1p7b/versions/v42",
+    trainer_image_tag="0.35.0",
+    max_supported_context_length=4096,
+    node_count=1,
+    deployment_shape_version="accounts/fw/deploymentShapes/ds-qwen3-1p7b/versions/v1",
+    deployment_image_tag="4.24.22",
+    accelerator_type="NVIDIA_H100_80GB",
+    accelerator_count=1,
+    base_model_weight_precision="bfloat16",
+    pipeline_parallelism=1,
+)
+
+
+class _CapturingMgr:
+    """Fake TrainerJobManager that captures the TrainerJobConfig."""
+
+    account_id = "test-account"
+
+    def __init__(self):
+        self.captured: TrainerJobConfig | None = None
+
+    def create_and_wait(self, config, **kwargs):
+        self.captured = config
+        return SimpleNamespace(job_id="job-smoke")
+
+
+def _serialize_payload(config: TrainerJobConfig) -> tuple[str, dict]:
+    """Run the real SDK ``_create`` serialization and return (url, payload)."""
+    mgr = TrainerJobManager(
+        api_key="test-key",
+        account_id="test-account",
+        base_url="https://smoke.test",
+    )
+    with patch("fireworks.training.sdk.trainer.request_with_retries") as mock_req:
+        resp = MagicMock()
+        resp.ok = True
+        resp.status_code = 200
+        resp.json.return_value = {"name": "accounts/test-account/rlorTrainerJobs/j"}
+        mock_req.return_value = resp
+
+        mgr._create(config)
+
+        url = mock_req.call_args[0][1]
+        payload = mock_req.call_args[1]["json"]
+    return url, payload
+
+
+# -----------------------------------------------------------------------
+# Path 1: Validated shape (training_shape_id, no skip_validations)
+# -----------------------------------------------------------------------
+
+
+class TestValidatedShapePath:
+    def test_config_has_minimal_fields(self):
+        mgr = _CapturingMgr()
+        infra_module.create_trainer_job(
+            mgr,
+            base_model=BASE_MODEL,
+            infra=InfraConfig(region="US_VIRGINIA_1"),
+            profile=PROFILE,
+            grad_accum=2,
+        )
+        c = mgr.captured
+
+        assert c.training_shape_ref == PROFILE.training_shape_version
+        assert c.base_model == BASE_MODEL
+        assert c.gradient_accumulation_steps == 2
+        assert c.region == "US_VIRGINIA_1"
+        assert c.skip_validations is False
+
+        assert c.accelerator_type is None
+        assert c.accelerator_count is None
+        assert c.custom_image_tag is None
+        assert c.max_context_length is None
+        assert c.node_count is None
+
+    def test_payload_omits_shape_derived_fields(self):
+        mgr = _CapturingMgr()
+        infra_module.create_trainer_job(
+            mgr,
+            base_model=BASE_MODEL,
+            infra=InfraConfig(region="US_VIRGINIA_1"),
+            profile=PROFILE,
+        )
+        url, payload = _serialize_payload(mgr.captured)
+        tc = payload["trainingConfig"]
+
+        assert "trainingShape=" in url
+        assert "skipValidations" not in url
+        assert "nodeCount" not in payload
+        assert "acceleratorType" not in tc
+        assert "acceleratorCount" not in tc
+        assert "customImageTag" not in tc
+        assert "maxContextLength" not in tc
+
+        assert tc["baseModel"] == BASE_MODEL
+        assert tc["region"] == "US_VIRGINIA_1"
+
+    def test_rejects_accelerator_override(self):
+        with pytest.raises(ValueError, match="accelerator_type"):
+            infra_module.create_trainer_job(
+                _CapturingMgr(),
+                base_model=BASE_MODEL,
+                infra=InfraConfig(accelerator_type="NVIDIA_H100_80GB"),
+                profile=PROFILE,
+            )
+
+    def test_rejects_accelerator_count_override(self):
+        with pytest.raises(ValueError, match="accelerator_count"):
+            infra_module.create_trainer_job(
+                _CapturingMgr(),
+                base_model=BASE_MODEL,
+                infra=InfraConfig(accelerator_count=8),
+                profile=PROFILE,
+            )
+
+    def test_rejects_custom_image_tag_override(self):
+        with pytest.raises(ValueError, match="custom_image_tag"):
+            infra_module.create_trainer_job(
+                _CapturingMgr(),
+                base_model=BASE_MODEL,
+                infra=InfraConfig(custom_image_tag="my-tag"),
+                profile=PROFILE,
+            )
+
+    def test_rejects_node_count_override(self):
+        with pytest.raises(ValueError, match="node_count"):
+            infra_module.create_trainer_job(
+                _CapturingMgr(),
+                base_model=BASE_MODEL,
+                infra=InfraConfig(node_count=4),
+                profile=PROFILE,
+            )
+
+    def test_extra_args_still_sent(self):
+        mgr = _CapturingMgr()
+        infra_module.create_trainer_job(
+            mgr,
+            base_model=BASE_MODEL,
+            infra=InfraConfig(extra_args=["--foo"]),
+            profile=PROFILE,
+        )
+        _, payload = _serialize_payload(mgr.captured)
+        assert payload["trainingConfig"]["extraArgs"] == ["--foo"]
+
+
+# -----------------------------------------------------------------------
+# Path 2: Override shape (training_shape_id + skip_validations=True)
+# -----------------------------------------------------------------------
+
+
+class TestOverrideShapePath:
+    def test_user_overrides_win(self):
+        mgr = _CapturingMgr()
+        infra_module.create_trainer_job(
+            mgr,
+            base_model=BASE_MODEL,
+            infra=InfraConfig(
+                region="US_OHIO_1",
+                accelerator_type="NVIDIA_A100_80GB",
+                accelerator_count=4,
+                custom_image_tag="custom:1",
+                skip_validations=True,
+            ),
+            profile=PROFILE,
+            max_seq_len=2048,
+            grad_accum=8,
+        )
+        c = mgr.captured
+
+        assert c.training_shape_ref == PROFILE.training_shape_version
+        assert c.skip_validations is True
+        assert c.accelerator_type == "NVIDIA_A100_80GB"
+        assert c.accelerator_count == 4
+        assert c.custom_image_tag == "custom:1"
+        assert c.max_context_length == 2048
+        assert c.gradient_accumulation_steps == 8
+
+    def test_shape_fills_unset_fields(self):
+        mgr = _CapturingMgr()
+        infra_module.create_trainer_job(
+            mgr,
+            base_model=BASE_MODEL,
+            infra=InfraConfig(skip_validations=True),
+            profile=PROFILE,
+            max_seq_len=2048,
+        )
+        c = mgr.captured
+
+        assert c.accelerator_type == "NVIDIA_H100_80GB"
+        assert c.accelerator_count == 1
+        assert c.custom_image_tag == "0.35.0"
+
+    def test_payload_sends_all_fields(self):
+        mgr = _CapturingMgr()
+        infra_module.create_trainer_job(
+            mgr,
+            base_model=BASE_MODEL,
+            infra=InfraConfig(
+                region="US_OHIO_1",
+                accelerator_type="NVIDIA_A100_80GB",
+                accelerator_count=4,
+                custom_image_tag="custom:1",
+                skip_validations=True,
+                node_count=2,
+            ),
+            profile=PROFILE,
+            max_seq_len=2048,
+        )
+        url, payload = _serialize_payload(mgr.captured)
+        tc = payload["trainingConfig"]
+
+        assert "trainingShape=" in url
+        assert "skipValidations=true" in url
+        assert tc["acceleratorType"] == "NVIDIA_A100_80GB"
+        assert tc["acceleratorCount"] == 4
+        assert tc["customImageTag"] == "custom:1"
+        assert tc["maxContextLength"] == 2048
+        assert payload["nodeCount"] == 2
+        assert tc["region"] == "US_OHIO_1"
+
+
+# -----------------------------------------------------------------------
+# Path 3: Manual (no training_shape_id / no profile)
+# -----------------------------------------------------------------------
+
+
+class TestManualPath:
+    def test_infra_fields_sent_directly(self):
+        mgr = _CapturingMgr()
+        infra_module.create_trainer_job(
+            mgr,
+            base_model=BASE_MODEL,
+            infra=InfraConfig(
+                region="US_VIRGINIA_1",
+                accelerator_type="NVIDIA_H100_80GB",
+                accelerator_count=1,
+                custom_image_tag="manual:1",
+                node_count=1,
+            ),
+            max_seq_len=4096,
+        )
+        c = mgr.captured
+
+        assert c.training_shape_ref is None
+        assert c.accelerator_type == "NVIDIA_H100_80GB"
+        assert c.accelerator_count == 1
+        assert c.custom_image_tag == "manual:1"
+        assert c.max_context_length == 4096
+        assert c.node_count == 1
+
+    def test_payload_sends_everything(self):
+        mgr = _CapturingMgr()
+        infra_module.create_trainer_job(
+            mgr,
+            base_model=BASE_MODEL,
+            infra=InfraConfig(
+                region="US_VIRGINIA_1",
+                accelerator_type="NVIDIA_H100_80GB",
+                accelerator_count=1,
+                custom_image_tag="manual:1",
+            ),
+            max_seq_len=4096,
+        )
+        url, payload = _serialize_payload(mgr.captured)
+        tc = payload["trainingConfig"]
+
+        assert "trainingShape" not in url
+        assert "skipValidations" not in url
+        assert tc["acceleratorType"] == "NVIDIA_H100_80GB"
+        assert tc["acceleratorCount"] == 1
+        assert tc["customImageTag"] == "manual:1"
+        assert tc["maxContextLength"] == 4096
+        assert payload["nodeCount"] == 1
+        assert tc["region"] == "US_VIRGINIA_1"
+
+    def test_no_shape_no_overrides(self):
+        """Bare minimum manual launch with only base_model."""
+        mgr = _CapturingMgr()
+        infra_module.create_trainer_job(
+            mgr,
+            base_model=BASE_MODEL,
+            infra=InfraConfig(),
+        )
+        c = mgr.captured
+
+        assert c.training_shape_ref is None
+        assert c.skip_validations is False
+        assert c.accelerator_type is None
+        assert c.accelerator_count is None
+        assert c.custom_image_tag is None
+
+        _, payload = _serialize_payload(c)
+        tc = payload["trainingConfig"]
+        assert "acceleratorType" not in tc
+        assert "acceleratorCount" not in tc
+        assert "customImageTag" not in tc
+        assert "trainingShape" not in _serialize_payload(c)[0]

--- a/training/tests/unit/test_supervised_rendering.py
+++ b/training/tests/unit/test_supervised_rendering.py
@@ -118,9 +118,9 @@ def test_render_messages_to_datum_supports_multimodal_model_input():
     assert len(rendered.token_ids) == 7
     assert len(rendered.token_weights) == 7
     assert rendered.token_weights == [0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0]
-    assert len(rendered.datum.model_input.chunks) == 3
     assert rendered.datum.loss_fn_inputs["target_tokens"].data == [11, 0, 0, 0, 12, 13]
     assert rendered.datum.loss_fn_inputs["weights"].data == [0.0, 0.0, 0.0, 1.0, 1.0, 1.0]
+    assert len(rendered.datum.model_input.chunks) == 3
 
 
 def test_build_datum_from_token_mask_reuses_ui_mask_semantics():

--- a/training/utils/config.py
+++ b/training/utils/config.py
@@ -24,11 +24,14 @@ StepCallback = Callable[[int, Dict[str, float]], None]
 class InfraConfig:
     """GPU, region, and image settings.
 
-    When ``training_shape_id`` is set, the SDK resolves the training shape
-    from the control plane and auto-populates region, accelerator, image tag,
-    node count, etc.  Manual overrides are still accepted but may be rejected
-    by the CP's training shape validation (use ``skip_validations=True`` to
-    bypass).
+    Two launch paths when ``training_shape_id`` is set:
+
+    * **Validated** (default): the backend owns all shape-derived fields
+      (accelerator, image tag, node count, etc.).  Setting
+      ``accelerator_type``, ``accelerator_count``, ``custom_image_tag``,
+      or ``node_count`` raises ``ValueError``.
+    * **Override** (``skip_validations=True``): the shape provides defaults
+      via ``apply_shape``, but explicit values here win.
     """
 
     training_shape_id: str | None = None
@@ -44,7 +47,7 @@ class InfraConfig:
     accelerator_type: str | None = None
     accelerator_count: int | None = None
     skip_validations: bool = False
-    node_count: int = 1
+    node_count: int | None = None
     trainer_timeout_s: float = 3600
     extra_args: list[str] | None = None
 
@@ -83,7 +86,7 @@ class DeployConfig:
         accel = None if self.deployment_shape else self.deployment_accelerator_type
         if not accel and not self.deployment_shape:
             accel = infra.accelerator_type
-        kwargs: dict = dict(
+        return DeploymentConfig(
             deployment_id=self.deployment_id,
             base_model=base_model,
             deployment_shape=self.deployment_shape,
@@ -94,12 +97,9 @@ class DeployConfig:
             min_replica_count=1,
             max_replica_count=1,
             accelerator_type=accel,
+            disable_speculative_decoding=self.disable_speculative_decoding,
             extra_values=self.extra_values,
         )
-        import inspect
-        if "disable_speculative_decoding" in inspect.signature(DeploymentConfig).parameters:
-            kwargs["disable_speculative_decoding"] = self.disable_speculative_decoding
-        return DeploymentConfig(**kwargs)
 
 
 @dataclass

--- a/training/utils/infra.py
+++ b/training/utils/infra.py
@@ -4,26 +4,44 @@ from __future__ import annotations
 
 import time
 import logging
-from typing import Any
 
-import requests as _requests
-
-from fireworks.training.sdk.client import FiretitanServiceClient, FiretitanTrainingClient
+from fireworks.training.sdk.client import (
+    FiretitanServiceClient,
+    FiretitanTrainingClient,
+)
 from fireworks.training.sdk.trainer import (
     TrainerJobConfig,
     TrainerJobManager,
     TrainingShapeProfile,
     TrainerServiceEndpoint,
 )
-from fireworks.training.sdk.deployment import (
-    DeploymentConfig,
-    DeploymentInfo,
-    DeploymentManager,
-    request_with_retries,
-)
+from fireworks.training.sdk.deployment import DeploymentInfo, DeploymentManager
 from training.utils.config import InfraConfig, DeployConfig
 
 logger = logging.getLogger(__name__)
+
+
+def _reject_shape_overrides(infra: InfraConfig) -> None:
+    """Raise ``ValueError`` if infra has shape-derived overrides set.
+
+    On the validated-shape path the backend populates accelerator,
+    image tag, node count, etc. from the shape.  User-side overrides
+    are only honoured on the ``skip_validations`` path.
+    """
+    overrides = []
+    if infra.accelerator_type:
+        overrides.append("accelerator_type")
+    if infra.accelerator_count:
+        overrides.append("accelerator_count")
+    if infra.custom_image_tag:
+        overrides.append("custom_image_tag")
+    if infra.node_count is not None:
+        overrides.append("node_count")
+    if overrides:
+        raise ValueError(
+            f"InfraConfig.{', '.join(overrides)} cannot be set on a validated "
+            f"training-shape launch. Use skip_validations=True to override."
+        )
 
 
 def create_trainer_job(
@@ -45,8 +63,17 @@ def create_trainer_job(
 ) -> TrainerServiceEndpoint:
     """Create a new RLOR trainer job (or reuse *job_id*).
 
-    When *profile* is provided, shape fields (image tag, node count,
-    accelerator type/count, context length) are applied to the config.
+    Two shape launch paths:
+
+    * **Validated** (profile + ``skip_validations=False``): sends only
+      ``training_shape_ref`` plus algorithm fields.  The backend
+      populates accelerator, image tag, node count, sharding, etc.
+      from the validated training shape.  ``InfraConfig`` overrides
+      for shape-derived fields are rejected.
+    * **Override** (profile + ``skip_validations=True``): resolves
+      shape defaults via ``apply_shape``, lets user overrides win,
+      and sends everything.
+    * **Manual** (no profile): sends all ``InfraConfig`` fields as-is.
 
     When *base_url_override* is provided alongside *job_id*, skip health
     polling and return an endpoint pointing at that URL directly.
@@ -58,41 +85,54 @@ def create_trainer_job(
             job_name = f"accounts/{rlor_mgr.account_id}/rlorTrainerJobs/{job_id}"
             logger.info("Using pre-created job %s at %s", job_id, base_url_override)
             return TrainerServiceEndpoint(
-                job_name=job_name, job_id=job_id, base_url=base_url_override,
+                job_name=job_name,
+                job_id=job_id,
+                base_url=base_url_override,
             )
         return _reuse_or_resume_job(rlor_mgr, job_id)
 
-    config = TrainerJobConfig(
-        base_model=base_model,
-        lora_rank=lora_rank,
-        max_context_length=max_seq_len,
-        learning_rate=learning_rate,
-        gradient_accumulation_steps=grad_accum,
-        node_count=infra.node_count if infra.node_count is not None else 1,
-        display_name=display_name,
-        hot_load_deployment_id=hot_load_deployment_id,
-        region=infra.region,
-        custom_image_tag=infra.custom_image_tag,
-        extra_args=extra_args or infra.extra_args,
-        accelerator_type=infra.accelerator_type,
-        accelerator_count=infra.accelerator_count,
-        skip_validations=infra.skip_validations,
-        forward_only=forward_only,
-    )
+    validated_shape = profile is not None and not infra.skip_validations
 
-    if profile is not None:
-        config.training_shape = profile.training_shape_version
-        # When training_shape is set, the server validates against the shape
-        # but does NOT auto-derive nodeCount from it. We must set it explicitly.
-        if profile.node_count:
-            config.node_count = profile.node_count
-        config.accelerator_type = None
-        config.accelerator_count = None
-        config.custom_image_tag = None
+    if validated_shape:
+        _reject_shape_overrides(infra)
+        config = TrainerJobConfig(
+            base_model=base_model,
+            lora_rank=lora_rank,
+            learning_rate=learning_rate,
+            gradient_accumulation_steps=grad_accum,
+            display_name=display_name,
+            hot_load_deployment_id=hot_load_deployment_id,
+            region=infra.region,
+            extra_args=extra_args or infra.extra_args,
+            forward_only=forward_only,
+            training_shape_ref=profile.training_shape_version,
+        )
+    else:
+        config = TrainerJobConfig(
+            base_model=base_model,
+            lora_rank=lora_rank,
+            max_context_length=max_seq_len,
+            learning_rate=learning_rate,
+            gradient_accumulation_steps=grad_accum,
+            node_count=infra.node_count,
+            display_name=display_name,
+            hot_load_deployment_id=hot_load_deployment_id,
+            region=infra.region,
+            custom_image_tag=infra.custom_image_tag,
+            extra_args=extra_args or infra.extra_args,
+            accelerator_type=infra.accelerator_type,
+            accelerator_count=infra.accelerator_count,
+            skip_validations=infra.skip_validations,
+            forward_only=forward_only,
+        )
+        if profile is not None:
+            config.apply_shape(profile)
+            config.training_shape_ref = profile.training_shape_version
 
     logger.info(
         "Creating trainer job '%s' (forward_only=%s)...",
-        display_name, forward_only,
+        display_name,
+        forward_only,
     )
     return rlor_mgr.create_and_wait(config, timeout_s=infra.trainer_timeout_s)
 
@@ -139,10 +179,17 @@ def setup_training_client(
     return svc, cli
 
 
-def _reuse_or_resume_job(rlor_mgr: TrainerJobManager, job_id: str) -> TrainerServiceEndpoint:
+def _reuse_or_resume_job(
+    rlor_mgr: TrainerJobManager, job_id: str
+) -> TrainerServiceEndpoint:
     job = rlor_mgr.get(job_id)
     state = job.get("state", "")
-    resumable = ("JOB_STATE_FAILED", "JOB_STATE_CANCELLED", "JOB_STATE_PAUSED", "JOB_STATE_COMPLETED")
+    resumable = (
+        "JOB_STATE_FAILED",
+        "JOB_STATE_CANCELLED",
+        "JOB_STATE_PAUSED",
+        "JOB_STATE_COMPLETED",
+    )
     if state in resumable:
         logger.info("Job %s is %s, resuming...", job_id, state)
         return rlor_mgr.resume_and_wait(job_id)

--- a/training/utils/supervised.py
+++ b/training/utils/supervised.py
@@ -344,6 +344,22 @@ def build_datum_from_tokens_and_weights(
     )
 
 
+def _extract_token_ids(model_input: tinker.ModelInput) -> list[int]:
+    """Extract token IDs from a ModelInput, handling multimodal chunks.
+
+    Text chunks contribute their token IDs directly.  Non-text chunks
+    (e.g. ``ImageAssetPointerChunk``) contribute placeholder zeros
+    matching their ``expected_tokens`` count.
+    """
+    ids: list[int] = []
+    for chunk in model_input.chunks:
+        if hasattr(chunk, "tokens"):
+            ids.extend(chunk.tokens)
+        elif hasattr(chunk, "expected_tokens"):
+            ids.extend([0] * chunk.expected_tokens)
+    return ids
+
+
 def build_datum_from_model_input_and_weights(
     model_input: tinker.ModelInput,
     token_weights: Sequence[int | float],
@@ -353,13 +369,7 @@ def build_datum_from_model_input_and_weights(
 ) -> RenderedSupervisedDatum:
     """Build a weighted datum from a multimodal-capable ``ModelInput``."""
     if datum_from_model_input_weights is None:
-        try:
-            token_ids = model_input.to_ints()
-        except ValueError as exc:
-            raise ValueError(
-                "Installed tinker-cookbook does not support multimodal supervised data. "
-                "Upgrade to the upstream multimodal renderer build."
-            ) from exc
+        token_ids = _extract_token_ids(model_input)
         return build_datum_from_tokens_and_weights(
             token_ids,
             token_weights,

--- a/training/utils/validation.py
+++ b/training/utils/validation.py
@@ -60,7 +60,7 @@ def validate_config(
                 resume.resume_from,
             )
 
-    if infra and infra.node_count < 1:
+    if infra and infra.node_count is not None and infra.node_count < 1:
         errors.append(
             format_sdk_error(
                 "Invalid node_count",


### PR DESCRIPTION
## Summary

Refactors the cookbook's training-shape launch path into two clean modes, and fixes multimodal supervised rendering with tinker 0.15.0.

### Two-path shape override contract

- **Validated path** (profile + no `skip_validations`): `create_trainer_job()` builds a minimal `TrainerJobConfig` with only `training_shape_ref` and algorithm fields. Shape-derived infra (accelerator, image tag, node count) is forbidden via `_reject_shape_overrides()` and omitted from the SDK payload.
- **Override path** (`skip_validations=True`): resolves shape defaults via `apply_shape()`, lets explicit `InfraConfig` values win, sends everything.
- **Manual path** (no profile): unchanged, all `InfraConfig` fields sent.

### Multimodal supervised rendering fix

- Adds `_extract_token_ids()` helper in `supervised.py` that iterates `ModelInput.chunks` to extract token IDs from multimodal inputs (text chunks contribute tokens, image chunks contribute placeholder zeros).
- Bumps `tinker-cookbook` pin to `934f0d9` which exports `datum_from_model_input_weights` for proper multimodal datum construction.

### Dependency bumps

- `fireworks-ai>=1.0.0a39` (two-path shape contract)
- `tinker-cookbook` updated to latest commit with multimodal support

### Changes

- `infra.py`: two-branch `create_trainer_job()` + `_reject_shape_overrides()` helper
- `config.py`: `InfraConfig` docstring + `node_count: int | None = None`
- `supervised.py`: `_extract_token_ids()` for multimodal fallback
- `validation.py`: None guard for `node_count`
- `test_shape_override_paths.py`: 13 tests covering all three paths end-to-end
- `test_sdk_compat.py`: DeployConfig test
- `test_supervised_rendering.py`: multimodal assertion restored
- `test_orpo_loop.py`: mock aligned with PR #186 `.result()` removal
- `pyproject.toml`: dependency bumps

### Related PRs

- Backend: https://github.com/fw-ai/fireworks/pull/19188 (fix maxContextLength filter)
- SDK tinker bump: https://github.com/stainless-sdks/fireworks-ai-python/pull/57

## Test plan
- [x] `pytest training/tests/unit/` -- 121/121 pass
- [x] `ruff check` clean
- [x] Live shape resolution verified with tinker 0.15.0 + fireworks-ai 1.0.0a39