### PR TITLE
fix: point deepmath launcher at validated grpo path

### DIFF
--- a/training/examples/deepmath_rl/run.sh
+++ b/training/examples/deepmath_rl/run.sh
@@ -1,18 +1,9 @@
-HERE=$(dirname $(realpath $0))
-echo $HERE
+#!/usr/bin/env bash
+set -euo pipefail
 
-export PYTHONPATH=$PYTHONPATH:$HERE/../../../../../
-echo $PYTHONPATH
-python train_deepmath.py \
-    --base-model accounts/fireworks/models/qwen3-4b \
-    --tokenizer-model Qwen/Qwen3-4b \
-    --dataset-path dataset.jsonl \
-    --training-shape qwen3-4b-minimum-h200 \
-    --deployment-id deepmath-qwen3-4b-$(date +%s) \
-    --region US_VIRGINIA_1 \
-    --max-rows 500 \
-    --epochs 3 \
-    --completions-per-prompt 8 \
-    --learning-rate 1e-5 \
-    --kl-beta 0.001 \
-    --output-model-id deepmath-qwen3-4b-$(date +%s)
+# Keep the default DeepMath launcher on a validated GRPO shape pair.
+# The older qwen3-4b launcher path is not currently runnable for the
+# public GRPO flow because it lacks a working policy/reference shape set.
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+exec "$HERE/run_qwen3_30b_a3b.sh" "$@"

--- a/training/tests/unit/test_train_deepmath.py
+++ b/training/tests/unit/test_train_deepmath.py
@@ -114,6 +114,8 @@ def test_main_builds_rl_config_and_calls_recipe(monkeypatch):
             dataset_path,
             "--training-shape",
             "ts-qwen3-4b-smoke-v1",
+            "--ref-training-shape",
+            "ts-qwen3-4b-smoke-v1-ref",
             "--deployment-id",
             "dep-123",
             "--region",
@@ -200,6 +202,7 @@ def test_main_builds_rl_config_and_calls_recipe(monkeypatch):
     assert cfg.router_replay_completion_only is True
     assert cfg.is_correction.tis_cap == 2.0
     assert cfg.infra.training_shape_id == "ts-qwen3-4b-smoke-v1"
+    assert cfg.infra.ref_training_shape_id == "ts-qwen3-4b-smoke-v1-ref"
     assert cfg.infra.region == "US_OHIO_1"
     assert cfg.deployment.deployment_id == "dep-123"
     assert cfg.deployment.deployment_region == "US_VIRGINIA_1"


### PR DESCRIPTION
Fixes FIR2-1141.

Summary:
- stop shipping the stale qwen3-4b DeepMath launcher as the default `run.sh`
- delegate the default launcher to the validated qwen3-30b-a3b GRPO script that provides both policy and reference shapes
- add unit coverage that the example still threads `--ref-training-shape` into `InfraConfig`

Test:
- /Users/bennychen/Documents/cookbook/training/.venv/bin/pytest -q training/tests/unit/test_train_deepmath.py
- bash -n training/examples/deepmath_rl/run.sh training/examples/deepmath_rl/run_qwen3_30b_a3b.sh