### PR TITLE
docs: replace deprecated ResumeConfig reference

### DIFF
--- a/training/README.md
+++ b/training/README.md
@@ -143,9 +143,9 @@ All recipes use composable dataclass configs:
 
 - **`InfraConfig`** -- region, accelerators, training shapes. When `training_shape_id` is set, `max_seq_len` and GPU config are auto-derived; use `skip_validations=True` only if you intentionally want explicit accelerator overrides to win.
 - **`DeployConfig`** -- inference deployment for RL rollouts. Set `deployment_id` to reuse an existing deployment, or omit to auto-create.
-- **`HotloadConfig`** -- weight sync cadence and checkpoint settings.
+- **`HotloadConfig`** -- weight sync cadence and checkpoint settings. Set `dcp_save_interval` to save DCP checkpoints for resume.
 - **`WandBConfig`** -- optional Weights & Biases logging.
-- **`ResumeConfig`** -- resume training from a checkpoint.
+- **`log_path`** (required on all Configs) -- directory for `checkpoints.jsonl` and logs. Resume is automatic: if `checkpoints.jsonl` exists in `log_path`, training continues from the last checkpoint. Use `init_from_checkpoint` to start from a specific checkpoint with fresh data.
 
 ## Directory layout
 


### PR DESCRIPTION
## Summary

`ResumeConfig` was removed in #187 (unified resume system). The README still referenced it in the configuration reference section.

Replace with the new `log_path` + `checkpoints.jsonl` resume pattern.

## Test plan

- [x] 208 unit tests pass (no code changes, docs only)

Made with [Cursor](https://cursor.com)