### PR TITLE
fix(rl): reuse policy trainer for lora grpo references

### DIFF
--- a/training/examples/frozen_lake/train_frozen_lake.py
+++ b/training/examples/frozen_lake/train_frozen_lake.py
@@ -24,7 +24,7 @@ import sys
 import time
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, cast
+from typing import Any, Dict, List, cast
 
 import tinker
 
@@ -32,10 +32,9 @@ _SRC = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..",
 if _SRC not in sys.path:
     sys.path.insert(0, _SRC)
 
-from eval_protocol.models import EvaluationRow, InputMetadata, Message
+from eval_protocol.models import EvaluationRow, InputMetadata
 from eval_protocol.pytest.types import RolloutProcessorConfig
 
-from training.examples.frozen_lake.frozen_lake_env import build_frozen_lake_tool_env
 from training.examples.frozen_lake.frozen_lake_rollout import (
     DEFAULT_SYSTEM_PROMPT_INSTRUCTIONS,
     FrozenLakeToolRolloutProcessor,
@@ -64,6 +63,7 @@ from training.utils import (
     create_trainer_job,
     compute_advantages,
     build_datum_from_token_mask,
+    build_base_model_reference_id,
 )
 from training.utils.rl import PromptGroup
 from training.utils.rl.train import TrainStepFns, run_rl_loop
@@ -304,7 +304,6 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
 
     completions_per_prompt = cfg.completions_per_prompt
     prompt_groups_per_step = cfg.prompt_groups_per_step
-    total_samples_per_step = prompt_groups_per_step * completions_per_prompt
 
     infra = InfraConfig(
         training_shape_id=cfg.training_shape or None,
@@ -360,6 +359,22 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
 
     # -- Resolve training shapes --------------------------------------------
 
+    use_reference = cfg.kl_beta != 0
+    if not use_reference:
+        logger.info("kl_beta=0: skipping reference model creation")
+    reuse_policy_base_reference = (
+        use_reference
+        and cfg.policy_loss == "grpo"
+        and cfg.lora_rank > 0
+        and not cfg.reference_job_id
+        and not infra.ref_training_shape_id
+    )
+    if reuse_policy_base_reference:
+        logger.info(
+            "lora_rank=%d: reusing policy trainer for base-model reference forwards",
+            cfg.lora_rank,
+        )
+
     profile = None
     if infra.training_shape_id:
         profile = rlor_mgr.resolve_training_profile(infra.training_shape_id)
@@ -384,12 +399,14 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
         cfg.max_seq_len = 4096
         logger.info("max_seq_len defaulting to %d (no training shape)", cfg.max_seq_len)
 
-    ref_profile = None
-    if infra.ref_training_shape_id:
+    ref_profile = profile
+    if (
+        use_reference
+        and not reuse_policy_base_reference
+        and infra.ref_training_shape_id
+    ):
+        logger.info("Using separate ref training shape: %s", infra.ref_training_shape_id)
         ref_profile = rlor_mgr.resolve_training_profile(infra.ref_training_shape_id)
-    use_reference = ref_profile is not None
-    if not use_reference:
-        logger.info("No ref_training_shape_id set, skipping reference model")
 
     # -- Infrastructure setup -----------------------------------------------
 
@@ -450,7 +467,7 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
             pol_fut = pool.submit(_make_job, "policy", cfg.policy_job_id, job_profile=profile)
             ref_fut = (
                 pool.submit(_make_job, "reference", cfg.reference_job_id, job_profile=ref_profile, forward_only=True)
-                if use_reference else None
+                if use_reference and not reuse_policy_base_reference else None
             )
 
             policy_ep, policy_job_id, precreated_policy = pol_fut.result()
@@ -471,11 +488,26 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
         )
         reference = (
             ReconnectableClient(
-                rlor_mgr, reference_ep.job_id, cfg.base_model, cfg.lora_rank,
+                rlor_mgr,
+                policy_ep.job_id,
+                cfg.base_model,
+                cfg.lora_rank,
                 fw_api_key=api_key,
-                endpoint=reference_ep,
+                endpoint=policy_ep,
+                model_id_override=build_base_model_reference_id(cfg.base_model),
             )
-            if reference_ep else None
+            if reuse_policy_base_reference
+            else (
+                ReconnectableClient(
+                    rlor_mgr,
+                    reference_ep.job_id,
+                    cfg.base_model,
+                    cfg.lora_rank,
+                    fw_api_key=api_key,
+                    endpoint=reference_ep,
+                )
+                if reference_ep else None
+            )
         )
 
         if dep_info:

--- a/training/examples/frozen_lake/train_frozen_lake.py
+++ b/training/examples/frozen_lake/train_frozen_lake.py
@@ -28,9 +28,7 @@ from typing import Any, Dict, List, cast
 
 import tinker
 
-_SRC = os.path.abspath(
-    os.path.join(os.path.dirname(__file__), "..", "..", "..", "..", "..")
-)
+_SRC = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..", "..", ".."))
 if _SRC not in sys.path:
     sys.path.insert(0, _SRC)
 
@@ -140,9 +138,7 @@ class FrozenLakeConfig:
     region: str = "US_VIRGINIA_1"
     deployment_region: str = "US_VIRGINIA_1"
 
-    wandb_entity: str = field(
-        default_factory=lambda: os.environ.get("WANDB_ENTITY", "")
-    )
+    wandb_entity: str = field(default_factory=lambda: os.environ.get("WANDB_ENTITY", ""))
     wandb_project: str = field(
         default_factory=lambda: os.environ.get("WANDB_PROJECT", "frozen-lake-grpo")
     )
@@ -153,24 +149,18 @@ class FrozenLakeConfig:
 
 
 def parse_args() -> FrozenLakeConfig:
-    parser = argparse.ArgumentParser(
-        description="GRPO training on FrozenLake tool calls"
-    )
+    parser = argparse.ArgumentParser(description="GRPO training on FrozenLake tool calls")
     parser.add_argument("--base-model", default="accounts/fireworks/models/qwen3-8b")
     parser.add_argument("--tokenizer-model", default="Qwen/Qwen3-8B")
-    parser.add_argument(
-        "--training-shape", default=os.environ.get("TRAINING_SHAPE", "")
-    )
+    parser.add_argument("--training-shape", default=os.environ.get("TRAINING_SHAPE", ""))
     parser.add_argument("--deployment-shape", default="")
     parser.add_argument("--accelerator-type", default="")
     parser.add_argument("--deployment-id", default=None)
     parser.add_argument("--region", default="US_VIRGINIA_1")
     parser.add_argument("--deployment-region", default="US_VIRGINIA_1")
 
-    parser.add_argument(
-        "--seed-jsonl-path",
-        default=os.path.join(os.path.dirname(__file__), "seeds.jsonl"),
-    )
+    parser.add_argument("--seed-jsonl-path",
+                        default=os.path.join(os.path.dirname(__file__), "seeds.jsonl"))
     parser.add_argument("--max-seeds", type=int, default=20)
     parser.add_argument("--max-steps", type=int, default=12)
     parser.add_argument("--map-name", default="4x4")
@@ -188,30 +178,17 @@ def parse_args() -> FrozenLakeConfig:
     parser.add_argument("--lora-rank", type=int, default=0)
 
     parser.add_argument("--wandb-entity", default=os.environ.get("WANDB_ENTITY", ""))
-    parser.add_argument(
-        "--wandb-project", default=os.environ.get("WANDB_PROJECT", "frozen-lake-grpo")
-    )
-    parser.add_argument(
-        "--visual-prompt-template", default=DEFAULT_VISUAL_PROMPT_TEMPLATE
-    )
+    parser.add_argument("--wandb-project", default=os.environ.get("WANDB_PROJECT", "frozen-lake-grpo"))
+    parser.add_argument("--visual-prompt-template", default=DEFAULT_VISUAL_PROMPT_TEMPLATE)
     parser.add_argument("--observation-mode", choices=("text", "image"), default="text")
     parser.add_argument("--allow-plaintext-action-fallback", action="store_true")
 
-    parser.add_argument(
-        "--policy-job-id",
-        default=None,
-        help="Pre-created policy trainer job ID (skip creation)",
-    )
-    parser.add_argument(
-        "--reference-job-id",
-        default=None,
-        help="Pre-created reference trainer job ID (skip creation)",
-    )
-    parser.add_argument(
-        "--inference-base-url",
-        default=None,
-        help="Direct base URL for inference deployment (skip gateway)",
-    )
+    parser.add_argument("--policy-job-id", default=None,
+                        help="Pre-created policy trainer job ID (skip creation)")
+    parser.add_argument("--reference-job-id", default=None,
+                        help="Pre-created reference trainer job ID (skip creation)")
+    parser.add_argument("--inference-base-url", default=None,
+                        help="Direct base URL for inference deployment (skip gateway)")
 
     return cast(FrozenLakeConfig, parser.parse_args(namespace=FrozenLakeConfig()))
 
@@ -230,13 +207,11 @@ def load_seed_contexts(path: str, max_seeds: int) -> List[Dict[str, Any]]:
             if not line:
                 continue
             entry = json.loads(line)
-            contexts.append(
-                {
-                    "map_name": entry.get("map_name", "4x4"),
-                    "use_random_map": True,
-                    "seed": int(entry["seed"]),
-                }
-            )
+            contexts.append({
+                "map_name": entry.get("map_name", "4x4"),
+                "use_random_map": True,
+                "seed": int(entry["seed"]),
+            })
             if len(contexts) >= max_seeds:
                 break
     return contexts
@@ -280,9 +255,7 @@ def evaluation_row_to_training_data(
         return [], 0, [], []
 
     # prompt_len = first turn's prompt length (system + user message, before any model output)
-    first_prompt_len = len(
-        [int(x) for x in (token_turn_traces[0].get("prompt_ids") or [])]
-    )
+    first_prompt_len = len([int(x) for x in (token_turn_traces[0].get("prompt_ids") or [])])
 
     model_request_traces = extra.get("model_request_traces") or []
     spans = compute_model_output_spans(token_turn_traces, model_request_traces)
@@ -358,23 +331,19 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
         run_name=cfg.deployment_id or f"frozen-lake-{int(time.time()) % 100000}",
     )
 
-    setup_wandb(
-        wandb_cfg,
-        {
-            "completions_per_prompt": completions_per_prompt,
-            "prompt_groups_per_step": prompt_groups_per_step,
-            "kl_beta": cfg.kl_beta,
-            "lr": cfg.learning_rate,
-            "temperature": cfg.temperature,
-            "max_steps": cfg.max_steps,
-            "max_seeds": cfg.max_seeds,
-        },
-    )
+    setup_wandb(wandb_cfg, {
+        "completions_per_prompt": completions_per_prompt,
+        "prompt_groups_per_step": prompt_groups_per_step,
+        "kl_beta": cfg.kl_beta,
+        "lr": cfg.learning_rate,
+        "temperature": cfg.temperature,
+        "max_steps": cfg.max_steps,
+        "max_seeds": cfg.max_seeds,
+    })
 
     rlor_mgr = TrainerJobManager(api_key=api_key, account_id=account, base_url=base_url)
     deploy_mgr = DeploymentManager(
-        api_key=api_key,
-        account_id=account,
+        api_key=api_key, account_id=account,
         base_url=base_url,
         hotload_api_url=base_url,
         inference_url=cfg.inference_base_url or base_url,
@@ -385,8 +354,7 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
     seed_contexts = load_seed_contexts(cfg.seed_jsonl_path, cfg.max_seeds)
     logger.info(
         "Loaded %d seed contexts from %s",
-        len(seed_contexts),
-        os.path.abspath(cfg.seed_jsonl_path),
+        len(seed_contexts), os.path.abspath(cfg.seed_jsonl_path),
     )
 
     # -- Resolve training shapes --------------------------------------------
@@ -415,16 +383,13 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
             # Strip /versions/... suffix to get the parent deployment shape
             idx = dsv.find("/versions/")
             deploy_cfg.deployment_shape = dsv[:idx] if idx >= 0 else dsv
-            logger.info(
-                "Deployment shape from training shape: %s", deploy_cfg.deployment_shape
-            )
+            logger.info("Deployment shape from training shape: %s", deploy_cfg.deployment_shape)
 
     if profile and profile.pipeline_parallelism > 1:
         pp_rec = compute_pp_recommendation(profile, completions_per_prompt)
         logger.info(
             "PP recommendation: prompt_groups_per_step=%d (current=%d)",
-            pp_rec.recommended_prompts_per_step,
-            prompt_groups_per_step,
+            pp_rec.recommended_prompts_per_step, prompt_groups_per_step,
         )
 
     if profile and cfg.max_seq_len is None:
@@ -440,9 +405,7 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
         and not reuse_policy_base_reference
         and infra.ref_training_shape_id
     ):
-        logger.info(
-            "Using separate ref training shape: %s", infra.ref_training_shape_id
-        )
+        logger.info("Using separate ref training shape: %s", infra.ref_training_shape_id)
         ref_profile = rlor_mgr.resolve_training_profile(infra.ref_training_shape_id)
 
     # -- Infrastructure setup -----------------------------------------------
@@ -472,48 +435,28 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
             logger.info("Skipping deployment setup — using pre-created resources")
         else:
             dep_info = setup_deployment(deploy_mgr, deploy_cfg, cfg.base_model, infra)
-            if (
-                not cfg.deployment_id
-                and deploy_cfg.deployment_id
-                and os.environ.get("KEEP_DEPLOYMENT", "0") != "1"
-            ):
+            if not cfg.deployment_id and deploy_cfg.deployment_id and os.environ.get("KEEP_DEPLOYMENT", "0") != "1":
                 cleanup.deployment(deploy_cfg.deployment_id)
-            elif (
-                deploy_cfg.deployment_id
-                and os.environ.get("KEEP_DEPLOYMENT", "0") == "1"
-            ):
-                logger.info(
-                    "Keeping deployment %s (KEEP_DEPLOYMENT=1)",
-                    deploy_cfg.deployment_id,
-                )
+            elif deploy_cfg.deployment_id and os.environ.get("KEEP_DEPLOYMENT", "0") == "1":
+                logger.info("Keeping deployment %s (KEEP_DEPLOYMENT=1)", deploy_cfg.deployment_id)
 
         # -- Create or reuse trainer jobs ------------------------------------
         # Pre-created job IDs let CI scripts manage jobs externally (e.g. via
         # firectl-admin for regions the main gateway doesn't support yet).
 
-        def _make_job(
-            label: str, precreated_id: str | None, job_profile=None, **extra_kw
-        ):
+        def _make_job(label: str, precreated_id: str | None, job_profile=None, **extra_kw):
             if precreated_id:
                 ep = create_trainer_job(
-                    rlor_mgr,
-                    base_model=cfg.base_model,
-                    infra=infra,
+                    rlor_mgr, base_model=cfg.base_model, infra=infra,
                     job_id=precreated_id,
                 )
                 return ep, precreated_id, True
             ep = create_trainer_job(
-                rlor_mgr,
-                base_model=cfg.base_model,
-                infra=infra,
-                profile=job_profile,
-                lora_rank=cfg.lora_rank,
-                max_seq_len=cfg.max_seq_len,
+                rlor_mgr, base_model=cfg.base_model, infra=infra, profile=job_profile,
+                lora_rank=cfg.lora_rank, max_seq_len=cfg.max_seq_len,
                 learning_rate=cfg.learning_rate,
                 display_name=f"frozen-lake-{label}",
-                hot_load_deployment_id=deploy_cfg.deployment_id
-                if label == "policy"
-                else None,  # weight sync target deployment
+                hot_load_deployment_id=deploy_cfg.deployment_id if label == "policy" else None,  # weight sync target deployment
                 **extra_kw,
             )
             return ep, ep.job_id, False
@@ -521,19 +464,10 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
         precreated_policy = False
         precreated_reference = False
         with ThreadPoolExecutor(max_workers=2) as pool:
-            pol_fut = pool.submit(
-                _make_job, "policy", cfg.policy_job_id, job_profile=profile
-            )
+            pol_fut = pool.submit(_make_job, "policy", cfg.policy_job_id, job_profile=profile)
             ref_fut = (
-                pool.submit(
-                    _make_job,
-                    "reference",
-                    cfg.reference_job_id,
-                    job_profile=ref_profile,
-                    forward_only=True,
-                )
-                if use_reference and not reuse_policy_base_reference
-                else None
+                pool.submit(_make_job, "reference", cfg.reference_job_id, job_profile=ref_profile, forward_only=True)
+                if use_reference and not reuse_policy_base_reference else None
             )
 
             policy_ep, policy_job_id, precreated_policy = pol_fut.result()
@@ -548,10 +482,7 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
                 cleanup.trainer(reference_job_id)
 
         policy = ReconnectableClient(
-            rlor_mgr,
-            policy_ep.job_id,
-            cfg.base_model,
-            cfg.lora_rank,
+            rlor_mgr, policy_ep.job_id, cfg.base_model, cfg.lora_rank,
             fw_api_key=api_key,
             endpoint=policy_ep,
         )
@@ -575,8 +506,7 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
                     fw_api_key=api_key,
                     endpoint=reference_ep,
                 )
-                if reference_ep
-                else None
+                if reference_ep else None
             )
         )
 
@@ -587,10 +517,8 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
         else:
             inference_model = cfg.base_model
         weight_syncer = WeightSyncer(
-            policy_client=policy.inner,
-            deploy_mgr=deploy_mgr,
-            deployment_id=deploy_cfg.deployment_id,
-            base_model=cfg.base_model,
+            policy_client=policy.inner, deploy_mgr=deploy_mgr,
+            deployment_id=deploy_cfg.deployment_id, base_model=cfg.base_model,
             hotload_timeout=weight_sync_cfg.weight_sync_timeout,
             first_checkpoint_type=weight_sync_cfg.first_checkpoint_type,
             dcp_timeout=weight_sync_cfg.dcp_timeout,
@@ -600,7 +528,6 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
         wandb_log({"train/step": 0, "infra/total_boot_time": infra_boot_time}, step=0)
 
         from training.utils.checkpoint_utils import resolve_resume
-
         resume_info = resolve_resume(policy, cfg.log_path)
         step_offset = resume_info.step if resume_info else 0
         if weight_sync_cfg.weight_sync_before_training and deploy_cfg.deployment_id:
@@ -612,7 +539,6 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
         inference_url = deploy_mgr.inference_url
         logger.info("Waiting for deployment to be ready for inference...")
         import httpx
-
         _inference_prefix = "/v1" if cfg.inference_base_url else "/inference/v1"
         _readiness_url = inference_url.rstrip("/") + _inference_prefix + "/completions"
         for _ready_attempt in range(600):
@@ -626,10 +552,7 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
                 if _resp.status_code == 200:
                     logger.info("Deployment is ready for inference")
                     break
-                logger.info(
-                    "Deployment not ready yet (status=%d), waiting...",
-                    _resp.status_code,
-                )
+                logger.info("Deployment not ready yet (status=%d), waiting...", _resp.status_code)
                 time.sleep(5)
                 continue
             except Exception as e:
@@ -639,9 +562,7 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
             logger.warning("Deployment readiness timeout, proceeding anyway")
 
         # -- Build rollout processor ----------------------------------------
-        rollout_base_url = inference_url.rstrip("/") + (
-            "" if cfg.inference_base_url else "/inference"
-        )
+        rollout_base_url = inference_url.rstrip("/") + ("" if cfg.inference_base_url else "/inference")
         rollout_processor = FrozenLakeToolRolloutProcessor(
             model_id=inference_model,
             tokenizer_name_or_path=cfg.tokenizer_model,
@@ -664,8 +585,7 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
 
         adam_params = tinker.AdamParams(learning_rate=cfg.learning_rate, **DEFAULT_ADAM)
         loss_builder = build_loss_fn(
-            policy_loss=cfg.policy_loss,
-            kl_beta=cfg.kl_beta,
+            policy_loss=cfg.policy_loss, kl_beta=cfg.kl_beta,
             is_config=ISConfig(),
         )
 
@@ -676,24 +596,20 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
         try:
             # -- Sample one prompt group ----------------------------------------
 
-            async def sample_one_prompt(
-                env_context: Dict[str, Any],
-            ) -> PromptGroup | None:
+            async def sample_one_prompt(env_context: Dict[str, Any]) -> PromptGroup | None:
                 """Run completions_per_prompt rollouts for one seed, return PromptGroup."""
                 rows: List[EvaluationRow] = []
                 for rollout_idx in range(completions_per_prompt):
-                    rows.append(
-                        EvaluationRow(
-                            input_metadata=InputMetadata(
-                                row_id=f"seed_{env_context.get('seed', 0)}_{rollout_idx}",
-                                dataset_info={
-                                    "environment_context": dict(env_context),
-                                    "user_prompt_template": cfg.user_prompt_template,
-                                    "visual_prompt_template": cfg.visual_prompt_template,
-                                },
-                            ),
-                        )
-                    )
+                    rows.append(EvaluationRow(
+                        input_metadata=InputMetadata(
+                            row_id=f"seed_{env_context.get('seed', 0)}_{rollout_idx}",
+                            dataset_info={
+                                "environment_context": dict(env_context),
+                                "user_prompt_template": cfg.user_prompt_template,
+                                "visual_prompt_template": cfg.visual_prompt_template,
+                            },
+                        ),
+                    ))
 
                 tasks = rollout_processor(rows, rollout_config)
                 completed_rows: List[EvaluationRow] = []
@@ -704,32 +620,21 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
                         if extra.get("rollout_error"):
                             logger.warning(
                                 "Rollout error for seed %s: %s",
-                                env_context.get("seed"),
-                                extra["rollout_error"],
+                                env_context.get("seed"), extra["rollout_error"],
                             )
                             continue
                         completed_rows.append(result)
                     except Exception as e:
-                        logger.warning(
-                            "Rollout task failed for seed %s: %s",
-                            env_context.get("seed"),
-                            e,
-                        )
+                        logger.warning("Rollout task failed for seed %s: %s", env_context.get("seed"), e)
 
                 if trajectory_log:
                     for row in completed_rows:
                         extra = row.execution_metadata.extra or {}
                         entry = {
                             "seed": env_context.get("seed"),
-                            "messages": [
-                                m.model_dump() if hasattr(m, "model_dump") else m
-                                for m in (row.messages or [])
-                            ],
+                            "messages": [m.model_dump() if hasattr(m, "model_dump") else m for m in (row.messages or [])],
                             "step_rewards": extra.get("step_rewards", []),
-                            "reward": 1.0
-                            if extra.get("step_rewards")
-                            and float(extra["step_rewards"][-1]) > 0
-                            else 0.0,
+                            "reward": 1.0 if extra.get("step_rewards") and float(extra["step_rewards"][-1]) > 0 else 0.0,
                             "rollout_error": extra.get("rollout_error"),
                         }
                         trajectory_log.write(json.dumps(entry) + "\n")
@@ -745,9 +650,7 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
                 first_prompt_len = 0
 
                 for row in completed_rows:
-                    datums, prompt_len, inf_lps, rewards = (
-                        evaluation_row_to_training_data(row)
-                    )
+                    datums, prompt_len, inf_lps, rewards = evaluation_row_to_training_data(row)
                     if not datums:
                         continue
                     all_datums.extend(datums)
@@ -792,18 +695,14 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
                 for pg in groups:
                     n = len(pg.ref_data)
                     pg.ref_logprobs = [
-                        ref_fwd.loss_fn_outputs[idx + i]["logprobs"].data
-                        for i in range(n)
+                        ref_fwd.loss_fn_outputs[idx + i]["logprobs"].data for i in range(n)
                     ]
                     idx += n
 
             def fwd_bwd_one(sub: list[PromptGroup]):
                 data, adv, ref_lp, prompt_lens, inf_lp = combine_prompt_groups(sub)
                 prox_fwd = policy.forward(data, "cross_entropy")
-                prox_lp = [
-                    prox_fwd.loss_fn_outputs[i]["logprobs"].data
-                    for i in range(len(data))
-                ]
+                prox_lp = [prox_fwd.loss_fn_outputs[i]["logprobs"].data for i in range(len(data))]
                 return policy.forward_backward_custom(
                     data, loss_builder(adv, ref_lp, prompt_lens, inf_lp, prox_lp)
                 )
@@ -816,46 +715,30 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
                 """ref_forward + fwd_bwd + optim_step + weight_sync + metrics (1:1)."""
                 t0 = time.time()
                 ref_forward_batch(prompt_groups)
-                logger.info(
-                    "[step %d] ref_forward: done (%.1fs)", step + 1, time.time() - t0
-                )
+                logger.info("[step %d] ref_forward: done (%.1fs)", step + 1, time.time() - t0)
 
                 t0 = time.time()
                 fwd_bwd_result = fwd_bwd_one(prompt_groups)
-                logger.info(
-                    "[step %d] fwd_bwd: done (%.1fs)", step + 1, time.time() - t0
-                )
+                logger.info("[step %d] fwd_bwd: done (%.1fs)", step + 1, time.time() - t0)
 
                 t0 = time.time()
                 optim_result = policy.optim_step(adam_params)
                 step += 1
-                logger.info(
-                    "[step %d] optim_step: done (%.1fs)", step, time.time() - t0
-                )
+                logger.info("[step %d] optim_step: done (%.1fs)", step, time.time() - t0)
 
-                if (
-                    weight_sync_cfg.weight_sync_interval > 0
-                    and step % weight_sync_cfg.weight_sync_interval == 0
-                ):
+                if weight_sync_cfg.weight_sync_interval > 0 and step % weight_sync_cfg.weight_sync_interval == 0:
                     logger.info("[step %d] weight_sync: saving + loading...", step)
                     t0 = time.time()
                     with timer("weight_sync"):
                         weight_syncer.save_and_hotload(f"step-{step}")
-                    logger.info(
-                        "[step %d] weight_sync: done (%.1fs)", step, time.time() - t0
-                    )
+                    logger.info("[step %d] weight_sync: done (%.1fs)", step, time.time() - t0)
 
-                if (
-                    weight_sync_cfg.dcp_save_interval > 0
-                    and step % weight_sync_cfg.dcp_save_interval == 0
-                ):
+                if weight_sync_cfg.dcp_save_interval > 0 and step % weight_sync_cfg.dcp_save_interval == 0:
                     logger.info("[step %d] dcp_save...", step)
                     t0 = time.time()
                     with timer("dcp_save"):
                         weight_syncer.save_dcp(f"step-{step}")
-                    logger.info(
-                        "[step %d] dcp_save: done (%.1fs)", step, time.time() - t0
-                    )
+                    logger.info("[step %d] dcp_save: done (%.1fs)", step, time.time() - t0)
 
                 metrics = compute_step_metrics(
                     prompt_groups=prompt_groups,
@@ -868,9 +751,7 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
                 )
                 metrics["train/step"] = step
                 if loop_stats:
-                    metrics["rollout/sample_fail_count"] = loop_stats.get(
-                        "sample_fails", 0
-                    )
+                    metrics["rollout/sample_fail_count"] = loop_stats.get("sample_fails", 0)
                     metrics["rollout/filter_drops"] = loop_stats.get("filter_drops", 0)
 
                 avg_reward = metrics.get("rollout/reward", 0.0)
@@ -883,14 +764,7 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
                 logger.info(
                     "Step %d | Reward: %.3f | KL: %.4f | Loss: %.4f "
                     "(adv=%.4f kl_pen=%.4f) | InfKLD: %.4f | MaskRatio: %.2f",
-                    step,
-                    avg_reward,
-                    avg_kl,
-                    mean_loss,
-                    adv_loss,
-                    kl_pen,
-                    inf_kld,
-                    mask_r,
+                    step, avg_reward, avg_kl, mean_loss, adv_loss, kl_pen, inf_kld, mask_r,
                 )
                 reward_history.append(avg_reward)
                 log_metrics_json(step, reward=avg_reward, kl=avg_kl)
@@ -907,11 +781,8 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
             logger.info(
                 "Training: %d seeds x %d epochs = %d prompt groups, "
                 "%d completions/prompt, %d groups/step",
-                len(seed_contexts),
-                cfg.epochs,
-                len(all_prompts),
-                completions_per_prompt,
-                prompt_groups_per_step,
+                len(seed_contexts), cfg.epochs, len(all_prompts),
+                completions_per_prompt, prompt_groups_per_step,
             )
 
             _wandb_step = [step_offset]
@@ -920,25 +791,21 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
                 _wandb_step[0] += 1
                 wandb_log(loop_metrics, step=_wandb_step[0])
 
-            global_step = asyncio.run(
-                run_rl_loop(
-                    sample_fns=(sample_one_prompt(ctx) for ctx in all_prompts),
-                    train_fns=train_fns,
-                    prompt_groups_per_step=prompt_groups_per_step,
-                    max_concurrent=cfg.max_concurrent,
-                    dynamic_filter_fn=should_accept,
-                    global_step=step_offset,
-                    metrics_callback=_filtered_step_callback,
-                )
-            )
+            global_step = asyncio.run(run_rl_loop(
+                sample_fns=(sample_one_prompt(ctx) for ctx in all_prompts),
+                train_fns=train_fns,
+                prompt_groups_per_step=prompt_groups_per_step,
+                max_concurrent=cfg.max_concurrent,
+                dynamic_filter_fn=should_accept,
+                global_step=step_offset,
+                metrics_callback=_filtered_step_callback,
+            ))
 
             # -- Final checkpoint -----------------------------------------------
 
             if global_step > step_offset:
                 try:
-                    policy.save_state(
-                        f"step-{global_step}", timeout=weight_sync_cfg.dcp_timeout
-                    )
+                    policy.save_state(f"step-{global_step}", timeout=weight_sync_cfg.dcp_timeout)
                 except Exception as e:
                     logger.warning("Failed to save final checkpoint: %s", e)
                 logger.info("Training complete: %d steps", global_step)

--- a/training/examples/frozen_lake/train_frozen_lake.py
+++ b/training/examples/frozen_lake/train_frozen_lake.py
@@ -28,7 +28,9 @@ from typing import Any, Dict, List, cast
 
 import tinker
 
-_SRC = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..", "..", ".."))
+_SRC = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..", "..", "..")
+)
 if _SRC not in sys.path:
     sys.path.insert(0, _SRC)
 
@@ -138,7 +140,9 @@ class FrozenLakeConfig:
     region: str = "US_VIRGINIA_1"
     deployment_region: str = "US_VIRGINIA_1"
 
-    wandb_entity: str = field(default_factory=lambda: os.environ.get("WANDB_ENTITY", ""))
+    wandb_entity: str = field(
+        default_factory=lambda: os.environ.get("WANDB_ENTITY", "")
+    )
     wandb_project: str = field(
         default_factory=lambda: os.environ.get("WANDB_PROJECT", "frozen-lake-grpo")
     )
@@ -149,18 +153,24 @@ class FrozenLakeConfig:
 
 
 def parse_args() -> FrozenLakeConfig:
-    parser = argparse.ArgumentParser(description="GRPO training on FrozenLake tool calls")
+    parser = argparse.ArgumentParser(
+        description="GRPO training on FrozenLake tool calls"
+    )
     parser.add_argument("--base-model", default="accounts/fireworks/models/qwen3-8b")
     parser.add_argument("--tokenizer-model", default="Qwen/Qwen3-8B")
-    parser.add_argument("--training-shape", default=os.environ.get("TRAINING_SHAPE", ""))
+    parser.add_argument(
+        "--training-shape", default=os.environ.get("TRAINING_SHAPE", "")
+    )
     parser.add_argument("--deployment-shape", default="")
     parser.add_argument("--accelerator-type", default="")
     parser.add_argument("--deployment-id", default=None)
     parser.add_argument("--region", default="US_VIRGINIA_1")
     parser.add_argument("--deployment-region", default="US_VIRGINIA_1")
 
-    parser.add_argument("--seed-jsonl-path",
-                        default=os.path.join(os.path.dirname(__file__), "seeds.jsonl"))
+    parser.add_argument(
+        "--seed-jsonl-path",
+        default=os.path.join(os.path.dirname(__file__), "seeds.jsonl"),
+    )
     parser.add_argument("--max-seeds", type=int, default=20)
     parser.add_argument("--max-steps", type=int, default=12)
     parser.add_argument("--map-name", default="4x4")
@@ -178,17 +188,30 @@ def parse_args() -> FrozenLakeConfig:
     parser.add_argument("--lora-rank", type=int, default=0)
 
     parser.add_argument("--wandb-entity", default=os.environ.get("WANDB_ENTITY", ""))
-    parser.add_argument("--wandb-project", default=os.environ.get("WANDB_PROJECT", "frozen-lake-grpo"))
-    parser.add_argument("--visual-prompt-template", default=DEFAULT_VISUAL_PROMPT_TEMPLATE)
+    parser.add_argument(
+        "--wandb-project", default=os.environ.get("WANDB_PROJECT", "frozen-lake-grpo")
+    )
+    parser.add_argument(
+        "--visual-prompt-template", default=DEFAULT_VISUAL_PROMPT_TEMPLATE
+    )
     parser.add_argument("--observation-mode", choices=("text", "image"), default="text")
     parser.add_argument("--allow-plaintext-action-fallback", action="store_true")
 
-    parser.add_argument("--policy-job-id", default=None,
-                        help="Pre-created policy trainer job ID (skip creation)")
-    parser.add_argument("--reference-job-id", default=None,
-                        help="Pre-created reference trainer job ID (skip creation)")
-    parser.add_argument("--inference-base-url", default=None,
-                        help="Direct base URL for inference deployment (skip gateway)")
+    parser.add_argument(
+        "--policy-job-id",
+        default=None,
+        help="Pre-created policy trainer job ID (skip creation)",
+    )
+    parser.add_argument(
+        "--reference-job-id",
+        default=None,
+        help="Pre-created reference trainer job ID (skip creation)",
+    )
+    parser.add_argument(
+        "--inference-base-url",
+        default=None,
+        help="Direct base URL for inference deployment (skip gateway)",
+    )
 
     return cast(FrozenLakeConfig, parser.parse_args(namespace=FrozenLakeConfig()))
 
@@ -207,11 +230,13 @@ def load_seed_contexts(path: str, max_seeds: int) -> List[Dict[str, Any]]:
             if not line:
                 continue
             entry = json.loads(line)
-            contexts.append({
-                "map_name": entry.get("map_name", "4x4"),
-                "use_random_map": True,
-                "seed": int(entry["seed"]),
-            })
+            contexts.append(
+                {
+                    "map_name": entry.get("map_name", "4x4"),
+                    "use_random_map": True,
+                    "seed": int(entry["seed"]),
+                }
+            )
             if len(contexts) >= max_seeds:
                 break
     return contexts
@@ -255,7 +280,9 @@ def evaluation_row_to_training_data(
         return [], 0, [], []
 
     # prompt_len = first turn's prompt length (system + user message, before any model output)
-    first_prompt_len = len([int(x) for x in (token_turn_traces[0].get("prompt_ids") or [])])
+    first_prompt_len = len(
+        [int(x) for x in (token_turn_traces[0].get("prompt_ids") or [])]
+    )
 
     model_request_traces = extra.get("model_request_traces") or []
     spans = compute_model_output_spans(token_turn_traces, model_request_traces)
@@ -331,19 +358,23 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
         run_name=cfg.deployment_id or f"frozen-lake-{int(time.time()) % 100000}",
     )
 
-    setup_wandb(wandb_cfg, {
-        "completions_per_prompt": completions_per_prompt,
-        "prompt_groups_per_step": prompt_groups_per_step,
-        "kl_beta": cfg.kl_beta,
-        "lr": cfg.learning_rate,
-        "temperature": cfg.temperature,
-        "max_steps": cfg.max_steps,
-        "max_seeds": cfg.max_seeds,
-    })
+    setup_wandb(
+        wandb_cfg,
+        {
+            "completions_per_prompt": completions_per_prompt,
+            "prompt_groups_per_step": prompt_groups_per_step,
+            "kl_beta": cfg.kl_beta,
+            "lr": cfg.learning_rate,
+            "temperature": cfg.temperature,
+            "max_steps": cfg.max_steps,
+            "max_seeds": cfg.max_seeds,
+        },
+    )
 
     rlor_mgr = TrainerJobManager(api_key=api_key, account_id=account, base_url=base_url)
     deploy_mgr = DeploymentManager(
-        api_key=api_key, account_id=account,
+        api_key=api_key,
+        account_id=account,
         base_url=base_url,
         hotload_api_url=base_url,
         inference_url=cfg.inference_base_url or base_url,
@@ -354,7 +385,8 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
     seed_contexts = load_seed_contexts(cfg.seed_jsonl_path, cfg.max_seeds)
     logger.info(
         "Loaded %d seed contexts from %s",
-        len(seed_contexts), os.path.abspath(cfg.seed_jsonl_path),
+        len(seed_contexts),
+        os.path.abspath(cfg.seed_jsonl_path),
     )
 
     # -- Resolve training shapes --------------------------------------------
@@ -383,13 +415,16 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
             # Strip /versions/... suffix to get the parent deployment shape
             idx = dsv.find("/versions/")
             deploy_cfg.deployment_shape = dsv[:idx] if idx >= 0 else dsv
-            logger.info("Deployment shape from training shape: %s", deploy_cfg.deployment_shape)
+            logger.info(
+                "Deployment shape from training shape: %s", deploy_cfg.deployment_shape
+            )
 
     if profile and profile.pipeline_parallelism > 1:
         pp_rec = compute_pp_recommendation(profile, completions_per_prompt)
         logger.info(
             "PP recommendation: prompt_groups_per_step=%d (current=%d)",
-            pp_rec.recommended_prompts_per_step, prompt_groups_per_step,
+            pp_rec.recommended_prompts_per_step,
+            prompt_groups_per_step,
         )
 
     if profile and cfg.max_seq_len is None:
@@ -405,7 +440,9 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
         and not reuse_policy_base_reference
         and infra.ref_training_shape_id
     ):
-        logger.info("Using separate ref training shape: %s", infra.ref_training_shape_id)
+        logger.info(
+            "Using separate ref training shape: %s", infra.ref_training_shape_id
+        )
         ref_profile = rlor_mgr.resolve_training_profile(infra.ref_training_shape_id)
 
     # -- Infrastructure setup -----------------------------------------------
@@ -435,28 +472,48 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
             logger.info("Skipping deployment setup — using pre-created resources")
         else:
             dep_info = setup_deployment(deploy_mgr, deploy_cfg, cfg.base_model, infra)
-            if not cfg.deployment_id and deploy_cfg.deployment_id and os.environ.get("KEEP_DEPLOYMENT", "0") != "1":
+            if (
+                not cfg.deployment_id
+                and deploy_cfg.deployment_id
+                and os.environ.get("KEEP_DEPLOYMENT", "0") != "1"
+            ):
                 cleanup.deployment(deploy_cfg.deployment_id)
-            elif deploy_cfg.deployment_id and os.environ.get("KEEP_DEPLOYMENT", "0") == "1":
-                logger.info("Keeping deployment %s (KEEP_DEPLOYMENT=1)", deploy_cfg.deployment_id)
+            elif (
+                deploy_cfg.deployment_id
+                and os.environ.get("KEEP_DEPLOYMENT", "0") == "1"
+            ):
+                logger.info(
+                    "Keeping deployment %s (KEEP_DEPLOYMENT=1)",
+                    deploy_cfg.deployment_id,
+                )
 
         # -- Create or reuse trainer jobs ------------------------------------
         # Pre-created job IDs let CI scripts manage jobs externally (e.g. via
         # firectl-admin for regions the main gateway doesn't support yet).
 
-        def _make_job(label: str, precreated_id: str | None, job_profile=None, **extra_kw):
+        def _make_job(
+            label: str, precreated_id: str | None, job_profile=None, **extra_kw
+        ):
             if precreated_id:
                 ep = create_trainer_job(
-                    rlor_mgr, base_model=cfg.base_model, infra=infra,
+                    rlor_mgr,
+                    base_model=cfg.base_model,
+                    infra=infra,
                     job_id=precreated_id,
                 )
                 return ep, precreated_id, True
             ep = create_trainer_job(
-                rlor_mgr, base_model=cfg.base_model, infra=infra, profile=job_profile,
-                lora_rank=cfg.lora_rank, max_seq_len=cfg.max_seq_len,
+                rlor_mgr,
+                base_model=cfg.base_model,
+                infra=infra,
+                profile=job_profile,
+                lora_rank=cfg.lora_rank,
+                max_seq_len=cfg.max_seq_len,
                 learning_rate=cfg.learning_rate,
                 display_name=f"frozen-lake-{label}",
-                hot_load_deployment_id=deploy_cfg.deployment_id if label == "policy" else None,  # weight sync target deployment
+                hot_load_deployment_id=deploy_cfg.deployment_id
+                if label == "policy"
+                else None,  # weight sync target deployment
                 **extra_kw,
             )
             return ep, ep.job_id, False
@@ -464,10 +521,19 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
         precreated_policy = False
         precreated_reference = False
         with ThreadPoolExecutor(max_workers=2) as pool:
-            pol_fut = pool.submit(_make_job, "policy", cfg.policy_job_id, job_profile=profile)
+            pol_fut = pool.submit(
+                _make_job, "policy", cfg.policy_job_id, job_profile=profile
+            )
             ref_fut = (
-                pool.submit(_make_job, "reference", cfg.reference_job_id, job_profile=ref_profile, forward_only=True)
-                if use_reference and not reuse_policy_base_reference else None
+                pool.submit(
+                    _make_job,
+                    "reference",
+                    cfg.reference_job_id,
+                    job_profile=ref_profile,
+                    forward_only=True,
+                )
+                if use_reference and not reuse_policy_base_reference
+                else None
             )
 
             policy_ep, policy_job_id, precreated_policy = pol_fut.result()
@@ -482,7 +548,10 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
                 cleanup.trainer(reference_job_id)
 
         policy = ReconnectableClient(
-            rlor_mgr, policy_ep.job_id, cfg.base_model, cfg.lora_rank,
+            rlor_mgr,
+            policy_ep.job_id,
+            cfg.base_model,
+            cfg.lora_rank,
             fw_api_key=api_key,
             endpoint=policy_ep,
         )
@@ -506,7 +575,8 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
                     fw_api_key=api_key,
                     endpoint=reference_ep,
                 )
-                if reference_ep else None
+                if reference_ep
+                else None
             )
         )
 
@@ -517,8 +587,10 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
         else:
             inference_model = cfg.base_model
         weight_syncer = WeightSyncer(
-            policy_client=policy.inner, deploy_mgr=deploy_mgr,
-            deployment_id=deploy_cfg.deployment_id, base_model=cfg.base_model,
+            policy_client=policy.inner,
+            deploy_mgr=deploy_mgr,
+            deployment_id=deploy_cfg.deployment_id,
+            base_model=cfg.base_model,
             hotload_timeout=weight_sync_cfg.weight_sync_timeout,
             first_checkpoint_type=weight_sync_cfg.first_checkpoint_type,
             dcp_timeout=weight_sync_cfg.dcp_timeout,
@@ -528,6 +600,7 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
         wandb_log({"train/step": 0, "infra/total_boot_time": infra_boot_time}, step=0)
 
         from training.utils.checkpoint_utils import resolve_resume
+
         resume_info = resolve_resume(policy, cfg.log_path)
         step_offset = resume_info.step if resume_info else 0
         if weight_sync_cfg.weight_sync_before_training and deploy_cfg.deployment_id:
@@ -539,6 +612,7 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
         inference_url = deploy_mgr.inference_url
         logger.info("Waiting for deployment to be ready for inference...")
         import httpx
+
         _inference_prefix = "/v1" if cfg.inference_base_url else "/inference/v1"
         _readiness_url = inference_url.rstrip("/") + _inference_prefix + "/completions"
         for _ready_attempt in range(600):
@@ -552,7 +626,10 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
                 if _resp.status_code == 200:
                     logger.info("Deployment is ready for inference")
                     break
-                logger.info("Deployment not ready yet (status=%d), waiting...", _resp.status_code)
+                logger.info(
+                    "Deployment not ready yet (status=%d), waiting...",
+                    _resp.status_code,
+                )
                 time.sleep(5)
                 continue
             except Exception as e:
@@ -562,7 +639,9 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
             logger.warning("Deployment readiness timeout, proceeding anyway")
 
         # -- Build rollout processor ----------------------------------------
-        rollout_base_url = inference_url.rstrip("/") + ("" if cfg.inference_base_url else "/inference")
+        rollout_base_url = inference_url.rstrip("/") + (
+            "" if cfg.inference_base_url else "/inference"
+        )
         rollout_processor = FrozenLakeToolRolloutProcessor(
             model_id=inference_model,
             tokenizer_name_or_path=cfg.tokenizer_model,
@@ -585,7 +664,8 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
 
         adam_params = tinker.AdamParams(learning_rate=cfg.learning_rate, **DEFAULT_ADAM)
         loss_builder = build_loss_fn(
-            policy_loss=cfg.policy_loss, kl_beta=cfg.kl_beta,
+            policy_loss=cfg.policy_loss,
+            kl_beta=cfg.kl_beta,
             is_config=ISConfig(),
         )
 
@@ -596,20 +676,24 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
         try:
             # -- Sample one prompt group ----------------------------------------
 
-            async def sample_one_prompt(env_context: Dict[str, Any]) -> PromptGroup | None:
+            async def sample_one_prompt(
+                env_context: Dict[str, Any],
+            ) -> PromptGroup | None:
                 """Run completions_per_prompt rollouts for one seed, return PromptGroup."""
                 rows: List[EvaluationRow] = []
                 for rollout_idx in range(completions_per_prompt):
-                    rows.append(EvaluationRow(
-                        input_metadata=InputMetadata(
-                            row_id=f"seed_{env_context.get('seed', 0)}_{rollout_idx}",
-                            dataset_info={
-                                "environment_context": dict(env_context),
-                                "user_prompt_template": cfg.user_prompt_template,
-                                "visual_prompt_template": cfg.visual_prompt_template,
-                            },
-                        ),
-                    ))
+                    rows.append(
+                        EvaluationRow(
+                            input_metadata=InputMetadata(
+                                row_id=f"seed_{env_context.get('seed', 0)}_{rollout_idx}",
+                                dataset_info={
+                                    "environment_context": dict(env_context),
+                                    "user_prompt_template": cfg.user_prompt_template,
+                                    "visual_prompt_template": cfg.visual_prompt_template,
+                                },
+                            ),
+                        )
+                    )
 
                 tasks = rollout_processor(rows, rollout_config)
                 completed_rows: List[EvaluationRow] = []
@@ -620,21 +704,32 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
                         if extra.get("rollout_error"):
                             logger.warning(
                                 "Rollout error for seed %s: %s",
-                                env_context.get("seed"), extra["rollout_error"],
+                                env_context.get("seed"),
+                                extra["rollout_error"],
                             )
                             continue
                         completed_rows.append(result)
                     except Exception as e:
-                        logger.warning("Rollout task failed for seed %s: %s", env_context.get("seed"), e)
+                        logger.warning(
+                            "Rollout task failed for seed %s: %s",
+                            env_context.get("seed"),
+                            e,
+                        )
 
                 if trajectory_log:
                     for row in completed_rows:
                         extra = row.execution_metadata.extra or {}
                         entry = {
                             "seed": env_context.get("seed"),
-                            "messages": [m.model_dump() if hasattr(m, "model_dump") else m for m in (row.messages or [])],
+                            "messages": [
+                                m.model_dump() if hasattr(m, "model_dump") else m
+                                for m in (row.messages or [])
+                            ],
                             "step_rewards": extra.get("step_rewards", []),
-                            "reward": 1.0 if extra.get("step_rewards") and float(extra["step_rewards"][-1]) > 0 else 0.0,
+                            "reward": 1.0
+                            if extra.get("step_rewards")
+                            and float(extra["step_rewards"][-1]) > 0
+                            else 0.0,
                             "rollout_error": extra.get("rollout_error"),
                         }
                         trajectory_log.write(json.dumps(entry) + "\n")
@@ -650,7 +745,9 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
                 first_prompt_len = 0
 
                 for row in completed_rows:
-                    datums, prompt_len, inf_lps, rewards = evaluation_row_to_training_data(row)
+                    datums, prompt_len, inf_lps, rewards = (
+                        evaluation_row_to_training_data(row)
+                    )
                     if not datums:
                         continue
                     all_datums.extend(datums)
@@ -695,14 +792,18 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
                 for pg in groups:
                     n = len(pg.ref_data)
                     pg.ref_logprobs = [
-                        ref_fwd.loss_fn_outputs[idx + i]["logprobs"].data for i in range(n)
+                        ref_fwd.loss_fn_outputs[idx + i]["logprobs"].data
+                        for i in range(n)
                     ]
                     idx += n
 
             def fwd_bwd_one(sub: list[PromptGroup]):
                 data, adv, ref_lp, prompt_lens, inf_lp = combine_prompt_groups(sub)
                 prox_fwd = policy.forward(data, "cross_entropy")
-                prox_lp = [prox_fwd.loss_fn_outputs[i]["logprobs"].data for i in range(len(data))]
+                prox_lp = [
+                    prox_fwd.loss_fn_outputs[i]["logprobs"].data
+                    for i in range(len(data))
+                ]
                 return policy.forward_backward_custom(
                     data, loss_builder(adv, ref_lp, prompt_lens, inf_lp, prox_lp)
                 )
@@ -715,30 +816,46 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
                 """ref_forward + fwd_bwd + optim_step + weight_sync + metrics (1:1)."""
                 t0 = time.time()
                 ref_forward_batch(prompt_groups)
-                logger.info("[step %d] ref_forward: done (%.1fs)", step + 1, time.time() - t0)
+                logger.info(
+                    "[step %d] ref_forward: done (%.1fs)", step + 1, time.time() - t0
+                )
 
                 t0 = time.time()
                 fwd_bwd_result = fwd_bwd_one(prompt_groups)
-                logger.info("[step %d] fwd_bwd: done (%.1fs)", step + 1, time.time() - t0)
+                logger.info(
+                    "[step %d] fwd_bwd: done (%.1fs)", step + 1, time.time() - t0
+                )
 
                 t0 = time.time()
                 optim_result = policy.optim_step(adam_params)
                 step += 1
-                logger.info("[step %d] optim_step: done (%.1fs)", step, time.time() - t0)
+                logger.info(
+                    "[step %d] optim_step: done (%.1fs)", step, time.time() - t0
+                )
 
-                if weight_sync_cfg.weight_sync_interval > 0 and step % weight_sync_cfg.weight_sync_interval == 0:
+                if (
+                    weight_sync_cfg.weight_sync_interval > 0
+                    and step % weight_sync_cfg.weight_sync_interval == 0
+                ):
                     logger.info("[step %d] weight_sync: saving + loading...", step)
                     t0 = time.time()
                     with timer("weight_sync"):
                         weight_syncer.save_and_hotload(f"step-{step}")
-                    logger.info("[step %d] weight_sync: done (%.1fs)", step, time.time() - t0)
+                    logger.info(
+                        "[step %d] weight_sync: done (%.1fs)", step, time.time() - t0
+                    )
 
-                if weight_sync_cfg.dcp_save_interval > 0 and step % weight_sync_cfg.dcp_save_interval == 0:
+                if (
+                    weight_sync_cfg.dcp_save_interval > 0
+                    and step % weight_sync_cfg.dcp_save_interval == 0
+                ):
                     logger.info("[step %d] dcp_save...", step)
                     t0 = time.time()
                     with timer("dcp_save"):
                         weight_syncer.save_dcp(f"step-{step}")
-                    logger.info("[step %d] dcp_save: done (%.1fs)", step, time.time() - t0)
+                    logger.info(
+                        "[step %d] dcp_save: done (%.1fs)", step, time.time() - t0
+                    )
 
                 metrics = compute_step_metrics(
                     prompt_groups=prompt_groups,
@@ -751,7 +868,9 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
                 )
                 metrics["train/step"] = step
                 if loop_stats:
-                    metrics["rollout/sample_fail_count"] = loop_stats.get("sample_fails", 0)
+                    metrics["rollout/sample_fail_count"] = loop_stats.get(
+                        "sample_fails", 0
+                    )
                     metrics["rollout/filter_drops"] = loop_stats.get("filter_drops", 0)
 
                 avg_reward = metrics.get("rollout/reward", 0.0)
@@ -764,7 +883,14 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
                 logger.info(
                     "Step %d | Reward: %.3f | KL: %.4f | Loss: %.4f "
                     "(adv=%.4f kl_pen=%.4f) | InfKLD: %.4f | MaskRatio: %.2f",
-                    step, avg_reward, avg_kl, mean_loss, adv_loss, kl_pen, inf_kld, mask_r,
+                    step,
+                    avg_reward,
+                    avg_kl,
+                    mean_loss,
+                    adv_loss,
+                    kl_pen,
+                    inf_kld,
+                    mask_r,
                 )
                 reward_history.append(avg_reward)
                 log_metrics_json(step, reward=avg_reward, kl=avg_kl)
@@ -781,8 +907,11 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
             logger.info(
                 "Training: %d seeds x %d epochs = %d prompt groups, "
                 "%d completions/prompt, %d groups/step",
-                len(seed_contexts), cfg.epochs, len(all_prompts),
-                completions_per_prompt, prompt_groups_per_step,
+                len(seed_contexts),
+                cfg.epochs,
+                len(all_prompts),
+                completions_per_prompt,
+                prompt_groups_per_step,
             )
 
             _wandb_step = [step_offset]
@@ -791,21 +920,25 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
                 _wandb_step[0] += 1
                 wandb_log(loop_metrics, step=_wandb_step[0])
 
-            global_step = asyncio.run(run_rl_loop(
-                sample_fns=(sample_one_prompt(ctx) for ctx in all_prompts),
-                train_fns=train_fns,
-                prompt_groups_per_step=prompt_groups_per_step,
-                max_concurrent=cfg.max_concurrent,
-                dynamic_filter_fn=should_accept,
-                global_step=step_offset,
-                metrics_callback=_filtered_step_callback,
-            ))
+            global_step = asyncio.run(
+                run_rl_loop(
+                    sample_fns=(sample_one_prompt(ctx) for ctx in all_prompts),
+                    train_fns=train_fns,
+                    prompt_groups_per_step=prompt_groups_per_step,
+                    max_concurrent=cfg.max_concurrent,
+                    dynamic_filter_fn=should_accept,
+                    global_step=step_offset,
+                    metrics_callback=_filtered_step_callback,
+                )
+            )
 
             # -- Final checkpoint -----------------------------------------------
 
             if global_step > step_offset:
                 try:
-                    policy.save_state(f"step-{global_step}", timeout=weight_sync_cfg.dcp_timeout)
+                    policy.save_state(
+                        f"step-{global_step}", timeout=weight_sync_cfg.dcp_timeout
+                    )
                 except Exception as e:
                     logger.warning("Failed to save final checkpoint: %s", e)
                 logger.info("Training complete: %d steps", global_step)

--- a/training/recipes/rl_loop.py
+++ b/training/recipes/rl_loop.py
@@ -48,6 +48,7 @@ from training.utils import (
     create_trainer_job,
     load_jsonl_dataset,
     prepare_sampling_messages,
+    build_base_model_reference_id,
 )
 from training.utils.checkpoint_utils import (
     resolve_resume,
@@ -260,6 +261,23 @@ def main(
 
     # -- Resolve training shapes -----------------------------------------------
 
+    use_reference = cfg.kl_beta != 0
+    if not use_reference:
+        logger.info("kl_beta=0: skipping reference model creation")
+    reuse_policy_base_reference = (
+        use_reference
+        and cfg.policy_loss == "grpo"
+        and cfg.lora_rank > 0
+        and not cfg.reference_job_id
+        and not cfg.reference_base_url
+        and not cfg.infra.ref_training_shape_id
+    )
+    if reuse_policy_base_reference:
+        logger.info(
+            "lora_rank=%d: reusing policy trainer for base-model reference forwards",
+            cfg.lora_rank,
+        )
+
     profile = None
     if cfg.infra.training_shape_id:
         profile = rlor_mgr.resolve_training_profile(cfg.infra.training_shape_id)
@@ -284,16 +302,19 @@ def main(
             "(InfraConfig.training_shape_id) to auto-populate it."
         )
 
-    ref_profile = None
-    if cfg.infra.ref_training_shape_id:
+    ref_profile = profile
+    if (
+        use_reference
+        and not reuse_policy_base_reference
+        and cfg.infra.ref_training_shape_id
+    ):
+        logger.info("Using separate ref training shape: %s", cfg.infra.ref_training_shape_id)
         ref_profile = rlor_mgr.resolve_training_profile(cfg.infra.ref_training_shape_id)
-
-    use_reference = ref_profile is not None
-    if not use_reference:
-        logger.info("No ref_training_shape_id set, skipping reference model")
 
     import time as _time
     _infra_start = _time.time()
+    policy_job_id: str | None = None
+    reference_job_id: str | None = None
 
     with ResourceCleanup(rlor_mgr, deploy_mgr) as cleanup:
         dep_info = setup_deployment(deploy_mgr, cfg.deployment, cfg.base_model, cfg.infra)
@@ -306,7 +327,7 @@ def main(
             completions_per_prompt,
         )
 
-        if use_reference:
+        if use_reference and not reuse_policy_base_reference:
             with ThreadPoolExecutor(max_workers=2) as pool:
                 pol_fut = pool.submit(
                     create_trainer_job, rlor_mgr,
@@ -358,11 +379,26 @@ def main(
         )
         reference = (
             ReconnectableClient(
-                rlor_mgr, reference_ep.job_id, cfg.base_model, cfg.lora_rank,
+                rlor_mgr,
+                policy_ep.job_id,
+                cfg.base_model,
+                cfg.lora_rank,
                 fw_api_key=api_key,
-                endpoint=reference_ep if cfg.reference_base_url else None,
+                endpoint=policy_ep if cfg.policy_base_url else None,
+                model_id_override=build_base_model_reference_id(cfg.base_model),
             )
-            if reference_ep else None
+            if reuse_policy_base_reference
+            else (
+                ReconnectableClient(
+                    rlor_mgr,
+                    reference_ep.job_id,
+                    cfg.base_model,
+                    cfg.lora_rank,
+                    fw_api_key=api_key,
+                    endpoint=reference_ep if cfg.reference_base_url else None,
+                )
+                if reference_ep else None
+            )
         )
 
         import transformers
@@ -517,7 +553,7 @@ def main(
 
         def ref_forward(groups: list[PromptGroup]) -> None:
             """Compute reference logprobs for all prompt groups (one call)."""
-            if not use_reference:
+            if not use_reference or reference is None:
                 return
             all_ref_data = [d for pg in groups for d in pg.ref_data]
             ref_fwd = reference.forward(all_ref_data, "cross_entropy")

--- a/training/recipes/rl_loop.py
+++ b/training/recipes/rl_loop.py
@@ -138,9 +138,7 @@ class Config:
     infra: InfraConfig = field(default_factory=InfraConfig)
     deployment: DeployConfig = field(default_factory=DeployConfig)
     weight_sync: WeightSyncConfig = field(default_factory=WeightSyncConfig)
-    wandb: WandBConfig = field(
-        default_factory=lambda: WandBConfig(project="grpo-tinker")
-    )
+    wandb: WandBConfig = field(default_factory=lambda: WandBConfig(project="grpo-tinker"))
 
 
 # ---------------------------------------------------------------------------
@@ -184,9 +182,7 @@ def should_accept(pg: PromptGroup) -> bool:
 # ---------------------------------------------------------------------------
 
 
-def _dump_trajectory(
-    trajectory_dir: str, step: int, prompt_groups: list[PromptGroup]
-) -> None:
+def _dump_trajectory(trajectory_dir: str, step: int, prompt_groups: list[PromptGroup]) -> None:
     """Write per-step trajectory JSONL: one line per individual completion."""
     os.makedirs(trajectory_dir, exist_ok=True)
     path = os.path.join(trajectory_dir, f"step_{step:04d}.jsonl")
@@ -201,31 +197,15 @@ def _dump_trajectory(
                     "completion_index": comp_idx,
                     "prompt": pg.prompt,
                     "completion": comp_text,
-                    "reward": pg.rewards[comp_idx]
-                    if comp_idx < len(pg.rewards)
-                    else None,
-                    "advantage": pg.advantages[comp_idx]
-                    if comp_idx < len(pg.advantages)
-                    else None,
-                    "completion_len": pg.completion_lens[comp_idx]
-                    if comp_idx < len(pg.completion_lens)
-                    else None,
-                    "truncated": pg.truncated[comp_idx]
-                    if comp_idx < len(pg.truncated)
-                    else None,
-                    "ground_truth": pg.row_meta.get("ground_truth")
-                    if pg.row_meta
-                    else None,
+                    "reward": pg.rewards[comp_idx] if comp_idx < len(pg.rewards) else None,
+                    "advantage": pg.advantages[comp_idx] if comp_idx < len(pg.advantages) else None,
+                    "completion_len": pg.completion_lens[comp_idx] if comp_idx < len(pg.completion_lens) else None,
+                    "truncated": pg.truncated[comp_idx] if comp_idx < len(pg.truncated) else None,
+                    "ground_truth": pg.row_meta.get("ground_truth") if pg.row_meta else None,
                 }
                 f.write(json.dumps(record, ensure_ascii=False) + "\n")
                 n_records += 1
-    logger.info(
-        "[step %d] Saved trajectory to %s (%d completions from %d groups)",
-        step,
-        path,
-        n_records,
-        len(prompt_groups),
-    )
+    logger.info("[step %d] Saved trajectory to %s (%d completions from %d groups)", step, path, n_records, len(prompt_groups))
 
 
 # ---------------------------------------------------------------------------
@@ -275,13 +255,9 @@ def main(
     base_url = os.environ.get("FIREWORKS_BASE_URL", "https://api.fireworks.ai")
 
     if rlor_mgr is None:
-        rlor_mgr = TrainerJobManager(
-            api_key=api_key, account_id=account, base_url=base_url
-        )
+        rlor_mgr = TrainerJobManager(api_key=api_key, account_id=account, base_url=base_url)
     if deploy_mgr is None:
-        deploy_mgr = DeploymentManager(
-            api_key=api_key, account_id=account, base_url=base_url
-        )
+        deploy_mgr = DeploymentManager(api_key=api_key, account_id=account, base_url=base_url)
 
     # -- Resolve training shapes -----------------------------------------------
 
@@ -305,9 +281,7 @@ def main(
     profile = None
     if cfg.infra.training_shape_id:
         profile = rlor_mgr.resolve_training_profile(cfg.infra.training_shape_id)
-        dep_shape = getattr(profile, "deployment_shape", None) or getattr(
-            profile, "deployment_shape_version", None
-        )
+        dep_shape = getattr(profile, "deployment_shape", None) or getattr(profile, "deployment_shape_version", None)
         if dep_shape and not cfg.deployment.deployment_shape:
             cfg.deployment.deployment_shape = dep_shape
 
@@ -334,21 +308,16 @@ def main(
         and not reuse_policy_base_reference
         and cfg.infra.ref_training_shape_id
     ):
-        logger.info(
-            "Using separate ref training shape: %s", cfg.infra.ref_training_shape_id
-        )
+        logger.info("Using separate ref training shape: %s", cfg.infra.ref_training_shape_id)
         ref_profile = rlor_mgr.resolve_training_profile(cfg.infra.ref_training_shape_id)
 
     import time as _time
-
     _infra_start = _time.time()
     policy_job_id: str | None = None
     reference_job_id: str | None = None
 
     with ResourceCleanup(rlor_mgr, deploy_mgr) as cleanup:
-        dep_info = setup_deployment(
-            deploy_mgr, cfg.deployment, cfg.base_model, cfg.infra
-        )
+        dep_info = setup_deployment(deploy_mgr, cfg.deployment, cfg.base_model, cfg.infra)
         if cleanup_on_exit:
             cleanup.deployment(cfg.deployment.deployment_id, action="scale_to_zero")
 
@@ -361,13 +330,9 @@ def main(
         if use_reference and not reuse_policy_base_reference:
             with ThreadPoolExecutor(max_workers=2) as pool:
                 pol_fut = pool.submit(
-                    create_trainer_job,
-                    rlor_mgr,
-                    base_model=cfg.base_model,
-                    infra=cfg.infra,
-                    profile=profile,
-                    lora_rank=cfg.lora_rank,
-                    max_seq_len=cfg.max_seq_len,
+                    create_trainer_job, rlor_mgr,
+                    base_model=cfg.base_model, infra=cfg.infra, profile=profile,
+                    lora_rank=cfg.lora_rank, max_seq_len=cfg.max_seq_len,
                     learning_rate=cfg.learning_rate,
                     display_name="grpo-policy",
                     hot_load_deployment_id=cfg.deployment.deployment_id,  # weight sync target deployment
@@ -375,16 +340,11 @@ def main(
                     base_url_override=cfg.policy_base_url,
                 )
                 ref_fut = pool.submit(
-                    create_trainer_job,
-                    rlor_mgr,
-                    base_model=cfg.base_model,
-                    infra=cfg.infra,
-                    profile=ref_profile,
-                    lora_rank=cfg.lora_rank,
-                    max_seq_len=cfg.max_seq_len,
+                    create_trainer_job, rlor_mgr,
+                    base_model=cfg.base_model, infra=cfg.infra, profile=ref_profile,
+                    lora_rank=cfg.lora_rank, max_seq_len=cfg.max_seq_len,
                     learning_rate=cfg.learning_rate,
-                    display_name="grpo-reference",
-                    forward_only=True,
+                    display_name="grpo-reference", forward_only=True,
                     job_id=cfg.reference_job_id,
                     base_url_override=cfg.reference_base_url,
                 )
@@ -399,11 +359,8 @@ def main(
         else:
             policy_ep = create_trainer_job(
                 rlor_mgr,
-                base_model=cfg.base_model,
-                infra=cfg.infra,
-                profile=profile,
-                lora_rank=cfg.lora_rank,
-                max_seq_len=cfg.max_seq_len,
+                base_model=cfg.base_model, infra=cfg.infra, profile=profile,
+                lora_rank=cfg.lora_rank, max_seq_len=cfg.max_seq_len,
                 learning_rate=cfg.learning_rate,
                 display_name="grpo-policy",
                 hot_load_deployment_id=cfg.deployment.deployment_id,
@@ -416,10 +373,7 @@ def main(
             reference_ep = None
 
         policy = ReconnectableClient(
-            rlor_mgr,
-            policy_ep.job_id,
-            cfg.base_model,
-            cfg.lora_rank,
+            rlor_mgr, policy_ep.job_id, cfg.base_model, cfg.lora_rank,
             fw_api_key=api_key,
             endpoint=policy_ep if cfg.policy_base_url else None,
         )
@@ -443,28 +397,21 @@ def main(
                     fw_api_key=api_key,
                     endpoint=reference_ep if cfg.reference_base_url else None,
                 )
-                if reference_ep
-                else None
+                if reference_ep else None
             )
         )
 
         import transformers
 
         inference_model = dep_info.inference_model if dep_info else cfg.base_model
-        tokenizer = transformers.AutoTokenizer.from_pretrained(
-            cfg.deployment.tokenizer_model, trust_remote_code=True
-        )
+        tokenizer = transformers.AutoTokenizer.from_pretrained(cfg.deployment.tokenizer_model, trust_remote_code=True)
         sampler = DeploymentSampler(
             inference_url=deploy_mgr.inference_url,
-            model=inference_model,
-            api_key=api_key,
-            tokenizer=tokenizer,
+            model=inference_model, api_key=api_key, tokenizer=tokenizer,
         )
         weight_syncer = WeightSyncer(
-            policy_client=policy.inner,
-            deploy_mgr=deploy_mgr,
-            deployment_id=cfg.deployment.deployment_id,
-            base_model=cfg.base_model,
+            policy_client=policy.inner, deploy_mgr=deploy_mgr,
+            deployment_id=cfg.deployment.deployment_id, base_model=cfg.base_model,
             hotload_timeout=cfg.weight_sync.weight_sync_timeout,
             first_checkpoint_type=cfg.weight_sync.first_checkpoint_type,
             dcp_timeout=cfg.weight_sync.dcp_timeout,
@@ -496,17 +443,14 @@ def main(
         rl_dataset = RLPromptDataset(all_rows, prompts_per_step=prompt_groups_per_step)
         adam_params = tinker.AdamParams(learning_rate=cfg.learning_rate, **DEFAULT_ADAM)
         loss_builder = build_loss_fn(
-            policy_loss=cfg.policy_loss,
-            kl_beta=cfg.kl_beta,
-            dapo_config=cfg.dapo,
-            gspo_config=cfg.gspo,
+            policy_loss=cfg.policy_loss, kl_beta=cfg.kl_beta,
+            dapo_config=cfg.dapo, gspo_config=cfg.gspo,
             cispo_config=cfg.cispo,
             is_config=cfg.is_correction,
         )
 
         sample_kwargs: dict = dict(
-            max_tokens=cfg.max_completion_tokens,
-            temperature=cfg.temperature,
+            max_tokens=cfg.max_completion_tokens, temperature=cfg.temperature,
             max_seq_len=cfg.max_seq_len,
             http_timeout=cfg.deployment.sample_timeout,
         )
@@ -554,20 +498,14 @@ def main(
                 rm = None
                 if cfg.router_replay:
                     rm = build_r3_routing_matrices(
-                        s.routing_matrices,
-                        s.prompt_len,
-                        model_input_len,
+                        s.routing_matrices, s.prompt_len, model_input_len,
                         completion_only=cfg.router_replay_completion_only,
                     )
 
                 policy_datum = tinker.Datum(
-                    model_input=tinker.ModelInput.from_ints(
-                        tokens[:-1], routing_matrices=rm
-                    ),
+                    model_input=tinker.ModelInput.from_ints(tokens[:-1], routing_matrices=rm),
                     loss_fn_inputs={
-                        "target_tokens": tinker.TensorData(
-                            data=tokens[1:], dtype="int64", shape=[model_input_len]
-                        ),
+                        "target_tokens": tinker.TensorData(data=tokens[1:], dtype="int64", shape=[model_input_len]),
                     },
                 )
                 policy_data.append(policy_datum)
@@ -576,9 +514,7 @@ def main(
                     reference_datum = tinker.Datum(
                         model_input=tinker.ModelInput.from_ints(tokens[:-1]),
                         loss_fn_inputs={
-                            "target_tokens": tinker.TensorData(
-                                data=tokens[1:], dtype="int64", shape=[model_input_len]
-                            ),
+                            "target_tokens": tinker.TensorData(data=tokens[1:], dtype="int64", shape=[model_input_len]),
                         },
                     )
                     reference_data.append(reference_datum)
@@ -593,9 +529,7 @@ def main(
                 response_start = max(0, prompt_len - 1)
                 echoed = getattr(s, "logprobs_echoed", False)
                 aligned = (
-                    list(s.inference_logprobs)
-                    if echoed
-                    else [0.0] * response_start + list(s.inference_logprobs)
+                    list(s.inference_logprobs) if echoed else [0.0] * response_start + list(s.inference_logprobs)
                 )
                 inf_logprobs_aligned.append(aligned)
 
@@ -606,20 +540,13 @@ def main(
             trunc = [s.finish_reason == "length" for s in sampled]
 
             return PromptGroup(
-                data=policy_data,
-                ref_data=reference_data,
-                advantages=adv_filtered,
-                ref_logprobs=None,
-                prompt_len=prompt_len,
-                rewards=rewards,
-                inf_logprobs=inf_logprobs_aligned,
-                completion_lens=comp_lens,
-                truncated=trunc,
+                data=policy_data, ref_data=reference_data,
+                advantages=adv_filtered, ref_logprobs=None,
+                prompt_len=prompt_len, rewards=rewards, inf_logprobs=inf_logprobs_aligned,
+                completion_lens=comp_lens, truncated=trunc,
                 prompt=input_messages if cfg.trajectory_dir else None,
                 completions=[s.text for s in sampled] if cfg.trajectory_dir else None,
-                row_meta={"ground_truth": row.get("ground_truth", "")}
-                if cfg.trajectory_dir
-                else None,
+                row_meta={"ground_truth": row.get("ground_truth", "")} if cfg.trajectory_dir else None,
             )
 
         # -- Training callbacks ----------------------------------------------------
@@ -643,21 +570,16 @@ def main(
             if not prompt_groups:
                 raise ValueError("fwd_bwd_one requires at least one prompt group")
 
-            data, adv, ref_lp, prompt_lens, inf_lp = combine_prompt_groups(
-                prompt_groups
-            )
+            data, adv, ref_lp, prompt_lens, inf_lp = combine_prompt_groups(prompt_groups)
 
             t0 = _time.time()
             prox_fwd = policy.forward(data, "cross_entropy")
-            prox_lp = [
-                prox_fwd.loss_fn_outputs[i]["logprobs"].data for i in range(len(data))
-            ]
+            prox_lp = [prox_fwd.loss_fn_outputs[i]["logprobs"].data for i in range(len(data))]
             logger.info("prox_forward: done (%.1fs)", _time.time() - t0)
 
             t0 = _time.time()
             fwd_bwd_result = policy.forward_backward_custom(
-                data,
-                loss_builder(adv, ref_lp, prompt_lens, inf_lp, prox_lp),
+                data, loss_builder(adv, ref_lp, prompt_lens, inf_lp, prox_lp),
             )
             logger.info("fwd_bwd: done (%.1fs)", _time.time() - t0)
             return fwd_bwd_result
@@ -670,9 +592,7 @@ def main(
             """ref_forward + fwd_bwd + optim_step + weight_sync + metrics (1:1)."""
             t0 = _time.time()
             ref_forward(prompt_groups)
-            logger.info(
-                "[step %d] ref_forward: done (%.1fs)", step + 1, _time.time() - t0
-            )
+            logger.info("[step %d] ref_forward: done (%.1fs)", step + 1, _time.time() - t0)
 
             t0 = _time.time()
             fwd_bwd_result = fwd_bwd_one(prompt_groups)
@@ -683,39 +603,24 @@ def main(
             step += 1
             logger.info("[step %d] optim_step: done (%.1fs)", step, _time.time() - t0)
 
-            if (
-                cfg.weight_sync.weight_sync_interval > 0
-                and step % cfg.weight_sync.weight_sync_interval == 0
-            ):
+            if cfg.weight_sync.weight_sync_interval > 0 and step % cfg.weight_sync.weight_sync_interval == 0:
                 logger.info("[step %d] weight_sync: saving + loading...", step)
                 t0 = _time.time()
                 with timer("weight_sync"):
                     weight_syncer.save_and_hotload(f"step-{step}")
-                logger.info(
-                    "[step %d] weight_sync: done (%.1fs)", step, _time.time() - t0
-                )
-            if (
-                cfg.weight_sync.dcp_save_interval > 0
-                and step % cfg.weight_sync.dcp_save_interval == 0
-            ):
+                logger.info("[step %d] weight_sync: done (%.1fs)", step, _time.time() - t0)
+            if cfg.weight_sync.dcp_save_interval > 0 and step % cfg.weight_sync.dcp_save_interval == 0:
                 logger.info("[step %d] dcp_save...", step)
                 t0 = _time.time()
                 with timer("dcp_save"):
                     weight_syncer.save_dcp(f"step-{step}")
                 logger.info("[step %d] dcp_save: done (%.1fs)", step, _time.time() - t0)
-                _data_consumed = (resume_info.data_consumed if resume_info else 0) + (
-                    step - step_offset
-                ) * prompt_groups_per_step
-                save_checkpoint(
-                    policy,
-                    f"step-{step}",
-                    cfg.log_path,
-                    {
-                        "step": step,
-                        "data_consumed": _data_consumed,
-                        "source_job_id": policy_job_id,
-                    },
-                )
+                _data_consumed = (resume_info.data_consumed if resume_info else 0) + (step - step_offset) * prompt_groups_per_step
+                save_checkpoint(policy, f"step-{step}", cfg.log_path, {
+                    "step": step,
+                    "data_consumed": _data_consumed,
+                    "source_job_id": policy_job_id,
+                })
 
             metrics = compute_step_metrics(
                 prompt_groups=prompt_groups,
@@ -733,10 +638,7 @@ def main(
             avg_kl = metrics.get("train/mean_kl", 0.0)
             logger.info(
                 "Step %d | Reward: %.3f | Acc: %.1f%% | KL: %.4f",
-                step,
-                avg_reward,
-                avg_acc * 100,
-                avg_kl,
+                step, avg_reward, avg_acc * 100, avg_kl,
             )
             log_metrics_json(step, reward=avg_reward, accuracy=avg_acc, kl=avg_kl)
             wandb_log(metrics, step)
@@ -758,34 +660,25 @@ def main(
         for i_step in range(step_offset, len(rl_dataset)):
             remaining_rows.extend(rl_dataset.get_batch(i_step))
 
-        global_step = asyncio.run(
-            run_rl_loop(
-                sample_fns=(sample_one_prompt(row) for row in remaining_rows),
-                train_fns=train_fns,
-                prompt_groups_per_step=prompt_groups_per_step,
-                dynamic_filter_fn=should_accept,
-                global_step=step_offset,
-                metrics_callback=_loop_metrics_callback,
-            )
-        )
+        global_step = asyncio.run(run_rl_loop(
+            sample_fns=(sample_one_prompt(row) for row in remaining_rows),
+            train_fns=train_fns,
+            prompt_groups_per_step=prompt_groups_per_step,
+            dynamic_filter_fn=should_accept,
+            global_step=step_offset,
+            metrics_callback=_loop_metrics_callback,
+        ))
 
         # -- Final checkpoint ----------------------------------------------------
 
         if global_step > step_offset:
             try:
-                _data_consumed = (resume_info.data_consumed if resume_info else 0) + (
-                    global_step - step_offset
-                ) * prompt_groups_per_step
-                save_checkpoint(
-                    policy,
-                    f"step-{global_step}",
-                    cfg.log_path,
-                    {
-                        "step": global_step,
-                        "data_consumed": _data_consumed,
-                        "source_job_id": policy_job_id,
-                    },
-                )
+                _data_consumed = (resume_info.data_consumed if resume_info else 0) + (global_step - step_offset) * prompt_groups_per_step
+                save_checkpoint(policy, f"step-{global_step}", cfg.log_path, {
+                    "step": global_step,
+                    "data_consumed": _data_consumed,
+                    "source_job_id": policy_job_id,
+                })
             except Exception as e:
                 logger.warning("Failed to save final checkpoint: %s", e)
 
@@ -799,7 +692,5 @@ def main(
 
 
 if __name__ == "__main__":
-    logging.basicConfig(
-        level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s"
-    )
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
     main(Config(log_path="./rl_logs"))

--- a/training/recipes/rl_loop.py
+++ b/training/recipes/rl_loop.py
@@ -138,7 +138,9 @@ class Config:
     infra: InfraConfig = field(default_factory=InfraConfig)
     deployment: DeployConfig = field(default_factory=DeployConfig)
     weight_sync: WeightSyncConfig = field(default_factory=WeightSyncConfig)
-    wandb: WandBConfig = field(default_factory=lambda: WandBConfig(project="grpo-tinker"))
+    wandb: WandBConfig = field(
+        default_factory=lambda: WandBConfig(project="grpo-tinker")
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -182,7 +184,9 @@ def should_accept(pg: PromptGroup) -> bool:
 # ---------------------------------------------------------------------------
 
 
-def _dump_trajectory(trajectory_dir: str, step: int, prompt_groups: list[PromptGroup]) -> None:
+def _dump_trajectory(
+    trajectory_dir: str, step: int, prompt_groups: list[PromptGroup]
+) -> None:
     """Write per-step trajectory JSONL: one line per individual completion."""
     os.makedirs(trajectory_dir, exist_ok=True)
     path = os.path.join(trajectory_dir, f"step_{step:04d}.jsonl")
@@ -197,15 +201,31 @@ def _dump_trajectory(trajectory_dir: str, step: int, prompt_groups: list[PromptG
                     "completion_index": comp_idx,
                     "prompt": pg.prompt,
                     "completion": comp_text,
-                    "reward": pg.rewards[comp_idx] if comp_idx < len(pg.rewards) else None,
-                    "advantage": pg.advantages[comp_idx] if comp_idx < len(pg.advantages) else None,
-                    "completion_len": pg.completion_lens[comp_idx] if comp_idx < len(pg.completion_lens) else None,
-                    "truncated": pg.truncated[comp_idx] if comp_idx < len(pg.truncated) else None,
-                    "ground_truth": pg.row_meta.get("ground_truth") if pg.row_meta else None,
+                    "reward": pg.rewards[comp_idx]
+                    if comp_idx < len(pg.rewards)
+                    else None,
+                    "advantage": pg.advantages[comp_idx]
+                    if comp_idx < len(pg.advantages)
+                    else None,
+                    "completion_len": pg.completion_lens[comp_idx]
+                    if comp_idx < len(pg.completion_lens)
+                    else None,
+                    "truncated": pg.truncated[comp_idx]
+                    if comp_idx < len(pg.truncated)
+                    else None,
+                    "ground_truth": pg.row_meta.get("ground_truth")
+                    if pg.row_meta
+                    else None,
                 }
                 f.write(json.dumps(record, ensure_ascii=False) + "\n")
                 n_records += 1
-    logger.info("[step %d] Saved trajectory to %s (%d completions from %d groups)", step, path, n_records, len(prompt_groups))
+    logger.info(
+        "[step %d] Saved trajectory to %s (%d completions from %d groups)",
+        step,
+        path,
+        n_records,
+        len(prompt_groups),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -255,9 +275,13 @@ def main(
     base_url = os.environ.get("FIREWORKS_BASE_URL", "https://api.fireworks.ai")
 
     if rlor_mgr is None:
-        rlor_mgr = TrainerJobManager(api_key=api_key, account_id=account, base_url=base_url)
+        rlor_mgr = TrainerJobManager(
+            api_key=api_key, account_id=account, base_url=base_url
+        )
     if deploy_mgr is None:
-        deploy_mgr = DeploymentManager(api_key=api_key, account_id=account, base_url=base_url)
+        deploy_mgr = DeploymentManager(
+            api_key=api_key, account_id=account, base_url=base_url
+        )
 
     # -- Resolve training shapes -----------------------------------------------
 
@@ -281,7 +305,9 @@ def main(
     profile = None
     if cfg.infra.training_shape_id:
         profile = rlor_mgr.resolve_training_profile(cfg.infra.training_shape_id)
-        dep_shape = getattr(profile, "deployment_shape", None) or getattr(profile, "deployment_shape_version", None)
+        dep_shape = getattr(profile, "deployment_shape", None) or getattr(
+            profile, "deployment_shape_version", None
+        )
         if dep_shape and not cfg.deployment.deployment_shape:
             cfg.deployment.deployment_shape = dep_shape
 
@@ -308,16 +334,21 @@ def main(
         and not reuse_policy_base_reference
         and cfg.infra.ref_training_shape_id
     ):
-        logger.info("Using separate ref training shape: %s", cfg.infra.ref_training_shape_id)
+        logger.info(
+            "Using separate ref training shape: %s", cfg.infra.ref_training_shape_id
+        )
         ref_profile = rlor_mgr.resolve_training_profile(cfg.infra.ref_training_shape_id)
 
     import time as _time
+
     _infra_start = _time.time()
     policy_job_id: str | None = None
     reference_job_id: str | None = None
 
     with ResourceCleanup(rlor_mgr, deploy_mgr) as cleanup:
-        dep_info = setup_deployment(deploy_mgr, cfg.deployment, cfg.base_model, cfg.infra)
+        dep_info = setup_deployment(
+            deploy_mgr, cfg.deployment, cfg.base_model, cfg.infra
+        )
         if cleanup_on_exit:
             cleanup.deployment(cfg.deployment.deployment_id, action="scale_to_zero")
 
@@ -330,9 +361,13 @@ def main(
         if use_reference and not reuse_policy_base_reference:
             with ThreadPoolExecutor(max_workers=2) as pool:
                 pol_fut = pool.submit(
-                    create_trainer_job, rlor_mgr,
-                    base_model=cfg.base_model, infra=cfg.infra, profile=profile,
-                    lora_rank=cfg.lora_rank, max_seq_len=cfg.max_seq_len,
+                    create_trainer_job,
+                    rlor_mgr,
+                    base_model=cfg.base_model,
+                    infra=cfg.infra,
+                    profile=profile,
+                    lora_rank=cfg.lora_rank,
+                    max_seq_len=cfg.max_seq_len,
                     learning_rate=cfg.learning_rate,
                     display_name="grpo-policy",
                     hot_load_deployment_id=cfg.deployment.deployment_id,  # weight sync target deployment
@@ -340,11 +375,16 @@ def main(
                     base_url_override=cfg.policy_base_url,
                 )
                 ref_fut = pool.submit(
-                    create_trainer_job, rlor_mgr,
-                    base_model=cfg.base_model, infra=cfg.infra, profile=ref_profile,
-                    lora_rank=cfg.lora_rank, max_seq_len=cfg.max_seq_len,
+                    create_trainer_job,
+                    rlor_mgr,
+                    base_model=cfg.base_model,
+                    infra=cfg.infra,
+                    profile=ref_profile,
+                    lora_rank=cfg.lora_rank,
+                    max_seq_len=cfg.max_seq_len,
                     learning_rate=cfg.learning_rate,
-                    display_name="grpo-reference", forward_only=True,
+                    display_name="grpo-reference",
+                    forward_only=True,
                     job_id=cfg.reference_job_id,
                     base_url_override=cfg.reference_base_url,
                 )
@@ -359,8 +399,11 @@ def main(
         else:
             policy_ep = create_trainer_job(
                 rlor_mgr,
-                base_model=cfg.base_model, infra=cfg.infra, profile=profile,
-                lora_rank=cfg.lora_rank, max_seq_len=cfg.max_seq_len,
+                base_model=cfg.base_model,
+                infra=cfg.infra,
+                profile=profile,
+                lora_rank=cfg.lora_rank,
+                max_seq_len=cfg.max_seq_len,
                 learning_rate=cfg.learning_rate,
                 display_name="grpo-policy",
                 hot_load_deployment_id=cfg.deployment.deployment_id,
@@ -373,7 +416,10 @@ def main(
             reference_ep = None
 
         policy = ReconnectableClient(
-            rlor_mgr, policy_ep.job_id, cfg.base_model, cfg.lora_rank,
+            rlor_mgr,
+            policy_ep.job_id,
+            cfg.base_model,
+            cfg.lora_rank,
             fw_api_key=api_key,
             endpoint=policy_ep if cfg.policy_base_url else None,
         )
@@ -397,21 +443,28 @@ def main(
                     fw_api_key=api_key,
                     endpoint=reference_ep if cfg.reference_base_url else None,
                 )
-                if reference_ep else None
+                if reference_ep
+                else None
             )
         )
 
         import transformers
 
         inference_model = dep_info.inference_model if dep_info else cfg.base_model
-        tokenizer = transformers.AutoTokenizer.from_pretrained(cfg.deployment.tokenizer_model, trust_remote_code=True)
+        tokenizer = transformers.AutoTokenizer.from_pretrained(
+            cfg.deployment.tokenizer_model, trust_remote_code=True
+        )
         sampler = DeploymentSampler(
             inference_url=deploy_mgr.inference_url,
-            model=inference_model, api_key=api_key, tokenizer=tokenizer,
+            model=inference_model,
+            api_key=api_key,
+            tokenizer=tokenizer,
         )
         weight_syncer = WeightSyncer(
-            policy_client=policy.inner, deploy_mgr=deploy_mgr,
-            deployment_id=cfg.deployment.deployment_id, base_model=cfg.base_model,
+            policy_client=policy.inner,
+            deploy_mgr=deploy_mgr,
+            deployment_id=cfg.deployment.deployment_id,
+            base_model=cfg.base_model,
             hotload_timeout=cfg.weight_sync.weight_sync_timeout,
             first_checkpoint_type=cfg.weight_sync.first_checkpoint_type,
             dcp_timeout=cfg.weight_sync.dcp_timeout,
@@ -443,14 +496,17 @@ def main(
         rl_dataset = RLPromptDataset(all_rows, prompts_per_step=prompt_groups_per_step)
         adam_params = tinker.AdamParams(learning_rate=cfg.learning_rate, **DEFAULT_ADAM)
         loss_builder = build_loss_fn(
-            policy_loss=cfg.policy_loss, kl_beta=cfg.kl_beta,
-            dapo_config=cfg.dapo, gspo_config=cfg.gspo,
+            policy_loss=cfg.policy_loss,
+            kl_beta=cfg.kl_beta,
+            dapo_config=cfg.dapo,
+            gspo_config=cfg.gspo,
             cispo_config=cfg.cispo,
             is_config=cfg.is_correction,
         )
 
         sample_kwargs: dict = dict(
-            max_tokens=cfg.max_completion_tokens, temperature=cfg.temperature,
+            max_tokens=cfg.max_completion_tokens,
+            temperature=cfg.temperature,
             max_seq_len=cfg.max_seq_len,
             http_timeout=cfg.deployment.sample_timeout,
         )
@@ -498,14 +554,20 @@ def main(
                 rm = None
                 if cfg.router_replay:
                     rm = build_r3_routing_matrices(
-                        s.routing_matrices, s.prompt_len, model_input_len,
+                        s.routing_matrices,
+                        s.prompt_len,
+                        model_input_len,
                         completion_only=cfg.router_replay_completion_only,
                     )
 
                 policy_datum = tinker.Datum(
-                    model_input=tinker.ModelInput.from_ints(tokens[:-1], routing_matrices=rm),
+                    model_input=tinker.ModelInput.from_ints(
+                        tokens[:-1], routing_matrices=rm
+                    ),
                     loss_fn_inputs={
-                        "target_tokens": tinker.TensorData(data=tokens[1:], dtype="int64", shape=[model_input_len]),
+                        "target_tokens": tinker.TensorData(
+                            data=tokens[1:], dtype="int64", shape=[model_input_len]
+                        ),
                     },
                 )
                 policy_data.append(policy_datum)
@@ -514,7 +576,9 @@ def main(
                     reference_datum = tinker.Datum(
                         model_input=tinker.ModelInput.from_ints(tokens[:-1]),
                         loss_fn_inputs={
-                            "target_tokens": tinker.TensorData(data=tokens[1:], dtype="int64", shape=[model_input_len]),
+                            "target_tokens": tinker.TensorData(
+                                data=tokens[1:], dtype="int64", shape=[model_input_len]
+                            ),
                         },
                     )
                     reference_data.append(reference_datum)
@@ -529,7 +593,9 @@ def main(
                 response_start = max(0, prompt_len - 1)
                 echoed = getattr(s, "logprobs_echoed", False)
                 aligned = (
-                    list(s.inference_logprobs) if echoed else [0.0] * response_start + list(s.inference_logprobs)
+                    list(s.inference_logprobs)
+                    if echoed
+                    else [0.0] * response_start + list(s.inference_logprobs)
                 )
                 inf_logprobs_aligned.append(aligned)
 
@@ -540,13 +606,20 @@ def main(
             trunc = [s.finish_reason == "length" for s in sampled]
 
             return PromptGroup(
-                data=policy_data, ref_data=reference_data,
-                advantages=adv_filtered, ref_logprobs=None,
-                prompt_len=prompt_len, rewards=rewards, inf_logprobs=inf_logprobs_aligned,
-                completion_lens=comp_lens, truncated=trunc,
+                data=policy_data,
+                ref_data=reference_data,
+                advantages=adv_filtered,
+                ref_logprobs=None,
+                prompt_len=prompt_len,
+                rewards=rewards,
+                inf_logprobs=inf_logprobs_aligned,
+                completion_lens=comp_lens,
+                truncated=trunc,
                 prompt=input_messages if cfg.trajectory_dir else None,
                 completions=[s.text for s in sampled] if cfg.trajectory_dir else None,
-                row_meta={"ground_truth": row.get("ground_truth", "")} if cfg.trajectory_dir else None,
+                row_meta={"ground_truth": row.get("ground_truth", "")}
+                if cfg.trajectory_dir
+                else None,
             )
 
         # -- Training callbacks ----------------------------------------------------
@@ -570,16 +643,21 @@ def main(
             if not prompt_groups:
                 raise ValueError("fwd_bwd_one requires at least one prompt group")
 
-            data, adv, ref_lp, prompt_lens, inf_lp = combine_prompt_groups(prompt_groups)
+            data, adv, ref_lp, prompt_lens, inf_lp = combine_prompt_groups(
+                prompt_groups
+            )
 
             t0 = _time.time()
             prox_fwd = policy.forward(data, "cross_entropy")
-            prox_lp = [prox_fwd.loss_fn_outputs[i]["logprobs"].data for i in range(len(data))]
+            prox_lp = [
+                prox_fwd.loss_fn_outputs[i]["logprobs"].data for i in range(len(data))
+            ]
             logger.info("prox_forward: done (%.1fs)", _time.time() - t0)
 
             t0 = _time.time()
             fwd_bwd_result = policy.forward_backward_custom(
-                data, loss_builder(adv, ref_lp, prompt_lens, inf_lp, prox_lp),
+                data,
+                loss_builder(adv, ref_lp, prompt_lens, inf_lp, prox_lp),
             )
             logger.info("fwd_bwd: done (%.1fs)", _time.time() - t0)
             return fwd_bwd_result
@@ -592,7 +670,9 @@ def main(
             """ref_forward + fwd_bwd + optim_step + weight_sync + metrics (1:1)."""
             t0 = _time.time()
             ref_forward(prompt_groups)
-            logger.info("[step %d] ref_forward: done (%.1fs)", step + 1, _time.time() - t0)
+            logger.info(
+                "[step %d] ref_forward: done (%.1fs)", step + 1, _time.time() - t0
+            )
 
             t0 = _time.time()
             fwd_bwd_result = fwd_bwd_one(prompt_groups)
@@ -603,24 +683,39 @@ def main(
             step += 1
             logger.info("[step %d] optim_step: done (%.1fs)", step, _time.time() - t0)
 
-            if cfg.weight_sync.weight_sync_interval > 0 and step % cfg.weight_sync.weight_sync_interval == 0:
+            if (
+                cfg.weight_sync.weight_sync_interval > 0
+                and step % cfg.weight_sync.weight_sync_interval == 0
+            ):
                 logger.info("[step %d] weight_sync: saving + loading...", step)
                 t0 = _time.time()
                 with timer("weight_sync"):
                     weight_syncer.save_and_hotload(f"step-{step}")
-                logger.info("[step %d] weight_sync: done (%.1fs)", step, _time.time() - t0)
-            if cfg.weight_sync.dcp_save_interval > 0 and step % cfg.weight_sync.dcp_save_interval == 0:
+                logger.info(
+                    "[step %d] weight_sync: done (%.1fs)", step, _time.time() - t0
+                )
+            if (
+                cfg.weight_sync.dcp_save_interval > 0
+                and step % cfg.weight_sync.dcp_save_interval == 0
+            ):
                 logger.info("[step %d] dcp_save...", step)
                 t0 = _time.time()
                 with timer("dcp_save"):
                     weight_syncer.save_dcp(f"step-{step}")
                 logger.info("[step %d] dcp_save: done (%.1fs)", step, _time.time() - t0)
-                _data_consumed = (resume_info.data_consumed if resume_info else 0) + (step - step_offset) * prompt_groups_per_step
-                save_checkpoint(policy, f"step-{step}", cfg.log_path, {
-                    "step": step,
-                    "data_consumed": _data_consumed,
-                    "source_job_id": policy_job_id,
-                })
+                _data_consumed = (resume_info.data_consumed if resume_info else 0) + (
+                    step - step_offset
+                ) * prompt_groups_per_step
+                save_checkpoint(
+                    policy,
+                    f"step-{step}",
+                    cfg.log_path,
+                    {
+                        "step": step,
+                        "data_consumed": _data_consumed,
+                        "source_job_id": policy_job_id,
+                    },
+                )
 
             metrics = compute_step_metrics(
                 prompt_groups=prompt_groups,
@@ -638,7 +733,10 @@ def main(
             avg_kl = metrics.get("train/mean_kl", 0.0)
             logger.info(
                 "Step %d | Reward: %.3f | Acc: %.1f%% | KL: %.4f",
-                step, avg_reward, avg_acc * 100, avg_kl,
+                step,
+                avg_reward,
+                avg_acc * 100,
+                avg_kl,
             )
             log_metrics_json(step, reward=avg_reward, accuracy=avg_acc, kl=avg_kl)
             wandb_log(metrics, step)
@@ -660,25 +758,34 @@ def main(
         for i_step in range(step_offset, len(rl_dataset)):
             remaining_rows.extend(rl_dataset.get_batch(i_step))
 
-        global_step = asyncio.run(run_rl_loop(
-            sample_fns=(sample_one_prompt(row) for row in remaining_rows),
-            train_fns=train_fns,
-            prompt_groups_per_step=prompt_groups_per_step,
-            dynamic_filter_fn=should_accept,
-            global_step=step_offset,
-            metrics_callback=_loop_metrics_callback,
-        ))
+        global_step = asyncio.run(
+            run_rl_loop(
+                sample_fns=(sample_one_prompt(row) for row in remaining_rows),
+                train_fns=train_fns,
+                prompt_groups_per_step=prompt_groups_per_step,
+                dynamic_filter_fn=should_accept,
+                global_step=step_offset,
+                metrics_callback=_loop_metrics_callback,
+            )
+        )
 
         # -- Final checkpoint ----------------------------------------------------
 
         if global_step > step_offset:
             try:
-                _data_consumed = (resume_info.data_consumed if resume_info else 0) + (global_step - step_offset) * prompt_groups_per_step
-                save_checkpoint(policy, f"step-{global_step}", cfg.log_path, {
-                    "step": global_step,
-                    "data_consumed": _data_consumed,
-                    "source_job_id": policy_job_id,
-                })
+                _data_consumed = (resume_info.data_consumed if resume_info else 0) + (
+                    global_step - step_offset
+                ) * prompt_groups_per_step
+                save_checkpoint(
+                    policy,
+                    f"step-{global_step}",
+                    cfg.log_path,
+                    {
+                        "step": global_step,
+                        "data_consumed": _data_consumed,
+                        "source_job_id": policy_job_id,
+                    },
+                )
             except Exception as e:
                 logger.warning("Failed to save final checkpoint: %s", e)
 
@@ -692,5 +799,7 @@ def main(
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s"
+    )
     main(Config(log_path="./rl_logs"))

--- a/training/tests/smoke_test/test_grpo_smoke.py
+++ b/training/tests/smoke_test/test_grpo_smoke.py
@@ -94,7 +94,9 @@ def test_grpo_smoke(
 
         smoke_lora_rank = int(os.environ.get("FIREWORKS_SMOKE_GRPO_LORA_RANK", "0"))
         default_kl_beta = 0.001 if smoke_lora_rank > 0 else 0.0
-        smoke_kl_beta = _get_float_env("FIREWORKS_SMOKE_GRPO_KL_BETA", default_kl_beta)
+        smoke_kl_beta = _get_float_env(
+            "FIREWORKS_SMOKE_GRPO_KL_BETA", default_kl_beta
+        )
         smoke_skip_validations = _get_bool_env(
             "FIREWORKS_SMOKE_SKIP_VALIDATIONS",
             default=smoke_custom_image_tag is not None,

--- a/training/tests/smoke_test/test_grpo_smoke.py
+++ b/training/tests/smoke_test/test_grpo_smoke.py
@@ -12,6 +12,14 @@ Requires env vars (skipped if not set):
 
 Usage:
     pytest training/tests/smoke_test/test_grpo_smoke.py -v -s
+
+Optional env vars to exercise LoRA reference reuse:
+    FIREWORKS_SMOKE_GRPO_LORA_RANK
+    FIREWORKS_SMOKE_GRPO_KL_BETA
+    FIREWORKS_SMOKE_GRPO_POLICY_JOB_ID
+    FIREWORKS_SMOKE_GRPO_POLICY_BASE_URL
+    FIREWORKS_SMOKE_GRPO_DEPLOYMENT_ID
+    FIREWORKS_SMOKE_GRPO_MAX_SEQ_LEN
 """
 
 from __future__ import annotations
@@ -28,6 +36,17 @@ logging.basicConfig(
     format="%(asctime)s %(levelname)s %(name)s: %(message)s",
     force=True,
 )
+
+
+def _get_float_env(name: str, default: float) -> float:
+    return float(os.environ.get(name, str(default)))
+
+
+def _get_bool_env(name: str, default: bool) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.lower() in {"1", "true", "yes", "on"}
 
 
 def _make_prompt_dataset(path: str, n: int = 4) -> None:
@@ -52,16 +71,20 @@ def test_grpo_smoke(
     smoke_sdk_managers,
     smoke_base_model,
     smoke_tokenizer_model,
-    smoke_infra,
+    smoke_training_shape,
+    smoke_custom_image_tag,
 ):
     """2-step GRPO on Qwen3-4B: train, weight sync, train again, cleanup."""
-    from training.utils import DeployConfig, WeightSyncConfig, WandBConfig
+    from training.utils import DeployConfig, InfraConfig, WeightSyncConfig, WandBConfig
     from training.recipes.rl_loop import Config, main
     import training.recipes.rl_loop as rl_mod
 
     rlor_mgr, deploy_mgr = smoke_sdk_managers
 
+    original_reward_fn = rl_mod.reward_fn
+    original_should_accept = rl_mod.should_accept
     rl_mod.reward_fn = _constant_reward
+    rl_mod.should_accept = lambda _pg: True
 
     with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
         dataset_path = f.name
@@ -69,19 +92,47 @@ def test_grpo_smoke(
     try:
         _make_prompt_dataset(dataset_path, n=4)
 
+        smoke_lora_rank = int(os.environ.get("FIREWORKS_SMOKE_GRPO_LORA_RANK", "0"))
+        default_kl_beta = 0.001 if smoke_lora_rank > 0 else 0.0
+        smoke_kl_beta = _get_float_env(
+            "FIREWORKS_SMOKE_GRPO_KL_BETA", default_kl_beta
+        )
+        smoke_skip_validations = _get_bool_env(
+            "FIREWORKS_SMOKE_SKIP_VALIDATIONS",
+            default=smoke_custom_image_tag is not None,
+        )
+        smoke_policy_job_id = os.environ.get("FIREWORKS_SMOKE_GRPO_POLICY_JOB_ID")
+        smoke_policy_base_url = os.environ.get("FIREWORKS_SMOKE_GRPO_POLICY_BASE_URL")
+        smoke_deployment_id = os.environ.get("FIREWORKS_SMOKE_GRPO_DEPLOYMENT_ID")
+        smoke_max_seq_len = (
+            int(os.environ.get("FIREWORKS_SMOKE_GRPO_MAX_SEQ_LEN", "4096"))
+            if smoke_policy_job_id
+            else None
+        )
+        smoke_training_shape_id = None if smoke_policy_job_id else smoke_training_shape
+
         config = Config(
             log_path=tempfile.mkdtemp(prefix="grpo_smoke_"),
             base_model=smoke_base_model,
             dataset=dataset_path,
             learning_rate=1e-4,
-            kl_beta=0,
+            kl_beta=smoke_kl_beta,
+            lora_rank=smoke_lora_rank,
             completions_per_prompt=4,
             prompt_groups_per_step=1,
             max_completion_tokens=32,
             max_rows=2,
             epochs=1,
-            infra=smoke_infra,
+            max_seq_len=smoke_max_seq_len,
+            policy_job_id=smoke_policy_job_id,
+            policy_base_url=smoke_policy_base_url,
+            infra=InfraConfig(
+                training_shape_id=smoke_training_shape_id,
+                skip_validations=smoke_skip_validations,
+                custom_image_tag=smoke_custom_image_tag,
+            ),
             deployment=DeployConfig(
+                deployment_id=smoke_deployment_id,
                 tokenizer_model=smoke_tokenizer_model,
             ),
             weight_sync=WeightSyncConfig(
@@ -103,18 +154,28 @@ def test_grpo_smoke(
         assert isinstance(metrics, dict), f"Expected dict, got {type(metrics)}"
         assert "steps" in metrics, f"Missing 'steps' in metrics: {metrics}"
         assert metrics["steps"] >= 2, f"Expected >= 2 steps, got {metrics['steps']}"
+        if smoke_lora_rank > 0 and smoke_kl_beta != 0:
+            assert metrics["reference_job_id"] is None, (
+                "LoRA GRPO should reuse the policy trainer for reference logprobs "
+                "instead of launching a separate reference trainer."
+            )
 
-        import httpx, time
-        time.sleep(3)
-        policy_job_id = metrics.get("policy_job_id")
-        if policy_job_id:
-            try:
-                job = rlor_mgr.get(policy_job_id)
-                state = job.get("state", "")
-                assert state in ("JOB_STATE_DELETING", "JOB_STATE_DELETED"), (
-                    f"ResourceCleanup failed: policy job {policy_job_id} still {state}"
-                )
-            except httpx.HTTPStatusError as e:
-                assert e.response.status_code == 404
+        if not smoke_policy_job_id:
+            import httpx
+            import time
+
+            time.sleep(3)
+            policy_job_id = metrics.get("policy_job_id")
+            if policy_job_id:
+                try:
+                    job = rlor_mgr.get(policy_job_id)
+                    state = job.get("state", "")
+                    assert state in ("JOB_STATE_DELETING", "JOB_STATE_DELETED"), (
+                        f"ResourceCleanup failed: policy job {policy_job_id} still {state}"
+                    )
+                except httpx.HTTPStatusError as e:
+                    assert e.response.status_code == 404
     finally:
+        rl_mod.reward_fn = original_reward_fn
+        rl_mod.should_accept = original_should_accept
         os.unlink(dataset_path)

--- a/training/tests/smoke_test/test_grpo_smoke.py
+++ b/training/tests/smoke_test/test_grpo_smoke.py
@@ -94,9 +94,7 @@ def test_grpo_smoke(
 
         smoke_lora_rank = int(os.environ.get("FIREWORKS_SMOKE_GRPO_LORA_RANK", "0"))
         default_kl_beta = 0.001 if smoke_lora_rank > 0 else 0.0
-        smoke_kl_beta = _get_float_env(
-            "FIREWORKS_SMOKE_GRPO_KL_BETA", default_kl_beta
-        )
+        smoke_kl_beta = _get_float_env("FIREWORKS_SMOKE_GRPO_KL_BETA", default_kl_beta)
         smoke_skip_validations = _get_bool_env(
             "FIREWORKS_SMOKE_SKIP_VALIDATIONS",
             default=smoke_custom_image_tag is not None,

--- a/training/tests/unit/test_client.py
+++ b/training/tests/unit/test_client.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import training.utils.client as module
+
+
+def test_build_base_model_reference_id_has_base_prefix() -> None:
+    """Base-model reference IDs must never look like LoRA session IDs."""
+    assert (
+        module.build_base_model_reference_id("accounts/test/models/qwen3-4b")
+        == "base::accounts/test/models/qwen3-4b"
+    )
+
+
+def test_reconnectable_client_uses_manual_model_id_override(monkeypatch) -> None:
+    """Manual model IDs should skip create_model and target the base model directly."""
+    events: dict[str, object] = {}
+
+    class FakeHolder:
+        def get_training_client_id(self) -> int:
+            events["training_client_id_calls"] = (
+                int(events.get("training_client_id_calls", 0)) + 1
+            )
+            return 7
+
+    class FakeServiceClient:
+        def __init__(self, base_url: str, api_key: str, **kwargs) -> None:
+            events["service_init"] = {
+                "base_url": base_url,
+                "api_key": api_key,
+                "kwargs": kwargs,
+            }
+            self.holder = FakeHolder()
+
+        def create_training_client(self, *args, **kwargs):
+            raise AssertionError(
+                "create_training_client should not run for model_id overrides"
+            )
+
+    class FakeTrainingClient:
+        def __init__(self, holder, model_seq_id: int, model_id: str) -> None:
+            self.holder = holder
+            self.model_seq_id = model_seq_id
+            self.model_id = model_id
+            events["manual_client"] = {
+                "model_seq_id": model_seq_id,
+                "model_id": model_id,
+            }
+
+    monkeypatch.setattr(module, "FiretitanServiceClient", FakeServiceClient)
+    monkeypatch.setattr(module, "FiretitanTrainingClient", FakeTrainingClient)
+
+    endpoint = SimpleNamespace(base_url="https://trainer.unit.test", job_id="job-123")
+    model_id = module.build_base_model_reference_id("accounts/test/models/qwen3-4b")
+
+    client = module.ReconnectableClient(
+        rlor_mgr=SimpleNamespace(),
+        job_id="job-123",
+        base_model="accounts/test/models/qwen3-4b",
+        lora_rank=8,
+        fw_api_key="fw-key",
+        endpoint=endpoint,
+        model_id_override=model_id,
+    )
+
+    assert events["manual_client"] == {
+        "model_seq_id": 7,
+        "model_id": model_id,
+    }
+    assert events["training_client_id_calls"] == 1
+    assert events["service_init"] == {
+        "base_url": "https://trainer.unit.test",
+        "api_key": "tml-local",
+        "kwargs": {
+            "default_headers": {
+                "X-API-Key": "fw-key",
+                "Authorization": "Bearer fw-key",
+            }
+        },
+    }
+    assert client.inner.model_id == model_id

--- a/training/tests/unit/test_rl_loop.py
+++ b/training/tests/unit/test_rl_loop.py
@@ -486,3 +486,299 @@ def test_main_runs_sampling_and_training_with_reference(monkeypatch, tmp_path):
     assert advantages[1] < 0
     assert events["deleted_jobs"] == ["reference-job", "policy-job"]
     assert events["scaled_deployments"] == ["dep-123"]
+
+
+def test_main_reuses_policy_trainer_for_lora_reference(monkeypatch, tmp_path):
+    monkeypatch.setenv("FIREWORKS_API_KEY", "test-key")
+    monkeypatch.setenv("FIREWORKS_ACCOUNT_ID", "acct")
+    monkeypatch.setenv("FIREWORKS_BASE_URL", "https://unit.test")
+
+    events: dict[str, object] = {
+        "create_trainer_job": [],
+        "deleted_jobs": [],
+        "scaled_deployments": [],
+        "client_inits": [],
+        "weight_sync_saves": [],
+        "build_loss_fn_calls": [],
+        "sampler_calls": [],
+    }
+
+    class FakeRlorMgr:
+        def resolve_training_profile(self, shape_id):
+            return SimpleNamespace(
+                deployment_shape="dep-shape-v3",
+                deployment_shape_version=None,
+                pipeline_parallelism=1,
+                max_supported_context_length=128,
+            )
+
+        def delete(self, job_id):
+            events["deleted_jobs"].append(job_id)
+
+    class FakeDeployMgr:
+        inference_url = "https://inference.unit.test"
+        boot_time_s = 1.5
+
+        def scale_to_zero(self, deployment_id):
+            events["scaled_deployments"].append(deployment_id)
+
+    class UnexpectedThreadPoolExecutor:
+        def __init__(self, *args, **kwargs):
+            raise AssertionError(
+                "LoRA reference reuse should not create a separate reference pool"
+            )
+
+    class FakeClient:
+        def __init__(self, _mgr, job_id, *_args, **kwargs):
+            self.job_id = job_id
+            self.model_id_override = kwargs.get("model_id_override")
+            self.inner = object()
+            events["client_inits"].append(
+                {
+                    "job_id": job_id,
+                    "model_id_override": self.model_id_override,
+                }
+            )
+
+        def forward(self, data, loss_fn):
+            logprobs = [-0.11, -0.12] if self.model_id_override else [-0.21, -0.22]
+            return SimpleNamespace(
+                loss_fn_outputs=[
+                    {"logprobs": SimpleNamespace(data=list(logprobs))} for _ in data
+                ]
+            )
+
+        def forward_backward_custom(self, data, loss_fn):
+            events["fwd_bwd_call"] = {"data": data, "loss_fn": loss_fn}
+            return SimpleNamespace(metrics={"loss": 1.0})
+
+        def optim_step(self, _params):
+            events["optim_step_called"] = True
+            return SimpleNamespace(metrics={"optimizer/lr": 1e-4})
+
+        def save_state(self, name, timeout=None):
+            events["saved_state"] = (name, timeout)
+            return SimpleNamespace(path=f"tinker://unit/state/{name}")
+
+        def save_weights_for_sampler_ext(self, name, checkpoint_type="base"):
+            return SimpleNamespace(path=f"tinker://unit/sampler/{name}")
+
+        def load_state_with_optimizer(self, path):
+            pass
+
+        def resolve_checkpoint_path(self, name, source_job_id=None):
+            return f"tinker://unit/state/{name}"
+
+    class FakeWeightSyncer:
+        def __init__(self, **kwargs):
+            events["weight_syncer_init"] = kwargs
+
+        def save_and_hotload(self, name, checkpoint_type="base"):
+            events["weight_sync_saves"].append((name, checkpoint_type))
+
+        def save_dcp(self, name):
+            events.setdefault("weight_sync_dcp", []).append(name)
+
+    class FakeSampler:
+        def __init__(self, **kwargs):
+            events["sampler_init"] = kwargs
+
+        async def sample_with_tokens(self, **kwargs):
+            events["sampler_calls"].append(kwargs)
+            return [
+                SimpleNamespace(
+                    text="<answer>7</answer>",
+                    full_tokens=[10, 11, 12, 13],
+                    prompt_len=2,
+                    inference_logprobs=[-0.5, -0.6],
+                    logprobs_echoed=False,
+                    finish_reason="stop",
+                    routing_matrices=None,
+                ),
+                SimpleNamespace(
+                    text="<answer>8</answer>",
+                    full_tokens=[20, 21, 22, 23],
+                    prompt_len=2,
+                    inference_logprobs=[-0.7, -0.8],
+                    logprobs_echoed=False,
+                    finish_reason="length",
+                    routing_matrices=None,
+                ),
+            ]
+
+    async def fake_run_rl_loop(**kwargs):
+        events["run_loop_kwargs"] = kwargs
+        sample_iter = iter(kwargs["sample_fns"])
+        pg = await next(sample_iter)
+        assert pg is not None
+        step, metrics = kwargs["train_fns"].train_step(
+            1,
+            [pg],
+            {
+                "valid_prompt_groups": 1,
+                "total_sampled": 1,
+                "filter_drops": 0,
+                "sample_fails": 0,
+                "sample_wait_time": 0.1,
+                "step_wall_time": 0.2,
+                "all_raw_rewards": list(pg.rewards),
+            },
+        )
+        kwargs["metrics_callback"]({"train/step": step, "rollout/sample_fail_count": 0})
+        events["finish_metrics"] = metrics
+        return step
+
+    def fake_create_trainer_job(*args, **kwargs):
+        events["create_trainer_job"].append(kwargs)
+        return SimpleNamespace(job_id="policy-job")
+
+    def fake_build_loss_fn(**kwargs):
+        def _builder(adv, ref_lp, prompt_lens, inf_lp, prox_lp):
+            events["build_loss_fn_calls"].append(
+                {
+                    "advantages": adv,
+                    "ref_logprobs": ref_lp,
+                    "prompt_lens": prompt_lens,
+                    "inf_logprobs": inf_lp,
+                    "prox_logprobs": prox_lp,
+                }
+            )
+            return "loss-fn"
+
+        return _builder
+
+    monkeypatch.setattr(module, "setup_wandb", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        module, "wandb_finish", lambda: events.__setitem__("wandb_finished", 1)
+    )
+    monkeypatch.setattr(
+        module,
+        "wandb_log",
+        lambda payload, step=0: events.setdefault("wandb_logs", []).append(
+            (step, payload)
+        ),
+    )
+    monkeypatch.setattr(
+        module,
+        "log_metrics_json",
+        lambda step, **kwargs: events.setdefault("metrics_logs", []).append(
+            (step, kwargs)
+        ),
+    )
+    monkeypatch.setattr(
+        module,
+        "setup_deployment",
+        lambda *args, **kwargs: SimpleNamespace(
+            inference_model="accounts/test/models/deployed"
+        ),
+    )
+    monkeypatch.setattr(module, "ThreadPoolExecutor", UnexpectedThreadPoolExecutor)
+    monkeypatch.setattr(module, "create_trainer_job", fake_create_trainer_job)
+    monkeypatch.setattr(module, "ReconnectableClient", FakeClient)
+    monkeypatch.setattr(
+        transformers.AutoTokenizer, "from_pretrained", lambda *args, **kwargs: object()
+    )
+    monkeypatch.setattr(module, "DeploymentSampler", FakeSampler)
+    monkeypatch.setattr(module, "WeightSyncer", FakeWeightSyncer)
+    from training.utils.checkpoint_utils import ResumeInfo
+
+    monkeypatch.setattr(
+        module, "resolve_resume", lambda *args, **kwargs: ResumeInfo(step=0)
+    )
+    monkeypatch.setattr(
+        module,
+        "load_jsonl_dataset",
+        lambda *args, **kwargs: [
+            {
+                "messages": [
+                    {"role": "user", "content": "Solve"},
+                ],
+                "ground_truth": "<answer>7</answer>",
+            }
+        ],
+    )
+    monkeypatch.setattr(module, "build_loss_fn", fake_build_loss_fn)
+    monkeypatch.setattr(module, "run_rl_loop", fake_run_rl_loop)
+    monkeypatch.setattr(
+        module,
+        "compute_step_metrics",
+        lambda **kwargs: {
+            "rollout/reward": 0.5,
+            "rollout/accuracy": 0.5,
+            "train/mean_kl": 0.02,
+        },
+    )
+    monkeypatch.setattr(module, "flush_timing", lambda: {"perf/step_time": 1.0})
+    monkeypatch.setattr(
+        module.tinker.ModelInput,
+        "from_ints",
+        lambda ints, routing_matrices=None: SimpleNamespace(
+            tokens=list(ints), routing_matrices=routing_matrices
+        ),
+    )
+    monkeypatch.setattr(
+        module.tinker,
+        "TensorData",
+        lambda data, dtype, shape: SimpleNamespace(data=data, dtype=dtype, shape=shape),
+    )
+    monkeypatch.setattr(
+        module.tinker,
+        "Datum",
+        lambda model_input, loss_fn_inputs: SimpleNamespace(
+            model_input=model_input, loss_fn_inputs=loss_fn_inputs
+        ),
+    )
+
+    cfg = module.Config(
+        log_path=str(tmp_path / "rl_logs"),
+        base_model="accounts/test/models/qwen3-4b",
+        dataset="/tmp/prompts.jsonl",
+        kl_beta=0.1,
+        lora_rank=8,
+        completions_per_prompt=2,
+        prompt_groups_per_step=1,
+        weight_sync=module.WeightSyncConfig(
+            weight_sync_interval=1,
+            dcp_save_interval=0,
+            weight_sync_before_training=True,
+        ),
+        deployment=module.DeployConfig(
+            deployment_id="dep-123",
+            tokenizer_model="Qwen/Qwen3-4B",
+        ),
+        infra=module.InfraConfig(training_shape_id="shape-a"),
+    )
+
+    result = module.main(
+        cfg,
+        rlor_mgr=FakeRlorMgr(),
+        deploy_mgr=FakeDeployMgr(),
+        cleanup_on_exit=True,
+    )
+
+    assert result == {
+        "steps": 2,
+        "policy_job_id": "policy-job",
+        "reference_job_id": None,
+    }
+    assert cfg.max_seq_len == 128
+    assert cfg.deployment.deployment_shape == "dep-shape-v3"
+    assert [call["display_name"] for call in events["create_trainer_job"]] == [
+        "grpo-policy",
+    ]
+    assert events["client_inits"] == [
+        {"job_id": "policy-job", "model_id_override": None},
+        {
+            "job_id": "policy-job",
+            "model_id_override": module.build_base_model_reference_id(
+                "accounts/test/models/qwen3-4b"
+            ),
+        },
+    ]
+    assert events["weight_sync_saves"][0] == ("step-0-base", "base")
+    assert events["build_loss_fn_calls"][0]["ref_logprobs"] == [
+        [-0.11, -0.12],
+        [-0.11, -0.12],
+    ]
+    assert events["deleted_jobs"] == ["policy-job"]
+    assert events["scaled_deployments"] == ["dep-123"]

--- a/training/tests/unit/test_rl_loop.py
+++ b/training/tests/unit/test_rl_loop.py
@@ -16,24 +16,14 @@ def test_extract_answer_reads_digits_from_answer_block():
 
 
 def test_reward_fn_requires_matching_numeric_answer():
-    assert (
-        module.reward_fn("<answer>7</answer>", {"ground_truth": "<answer>7</answer>"})
-        == 1.0
-    )
-    assert (
-        module.reward_fn("<answer>8</answer>", {"ground_truth": "<answer>7</answer>"})
-        == 0.0
-    )
+    assert module.reward_fn("<answer>7</answer>", {"ground_truth": "<answer>7</answer>"}) == 1.0
+    assert module.reward_fn("<answer>8</answer>", {"ground_truth": "<answer>7</answer>"}) == 0.0
     assert module.reward_fn("missing", {"ground_truth": "<answer>7</answer>"}) == 0.0
 
 
 def test_should_accept_requires_reward_variance():
-    same_rewards = PromptGroup(
-        data=[], advantages=[], ref_logprobs=[], prompt_len=0, rewards=[0.0, 0.0]
-    )
-    varied_rewards = PromptGroup(
-        data=[], advantages=[], ref_logprobs=[], prompt_len=0, rewards=[0.0, 1.0]
-    )
+    same_rewards = PromptGroup(data=[], advantages=[], ref_logprobs=[], prompt_len=0, rewards=[0.0, 0.0])
+    varied_rewards = PromptGroup(data=[], advantages=[], ref_logprobs=[], prompt_len=0, rewards=[0.0, 1.0])
 
     assert module.should_accept(same_rewards) is False
     assert module.should_accept(varied_rewards) is True
@@ -161,39 +151,20 @@ def test_main_bootstraps_without_reference_and_cleans_up(monkeypatch):
         return 0
 
     monkeypatch.setattr(module, "setup_wandb", lambda *args, **kwargs: None)
-    monkeypatch.setattr(
-        module, "wandb_finish", lambda: events.__setitem__("wandb_finished", 1)
-    )
-    monkeypatch.setattr(
-        module,
-        "wandb_log",
-        lambda payload, step=0: events["wandb_logs"].append((step, payload)),
-    )
-    monkeypatch.setattr(
-        module,
-        "setup_deployment",
-        lambda *args, **kwargs: SimpleNamespace(
-            inference_model="accounts/test/models/deployed"
-        ),
-    )
+    monkeypatch.setattr(module, "wandb_finish", lambda: events.__setitem__("wandb_finished", 1))
+    monkeypatch.setattr(module, "wandb_log", lambda payload, step=0: events["wandb_logs"].append((step, payload)))
+    monkeypatch.setattr(module, "setup_deployment", lambda *args, **kwargs: SimpleNamespace(inference_model="accounts/test/models/deployed"))
     monkeypatch.setattr(
         module,
         "create_trainer_job",
-        lambda *args, **kwargs: (
-            events["create_trainer_job"].append(kwargs)
-            or SimpleNamespace(job_id="policy-job")
-        ),
+        lambda *args, **kwargs: events["create_trainer_job"].append(kwargs) or SimpleNamespace(job_id="policy-job"),
     )
     monkeypatch.setattr(module, "ReconnectableClient", FakePolicyClient)
-    monkeypatch.setattr(
-        transformers.AutoTokenizer, "from_pretrained", lambda *args, **kwargs: object()
-    )
+    monkeypatch.setattr(transformers.AutoTokenizer, "from_pretrained", lambda *args, **kwargs: object())
     monkeypatch.setattr(module, "DeploymentSampler", FakeSampler)
     monkeypatch.setattr(module, "WeightSyncer", FakeWeightSyncer)
     monkeypatch.setattr(module, "load_jsonl_dataset", lambda *args, **kwargs: [])
-    monkeypatch.setattr(
-        module, "build_loss_fn", lambda **kwargs: ("loss-builder", kwargs)
-    )
+    monkeypatch.setattr(module, "build_loss_fn", lambda **kwargs: ("loss-builder", kwargs))
     monkeypatch.setattr(module, "run_rl_loop", fake_run_rl_loop)
 
     cfg = module.Config(
@@ -223,10 +194,7 @@ def test_main_bootstraps_without_reference_and_cleans_up(monkeypatch):
     assert events["create_trainer_job"][0]["hot_load_deployment_id"] == "dep-123"
     assert events["sampler_init"]["model"] == "accounts/test/models/deployed"
     assert events["weight_syncer_init"]["deployment_id"] == "dep-123"
-    assert (
-        events["run_loop_kwargs"]["prompt_groups_per_step"]
-        == cfg.prompt_groups_per_step
-    )
+    assert events["run_loop_kwargs"]["prompt_groups_per_step"] == cfg.prompt_groups_per_step
     assert events["deleted_jobs"] == ["policy-job"]
     assert events["scaled_deployments"] == ["dep-123"]
     assert events["wandb_finished"] == 0
@@ -304,12 +272,14 @@ def test_main_runs_sampling_and_training_with_reference(monkeypatch, tmp_path):
             if self.job_id == "reference-job":
                 return SimpleNamespace(
                     loss_fn_outputs=[
-                        {"logprobs": SimpleNamespace(data=[-0.11, -0.12])} for _ in data
+                        {"logprobs": SimpleNamespace(data=[-0.11, -0.12])}
+                        for _ in data
                     ]
                 )
             return SimpleNamespace(
                 loss_fn_outputs=[
-                    {"logprobs": SimpleNamespace(data=[-0.21, -0.22])} for _ in data
+                    {"logprobs": SimpleNamespace(data=[-0.21, -0.22])}
+                    for _ in data
                 ]
             )
 
@@ -416,85 +386,42 @@ def test_main_runs_sampling_and_training_with_reference(monkeypatch, tmp_path):
         return _builder
 
     monkeypatch.setattr(module, "setup_wandb", lambda *args, **kwargs: None)
-    monkeypatch.setattr(
-        module, "wandb_finish", lambda: events.__setitem__("wandb_finished", 1)
-    )
-    monkeypatch.setattr(
-        module,
-        "wandb_log",
-        lambda payload, step=0: events["wandb_logs"].append((step, payload)),
-    )
-    monkeypatch.setattr(
-        module,
-        "log_metrics_json",
-        lambda step, **kwargs: events.setdefault("metrics_logs", []).append(
-            (step, kwargs)
-        ),
-    )
-    monkeypatch.setattr(
-        module,
-        "setup_deployment",
-        lambda *args, **kwargs: SimpleNamespace(
-            inference_model="accounts/test/models/deployed"
-        ),
-    )
+    monkeypatch.setattr(module, "wandb_finish", lambda: events.__setitem__("wandb_finished", 1))
+    monkeypatch.setattr(module, "wandb_log", lambda payload, step=0: events["wandb_logs"].append((step, payload)))
+    monkeypatch.setattr(module, "log_metrics_json", lambda step, **kwargs: events.setdefault("metrics_logs", []).append((step, kwargs)))
+    monkeypatch.setattr(module, "setup_deployment", lambda *args, **kwargs: SimpleNamespace(inference_model="accounts/test/models/deployed"))
     monkeypatch.setattr(module, "ThreadPoolExecutor", FakeThreadPoolExecutor)
     monkeypatch.setattr(module, "create_trainer_job", fake_create_trainer_job)
     monkeypatch.setattr(module, "ReconnectableClient", FakeClient)
-    monkeypatch.setattr(
-        transformers.AutoTokenizer, "from_pretrained", lambda *args, **kwargs: object()
-    )
+    monkeypatch.setattr(transformers.AutoTokenizer, "from_pretrained", lambda *args, **kwargs: object())
     monkeypatch.setattr(module, "DeploymentSampler", FakeSampler)
     monkeypatch.setattr(module, "WeightSyncer", FakeWeightSyncer)
     from training.utils.checkpoint_utils import ResumeInfo
-
-    monkeypatch.setattr(
-        module, "resolve_resume", lambda *args, **kwargs: ResumeInfo(step=0)
-    )
-    monkeypatch.setattr(
-        module,
-        "load_jsonl_dataset",
-        lambda *args, **kwargs: [
-            {
-                "messages": [
-                    {"role": "system", "content": "sys"},
-                    {"role": "user", "content": "Solve"},
-                    {"role": "assistant", "content": "prior"},
-                ],
-                "ground_truth": "<answer>7</answer>",
-            }
-        ],
-    )
+    monkeypatch.setattr(module, "resolve_resume", lambda *args, **kwargs: ResumeInfo(step=0))
+    monkeypatch.setattr(module, "load_jsonl_dataset", lambda *args, **kwargs: [
+        {
+            "messages": [
+                {"role": "system", "content": "sys"},
+                {"role": "user", "content": "Solve"},
+                {"role": "assistant", "content": "prior"},
+            ],
+            "ground_truth": "<answer>7</answer>",
+        }
+    ])
     monkeypatch.setattr(module, "build_loss_fn", fake_build_loss_fn)
     monkeypatch.setattr(module, "run_rl_loop", fake_run_rl_loop)
-    monkeypatch.setattr(
-        module,
-        "compute_pp_recommendation",
-        lambda *args, **kwargs: SimpleNamespace(recommended_prompts_per_step=3),
-    )
-    monkeypatch.setattr(
-        module,
-        "compute_step_metrics",
-        lambda **kwargs: {
-            "rollout/reward": 0.5,
-            "rollout/accuracy": 0.5,
-            "train/mean_kl": 0.02,
-        },
-    )
+    monkeypatch.setattr(module, "compute_pp_recommendation", lambda *args, **kwargs: SimpleNamespace(recommended_prompts_per_step=3))
+    monkeypatch.setattr(module, "compute_step_metrics", lambda **kwargs: {
+        "rollout/reward": 0.5,
+        "rollout/accuracy": 0.5,
+        "train/mean_kl": 0.02,
+    })
     monkeypatch.setattr(module, "flush_timing", lambda: {"perf/step_time": 1.0})
-    monkeypatch.setattr(
-        module,
-        "build_r3_routing_matrices",
-        lambda *args, **kwargs: (
-            events["routing_matrix_calls"].append((args, kwargs)) or {"rm": True}
-        ),
-    )
+    monkeypatch.setattr(module, "build_r3_routing_matrices", lambda *args, **kwargs: events["routing_matrix_calls"].append((args, kwargs)) or {"rm": True})
     monkeypatch.setattr(
         module.tinker.ModelInput,
         "from_ints",
-        lambda ints, routing_matrices=None: SimpleNamespace(
-            tokens=list(ints), routing_matrices=routing_matrices
-        ),
+        lambda ints, routing_matrices=None: SimpleNamespace(tokens=list(ints), routing_matrices=routing_matrices),
     )
     monkeypatch.setattr(
         module.tinker,
@@ -504,9 +431,7 @@ def test_main_runs_sampling_and_training_with_reference(monkeypatch, tmp_path):
     monkeypatch.setattr(
         module.tinker,
         "Datum",
-        lambda model_input, loss_fn_inputs: SimpleNamespace(
-            model_input=model_input, loss_fn_inputs=loss_fn_inputs
-        ),
+        lambda model_input, loss_fn_inputs: SimpleNamespace(model_input=model_input, loss_fn_inputs=loss_fn_inputs),
     )
 
     cfg = module.Config(
@@ -518,18 +443,12 @@ def test_main_runs_sampling_and_training_with_reference(monkeypatch, tmp_path):
         prompt_groups_per_step=1,
         router_replay=True,
         trajectory_dir=str(tmp_path),
-        weight_sync=module.WeightSyncConfig(
-            weight_sync_interval=1,
-            dcp_save_interval=1,
-            weight_sync_before_training=True,
-        ),
+        weight_sync=module.WeightSyncConfig(weight_sync_interval=1, dcp_save_interval=1, weight_sync_before_training=True),
         deployment=module.DeployConfig(
             deployment_id="dep-123",
             tokenizer_model="Qwen/Qwen3-4B",
         ),
-        infra=module.InfraConfig(
-            training_shape_id="shape-a", ref_training_shape_id="ref-shape"
-        ),
+        infra=module.InfraConfig(training_shape_id="shape-a", ref_training_shape_id="ref-shape"),
     )
 
     result = module.main(

--- a/training/tests/unit/test_rl_loop.py
+++ b/training/tests/unit/test_rl_loop.py
@@ -16,14 +16,24 @@ def test_extract_answer_reads_digits_from_answer_block():
 
 
 def test_reward_fn_requires_matching_numeric_answer():
-    assert module.reward_fn("<answer>7</answer>", {"ground_truth": "<answer>7</answer>"}) == 1.0
-    assert module.reward_fn("<answer>8</answer>", {"ground_truth": "<answer>7</answer>"}) == 0.0
+    assert (
+        module.reward_fn("<answer>7</answer>", {"ground_truth": "<answer>7</answer>"})
+        == 1.0
+    )
+    assert (
+        module.reward_fn("<answer>8</answer>", {"ground_truth": "<answer>7</answer>"})
+        == 0.0
+    )
     assert module.reward_fn("missing", {"ground_truth": "<answer>7</answer>"}) == 0.0
 
 
 def test_should_accept_requires_reward_variance():
-    same_rewards = PromptGroup(data=[], advantages=[], ref_logprobs=[], prompt_len=0, rewards=[0.0, 0.0])
-    varied_rewards = PromptGroup(data=[], advantages=[], ref_logprobs=[], prompt_len=0, rewards=[0.0, 1.0])
+    same_rewards = PromptGroup(
+        data=[], advantages=[], ref_logprobs=[], prompt_len=0, rewards=[0.0, 0.0]
+    )
+    varied_rewards = PromptGroup(
+        data=[], advantages=[], ref_logprobs=[], prompt_len=0, rewards=[0.0, 1.0]
+    )
 
     assert module.should_accept(same_rewards) is False
     assert module.should_accept(varied_rewards) is True
@@ -151,20 +161,39 @@ def test_main_bootstraps_without_reference_and_cleans_up(monkeypatch):
         return 0
 
     monkeypatch.setattr(module, "setup_wandb", lambda *args, **kwargs: None)
-    monkeypatch.setattr(module, "wandb_finish", lambda: events.__setitem__("wandb_finished", 1))
-    monkeypatch.setattr(module, "wandb_log", lambda payload, step=0: events["wandb_logs"].append((step, payload)))
-    monkeypatch.setattr(module, "setup_deployment", lambda *args, **kwargs: SimpleNamespace(inference_model="accounts/test/models/deployed"))
+    monkeypatch.setattr(
+        module, "wandb_finish", lambda: events.__setitem__("wandb_finished", 1)
+    )
+    monkeypatch.setattr(
+        module,
+        "wandb_log",
+        lambda payload, step=0: events["wandb_logs"].append((step, payload)),
+    )
+    monkeypatch.setattr(
+        module,
+        "setup_deployment",
+        lambda *args, **kwargs: SimpleNamespace(
+            inference_model="accounts/test/models/deployed"
+        ),
+    )
     monkeypatch.setattr(
         module,
         "create_trainer_job",
-        lambda *args, **kwargs: events["create_trainer_job"].append(kwargs) or SimpleNamespace(job_id="policy-job"),
+        lambda *args, **kwargs: (
+            events["create_trainer_job"].append(kwargs)
+            or SimpleNamespace(job_id="policy-job")
+        ),
     )
     monkeypatch.setattr(module, "ReconnectableClient", FakePolicyClient)
-    monkeypatch.setattr(transformers.AutoTokenizer, "from_pretrained", lambda *args, **kwargs: object())
+    monkeypatch.setattr(
+        transformers.AutoTokenizer, "from_pretrained", lambda *args, **kwargs: object()
+    )
     monkeypatch.setattr(module, "DeploymentSampler", FakeSampler)
     monkeypatch.setattr(module, "WeightSyncer", FakeWeightSyncer)
     monkeypatch.setattr(module, "load_jsonl_dataset", lambda *args, **kwargs: [])
-    monkeypatch.setattr(module, "build_loss_fn", lambda **kwargs: ("loss-builder", kwargs))
+    monkeypatch.setattr(
+        module, "build_loss_fn", lambda **kwargs: ("loss-builder", kwargs)
+    )
     monkeypatch.setattr(module, "run_rl_loop", fake_run_rl_loop)
 
     cfg = module.Config(
@@ -194,7 +223,10 @@ def test_main_bootstraps_without_reference_and_cleans_up(monkeypatch):
     assert events["create_trainer_job"][0]["hot_load_deployment_id"] == "dep-123"
     assert events["sampler_init"]["model"] == "accounts/test/models/deployed"
     assert events["weight_syncer_init"]["deployment_id"] == "dep-123"
-    assert events["run_loop_kwargs"]["prompt_groups_per_step"] == cfg.prompt_groups_per_step
+    assert (
+        events["run_loop_kwargs"]["prompt_groups_per_step"]
+        == cfg.prompt_groups_per_step
+    )
     assert events["deleted_jobs"] == ["policy-job"]
     assert events["scaled_deployments"] == ["dep-123"]
     assert events["wandb_finished"] == 0
@@ -272,14 +304,12 @@ def test_main_runs_sampling_and_training_with_reference(monkeypatch, tmp_path):
             if self.job_id == "reference-job":
                 return SimpleNamespace(
                     loss_fn_outputs=[
-                        {"logprobs": SimpleNamespace(data=[-0.11, -0.12])}
-                        for _ in data
+                        {"logprobs": SimpleNamespace(data=[-0.11, -0.12])} for _ in data
                     ]
                 )
             return SimpleNamespace(
                 loss_fn_outputs=[
-                    {"logprobs": SimpleNamespace(data=[-0.21, -0.22])}
-                    for _ in data
+                    {"logprobs": SimpleNamespace(data=[-0.21, -0.22])} for _ in data
                 ]
             )
 
@@ -386,42 +416,85 @@ def test_main_runs_sampling_and_training_with_reference(monkeypatch, tmp_path):
         return _builder
 
     monkeypatch.setattr(module, "setup_wandb", lambda *args, **kwargs: None)
-    monkeypatch.setattr(module, "wandb_finish", lambda: events.__setitem__("wandb_finished", 1))
-    monkeypatch.setattr(module, "wandb_log", lambda payload, step=0: events["wandb_logs"].append((step, payload)))
-    monkeypatch.setattr(module, "log_metrics_json", lambda step, **kwargs: events.setdefault("metrics_logs", []).append((step, kwargs)))
-    monkeypatch.setattr(module, "setup_deployment", lambda *args, **kwargs: SimpleNamespace(inference_model="accounts/test/models/deployed"))
+    monkeypatch.setattr(
+        module, "wandb_finish", lambda: events.__setitem__("wandb_finished", 1)
+    )
+    monkeypatch.setattr(
+        module,
+        "wandb_log",
+        lambda payload, step=0: events["wandb_logs"].append((step, payload)),
+    )
+    monkeypatch.setattr(
+        module,
+        "log_metrics_json",
+        lambda step, **kwargs: events.setdefault("metrics_logs", []).append(
+            (step, kwargs)
+        ),
+    )
+    monkeypatch.setattr(
+        module,
+        "setup_deployment",
+        lambda *args, **kwargs: SimpleNamespace(
+            inference_model="accounts/test/models/deployed"
+        ),
+    )
     monkeypatch.setattr(module, "ThreadPoolExecutor", FakeThreadPoolExecutor)
     monkeypatch.setattr(module, "create_trainer_job", fake_create_trainer_job)
     monkeypatch.setattr(module, "ReconnectableClient", FakeClient)
-    monkeypatch.setattr(transformers.AutoTokenizer, "from_pretrained", lambda *args, **kwargs: object())
+    monkeypatch.setattr(
+        transformers.AutoTokenizer, "from_pretrained", lambda *args, **kwargs: object()
+    )
     monkeypatch.setattr(module, "DeploymentSampler", FakeSampler)
     monkeypatch.setattr(module, "WeightSyncer", FakeWeightSyncer)
     from training.utils.checkpoint_utils import ResumeInfo
-    monkeypatch.setattr(module, "resolve_resume", lambda *args, **kwargs: ResumeInfo(step=0))
-    monkeypatch.setattr(module, "load_jsonl_dataset", lambda *args, **kwargs: [
-        {
-            "messages": [
-                {"role": "system", "content": "sys"},
-                {"role": "user", "content": "Solve"},
-                {"role": "assistant", "content": "prior"},
-            ],
-            "ground_truth": "<answer>7</answer>",
-        }
-    ])
+
+    monkeypatch.setattr(
+        module, "resolve_resume", lambda *args, **kwargs: ResumeInfo(step=0)
+    )
+    monkeypatch.setattr(
+        module,
+        "load_jsonl_dataset",
+        lambda *args, **kwargs: [
+            {
+                "messages": [
+                    {"role": "system", "content": "sys"},
+                    {"role": "user", "content": "Solve"},
+                    {"role": "assistant", "content": "prior"},
+                ],
+                "ground_truth": "<answer>7</answer>",
+            }
+        ],
+    )
     monkeypatch.setattr(module, "build_loss_fn", fake_build_loss_fn)
     monkeypatch.setattr(module, "run_rl_loop", fake_run_rl_loop)
-    monkeypatch.setattr(module, "compute_pp_recommendation", lambda *args, **kwargs: SimpleNamespace(recommended_prompts_per_step=3))
-    monkeypatch.setattr(module, "compute_step_metrics", lambda **kwargs: {
-        "rollout/reward": 0.5,
-        "rollout/accuracy": 0.5,
-        "train/mean_kl": 0.02,
-    })
+    monkeypatch.setattr(
+        module,
+        "compute_pp_recommendation",
+        lambda *args, **kwargs: SimpleNamespace(recommended_prompts_per_step=3),
+    )
+    monkeypatch.setattr(
+        module,
+        "compute_step_metrics",
+        lambda **kwargs: {
+            "rollout/reward": 0.5,
+            "rollout/accuracy": 0.5,
+            "train/mean_kl": 0.02,
+        },
+    )
     monkeypatch.setattr(module, "flush_timing", lambda: {"perf/step_time": 1.0})
-    monkeypatch.setattr(module, "build_r3_routing_matrices", lambda *args, **kwargs: events["routing_matrix_calls"].append((args, kwargs)) or {"rm": True})
+    monkeypatch.setattr(
+        module,
+        "build_r3_routing_matrices",
+        lambda *args, **kwargs: (
+            events["routing_matrix_calls"].append((args, kwargs)) or {"rm": True}
+        ),
+    )
     monkeypatch.setattr(
         module.tinker.ModelInput,
         "from_ints",
-        lambda ints, routing_matrices=None: SimpleNamespace(tokens=list(ints), routing_matrices=routing_matrices),
+        lambda ints, routing_matrices=None: SimpleNamespace(
+            tokens=list(ints), routing_matrices=routing_matrices
+        ),
     )
     monkeypatch.setattr(
         module.tinker,
@@ -431,7 +504,9 @@ def test_main_runs_sampling_and_training_with_reference(monkeypatch, tmp_path):
     monkeypatch.setattr(
         module.tinker,
         "Datum",
-        lambda model_input, loss_fn_inputs: SimpleNamespace(model_input=model_input, loss_fn_inputs=loss_fn_inputs),
+        lambda model_input, loss_fn_inputs: SimpleNamespace(
+            model_input=model_input, loss_fn_inputs=loss_fn_inputs
+        ),
     )
 
     cfg = module.Config(
@@ -443,12 +518,18 @@ def test_main_runs_sampling_and_training_with_reference(monkeypatch, tmp_path):
         prompt_groups_per_step=1,
         router_replay=True,
         trajectory_dir=str(tmp_path),
-        weight_sync=module.WeightSyncConfig(weight_sync_interval=1, dcp_save_interval=1, weight_sync_before_training=True),
+        weight_sync=module.WeightSyncConfig(
+            weight_sync_interval=1,
+            dcp_save_interval=1,
+            weight_sync_before_training=True,
+        ),
         deployment=module.DeployConfig(
             deployment_id="dep-123",
             tokenizer_model="Qwen/Qwen3-4B",
         ),
-        infra=module.InfraConfig(training_shape_id="shape-a", ref_training_shape_id="ref-shape"),
+        infra=module.InfraConfig(
+            training_shape_id="shape-a", ref_training_shape_id="ref-shape"
+        ),
     )
 
     result = module.main(

--- a/training/utils/__init__.py
+++ b/training/utils/__init__.py
@@ -12,6 +12,7 @@ __all__ = [
     "WeightSyncConfig",
     "InfraConfig",
     "ReconnectableClient",
+    "build_base_model_reference_id",
     "ResourceCleanup",
     "RewardFn",
     "RLPromptDataset",
@@ -72,7 +73,7 @@ from training.utils.infra import (
     setup_training_client,
 )
 from training.utils.timer import timed, timer, flush_timing
-from training.utils.client import ReconnectableClient
+from training.utils.client import ReconnectableClient, build_base_model_reference_id
 from training.utils.config import (
     DEFAULT_ADAM,
     EvalFn,

--- a/training/utils/client.py
+++ b/training/utils/client.py
@@ -15,10 +15,15 @@ from __future__ import annotations
 import logging
 import os
 
-from fireworks.training.sdk.client import FiretitanServiceClient, FiretitanTrainingClient
+from fireworks.training.sdk.client import (
+    FiretitanServiceClient,
+    FiretitanTrainingClient,
+)
 from fireworks.training.sdk.trainer import TrainerJobManager, TrainerServiceEndpoint
 import tinker.lib.api_future_impl as tinker_api_future_impl
-from tinker.types.future_retrieve_request import FutureRetrieveRequest as _FutureRetrieveRequest
+from tinker.types.future_retrieve_request import (
+    FutureRetrieveRequest as _FutureRetrieveRequest,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -27,6 +32,9 @@ DEFAULT_TIMEOUT_S: int = 600
 
 DCP_TIMEOUT_S: int = 2700
 """Default timeout for save_state / load_state_with_optimizer (45 min)."""
+
+BASE_MODEL_REFERENCE_PREFIX = "base::"
+"""Prefix for model_ids that should run with LoRA adapters disabled."""
 
 
 def _install_tinker_future_retrieve_compat() -> None:
@@ -43,6 +51,11 @@ def _install_tinker_future_retrieve_compat() -> None:
 
 
 _install_tinker_future_retrieve_compat()
+
+
+def build_base_model_reference_id(base_model: str) -> str:
+    """Return a model_id that routes LoRA trainers through the frozen base model."""
+    return f"{BASE_MODEL_REFERENCE_PREFIX}{base_model}"
 
 
 class ReconnectableClient:
@@ -63,6 +76,7 @@ class ReconnectableClient:
         fw_api_key: str | None = None,
         default_timeout: int = DEFAULT_TIMEOUT_S,
         endpoint: TrainerServiceEndpoint | None = None,
+        model_id_override: str | None = None,
     ):
         self._rlor_mgr = rlor_mgr
         self._job_id = job_id
@@ -71,6 +85,7 @@ class ReconnectableClient:
         self._api_key = api_key
         self._fw_api_key = fw_api_key or os.environ.get("FIREWORKS_API_KEY")
         self._default_timeout = default_timeout
+        self._model_id_override = model_id_override
         self._endpoint: TrainerServiceEndpoint | None = None
         self._client: FiretitanTrainingClient | None = None
         if endpoint:
@@ -113,16 +128,45 @@ class ReconnectableClient:
     def load_state_with_optimizer(self, path: str, timeout: int = DCP_TIMEOUT_S):
         return self._client.load_state_with_optimizer(path).result(timeout=timeout)
 
-    def save_weights_for_sampler_ext(self, name: str, checkpoint_type: str | None = None, timeout: int = DCP_TIMEOUT_S):
-        return self.inner.save_weights_for_sampler_ext(name, checkpoint_type=checkpoint_type)
+    def save_weights_for_sampler_ext(
+        self,
+        name: str,
+        checkpoint_type: str | None = None,
+        timeout: int = DCP_TIMEOUT_S,
+    ):
+        return self.inner.save_weights_for_sampler_ext(
+            name, checkpoint_type=checkpoint_type
+        )
 
-    def resolve_checkpoint_path(self, name: str, source_job_id: str | None = None) -> str:
+    def resolve_checkpoint_path(
+        self, name: str, source_job_id: str | None = None
+    ) -> str:
         return self.inner.resolve_checkpoint_path(name, source_job_id=source_job_id)
 
     def list_checkpoints(self) -> list[str]:
         return self.inner.list_checkpoints()
 
     # -- Internal --------------------------------------------------------------
+
+    def _build_training_client(
+        self,
+        svc: FiretitanServiceClient,
+    ) -> FiretitanTrainingClient:
+        if self._model_id_override is not None:
+            logger.info(
+                "Using manual model_id override '%s' for job %s",
+                self._model_id_override,
+                self._job_id,
+            )
+            return FiretitanTrainingClient(
+                holder=svc.holder,
+                model_seq_id=svc.holder.get_training_client_id(),
+                model_id=self._model_id_override,
+            )
+        return svc.create_training_client(
+            base_model=self._base_model,
+            lora_rank=self._lora_rank,
+        )
 
     def _use_endpoint(self, ep: TrainerServiceEndpoint) -> None:
         kwargs: dict = {}
@@ -132,12 +176,11 @@ class ReconnectableClient:
                 "Authorization": f"Bearer {self._fw_api_key}",
             }
         svc = FiretitanServiceClient(
-            base_url=ep.base_url, api_key=self._api_key, **kwargs,
+            base_url=ep.base_url,
+            api_key=self._api_key,
+            **kwargs,
         )
-        self._client = svc.create_training_client(
-            base_model=self._base_model,
-            lora_rank=self._lora_rank,
-        )
+        self._client = self._build_training_client(svc)
         self._endpoint = ep
 
     def _connect(self) -> None:


### PR DESCRIPTION
## Summary
- reuse the policy trainer for LoRA GRPO reference forwards by opening a base-model reference client on the same trainer instead of launching a second forward-only job
- preserve the existing explicit reference path when a reference job, base URL, or reference training shape is provided, and mirror the same reuse logic in the FrozenLake GRPO example
- add unit coverage for the manual `model_id` override path and the LoRA reference reuse flow, and extend the GRPO smoke harness so it can validate LoRA reuse with env-driven resource overrides

## Testing
- [x] `uvx ruff check training/utils/__init__.py training/utils/client.py training/recipes/rl_loop.py training/examples/frozen_lake/train_frozen_lake.py training/tests/smoke_test/test_grpo_smoke.py training/tests/unit/test_client.py training/tests/unit/test_rl_loop.py --ignore E402`
- [x] `../.venv/bin/python -m pytest tests/unit/test_client.py tests/unit/test_rl_loop.py tests/test_smoke_imports.py -q`
- [ ] `../.venv/bin/python -m pytest tests/smoke_test/test_grpo_smoke.py -q -s`

## Notes
- the remote GRPO smoke harness now accepts LoRA-specific env overrides (`FIREWORKS_SMOKE_GRPO_*`) so the reuse path can be exercised either with a fresh validated shape or with pre-created policy/deployment resources
- I attempted the remote LoRA smoke earlier, but fresh launches were blocked by validated `LORA_TRAINER` shape availability on the account and a pre-created trainer I could reuse was short-lived; the local unit coverage here is green, and the smoke harness changes are included so the live check can be retried from a compatible environment

## Diagram
```mermaid
flowchart LR
    A[GRPO config] --> B{LoRA + grpo + kl_beta != 0\nwithout explicit reference config}
    B -- yes --> C[Create policy trainer once]
    C --> D[Policy client]
    C --> E[Base-model reference client\non same trainer]
    D --> F[forward/backward + optim step]
    E --> G[reference logprobs\nwith LoRA adapters disabled]
    B -- no --> H[Existing separate reference path]
```

Made with [Cursor](https://cursor.com)