### PR TITLE
Infer rollout region from deployment shape accelerator

### DIFF
--- a/training/tests/unit/test_infra.py
+++ b/training/tests/unit/test_infra.py
@@ -23,17 +23,33 @@ def test_setup_deployment_omits_placement_for_shape_backed_create():
     captured = {}
 
     class FakeResponse:
+        def __init__(self, payload=None):
+            self._payload = payload or {"name": "accounts/acct/deployments/dep-123", "state": "CREATING"}
+
         def raise_for_status(self):
             return None
 
         def json(self):
-            return {"name": "accounts/acct/deployments/dep-123", "state": "CREATING"}
+            return self._payload
 
     class FakeMgr:
         account_id = "acct"
 
         def get(self, _deployment_id):
             return None
+
+        def _get(self, path, timeout):
+            captured["shape_path"] = path
+            captured["shape_timeout"] = timeout
+            return FakeResponse(
+                {
+                    "deploymentShapeVersions": [
+                        {
+                            "snapshot": {},
+                        }
+                    ]
+                }
+            )
 
         def _post(self, path, json, timeout):
             captured["path"] = path
@@ -58,6 +74,110 @@ def test_setup_deployment_omits_placement_for_shape_backed_create():
     )
 
     assert info.state == "READY"
+    assert captured["shape_timeout"] == 30
     assert captured["timeout"] == 60
     assert captured["json"]["deploymentShape"] == "accounts/fireworks/deploymentShapes/rft-kimi-k2p5-v2"
     assert "placement" not in captured["json"]
+
+
+def test_setup_deployment_infers_ohio_for_b200_shape():
+    captured = {}
+
+    class FakeResponse:
+        def __init__(self, payload):
+            self._payload = payload
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return self._payload
+
+    class FakeMgr:
+        account_id = "acct"
+
+        def get(self, _deployment_id):
+            return None
+
+        def _get(self, path, timeout):
+            captured["shape_path"] = path
+            captured["shape_timeout"] = timeout
+            return FakeResponse(
+                {
+                    "deploymentShapeVersions": [
+                        {
+                            "snapshot": {"acceleratorType": "NVIDIA_B200_180GB"},
+                        }
+                    ]
+                }
+            )
+
+        def create_or_get(self, config):
+            captured["config"] = config
+            return SimpleNamespace(deployment_id=config.deployment_id, state="READY")
+
+    info = setup_deployment(
+        FakeMgr(),
+        DeployConfig(
+            deployment_id="dep-123",
+            deployment_shape="accounts/fireworks/deploymentShapes/rft-kimi-k2p5-v2",
+        ),
+        "accounts/fireworks/models/kimi-k2p5",
+        InfraConfig(region="US_VIRGINIA_1"),
+    )
+
+    assert info.state == "READY"
+    assert captured["shape_timeout"] == 30
+    assert captured["shape_path"].startswith(
+        "/v1/accounts/fireworks/deploymentShapes/rft-kimi-k2p5-v2/versions?"
+    )
+    assert "pageSize=1" in captured["shape_path"]
+    assert captured["config"].region == "US_OHIO_1"
+
+
+def test_setup_deployment_infers_virginia_for_versioned_h200_shape():
+    captured = {}
+
+    class FakeResponse:
+        def __init__(self, payload):
+            self._payload = payload
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return self._payload
+
+    class FakeMgr:
+        account_id = "acct"
+
+        def get(self, _deployment_id):
+            return None
+
+        def _get(self, path, timeout):
+            captured["shape_path"] = path
+            captured["shape_timeout"] = timeout
+            return FakeResponse(
+                {
+                    "snapshot": {"acceleratorType": "NVIDIA_H200_141GB"},
+                }
+            )
+
+        def create_or_get(self, config):
+            captured["config"] = config
+            return SimpleNamespace(deployment_id=config.deployment_id, state="READY")
+
+    info = setup_deployment(
+        FakeMgr(),
+        DeployConfig(
+            deployment_id="dep-456",
+            deployment_shape="accounts/fireworks/deploymentShapes/qwen-h200/versions/rv1",
+        ),
+        "accounts/fireworks/models/qwen3-4b",
+        InfraConfig(),
+    )
+
+    assert info.state == "READY"
+    assert captured["shape_path"] == "/v1/accounts/fireworks/deploymentShapes/qwen-h200/versions/rv1"
+    assert captured["shape_timeout"] == 30
+    assert captured["config"].region == "US_VIRGINIA_1"

--- a/training/utils/infra.py
+++ b/training/utils/infra.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import time
 import logging
 from typing import Any
+from urllib.parse import urlencode
 
 from fireworks.training.sdk.client import (
     FiretitanServiceClient,
@@ -20,6 +21,11 @@ from fireworks.training.sdk.deployment import DeploymentConfig, DeploymentInfo, 
 from training.utils.config import InfraConfig, DeployConfig
 
 logger = logging.getLogger(__name__)
+
+_DEPLOYMENT_ACCELERATOR_REGION_PREFIXES: tuple[tuple[str, str], ...] = (
+    ("NVIDIA_H200", "US_VIRGINIA_1"),
+    ("NVIDIA_B200", "US_OHIO_1"),
+)
 
 
 class ResourceCleanup:
@@ -180,6 +186,10 @@ def setup_deployment(
     info = deploy_mgr.get(deploy_cfg.deployment_id)
     if not info:
         dep_config = deploy_cfg.to_deployment_config(base_model, infra)
+        if dep_config.region is None and dep_config.deployment_shape:
+            dep_config.region = _infer_region_from_deployment_shape(
+                deploy_mgr, dep_config.deployment_shape
+            )
         if dep_config.region is None:
             info = _create_deployment_via_cookbook(deploy_mgr, dep_config)
         else:
@@ -191,6 +201,62 @@ def setup_deployment(
             timeout_s=deploy_cfg.deployment_timeout_s,
         )
     return info
+
+
+def _infer_region_from_deployment_shape(
+    deploy_mgr: DeploymentManager,
+    deployment_shape: str,
+) -> str | None:
+    """Infer a rollout region from a validated deployment shape snapshot."""
+    version = _get_deployment_shape_version(deploy_mgr, deployment_shape)
+    snapshot = version.get("snapshot", {}) or {}
+    accelerator = snapshot.get("acceleratorType", "")
+    for prefix, region in _DEPLOYMENT_ACCELERATOR_REGION_PREFIXES:
+        if accelerator.startswith(prefix):
+            logger.info(
+                "Inferred deployment region %s from deployment shape %s (accelerator=%s)",
+                region,
+                deployment_shape,
+                accelerator,
+            )
+            return region
+    if accelerator:
+        logger.info(
+            "No cookbook deployment-region override for deployment shape %s (accelerator=%s); using auto placement",
+            deployment_shape,
+            accelerator,
+        )
+    else:
+        logger.info(
+            "Deployment shape %s returned no accelerator type; using auto placement",
+            deployment_shape,
+        )
+    return None
+
+
+def _get_deployment_shape_version(
+    deploy_mgr: DeploymentManager,
+    deployment_shape: str,
+) -> dict[str, Any]:
+    """Fetch an exact or latest-validated deployment-shape version."""
+    if "/versions/" in deployment_shape:
+        path = f"/v1/{deployment_shape}"
+    else:
+        path = (
+            f"/v1/{deployment_shape}/versions?"
+            f"{urlencode({'filter': 'latest_validated=true', 'pageSize': 1})}"
+        )
+    resp = deploy_mgr._get(path, timeout=30)
+    resp.raise_for_status()
+    data = resp.json()
+    if "/versions/" in deployment_shape:
+        return data
+    versions = data.get("deploymentShapeVersions", []) or []
+    if not versions:
+        raise RuntimeError(
+            f"No latest validated deployment-shape version was returned for '{deployment_shape}'"
+        )
+    return versions[0]
 
 
 def _create_deployment_via_cookbook(


### PR DESCRIPTION
## Summary
- infer rollout region for shape-backed deployments from the resolved deployment shape snapshot
- map H200 shapes to `US_VIRGINIA_1` and B200 shapes to `US_OHIO_1` when the user does not set `deployment_region`
- keep the existing auto-placement fallback when the shape does not expose a mapped accelerator

## Testing
- env PYTHONPATH=/tmp/cookbook-shape-region-inference /Users/bennychen/Documents/cookbook/training/.venv/bin/pytest -q training/tests/unit/test_infra.py training/tests/unit/test_train_frozen_lake.py

## Runtime verification
- created `kimi-k2p5-inferred-1773682748` through `training.utils.infra.setup_deployment()` with no explicit region
- confirmed cookbook inferred `US_OHIO_1` from `accounts/fireworks/deploymentShapes/rft-kimi-k2p5-v2`
- verified direct completions moved from transient `503 no healthy upstream` during model init to `200` once the rollout reached `READY`