### PR TITLE
fix(examples): add missing required log_path to ifeval_orpo Config

### DIFF
--- a/training/examples/ifeval_orpo/train_ifeval_orpo.py
+++ b/training/examples/ifeval_orpo/train_ifeval_orpo.py
@@ -83,6 +83,7 @@ def main():
     )
 
     config = orpo_loop.Config(
+        log_path="./ifeval_orpo_logs",
         base_model=args.base_model,
         dataset=args.dataset_path,
         tokenizer_model=args.tokenizer_model,


### PR DESCRIPTION
## Summary

- `training/examples/ifeval_orpo/train_ifeval_orpo.py` constructs `orpo_loop.Config(...)` without `log_path`, which is a required field with no default. This causes a `TypeError` at runtime.
- Adds `log_path="./ifeval_orpo_logs"` to match the convention used by all other example scripts (e.g. `./text2sql_logs`, `./deepmath_logs`, `./frozen_lake_logs`).

## Test plan

- [x] Verified all other recipe `__main__` blocks and example scripts already provide `log_path`
- [ ] Run `python -m training.examples.ifeval_orpo.train_ifeval_orpo --help` to confirm no import/init crash

Made with [Cursor](https://cursor.com)