### PR TITLE
fix: pass fw_api_key in ORPO/DPO recipes and guard wandb entity

### DIFF
--- a/training/examples/deepmath_rl/train_deepmath.py
+++ b/training/examples/deepmath_rl/train_deepmath.py
@@ -317,7 +317,7 @@ def main():
             hot_load_timeout=600,
         ),
         wandb=WandBConfig(
-            entity=args.wandb_entity,
+            entity=args.wandb_entity or None,
             project=args.wandb_project,
             run_name=args.deployment_id or f"deepmath-{int(time.time()) % 100000}",
         ),

--- a/training/examples/ifeval_orpo/train_ifeval_orpo.py
+++ b/training/examples/ifeval_orpo/train_ifeval_orpo.py
@@ -98,7 +98,7 @@ def main():
             region=args.region,
         ),
         wandb=WandBConfig(
-            entity=args.wandb_entity,
+            entity=args.wandb_entity or None,
             project=args.wandb_project,
             run_name=f"ifeval-orpo-{args.base_model.rsplit('/', 1)[-1]}",
         ),

--- a/training/examples/sft_getting_started/train_sft.py
+++ b/training/examples/sft_getting_started/train_sft.py
@@ -49,6 +49,11 @@ def parse_args():
     parser.add_argument("--learning-rate", type=float, default=1e-5)
     parser.add_argument("--lora-rank", type=int, default=0)
     parser.add_argument("--renderer-name", default="")
+    parser.add_argument("--wandb-entity", default=os.environ.get("WANDB_ENTITY", ""),
+                        help="WandB team/entity for logging (optional, omit to disable WandB)")
+    parser.add_argument("--wandb-project", default="sft-tinker",
+                        help="WandB project name (only used when --wandb-entity is set)")
+    parser.add_argument("--extra-args", action="append", default=[], help="Extra trainer args (repeatable, e.g. --extra-args='--moe-gate-fp32')")
     return parser.parse_args()
 
 
@@ -87,9 +92,11 @@ def main():
         infra=InfraConfig(
             training_shape_id=args.training_shape,
             region=args.region,
+            extra_args=args.extra_args or None,
         ),
         wandb=WandBConfig(
-            project="sft-tinker",
+            entity=args.wandb_entity or None,
+            project=args.wandb_project,
             run_name=f"sft-{args.base_model.rsplit('/', 1)[-1]}",
         ),
     )

--- a/training/recipes/dpo_loop.py
+++ b/training/recipes/dpo_loop.py
@@ -474,8 +474,8 @@ def main(
         policy_job_id = policy_ep.job_id
         reference_job_id = reference_ep.job_id
 
-        policy = ReconnectableClient(rlor_mgr, policy_ep.job_id, cfg.base_model, cfg.lora_rank)
-        reference = ReconnectableClient(rlor_mgr, reference_ep.job_id, cfg.base_model, cfg.lora_rank)
+        policy = ReconnectableClient(rlor_mgr, policy_ep.job_id, cfg.base_model, cfg.lora_rank, fw_api_key=api_key)
+        reference = ReconnectableClient(rlor_mgr, reference_ep.job_id, cfg.base_model, cfg.lora_rank, fw_api_key=api_key)
 
         weight_syncer = WeightSyncer(
             policy_client=policy.inner,

--- a/training/recipes/orpo_loop.py
+++ b/training/recipes/orpo_loop.py
@@ -173,7 +173,7 @@ def main(
         display_name="orpo-trainer",
     )
     client = ReconnectableClient(
-        rlor_mgr, endpoint.job_id, cfg.base_model, cfg.lora_rank
+        rlor_mgr, endpoint.job_id, cfg.base_model, cfg.lora_rank, fw_api_key=api_key
     )
 
     job_id = endpoint.job_id

--- a/training/utils/client.py
+++ b/training/utils/client.py
@@ -13,6 +13,7 @@ cleanly and resume from the last DCP checkpoint.
 from __future__ import annotations
 
 import logging
+import os
 
 from fireworks.training.sdk.client import FiretitanServiceClient, FiretitanTrainingClient
 from fireworks.training.sdk.trainer import TrainerJobManager, TrainerServiceEndpoint
@@ -68,7 +69,7 @@ class ReconnectableClient:
         self._base_model = base_model
         self._lora_rank = lora_rank
         self._api_key = api_key
-        self._fw_api_key = fw_api_key
+        self._fw_api_key = fw_api_key or os.environ.get("FIREWORKS_API_KEY")
         self._default_timeout = default_timeout
         self._endpoint: TrainerServiceEndpoint | None = None
         self._client: FiretitanTrainingClient | None = None


### PR DESCRIPTION
## Summary

- Fix 401 auth errors in ORPO and DPO recipes by passing `fw_api_key` to `ReconnectableClient`
- Add env var fallback in `ReconnectableClient` so future recipes don't hit this bug
- Guard wandb entity to prevent crashes when `--wandb-entity` is omitted
- Add missing `--wandb-entity`, `--wandb-project`, `--extra-args` CLI args to `train_sft.py`

## Motivation

Found during E2E dogfooding of the customer SFT/ORPO path for Qwen3.5-397B-A17B on production. Both ORPO and DPO recipes crash with `401 UNAUTHORIZED` because `ReconnectableClient` never receives the API key -- the `fw_api_key` parameter was passed in `sft_loop.py` and `rl_loop.py` but missed in `orpo_loop.py` and `dpo_loop.py`.

## Changes

| File | Fix |
|------|-----|
| `training/utils/client.py` | Fall back to `FIREWORKS_API_KEY` env var when `fw_api_key` not passed |
| `training/recipes/orpo_loop.py` | Pass `fw_api_key=api_key` to `ReconnectableClient` |
| `training/recipes/dpo_loop.py` | Pass `fw_api_key=api_key` to both policy and reference clients |
| `training/examples/ifeval_orpo/train_ifeval_orpo.py` | Add `or None` guard on wandb entity |
| `training/examples/deepmath_rl/train_deepmath.py` | Add `or None` guard on wandb entity |
| `training/examples/sft_getting_started/train_sft.py` | Add `--wandb-entity`, `--wandb-project`, `--extra-args` args |

## Test plan

- [x] ORPO E2E on Qwen3.5-397B: verified training runs successfully with fix
- [x] SFT E2E on Qwen3.5-397B: verified 10 steps complete with loss output
- [ ] DPO E2E: not tested yet but same fix pattern as ORPO
- [ ] Verify wandb disabled gracefully when `--wandb-entity` omitted

Made with [Cursor](https://cursor.com)