### PR TITLE
fix(frozen-lake): reuse one tokenizer per rollout invocation

### DIFF
--- a/training/examples/frozen_lake/frozen_lake_rollout.py
+++ b/training/examples/frozen_lake/frozen_lake_rollout.py
@@ -856,13 +856,27 @@ class FrozenLakeToolRolloutProcessor(RolloutProcessor):
             or completion_params.get("visual_prompt_template")
             or DEFAULT_VISUAL_PROMPT_TEMPLATE
         )
+        _shared_tokenizer = None
+        _shared_tokenizer_lock = asyncio.Lock()
+
+        async def _load_shared_tokenizer():
+            nonlocal _shared_tokenizer
+            if _shared_tokenizer is not None:
+                return _shared_tokenizer
+            async with _shared_tokenizer_lock:
+                if _shared_tokenizer is None:
+                    # Load once per rollout invocation so per-row clients share
+                    # the same tokenizer instead of re-fetching from HF.
+                    _shared_tokenizer = _get_hf_tokenizer(str(tokenizer_name_or_path))
+            return _shared_tokenizer
 
         async def process_row(row: EvaluationRow) -> EvaluationRow:
             start_time = time.perf_counter()
+            shared_tokenizer = await _load_shared_tokenizer()
 
             tool_call_parser = build_frozen_lake_tool_call_parser(
                 allow_plaintext_action_fallback=allow_plaintext_action_fallback,
-                tokenizer_getter=lambda: _get_hf_tokenizer(str(tokenizer_name_or_path)),
+                tokenizer_getter=lambda: shared_tokenizer,
                 model_id=model_id,
             )
             text_client = None
@@ -881,6 +895,7 @@ class FrozenLakeToolRolloutProcessor(RolloutProcessor):
                     tool_call_parser=tool_call_parser,
                     default_tools=FROZEN_LAKE_TOOLS,
                 )
+                image_client._tokenizer = shared_tokenizer
             else:
                 text_client = FireworksV1CompletionsClient(
                     model_id=model_id,
@@ -895,6 +910,7 @@ class FrozenLakeToolRolloutProcessor(RolloutProcessor):
                     tool_call_parser=tool_call_parser,
                     default_tools=FROZEN_LAKE_TOOLS,
                 )
+                text_client._tokenizer = shared_tokenizer
             usage = {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
             all_prompt_ids: List[int] = []
             all_completion_ids: List[int] = []


### PR DESCRIPTION
## Summary

- load the FrozenLake tokenizer once per rollout invocation and reuse it across per-row completions clients so repeated rollout rows stop re-fetching from HuggingFace
- keep the first tokenizer load inside `process_row()` behind a per-invocation `asyncio.Lock` so existing callers still see tokenizer load failures through their per-task error handling path
- split this tokenizer fix out from `fw-ai/cookbook#190` so it can land independently on top of current `main`

## Code Overview Diagram

```mermaid
flowchart LR
    A[process_row task] --> B[await _load_shared_tokenizer()]
    B --> C[shared tokenizer cached once per rollout invocation]
    C --> D[tool_call_parser uses shared tokenizer]
    C --> E[image/text completions client gets injected tokenizer]
```

## Test plan

- [x] `python -m pytest training/tests/unit/test_frozen_lake_visual_rollout.py -q`
- [x] Independent agent review of the diff

## Related

- split from `fw-ai/cookbook#190`
- narrower current-`main` variant of `fw-ai/cookbook#188`

Made with [Cursor](https://cursor.com)