### PR TITLE
Fix DeepMath GRPO run script

### DIFF
--- a/training/examples/deepmath_rl/run.sh
+++ b/training/examples/deepmath_rl/run.sh
@@ -1,13 +1,15 @@
-HERE=$(dirname $(realpath $0))
-echo $HERE
+#!/usr/bin/env bash
+set -euo pipefail
 
-export PYTHONPATH=$PYTHONPATH:$HERE/../../../../../
-echo $PYTHONPATH
-python train_deepmath.py \
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+export PYTHONPATH="${REPO_ROOT}:${PYTHONPATH:-}"
+
+python "$HERE/train_deepmath.py" \
     --base-model accounts/fireworks/models/qwen3-4b \
-    --tokenizer-model Qwen/Qwen3-4b \
-    --dataset-path dataset.jsonl \
-    --training-shape acounts/fireworks/trainingShapes/qwen3-4b-minimum-h200 \
+    --tokenizer-model Qwen/Qwen3-4B \
+    --dataset-path "$HERE/dataset.jsonl" \
+    --training-shape accounts/fireworks/trainingShapes/qwen3-4b-minimum-h200 \
     --ref-training-shape accounts/fireworks/trainingShapes/qwen3-4b-minimum-h200-forward \
     --deployment-id deepmath-qwen3-4b-$(date +%s) \
     --region US_VIRGINIA_1 \


### PR DESCRIPTION
## Summary
- fix the broken `training_shape` path in `training/examples/deepmath_rl/run.sh`
- normalize the tokenizer name to `Qwen/Qwen3-4B`
- make the script robust to the caller's working directory by using repo-relative absolute paths
- add a proper bash shebang and `set -euo pipefail`

## Validation
- `bash -n training/examples/deepmath_rl/run.sh`
- ran the DeepMath GRPO example end to end on Fireworks with a tiny 1-row dataset using `accounts/fireworks/models/qwen3-4b`
- verified a successful 1-step GRPO run, checkpoint save, and model promotion to `accounts/pyroworks/models/deepmath-e2e-1773785559`
