### PR TITLE
fix(frozen-lake): harden gateway-backed smoke path

### DIFF
--- a/training/examples/frozen_lake/train_frozen_lake.py
+++ b/training/examples/frozen_lake/train_frozen_lake.py
@@ -32,6 +32,7 @@ _SRC = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..",
 if _SRC not in sys.path:
     sys.path.insert(0, _SRC)
 
+from fireworks import AsyncFireworks
 from eval_protocol.models import EvaluationRow, InputMetadata, Message
 from eval_protocol.pytest.types import RolloutProcessorConfig
 
@@ -301,6 +302,7 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
     api_key = os.environ["FIREWORKS_API_KEY"]
     account = os.environ.get("FIREWORKS_ACCOUNT_ID", "")
     base_url = os.environ.get("FIREWORKS_BASE_URL", "https://api.fireworks.ai")
+    inference_api_base = cfg.inference_base_url or f"{base_url.rstrip('/')}/inference"
 
     completions_per_prompt = cfg.completions_per_prompt
     prompt_groups_per_step = cfg.prompt_groups_per_step
@@ -347,7 +349,7 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
         api_key=api_key, account_id=account,
         base_url=base_url,
         hotload_api_url=base_url,
-        inference_url=cfg.inference_base_url or base_url,
+        inference_url=base_url,
     )
 
     # -- Load seed contexts --------------------------------------------------
@@ -504,25 +506,34 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
 
         # -- Wait for deployment readiness -----------------------------------
 
-        inference_url = deploy_mgr.inference_url
-        logger.info("Waiting for deployment to be ready for inference...")
-        import httpx
-        _inference_prefix = "/v1" if cfg.inference_base_url else "/inference/v1"
-        _readiness_url = inference_url.rstrip("/") + _inference_prefix + "/completions"
-        for _ready_attempt in range(600):
-            try:
-                _resp = httpx.post(
-                    _readiness_url,
-                    json={"model": inference_model, "prompt": "test", "max_tokens": 1},
-                    headers={"Authorization": f"Bearer {api_key}"},
-                    timeout=15,
+        logger.info("Waiting for deployment to be ready for inference (base=%s)...", inference_api_base)
+
+        async def _check_readiness_burst(burst_size: int = 8) -> bool:
+            async with AsyncFireworks(api_key=api_key, base_url=inference_api_base) as readiness_client:
+                async def _one():
+                    resp = await readiness_client.completions.create(
+                        model=inference_model,
+                        prompt=[1, 2],
+                        max_tokens=1,
+                        temperature=0.0,
+                    )
+                    return resp is not None
+
+                results = await asyncio.gather(
+                    *[_one() for _ in range(burst_size)],
+                    return_exceptions=True,
                 )
-                if _resp.status_code == 200:
+                ok = sum(1 for result in results if result is True)
+                logger.info("Readiness burst: %d/%d succeeded", ok, burst_size)
+                return ok == burst_size
+
+        for _ready_attempt in range(120):
+            try:
+                if asyncio.run(_check_readiness_burst()):
                     logger.info("Deployment is ready for inference")
                     break
-                logger.info("Deployment not ready yet (status=%d), waiting...", _resp.status_code)
+                logger.info("Deployment not fully ready, waiting...")
                 time.sleep(5)
-                continue
             except Exception as e:
                 logger.info("Readiness check failed (%s), waiting...", e)
                 time.sleep(5)
@@ -530,12 +541,11 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
             logger.warning("Deployment readiness timeout, proceeding anyway")
 
         # -- Build rollout processor ----------------------------------------
-        rollout_base_url = inference_url.rstrip("/") + ("" if cfg.inference_base_url else "/inference")
         rollout_processor = FrozenLakeToolRolloutProcessor(
             model_id=inference_model,
             tokenizer_name_or_path=cfg.tokenizer_model,
             api_key=api_key,
-            base_url=rollout_base_url,
+            base_url=inference_api_base,
             temperature=cfg.temperature,
             max_tokens=cfg.max_completion_tokens,
             system_prompt=cfg.system_prompt,

--- a/training/examples/frozen_lake/train_frozen_lake.py
+++ b/training/examples/frozen_lake/train_frozen_lake.py
@@ -773,7 +773,6 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
                 sample_fns=(sample_one_prompt(ctx) for ctx in all_prompts),
                 train_fns=train_fns,
                 prompt_groups_per_step=prompt_groups_per_step,
-                max_concurrent=cfg.max_concurrent,
                 dynamic_filter_fn=should_accept,
                 global_step=step_offset,
                 metrics_callback=_filtered_step_callback,

--- a/training/examples/frozen_lake/train_frozen_lake.py
+++ b/training/examples/frozen_lake/train_frozen_lake.py
@@ -492,6 +492,7 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
             hotload_timeout=weight_sync_cfg.weight_sync_timeout,
             first_checkpoint_type=weight_sync_cfg.first_checkpoint_type,
             dcp_timeout=weight_sync_cfg.dcp_timeout,
+            lora_mode=cfg.lora_rank > 0,
         )
 
         infra_boot_time = time.time() - _infra_start

--- a/training/recipes/rl_loop.py
+++ b/training/recipes/rl_loop.py
@@ -379,6 +379,7 @@ def main(
             hotload_timeout=cfg.weight_sync.weight_sync_timeout,
             first_checkpoint_type=cfg.weight_sync.first_checkpoint_type,
             dcp_timeout=cfg.weight_sync.dcp_timeout,
+            lora_mode=cfg.lora_rank > 0,
         )
 
         infra_boot_time = _time.time() - _infra_start

--- a/training/tests/unit/test_infra.py
+++ b/training/tests/unit/test_infra.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import training.utils.infra as infra_module
+
+
+def test_reuse_or_resume_job_reuses_existing_job():
+    expected_endpoint = SimpleNamespace(job_id="job-123", base_url="https://trainer.unit.test")
+    events: dict[str, object] = {}
+
+    class FakeTrainerJobManager:
+        account_id = "acct"
+
+        def get(self, job_id):
+            events["get_job_id"] = job_id
+            return {"state": "JOB_STATE_RUNNING"}
+
+        def wait_for_existing(self, job_id):
+            events["wait_job_id"] = job_id
+            return expected_endpoint
+
+    endpoint = infra_module._reuse_or_resume_job(FakeTrainerJobManager(), "job-123")
+
+    assert endpoint is expected_endpoint
+    assert events == {
+        "get_job_id": "job-123",
+        "wait_job_id": "job-123",
+    }
+
+
+def test_reuse_or_resume_job_falls_back_to_gateway_when_lookup_fails(monkeypatch):
+    events: dict[str, object] = {
+        "healthz_urls": [],
+        "sleeps": [],
+    }
+
+    class FakeTrainerJobManager:
+        account_id = "acct"
+
+        def get(self, _job_id):
+            raise RuntimeError("403 forbidden")
+
+        def _get_trainer_gateway_url(self, job_id):
+            return f"https://gateway.unit.test/training/v1/rlorTrainerJobs/acct/{job_id}"
+
+        def _check_healthz(self, base_url):
+            events["healthz_urls"].append(base_url)
+            return len(events["healthz_urls"]) >= 2
+
+    monkeypatch.setattr(infra_module.time, "sleep", lambda seconds: events["sleeps"].append(seconds))
+
+    endpoint = infra_module._reuse_or_resume_job(FakeTrainerJobManager(), "job-123")
+
+    assert endpoint.job_id == "job-123"
+    assert endpoint.job_name == "accounts/acct/rlorTrainerJobs/job-123"
+    assert endpoint.base_url == "https://gateway.unit.test/training/v1/rlorTrainerJobs/acct/job-123"
+    assert events["healthz_urls"] == [
+        "https://gateway.unit.test/training/v1/rlorTrainerJobs/acct/job-123",
+        "https://gateway.unit.test/training/v1/rlorTrainerJobs/acct/job-123",
+    ]
+    assert events["sleeps"] == [5]

--- a/training/tests/unit/test_train_frozen_lake.py
+++ b/training/tests/unit/test_train_frozen_lake.py
@@ -5,7 +5,6 @@ import sys
 from types import SimpleNamespace
 
 from eval_protocol.models import EvaluationRow, InputMetadata, Message
-import httpx
 
 import training.examples.frozen_lake.train_frozen_lake as train_module
 from training.examples.frozen_lake.masking import (
@@ -19,6 +18,31 @@ from training.examples.frozen_lake.train_frozen_lake import (
     load_seed_contexts,
     parse_args,
 )
+
+
+class _FakeAsyncFireworks:
+    init_kwargs: list[dict[str, object]] = []
+    create_kwargs: list[dict[str, object]] = []
+    responses: list[object | None] = []
+
+    def __init__(self, *, api_key, base_url):
+        type(self).init_kwargs.append({
+            "api_key": api_key,
+            "base_url": base_url,
+        })
+        self.completions = self
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def create(self, **kwargs):
+        type(self).create_kwargs.append(dict(kwargs))
+        if type(self).responses:
+            return type(self).responses.pop(0)
+        return object()
 
 
 def test_parse_args_applies_cli_overrides(monkeypatch):
@@ -231,6 +255,7 @@ def test_main_bootstraps_without_reference_and_cleans_up(monkeypatch):
                 "account_id": account_id,
                 "base_url": base_url,
                 "hotload_api_url": hotload_api_url,
+                "inference_url": inference_url,
             }
 
         def delete(self, deployment_id):
@@ -292,7 +317,10 @@ def test_main_bootstraps_without_reference_and_cleans_up(monkeypatch):
     monkeypatch.setattr(train_module, "FrozenLakeToolRolloutProcessor", FakeRolloutProcessor)
     monkeypatch.setattr(train_module, "build_loss_fn", lambda **kwargs: ("loss-builder", kwargs))
     monkeypatch.setattr(train_module, "run_rl_loop", fake_run_rl_loop)
-    monkeypatch.setattr(httpx, "post", lambda *args, **kwargs: SimpleNamespace(status_code=200))
+    _FakeAsyncFireworks.init_kwargs = []
+    _FakeAsyncFireworks.create_kwargs = []
+    _FakeAsyncFireworks.responses = []
+    monkeypatch.setattr(train_module, "AsyncFireworks", _FakeAsyncFireworks)
 
     train_module.main()
 
@@ -302,8 +330,11 @@ def test_main_bootstraps_without_reference_and_cleans_up(monkeypatch):
     assert events["trainer_jobs"][0]["display_name"] == "frozen-lake-policy"
     assert events["trainer_jobs"][0]["hot_load_deployment_id"] == "dep-123"
     assert events["weight_syncer_init"]["deployment_id"] == "dep-123"
+    assert events["deploy_mgr_init"]["inference_url"] == "https://unit.test"
+    assert _FakeAsyncFireworks.init_kwargs[0]["base_url"] == "https://unit.test/inference"
     assert events["rollout_processor_init"]["observation_mode"] == "image"
     assert events["rollout_processor_init"]["allow_plaintext_action_fallback"] is True
+    assert events["rollout_processor_init"]["base_url"] == "https://unit.test/inference"
     assert events["run_rl_loop_kwargs"]["prompt_groups_per_step"] == 4
     assert "train_fns" in events["run_rl_loop_kwargs"]
     assert events["deleted_jobs"] == ["policy-job"]
@@ -373,6 +404,7 @@ def test_main_runs_sampling_and_training_with_reference(monkeypatch):
                 "account_id": account_id,
                 "base_url": base_url,
                 "hotload_api_url": hotload_api_url,
+                "inference_url": inference_url,
             }
 
         def delete(self, deployment_id):
@@ -506,8 +538,6 @@ def test_main_runs_sampling_and_training_with_reference(monkeypatch):
 
         return _builder
 
-    readiness_status = iter([503, 200])
-
     monkeypatch.setattr(train_module, "parse_args", lambda: cfg)
     monkeypatch.setattr(train_module, "setup_wandb", lambda *args, **kwargs: None)
     monkeypatch.setattr(train_module, "wandb_finish", lambda: events.__setitem__("wandb_finished", 1))
@@ -545,11 +575,10 @@ def test_main_runs_sampling_and_training_with_reference(monkeypatch):
         lambda **kwargs: _OrigInfraConfig(ref_training_shape_id="ts-qwen3-4b-smoke-v1", **kwargs),
     )
     monkeypatch.setattr(train_module.time, "sleep", lambda seconds: events["sleeps"].append(seconds))
-    monkeypatch.setattr(
-        httpx,
-        "post",
-        lambda *args, **kwargs: SimpleNamespace(status_code=next(readiness_status)),
-    )
+    _FakeAsyncFireworks.init_kwargs = []
+    _FakeAsyncFireworks.create_kwargs = []
+    _FakeAsyncFireworks.responses = [None] * 8 + [object() for _ in range(8)]
+    monkeypatch.setattr(train_module, "AsyncFireworks", _FakeAsyncFireworks)
 
     train_module.main()
 
@@ -559,7 +588,10 @@ def test_main_runs_sampling_and_training_with_reference(monkeypatch):
         "frozen-lake-policy",
         "frozen-lake-reference",
     ]
+    assert events["deploy_mgr_init"]["inference_url"] == "https://unit.test"
+    assert _FakeAsyncFireworks.init_kwargs[0]["base_url"] == "https://unit.test/inference"
     assert events["rollout_processor_call"]["row_ids"] == ["seed_101_0", "seed_101_1"]
+    assert events["rollout_processor_init"]["base_url"] == "https://unit.test/inference"
     assert events["weight_sync_saves"] == [("step-0-base", "base"), ("step-1", "base")]
     assert events["weight_sync_dcp"] == []
     assert events["final_save"] == ("step-1", 2700)
@@ -572,3 +604,4 @@ def test_main_runs_sampling_and_training_with_reference(monkeypatch):
     assert events["deleted_jobs"] == ["reference-job", "policy-job"]
     assert events["deleted_deployments"] == []
     assert events["wandb_finished"] == 1
+    assert events["sleeps"] == [5]

--- a/training/tests/unit/test_train_frozen_lake.py
+++ b/training/tests/unit/test_train_frozen_lake.py
@@ -336,6 +336,7 @@ def test_main_bootstraps_without_reference_and_cleans_up(monkeypatch):
     assert events["rollout_processor_init"]["allow_plaintext_action_fallback"] is True
     assert events["rollout_processor_init"]["base_url"] == "https://unit.test/inference"
     assert events["run_rl_loop_kwargs"]["prompt_groups_per_step"] == 4
+    assert "max_concurrent" not in events["run_rl_loop_kwargs"]
     assert "train_fns" in events["run_rl_loop_kwargs"]
     assert events["deleted_jobs"] == ["policy-job"]
     assert events["deleted_deployments"] == []
@@ -592,6 +593,7 @@ def test_main_runs_sampling_and_training_with_reference(monkeypatch):
     assert _FakeAsyncFireworks.init_kwargs[0]["base_url"] == "https://unit.test/inference"
     assert events["rollout_processor_call"]["row_ids"] == ["seed_101_0", "seed_101_1"]
     assert events["rollout_processor_init"]["base_url"] == "https://unit.test/inference"
+    assert "max_concurrent" not in events["run_rl_loop_kwargs"]
     assert events["weight_sync_saves"] == [("step-0-base", "base"), ("step-1", "base")]
     assert events["weight_sync_dcp"] == []
     assert events["final_save"] == ("step-1", 2700)

--- a/training/utils/infra.py
+++ b/training/utils/infra.py
@@ -201,18 +201,49 @@ def setup_training_client(
     return svc, cli
 
 
+def _wait_for_existing_job_gateway(
+    rlor_mgr: TrainerJobManager,
+    job_id: str,
+) -> TrainerServiceEndpoint:
+    """Fall back to the trainer gateway when control-plane lookups fail.
+
+    Some pre-created smoke-test jobs are reachable via the gateway but can still
+    fail follow-up control-plane `get()`/`wait_for_existing()` calls due to
+    account or environment mismatches. In that case, reuse the gateway endpoint
+    directly and wait for `/api/v1/healthz`.
+    """
+    job_name = f"accounts/{rlor_mgr.account_id}/rlorTrainerJobs/{job_id}"
+    base_url = rlor_mgr._get_trainer_gateway_url(job_id)
+    for _ in range(24):
+        if rlor_mgr._check_healthz(base_url):
+            logger.info("Using pre-created job %s at %s", job_id, base_url)
+            return TrainerServiceEndpoint(job_name=job_name, job_id=job_id, base_url=base_url)
+        time.sleep(5)
+    logger.warning("Pre-created job %s healthz did not pass; proceeding anyway", job_id)
+    return TrainerServiceEndpoint(job_name=job_name, job_id=job_id, base_url=base_url)
+
+
 def _reuse_or_resume_job(
     rlor_mgr: TrainerJobManager, job_id: str
 ) -> TrainerServiceEndpoint:
-    job = rlor_mgr.get(job_id)
-    state = job.get("state", "")
     resumable = (
         "JOB_STATE_FAILED",
         "JOB_STATE_CANCELLED",
         "JOB_STATE_PAUSED",
         "JOB_STATE_COMPLETED",
     )
-    if state in resumable:
-        logger.info("Job %s is %s, resuming...", job_id, state)
-        return rlor_mgr.resume_and_wait(job_id)
-    return rlor_mgr.wait_for_existing(job_id)
+    try:
+        job = rlor_mgr.get(job_id)
+        state = job.get("state", "")
+        if state in resumable:
+            logger.info("Job %s is %s, resuming...", job_id, state)
+            return rlor_mgr.resume_and_wait(job_id)
+        return rlor_mgr.wait_for_existing(job_id)
+    except Exception as e:
+        logger.warning(
+            "Failed to look up pre-created job %s via control plane (%s); "
+            "falling back to trainer gateway health checks",
+            job_id,
+            e,
+        )
+        return _wait_for_existing_job_gateway(rlor_mgr, job_id)


### PR DESCRIPTION
## Summary

- Fall back to trainer-gateway health checks when pre-created FrozenLake trainer job lookups fail, so smoke runs can still attach to already-running jobs instead of dying on follow-up control-plane calls
- Use a single `inference_api_base` for both rollout traffic and deployment readiness probes, and run readiness through the same `AsyncFireworks` client path the recipe uses for inference
- **Add `lora_mode` to `WeightSyncer` instantiation** in both `rl_loop.py` and `train_frozen_lake.py` — LoRA adapter checkpoints are always complete (not diffs), so incremental/delta hotload metadata must be disabled to avoid crashing the serving container with a 503

## Test plan

- [x] End-to-end RLOR smoke test (LoRA + full-param + Kimi B300 80k) all 3 jobs passing in CI

## Related

- Pairs with [fw-ai/fireworks#19411](https://github.com/fw-ai/fireworks/pull/19411) (trainer-side LoRA DCP + CI smoke test)
- SDK `lora_mode` field added in `fireworks-ai-python` `weight_syncer.py`