### PR TITLE
Fix FrozenLake RL loop call signature

### DIFF
--- a/training/examples/frozen_lake/train_frozen_lake.py
+++ b/training/examples/frozen_lake/train_frozen_lake.py
@@ -766,7 +766,6 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
                 sample_fns=(sample_one_prompt(ctx) for ctx in all_prompts),
                 train_fns=train_fns,
                 prompt_groups_per_step=prompt_groups_per_step,
-                max_concurrent=cfg.max_concurrent,
                 dynamic_filter_fn=should_accept,
                 global_step=step_offset,
                 metrics_callback=_filtered_step_callback,

--- a/training/tests/unit/test_train_frozen_lake.py
+++ b/training/tests/unit/test_train_frozen_lake.py
@@ -308,6 +308,7 @@ def test_main_bootstraps_without_reference_and_cleans_up(monkeypatch):
     assert events["rollout_processor_init"]["allow_plaintext_action_fallback"] is True
     assert events["run_rl_loop_kwargs"]["prompt_groups_per_step"] == 4
     assert "train_fns" in events["run_rl_loop_kwargs"]
+    assert "max_concurrent" not in events["run_rl_loop_kwargs"]
     assert events["deleted_jobs"] == ["policy-job"]
     assert events["deleted_deployments"] == []
     assert events["wandb_finished"] == 1


### PR DESCRIPTION
## Summary
- stop passing the removed `max_concurrent` kwarg into `run_rl_loop`
- add unit coverage that the FrozenLake example uses the current RL loop API

## Testing
- `env PYTHONPATH=/tmp/cookbook-frozenlake-loop /Users/bennychen/Documents/cookbook/training/.venv/bin/pytest -q training/tests/unit/test_train_frozen_lake.py`

## Validation
- reran the tiny public FrozenLake smoke on Qwen3-4B with `accounts/fireworks/trainingShapes/qwen3-4b-minimum-h200`
- the run completed from deployment create -> trainer boot -> rollout sampling -> cleanup
- this tiny smoke finished with `0` optimizer steps because the only prompt group was filtered out, but the cookbook path exited successfully
