### PR TITLE
fix: update SDK reference link after training-sdk docs restructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The Fireworks AI Cookbook provides ready-to-run recipes and utilities for training models on [Fireworks](https://fireworks.ai). It covers supervised fine-tuning (SFT), reinforcement learning (GRPO, DAPO, GSPO, CISPO), and preference optimization (DPO, ORPO) — all driven by the Fireworks Training SDK.
 
-For full SDK documentation, see the [Fireworks Training SDK Reference](https://docs.fireworks.ai/api-reference/training-sdk/overview).
+For full SDK documentation, see the [Fireworks Training SDK Reference](https://docs.fireworks.ai/fine-tuning/training-sdk/introduction).
 
 ## Getting Started
 


### PR DESCRIPTION
## Summary

- Update the SDK reference link in `README.md` from the retired `api-reference/training-sdk/overview` URL to the new `fine-tuning/training-sdk/introduction` URL

The training SDK docs were restructured in [docs#832](https://github.com/fw-ai/docs/pull/832), moving all pages from `api-reference/training-sdk/` to `fine-tuning/training-sdk/`. The old README link would rely on a redirect instead of pointing directly to the canonical page.

## Test plan

- [x] Verified the new URL matches the redirect destination in `docs.json`
- [ ] Confirm `https://docs.fireworks.ai/fine-tuning/training-sdk/introduction` resolves correctly

Made with [Cursor](https://cursor.com)