### PR TITLE
fix: clean up sft getting-started defaults

### DIFF
--- a/training/examples/sft_getting_started/train_sft.py
+++ b/training/examples/sft_getting_started/train_sft.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""SFT training on DeepMath dataset with ground-truth answers."""
+"""SFT getting-started example for the bundled text2sql dataset."""
 
 from __future__ import annotations
 
@@ -36,11 +36,14 @@ def _signal_handler(signum, frame):
 
 
 def parse_args():
-    parser = argparse.ArgumentParser(description="SFT on DeepMath")
+    parser = argparse.ArgumentParser(description="SFT on the bundled text2sql dataset")
     parser.add_argument("--output-model-id", type=str, required=True, help="Final output model name")
     parser.add_argument("--base-model", default="accounts/fireworks/models/qwen3-8b")
     parser.add_argument("--tokenizer-model", default="Qwen/Qwen3-8B")
-    parser.add_argument("--dataset-path", default=os.path.join(os.path.dirname(__file__), "sft_dataset.jsonl"))
+    parser.add_argument(
+        "--dataset-path",
+        default=os.path.join(os.path.dirname(__file__), "text2sql_dataset.jsonl"),
+    )
     parser.add_argument("--training-shape", default="")
     parser.add_argument("--region", default="US_VIRGINIA_1")
     parser.add_argument("--max-examples", type=int, default=500)
@@ -58,10 +61,13 @@ def main():
     signal.signal(signal.SIGINT, _signal_handler)
 
     args = parse_args()
-    logger.info("SFT DeepMath training: model=%s shape=%s", args.base_model, args.training_shape)
+    logger.info("SFT text2sql training: model=%s shape=%s", args.base_model, args.training_shape)
 
     if not os.path.exists(args.dataset_path):
-        raise FileNotFoundError(f"Dataset not found at {args.dataset_path}. Run prepare_sft_data.py first.")
+        raise FileNotFoundError(
+            f"Dataset not found at {args.dataset_path}. "
+            "Use the bundled text2sql_dataset.jsonl or pass --dataset-path explicitly."
+        )
 
     os.environ["FIREWORKS_API_KEY"] = FIREWORKS_API_KEY
     os.environ["FIREWORKS_ACCOUNT_ID"] = FIREWORKS_ACCOUNT_ID

--- a/training/tests/unit/test_text2sql_train_sft.py
+++ b/training/tests/unit/test_text2sql_train_sft.py
@@ -63,12 +63,21 @@ def test_parse_args_reads_overrides(monkeypatch):
     assert args.lora_rank == 8
 
 
+def test_parse_args_uses_bundled_text2sql_dataset_by_default(monkeypatch):
+    module = _load_module(monkeypatch)
+    monkeypatch.setattr(sys, "argv", ["train_sft.py", "--output-model-id", "out-model"])
+
+    args = module.parse_args()
+
+    assert os.path.basename(args.dataset_path) == "text2sql_dataset.jsonl"
+
+
 def test_main_raises_when_dataset_is_missing(monkeypatch):
     module = _load_module(monkeypatch)
     monkeypatch.setattr(sys, "argv", ["train_sft.py", "--dataset-path", "/tmp/missing.jsonl", "--output-model-id", "out"])
     monkeypatch.setattr(module.os.path, "exists", lambda path: False)
 
-    with pytest.raises(FileNotFoundError, match="Dataset not found"):
+    with pytest.raises(FileNotFoundError, match="text2sql_dataset.jsonl|Dataset not found"):
         module.main()
 
 


### PR DESCRIPTION
Fixes FIR2-1131.

Summary:
- default the getting-started SFT example to the bundled `text2sql_dataset.jsonl`
- remove stale DeepMath/`prepare_sft_data.py` wording from the example
- add unit coverage for the default dataset path and missing-dataset guidance

Test:
- /Users/bennychen/Documents/cookbook/training/.venv/bin/pytest -q training/tests/unit/test_text2sql_train_sft.py