### PR TITLE
feat(training): add async RL loop with AReaL-style scheduling

### DIFF
--- a/training/examples/off_policy_rl/train_off_policy.py
+++ b/training/examples/off_policy_rl/train_off_policy.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Off-policy RL example using the async RL loop.
+
+This example keeps the current recompute-prox loss path, enables the new
+``async_rl_loop(...)`` scheduler, and turns on serving-side async hotload
+transition via deployment extra args.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import re
+import sys
+import time
+from dataclasses import dataclass, field
+from typing import cast
+
+from dotenv import load_dotenv
+
+_SRC = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+if _SRC not in sys.path:
+    sys.path.insert(0, _SRC)
+
+import training.recipes.rl_loop as rl_loop
+from fireworks.training.sdk import DeploymentManager, TrainerJobManager
+from training.utils import DeployConfig, InfraConfig, WandBConfig, WeightSyncConfig
+from training.utils.rl import TISConfig
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
+load_dotenv()
+
+FIREWORKS_API_KEY = os.environ["FIREWORKS_API_KEY"]
+FIREWORKS_BASE_URL = os.environ.get("FIREWORKS_BASE_URL", "https://api.fireworks.ai")
+GSM8K_URL = "https://raw.githubusercontent.com/eval-protocol/python-sdk/main/development/gsm8k_sample.jsonl"
+
+
+@dataclass
+class TrainArgs:
+    base_model: str = "accounts/fireworks/models/qwen3-8b"
+    tokenizer_model: str = "Qwen/Qwen3-8B"
+    dataset_path: str = GSM8K_URL
+    training_shape: str = field(default_factory=lambda: os.environ.get("TRAINING_SHAPE", ""))
+    ref_training_shape: str | None = None
+    deployment_id: str | None = None
+    region: str = "US_OHIO_1"
+    deployment_region: str | None = None
+    log_path: str = "./off_policy_logs"
+
+    max_rows: int = 200
+    epochs: int = 1
+    completions_per_prompt: int = 4
+    learning_rate: float = 1e-5
+    kl_beta: float = 0.001
+    temperature: float = 1.0
+    max_completion_tokens: int = 1024
+
+    prompt_groups_per_fwd_bkwd: int = 1
+    prompt_groups_per_step: int = 4
+    prompt_groups_per_policy: int = 8
+    max_head_offpolicy_versions: int = 1
+
+    policy_loss: str = "grpo"
+    hot_load_async_transition: bool = True
+    eps_clip: float = 0.2
+
+    wandb_entity: str = field(default_factory=lambda: os.environ.get("WANDB_ENTITY", ""))
+    wandb_project: str = field(default_factory=lambda: os.environ.get("WANDB_PROJECT", "grpo-tinker"))
+    skip_cleanup: bool = False
+
+
+def extract_answer(text: str) -> str | None:
+    match = re.search(r"<answer>(.*?)</answer>", text, re.IGNORECASE | re.DOTALL)
+    if not match:
+        return None
+    digits = re.search(r"(-?\d+)", match.group(1))
+    return digits.group(1) if digits else None
+
+
+def gsm8k_reward(completion: str, row: dict) -> float:
+    predicted = extract_answer(completion)
+    truth = extract_answer(str(row.get("ground_truth", "")))
+    if predicted is None or truth is None:
+        return 0.0
+    return 1.0 if predicted == truth else 0.0
+
+
+def parse_args() -> TrainArgs:
+    defaults = TrainArgs()
+    parser = argparse.ArgumentParser(description="Off-policy RL with async rollout scheduling")
+    parser.add_argument("--base-model")
+    parser.add_argument("--tokenizer-model")
+    parser.add_argument("--dataset-path")
+    parser.add_argument("--training-shape")
+    parser.add_argument("--ref-training-shape")
+    parser.add_argument("--deployment-id")
+    parser.add_argument("--region")
+    parser.add_argument("--deployment-region")
+    parser.add_argument("--log-path")
+
+    parser.add_argument("--max-rows", type=int)
+    parser.add_argument("--epochs", type=int)
+    parser.add_argument("--completions-per-prompt", type=int)
+    parser.add_argument("--learning-rate", type=float)
+    parser.add_argument("--kl-beta", type=float)
+    parser.add_argument("--temperature", type=float)
+    parser.add_argument("--max-completion-tokens", type=int)
+    parser.add_argument("--prompt-groups-per-fwd-bkwd", type=int)
+    parser.add_argument("--prompt-groups-per-step", type=int)
+    parser.add_argument("--prompt-groups-per-policy", type=int)
+    parser.add_argument("--max-head-offpolicy-versions", type=int)
+    parser.add_argument("--policy-loss")
+    parser.add_argument("--eps-clip", type=float)
+    parser.add_argument("--hot-load-async-transition", action=argparse.BooleanOptionalAction)
+
+    parser.add_argument("--wandb-entity")
+    parser.add_argument("--wandb-project")
+    parser.add_argument("--skip-cleanup", action="store_true")
+
+    return cast(TrainArgs, parser.parse_args(namespace=defaults))
+
+
+def main():
+    args = parse_args()
+
+    logger.info(
+        "Async off-policy RL | policy_loss=%s | fwd_bkwd=%d | step=%d | policy=%d | max_offpolicy_versions=%d",
+        args.policy_loss,
+        args.prompt_groups_per_fwd_bkwd,
+        args.prompt_groups_per_step,
+        args.prompt_groups_per_policy,
+        args.max_head_offpolicy_versions,
+    )
+
+    os.environ["FIREWORKS_API_KEY"] = FIREWORKS_API_KEY
+    os.environ["FIREWORKS_BASE_URL"] = FIREWORKS_BASE_URL
+
+    rlor_mgr = TrainerJobManager(api_key=FIREWORKS_API_KEY, base_url=FIREWORKS_BASE_URL)
+    deploy_mgr = DeploymentManager(
+        api_key=FIREWORKS_API_KEY,
+        base_url=FIREWORKS_BASE_URL,
+        hotload_api_url=FIREWORKS_BASE_URL,
+    )
+
+    config = rl_loop.Config(
+        log_path=args.log_path,
+        base_model=args.base_model,
+        dataset=args.dataset_path,
+        learning_rate=args.learning_rate,
+        kl_beta=args.kl_beta,
+        completions_per_prompt=args.completions_per_prompt,
+        max_completion_tokens=args.max_completion_tokens,
+        temperature=args.temperature,
+        epochs=args.epochs,
+        max_rows=args.max_rows,
+        async_rollout=True,
+        prompt_groups_per_fwd_bkwd=args.prompt_groups_per_fwd_bkwd,
+        prompt_groups_per_step=args.prompt_groups_per_step,
+        prompt_groups_per_policy=args.prompt_groups_per_policy,
+        max_head_offpolicy_versions=args.max_head_offpolicy_versions,
+        policy_loss=args.policy_loss,
+        eps_clip=args.eps_clip,
+        infra=InfraConfig(
+            training_shape_id=args.training_shape,
+            ref_training_shape_id=args.ref_training_shape,
+            region=args.region,
+        ),
+        deployment=DeployConfig(
+            deployment_id=args.deployment_id,
+            deployment_region=args.deployment_region,
+            tokenizer_model=args.tokenizer_model,
+            sample_timeout=1200,
+            hot_load_async_transition=args.hot_load_async_transition,
+        ),
+        weight_sync=WeightSyncConfig(
+            weight_sync_interval=0,
+            dcp_save_interval=20,
+            dcp_timeout=2700,
+            first_checkpoint_type="base",
+            weight_sync_before_training=True,
+            weight_sync_timeout=600,
+        ),
+        tis=TISConfig(cap=5.0),
+        wandb=WandBConfig(
+            entity=args.wandb_entity,
+            project=args.wandb_project,
+            run_name=f"async-offpol-{int(time.time()) % 100000}",
+        ),
+    )
+
+    rl_loop.reward_fn = gsm8k_reward
+    metrics = rl_loop.main(
+        config,
+        rlor_mgr=rlor_mgr,
+        deploy_mgr=deploy_mgr,
+        cleanup_on_exit=not args.skip_cleanup,
+    )
+
+    logger.info("Training complete. Final metrics: %s", metrics)
+
+
+if __name__ == "__main__":
+    main()

--- a/training/recipes/rl_loop.py
+++ b/training/recipes/rl_loop.py
@@ -68,7 +68,7 @@ from training.utils.timer import timer, flush_timing
 from training.utils.rl.dapo import DAPOConfig
 from training.utils.rl.gspo import GSPOConfig
 from training.utils.rl.cispo import CISPOConfig
-from training.utils.rl.train import TrainStepFns, run_rl_loop
+from training.utils.rl.train import AsyncRLState, TrainStepFns, async_rl_loop, run_rl_loop
 from training.utils.rl.losses import (
     build_builtin_loss_datums,
     build_loss_fn,
@@ -112,6 +112,21 @@ class Config:
 
     All groups are collected before a single ``forward_backward_custom`` +
     ``optim_step`` pair fires (1:1 ratio)."""
+
+    async_rollout: bool = False
+    """If True, use ``async_rl_loop(...)`` instead of the current sync loop."""
+
+    prompt_groups_per_fwd_bkwd: int | None = None
+    """Accepted prompt groups consumed by one ``forward_backward*`` call.
+    Defaults to ``prompt_groups_per_step`` when unset."""
+
+    prompt_groups_per_policy: int | None = None
+    """Accepted prompt groups consumed under one deployment policy version
+    before the next hotload. Defaults to ``prompt_groups_per_step`` when unset."""
+
+    max_head_offpolicy_versions: int = 0
+    """Extra hard stop for async admission: stop launching new requests once
+    ``current_launch_version - oldest_unfinished_version`` exceeds this value."""
 
     router_replay: bool = False
     router_replay_completion_only: bool = True
@@ -268,6 +283,21 @@ def main(
     )
     completions_per_prompt = cfg.completions_per_prompt
     prompt_groups_per_step = cfg.prompt_groups_per_step
+    prompt_groups_per_fwd_bkwd = cfg.prompt_groups_per_fwd_bkwd or prompt_groups_per_step
+    prompt_groups_per_policy = cfg.prompt_groups_per_policy or prompt_groups_per_step
+    async_rollout = cfg.async_rollout
+    if prompt_groups_per_fwd_bkwd <= 0:
+        raise ValueError("prompt_groups_per_fwd_bkwd must be positive")
+    if prompt_groups_per_policy <= 0:
+        raise ValueError("prompt_groups_per_policy must be positive")
+    if prompt_groups_per_step % prompt_groups_per_fwd_bkwd != 0:
+        raise ValueError(
+            "prompt_groups_per_step must be a multiple of prompt_groups_per_fwd_bkwd"
+        )
+    if prompt_groups_per_policy % prompt_groups_per_step != 0:
+        raise ValueError(
+            "prompt_groups_per_policy must be a multiple of prompt_groups_per_step"
+        )
     if not cfg.deployment.tokenizer_model:
         raise ValueError(
             "deployment.tokenizer_model is required for client-side tokenization. "
@@ -278,6 +308,9 @@ def main(
         {
             "completions_per_prompt": completions_per_prompt,
             "prompt_groups_per_step": prompt_groups_per_step,
+            "prompt_groups_per_fwd_bkwd": prompt_groups_per_fwd_bkwd,
+            "prompt_groups_per_policy": prompt_groups_per_policy,
+            "async_rollout": int(async_rollout),
             "kl_beta": cfg.kl_beta,
             "lr": cfg.learning_rate,
         },
@@ -329,8 +362,13 @@ def main(
             cleanup.deployment(cfg.deployment.deployment_id, action="scale_to_zero")
 
         logger.info(
-            "Training: prompt_groups_per_step=%d | completions_per_prompt=%d",
+            "Training: async=%s | prompt_groups_per_fwd_bkwd=%d | "
+            "prompt_groups_per_step=%d | prompt_groups_per_policy=%d | "
+            "completions_per_prompt=%d",
+            async_rollout,
+            prompt_groups_per_fwd_bkwd,
             prompt_groups_per_step,
+            prompt_groups_per_policy,
             completions_per_prompt,
         )
 
@@ -650,6 +688,41 @@ def main(
             logger.info("fwd_bwd: done (%.1fs)", _time.time() - t0)
             return fwd_bwd_result
 
+        def _log_step_metrics(
+            step: int,
+            prompt_groups: list[PromptGroup],
+            fwd_bwd_results: list,
+            optim_result,
+            loop_stats: dict | None = None,
+        ) -> dict:
+            metrics = compute_step_metrics(
+                prompt_groups=prompt_groups,
+                fwd_bwd_results=fwd_bwd_results,
+                optim_result=optim_result,
+                n_accum=len(fwd_bwd_results),
+                timing_metrics=flush_timing(),
+                loop_stats=loop_stats,
+                completions_per_prompt=completions_per_prompt,
+            )
+            metrics["train/step"] = step
+
+            avg_reward = metrics.get("rollout/reward", 0.0)
+            avg_acc = metrics.get("rollout/accuracy", 0.0)
+            avg_kl = metrics.get("train/mean_kl", 0.0)
+            logger.info(
+                "Step %d | Reward: %.3f | Acc: %.1f%% | KL: %.4f",
+                step,
+                avg_reward,
+                avg_acc * 100,
+                avg_kl,
+            )
+            log_metrics_json(step, reward=avg_reward, accuracy=avg_acc, kl=avg_kl)
+            wandb_log(metrics, step)
+
+            if cfg.trajectory_dir:
+                _dump_trajectory(cfg.trajectory_dir, step, prompt_groups)
+            return metrics
+
         def train_step(
             step: int,
             prompt_groups: list[PromptGroup],
@@ -697,33 +770,56 @@ def main(
                     kind=CheckpointKind.STATE,
                 )
 
-            metrics = compute_step_metrics(
-                prompt_groups=prompt_groups,
-                fwd_bwd_results=[fwd_bwd_result],
-                optim_result=optim_result,
-                n_accum=1,
-                timing_metrics=flush_timing(),
-                loop_stats=loop_stats,
-                completions_per_prompt=completions_per_prompt,
-            )
-            metrics["train/step"] = step
-
-            avg_reward = metrics.get("rollout/reward", 0.0)
-            avg_acc = metrics.get("rollout/accuracy", 0.0)
-            avg_kl = metrics.get("train/mean_kl", 0.0)
-            logger.info(
-                "Step %d | Reward: %.3f | Acc: %.1f%% | KL: %.4f",
+            metrics = _log_step_metrics(
                 step,
-                avg_reward,
-                avg_acc * 100,
-                avg_kl,
+                prompt_groups,
+                [fwd_bwd_result],
+                optim_result,
+                loop_stats,
             )
-            log_metrics_json(step, reward=avg_reward, accuracy=avg_acc, kl=avg_kl)
-            wandb_log(metrics, step)
+            return step, metrics
 
-            if cfg.trajectory_dir:
-                _dump_trajectory(cfg.trajectory_dir, step, prompt_groups)
+        def train_step_async(
+            step: int,
+            prompt_groups: list[PromptGroup],
+            loop_stats: dict | None = None,
+        ) -> tuple[int, dict]:
+            """ref_forward + microbatched fwd_bwd + optim_step + metrics."""
+            t0 = _time.time()
+            ref_forward(prompt_groups)
+            logger.info("[step %d] ref_forward: done (%.1fs)", step + 1, _time.time() - t0)
 
+            fwd_bwd_results = []
+            n_chunks = (len(prompt_groups) + prompt_groups_per_fwd_bkwd - 1) // prompt_groups_per_fwd_bkwd
+            for chunk_idx in range(n_chunks):
+                start = chunk_idx * prompt_groups_per_fwd_bkwd
+                end = start + prompt_groups_per_fwd_bkwd
+                sub_groups = prompt_groups[start:end]
+                t0 = _time.time()
+                fwd_bwd_results.append(fwd_bwd_one(sub_groups))
+                logger.info(
+                    "[step %d] fwd_bwd chunk %d/%d: done (%.1fs)",
+                    step + 1,
+                    chunk_idx + 1,
+                    n_chunks,
+                    _time.time() - t0,
+                )
+
+            t0 = _time.time()
+            optim_result = policy.optim_step(
+                adam_params,
+                grad_accumulation_normalization=cfg.grad_accumulation_normalization,
+            )
+            step += 1
+            logger.info("[step %d] optim_step: done (%.1fs)", step, _time.time() - t0)
+
+            metrics = _log_step_metrics(
+                step,
+                prompt_groups,
+                fwd_bwd_results,
+                optim_result,
+                loop_stats,
+            )
             return step, metrics
 
         # -- Run ----------------------------------------------------------------
@@ -732,40 +828,111 @@ def main(
             """Called by run_rl_loop after each train step with loop-level metrics."""
             wandb_log(loop_metrics, step=loop_metrics.get("train/step", 0))
 
-        train_fns = TrainStepFns(train_step=train_step)
+        async_state: AsyncRLState | None = None
+        if async_rollout:
+            def _async_post_step(state: AsyncRLState) -> None:
+                step = state.global_step
+                if cfg.weight_sync.dcp_save_interval > 0 and step % cfg.weight_sync.dcp_save_interval == 0:
+                    logger.info("[step %d] dcp_save...", step)
+                    t0 = _time.time()
+                    save_checkpoint(
+                        policy,
+                        f"step-{step}",
+                        cfg.log_path,
+                        {
+                            "step": step,
+                            "data_consumed": state.rows_submitted,
+                            "rows_submitted": state.rows_submitted,
+                            "accepted_total": state.accepted_total,
+                            "current_launch_version": state.current_launch_version,
+                            "source_job_id": policy_job_id,
+                        },
+                        kind=CheckpointKind.STATE,
+                    )
+                    logger.info("[step %d] dcp_save: done (%.1fs)", step, _time.time() - t0)
 
-        remaining_rows = []
-        for i_step in range(step_offset, len(rl_dataset)):
-            remaining_rows.extend(rl_dataset.get_batch(i_step))
+            def _async_policy_boundary(state: AsyncRLState) -> None:
+                logger.info(
+                    "[step %d] policy boundary: launch_version=%d | weight_sync: saving + loading...",
+                    state.global_step,
+                    state.current_launch_version,
+                )
+                t0 = _time.time()
+                with timer("weight_sync"):
+                    weight_syncer.save_and_hotload(f"step-{state.global_step}")
+                logger.info(
+                    "[step %d] weight_sync: done (%.1fs)",
+                    state.global_step,
+                    _time.time() - t0,
+                )
 
-        global_step = asyncio.run(
-            run_rl_loop(
-                sample_fns=(sample_one_prompt(row) for row in remaining_rows),
-                train_fns=train_fns,
-                prompt_groups_per_step=prompt_groups_per_step,
-                dynamic_filter_fn=should_accept,
-                global_step=step_offset,
-                metrics_callback=_loop_metrics_callback,
+            train_fns = TrainStepFns(train_step=train_step_async)
+            remaining_rows = all_rows[(resume_info.rows_submitted if resume_info else 0):]
+            async_state = asyncio.run(
+                async_rl_loop(
+                    sample_fns=(sample_one_prompt(row) for row in remaining_rows),
+                    train_fns=train_fns,
+                    prompt_groups_per_step=prompt_groups_per_step,
+                    prompt_groups_per_policy=prompt_groups_per_policy,
+                    max_head_offpolicy_versions=cfg.max_head_offpolicy_versions,
+                    dynamic_filter_fn=should_accept,
+                    global_step=step_offset,
+                    metrics_callback=_loop_metrics_callback,
+                    current_launch_version=resume_info.current_launch_version if resume_info else 0,
+                    rows_submitted=resume_info.rows_submitted if resume_info else 0,
+                    accepted_total=resume_info.accepted_total if resume_info else 0,
+                    post_step_fn=_async_post_step,
+                    policy_boundary_fn=_async_policy_boundary,
+                )
             )
-        )
+            global_step = async_state.global_step
+        else:
+            train_fns = TrainStepFns(train_step=train_step)
+
+            remaining_rows = []
+            for i_step in range(step_offset, len(rl_dataset)):
+                remaining_rows.extend(rl_dataset.get_batch(i_step))
+
+            global_step = asyncio.run(
+                run_rl_loop(
+                    sample_fns=(sample_one_prompt(row) for row in remaining_rows),
+                    train_fns=train_fns,
+                    prompt_groups_per_step=prompt_groups_per_step,
+                    dynamic_filter_fn=should_accept,
+                    global_step=step_offset,
+                    metrics_callback=_loop_metrics_callback,
+                )
+            )
 
         # -- Final checkpoint ----------------------------------------------------
 
         if global_step > step_offset:
             try:
-                _data_consumed = (resume_info.data_consumed if resume_info else 0) + (
-                    global_step - step_offset
-                ) * prompt_groups_per_step
+                if async_rollout and async_state is not None:
+                    _data_consumed = async_state.rows_submitted
+                    loop_state = {
+                        "step": global_step,
+                        "data_consumed": _data_consumed,
+                        "rows_submitted": async_state.rows_submitted,
+                        "accepted_total": async_state.accepted_total,
+                        "current_launch_version": async_state.current_launch_version,
+                        "source_job_id": policy_job_id,
+                    }
+                else:
+                    _data_consumed = (resume_info.data_consumed if resume_info else 0) + (
+                        global_step - step_offset
+                    ) * prompt_groups_per_step
+                    loop_state = {
+                        "step": global_step,
+                        "data_consumed": _data_consumed,
+                        "source_job_id": policy_job_id,
+                    }
                 cp_name = f"step-{global_step}"
                 paths = save_checkpoint(
                     policy,
                     cp_name,
                     cfg.log_path,
-                    {
-                        "step": global_step,
-                        "data_consumed": _data_consumed,
-                        "source_job_id": policy_job_id,
-                    },
+                    loop_state,
                     kind=CheckpointKind.BOTH,
                 )
 

--- a/training/tests/unit/test_async_rl_loop.py
+++ b/training/tests/unit/test_async_rl_loop.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import asyncio
+
+from training.utils.rl.losses import PromptGroup
+from training.utils.rl.train import AsyncRLState, TrainStepFns, async_rl_loop
+
+
+def _prompt_group(*, rewards: list[float]) -> PromptGroup:
+    return PromptGroup(
+        data=[],
+        advantages=[0.0 for _ in rewards],
+        ref_logprobs=[],
+        prompt_len=0,
+        rewards=rewards,
+    )
+
+
+async def _sample_after(delay_s: float, pg: PromptGroup | None) -> PromptGroup | None:
+    await asyncio.sleep(delay_s)
+    return pg
+
+
+def test_async_rl_loop_refills_until_full_accepted_batch():
+    events: dict[str, object] = {"steps": []}
+
+    def train_step(step: int, prompt_groups: list[PromptGroup], loop_stats: dict | None):
+        events["steps"].append(
+            {
+                "step": step + 1,
+                "n_groups": len(prompt_groups),
+                "total_sampled": loop_stats["total_sampled"],
+                "filter_drops": loop_stats["filter_drops"],
+            }
+        )
+        return step + 1, {}
+
+    async def _run():
+        return await async_rl_loop(
+            sample_fns=[
+                _sample_after(0.0, _prompt_group(rewards=[0.0, 0.0])),
+                _sample_after(0.0, _prompt_group(rewards=[0.0, 1.0])),
+                _sample_after(0.0, _prompt_group(rewards=[1.0, 0.0])),
+            ],
+            train_fns=TrainStepFns(train_step=train_step),
+            prompt_groups_per_step=2,
+            prompt_groups_per_policy=2,
+            dynamic_filter_fn=lambda pg: len(set(pg.rewards)) > 1,
+        )
+
+    state = asyncio.run(_run())
+
+    assert events["steps"] == [
+        {
+            "step": 1,
+            "n_groups": 2,
+            "total_sampled": 3,
+            "filter_drops": 1,
+        }
+    ]
+    assert isinstance(state, AsyncRLState)
+    assert state.global_step == 1
+    assert state.rows_submitted == 3
+    assert state.accepted_total == 2
+
+
+def test_async_rl_loop_triggers_policy_boundary_by_policy_quota():
+    boundaries: list[tuple[int, int]] = []
+
+    def train_step(step: int, prompt_groups: list[PromptGroup], loop_stats: dict | None):
+        return step + 1, {}
+
+    def policy_boundary(state: AsyncRLState):
+        boundaries.append((state.global_step, state.current_launch_version))
+
+    async def _accepted() -> PromptGroup:
+        await asyncio.sleep(0.0)
+        return _prompt_group(rewards=[0.0, 1.0])
+
+    async def _run():
+        return await async_rl_loop(
+            sample_fns=[
+                _accepted(),
+                _accepted(),
+                _accepted(),
+                _accepted(),
+            ],
+            train_fns=TrainStepFns(train_step=train_step),
+            prompt_groups_per_step=2,
+            prompt_groups_per_policy=2,
+            max_head_offpolicy_versions=0,
+            policy_boundary_fn=policy_boundary,
+        )
+
+    state = asyncio.run(_run())
+
+    assert state.global_step == 2
+    assert boundaries == [(1, 0)]
+    assert state.current_launch_version == 1

--- a/training/tests/unit/test_checkpoint_utils.py
+++ b/training/tests/unit/test_checkpoint_utils.py
@@ -65,6 +65,9 @@ class TestResolveResume:
             "name": "step-5",
             "step": 5,
             "data_consumed": 40,
+            "rows_submitted": 52,
+            "accepted_total": 44,
+            "current_launch_version": 3,
             "state_path": "cross_job://job-abc/step-5",
             "source_job_id": "job-abc",
         })
@@ -73,6 +76,9 @@ class TestResolveResume:
         assert result is not None
         assert result.step == 5
         assert result.data_consumed == 40
+        assert result.rows_submitted == 52
+        assert result.accepted_total == 44
+        assert result.current_launch_version == 3
         assert result.source_job_id == "job-abc"
         client.load_state_with_optimizer.assert_called_once_with("cross_job://job-abc/step-5")
 

--- a/training/tests/unit/test_rl_loop.py
+++ b/training/tests/unit/test_rl_loop.py
@@ -250,6 +250,93 @@ def test_main_raises_when_builtin_loss_with_pp(monkeypatch):
         module.main(cfg, rlor_mgr=FakeRlorMgr(), deploy_mgr=FakeDeployMgr())
 
 
+def test_main_routes_to_async_rl_loop(monkeypatch):
+    monkeypatch.setenv("FIREWORKS_API_KEY", "test-key")
+    monkeypatch.setenv("FIREWORKS_BASE_URL", "https://unit.test")
+
+    events: dict[str, object] = {}
+
+    class FakeRlorMgr:
+        def resolve_training_profile(self, shape_id):
+            return SimpleNamespace(
+                deployment_shape="dep-shape-v1",
+                pipeline_parallelism=1,
+                max_supported_context_length=128,
+            )
+
+        def delete(self, job_id):
+            pass
+
+    class FakeDeployMgr:
+        inference_url = "https://inference.unit.test"
+        boot_time_s = 1.0
+
+        def scale_to_zero(self, deployment_id):
+            pass
+
+    class FakePolicyClient:
+        def __init__(self, *args, **kwargs):
+            self.inner = object()
+
+        def save_state(self, name, timeout=None):
+            return SimpleNamespace(path=f"tinker://unit/state/{name}")
+
+        def save_weights_for_sampler_ext(self, name, checkpoint_type="base"):
+            return SimpleNamespace(path=f"tinker://unit/sampler/{name}")
+
+        def load_state_with_optimizer(self, path):
+            pass
+
+        def resolve_checkpoint_path(self, name, source_job_id=None):
+            return f"tinker://unit/state/{name}"
+
+    async def fake_async_rl_loop(**kwargs):
+        events["async_kwargs"] = kwargs
+        return module.AsyncRLState(
+            global_step=0,
+            current_launch_version=0,
+            rows_submitted=0,
+            accepted_total=0,
+            buffered_accepted=0,
+            running=0,
+            oldest_unfinished_version=0,
+            consumed_in_current_policy=0,
+        )
+
+    monkeypatch.setattr(module, "setup_wandb", lambda *args, **kwargs: None)
+    monkeypatch.setattr(module, "wandb_finish", lambda: None)
+    monkeypatch.setattr(module, "wandb_log", lambda *args, **kwargs: None)
+    monkeypatch.setattr(module, "setup_deployment", lambda *args, **kwargs: SimpleNamespace(inference_model="accounts/test/models/deployed"))
+    monkeypatch.setattr(module, "create_trainer_job", lambda *args, **kwargs: SimpleNamespace(job_id="policy-job"))
+    monkeypatch.setattr(module, "ReconnectableClient", FakePolicyClient)
+    monkeypatch.setattr(transformers.AutoTokenizer, "from_pretrained", lambda *args, **kwargs: object())
+    monkeypatch.setattr(module, "DeploymentSampler", lambda **kwargs: object())
+    monkeypatch.setattr(module, "WeightSyncer", lambda **kwargs: object())
+    monkeypatch.setattr(module, "load_jsonl_dataset", lambda *args, **kwargs: [])
+    monkeypatch.setattr(module, "build_loss_fn", lambda **kwargs: None)
+    monkeypatch.setattr(module, "async_rl_loop", fake_async_rl_loop)
+    monkeypatch.setattr(module, "run_rl_loop", lambda **kwargs: (_ for _ in ()).throw(AssertionError("run_rl_loop should not be used")))
+
+    cfg = module.Config(
+        log_path="/tmp/rl_test_logs",
+        dataset="/tmp/prompts.jsonl",
+        async_rollout=True,
+        prompt_groups_per_step=2,
+        prompt_groups_per_fwd_bkwd=1,
+        prompt_groups_per_policy=4,
+        max_head_offpolicy_versions=1,
+        deployment=module.DeployConfig(deployment_id="dep-123", tokenizer_model="Qwen/Qwen3-4B"),
+        infra=module.InfraConfig(training_shape_id="ts-qwen3-4b-smoke-v1"),
+    )
+
+    result = module.main(cfg, rlor_mgr=FakeRlorMgr(), deploy_mgr=FakeDeployMgr())
+
+    assert result is None
+    assert events["async_kwargs"]["prompt_groups_per_step"] == 2
+    assert events["async_kwargs"]["prompt_groups_per_policy"] == 4
+    assert events["async_kwargs"]["max_head_offpolicy_versions"] == 1
+
+
 def test_main_runs_sampling_and_training_with_reference(monkeypatch, tmp_path):
     monkeypatch.setenv("FIREWORKS_API_KEY", "test-key")
     monkeypatch.setenv("FIREWORKS_BASE_URL", "https://unit.test")

--- a/training/tests/unit/test_sdk_compat.py
+++ b/training/tests/unit/test_sdk_compat.py
@@ -33,3 +33,17 @@ def test_to_deployment_config_does_not_infer_region_from_trainer():
 
     assert isinstance(deployment_config, DeploymentConfig)
     assert deployment_config.region is None
+
+
+def test_to_deployment_config_adds_hot_load_async_transition_flag():
+    deploy_cfg = config_module.DeployConfig(
+        deployment_id="dep-123",
+        hot_load_async_transition=True,
+    )
+
+    deployment_config = deploy_cfg.to_deployment_config(
+        "accounts/test/models/qwen3-4b",
+        config_module.InfraConfig(),
+    )
+
+    assert deployment_config.extra_args == ["--hot-load-async-transition"]

--- a/training/utils/checkpoint_utils.py
+++ b/training/utils/checkpoint_utils.py
@@ -45,6 +45,9 @@ class ResumeInfo:
     step: int = 0
     data_consumed: int = 0
     source_job_id: str | None = None
+    rows_submitted: int = 0
+    accepted_total: int = 0
+    current_launch_version: int = 0
 
 
 def _parse_cross_job(spec: str) -> tuple[str | None, str]:
@@ -85,6 +88,9 @@ def resolve_resume(
             step=last.get("step", 0),
             data_consumed=last.get("data_consumed", 0),
             source_job_id=last.get("source_job_id"),
+            rows_submitted=last.get("rows_submitted", last.get("data_consumed", 0)),
+            accepted_total=last.get("accepted_total", last.get("data_consumed", 0)),
+            current_launch_version=last.get("current_launch_version", 0),
         )
 
     logger.info("Fresh start (no checkpoint)")

--- a/training/utils/config.py
+++ b/training/utils/config.py
@@ -74,6 +74,8 @@ class DeployConfig:
     Increase for R3 + long completions where responses can be very large."""
     disable_speculative_decoding: bool = True
     """Disable base model's default draft/EAGLE speculation for hotload compatibility."""
+    hot_load_async_transition: bool = False
+    """Enable serving-side async hotload transition via ``--hot-load-async-transition``."""
     extra_values: dict[str, str] | None = None
     """Extra Helm values for the deployment (e.g. ``{"priorityClass": "deployment"}``)."""
 
@@ -87,6 +89,9 @@ class DeployConfig:
         accel = None if self.deployment_shape else self.deployment_accelerator_type
         if not accel and not self.deployment_shape:
             accel = infra.accelerator_type
+        extra_args = list(self.deployment_extra_args or [])
+        if self.hot_load_async_transition and "--hot-load-async-transition" not in extra_args:
+            extra_args.append("--hot-load-async-transition")
         return DeploymentConfig(
             deployment_id=self.deployment_id,
             base_model=base_model,
@@ -94,7 +99,7 @@ class DeployConfig:
             region=self.deployment_region or None,
             hot_load_bucket_type=self.hot_load_bucket_type,
             skip_shape_validation=skip_validation,
-            extra_args=self.deployment_extra_args,
+            extra_args=extra_args or None,
             min_replica_count=1,
             max_replica_count=1,
             accelerator_type=accel,

--- a/training/utils/rl/train.py
+++ b/training/utils/rl/train.py
@@ -11,8 +11,9 @@ import time
 import asyncio
 import logging
 import itertools
+from collections import deque
 from typing import Any, Callable, Iterable, Coroutine
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from tqdm import tqdm
 
@@ -23,7 +24,9 @@ logger = logging.getLogger(__name__)
 __all__ = [
     "TrainStepFns",
     "DynamicFilterFn",
+    "AsyncRLState",
     "run_rl_loop",
+    "async_rl_loop",
 ]
 
 DynamicFilterFn = Callable[[PromptGroup], bool]
@@ -43,6 +46,20 @@ class TrainStepFns:
     """
 
     train_step: Callable[[int, list[PromptGroup], dict | None], tuple[int, dict]]
+
+
+@dataclass
+class AsyncRLState:
+    """Observable state of the async RL scheduler."""
+
+    global_step: int
+    current_launch_version: int
+    rows_submitted: int
+    accepted_total: int
+    buffered_accepted: int
+    running: int
+    oldest_unfinished_version: int
+    consumed_in_current_policy: int
 
 
 async def run_rl_loop(
@@ -169,3 +186,230 @@ async def run_rl_loop(
             })
 
     return global_step
+
+
+async def async_rl_loop(
+    sample_fns: Iterable[Coroutine[Any, Any, PromptGroup | None]],
+    *,
+    train_fns: TrainStepFns,
+    prompt_groups_per_step: int = 1,
+    prompt_groups_per_policy: int | None = None,
+    max_head_offpolicy_versions: int = 0,
+    dynamic_filter_fn: DynamicFilterFn | None = None,
+    global_step: int = 0,
+    metrics_callback: Callable[[dict[str, Any]], None] | None = None,
+    current_launch_version: int = 0,
+    rows_submitted: int = 0,
+    accepted_total: int = 0,
+    consumed_by_version: dict[int, int] | None = None,
+    post_step_fn: Callable[[AsyncRLState], None] | None = None,
+    policy_boundary_fn: Callable[[AsyncRLState], None] | None = None,
+) -> AsyncRLState:
+    """Run an AReaL-style async RL loop.
+
+    The scheduler continuously tops up sampling requests while:
+    - the accepted buffer for the next step is not yet full,
+    - in-flight work is below the concurrency target,
+    - the AReaL-style count gate is open, and
+    - the extra oldest-version hard stop is open.
+
+    Training starts whenever ``prompt_groups_per_step`` accepted prompt groups
+    are buffered. The caller is responsible for handling any microbatching
+    inside ``train_fns.train_step``.
+    """
+    if prompt_groups_per_step <= 0:
+        raise ValueError("prompt_groups_per_step must be positive")
+    policy_target = prompt_groups_per_step if prompt_groups_per_policy is None else prompt_groups_per_policy
+    if policy_target <= 0:
+        raise ValueError("prompt_groups_per_policy must be positive")
+    if max_head_offpolicy_versions < 0:
+        raise ValueError("max_head_offpolicy_versions must be non-negative")
+
+    coros = iter(sample_fns)
+    queue: asyncio.Queue[tuple[int, PromptGroup | None]] = asyncio.Queue()
+    worker_error: BaseException | None = None
+    exhausted = False
+
+    accepted_buffer: deque[tuple[int, PromptGroup]] = deque()
+    pending_tasks: set[asyncio.Task[None]] = set()
+    task_versions: dict[asyncio.Task[None], int] = {}
+    consumed = dict(consumed_by_version or {})
+
+    step_filter_drops = 0
+    step_sample_fails = 0
+    step_total_sampled = 0
+    step_total_completions = 0
+    step_sample_wait_time = 0.0
+    step_all_raw_rewards: list[float] = []
+    step_start_time = time.time()
+
+    def oldest_unfinished_version() -> int:
+        if not task_versions:
+            return current_launch_version
+        return min(task_versions.values())
+
+    def count_gate_capacity() -> int:
+        allowed = (current_launch_version + max_head_offpolicy_versions + 1) * policy_target
+        return allowed - (accepted_total + len(pending_tasks))
+
+    def build_state() -> AsyncRLState:
+        return AsyncRLState(
+            global_step=global_step,
+            current_launch_version=current_launch_version,
+            rows_submitted=rows_submitted,
+            accepted_total=accepted_total,
+            buffered_accepted=len(accepted_buffer),
+            running=len(pending_tasks),
+            oldest_unfinished_version=oldest_unfinished_version(),
+            consumed_in_current_policy=consumed.get(current_launch_version, 0),
+        )
+
+    async def _worker(coro: Coroutine[Any, Any, PromptGroup | None], launch_version: int) -> None:
+        nonlocal worker_error
+        try:
+            result = await coro
+            queue.put_nowait((launch_version, result))
+        except BaseException as exc:
+            if worker_error is None:
+                worker_error = exc
+            queue.put_nowait((launch_version, None))
+
+    def _forget_task(task: asyncio.Task[None]) -> None:
+        pending_tasks.discard(task)
+        task_versions.pop(task, None)
+
+    def reap_finished_tasks() -> None:
+        for task in list(pending_tasks):
+            if task.done():
+                _forget_task(task)
+
+    def try_submit_more() -> None:
+        nonlocal exhausted, rows_submitted
+        reap_finished_tasks()
+        while True:
+            concurrency_capacity = prompt_groups_per_step - (len(accepted_buffer) + len(pending_tasks))
+            version_gap = current_launch_version - oldest_unfinished_version()
+            if (
+                exhausted
+                or concurrency_capacity <= 0
+                or count_gate_capacity() <= 0
+                or version_gap > max_head_offpolicy_versions
+            ):
+                return
+            try:
+                coro = next(coros)
+            except StopIteration:
+                exhausted = True
+                return
+            task = asyncio.create_task(_worker(coro, current_launch_version))
+            pending_tasks.add(task)
+            task_versions[task] = current_launch_version
+            task.add_done_callback(_forget_task)
+            rows_submitted += 1
+
+    def finalize_step_stats() -> dict[str, Any]:
+        return {
+            "valid_prompt_groups": prompt_groups_per_step,
+            "total_sampled": step_total_sampled,
+            "filter_drops": step_filter_drops,
+            "sample_fails": step_sample_fails,
+            "sample_wait_time": step_sample_wait_time,
+            "step_wall_time": time.time() - step_start_time,
+            "all_raw_rewards": list(step_all_raw_rewards),
+        }
+
+    def reset_step_stats() -> None:
+        nonlocal step_filter_drops, step_sample_fails, step_total_sampled
+        nonlocal step_total_completions, step_sample_wait_time, step_all_raw_rewards, step_start_time
+        step_filter_drops = 0
+        step_sample_fails = 0
+        step_total_sampled = 0
+        step_total_completions = 0
+        step_sample_wait_time = 0.0
+        step_all_raw_rewards = []
+        step_start_time = time.time()
+
+    try_submit_more()
+
+    while True:
+        reap_finished_tasks()
+        while len(accepted_buffer) >= prompt_groups_per_step:
+            step_groups = [accepted_buffer.popleft() for _ in range(prompt_groups_per_step)]
+            prompt_groups = [pg for _, pg in step_groups]
+            loop_stats = finalize_step_stats()
+            logger.info(
+                "Async sampling complete: %d accepted groups (%d sampled, failed=%d, filtered=%d, %.1fs)",
+                len(prompt_groups),
+                step_total_sampled,
+                step_sample_fails,
+                step_filter_drops,
+                loop_stats["step_wall_time"],
+            )
+
+            global_step, _ = await asyncio.to_thread(
+                train_fns.train_step, global_step, prompt_groups, loop_stats,
+            )
+
+            for version, _ in step_groups:
+                consumed[version] = consumed.get(version, 0) + 1
+
+            if metrics_callback is not None:
+                metrics_callback({
+                    "train/step": global_step,
+                    "rollout/sample_fails": step_sample_fails,
+                    "rollout/filter_drops": step_filter_drops,
+                })
+
+            if post_step_fn is not None:
+                await asyncio.to_thread(post_step_fn, build_state())
+
+            reset_step_stats()
+
+            while consumed.get(current_launch_version, 0) >= policy_target:
+                if policy_boundary_fn is not None:
+                    await asyncio.to_thread(policy_boundary_fn, build_state())
+                current_launch_version += 1
+
+            try_submit_more()
+
+        if exhausted and not pending_tasks:
+            break
+
+        if not pending_tasks:
+            try_submit_more()
+            if exhausted and not pending_tasks:
+                break
+
+        t_wait = time.time()
+        launch_version, item = await queue.get()
+        step_sample_wait_time += time.time() - t_wait
+
+        if worker_error is not None:
+            raise RuntimeError(f"Sampling worker failed: {worker_error}") from worker_error
+
+        step_total_sampled += 1
+
+        if item is None:
+            step_sample_fails += 1
+            try_submit_more()
+            continue
+
+        step_total_completions += len(item.rewards)
+        step_all_raw_rewards.extend(item.rewards)
+
+        if dynamic_filter_fn is not None and not dynamic_filter_fn(item):
+            step_filter_drops += 1
+            try_submit_more()
+            continue
+
+        accepted_total += 1
+        accepted_buffer.append((launch_version, item))
+        try_submit_more()
+
+    if accepted_buffer:
+        logger.info(
+            "Async loop finished with %d buffered accepted groups below the step size; dropping tail.",
+            len(accepted_buffer),
+        )
+
+    return build_state()


### PR DESCRIPTION
## Summary
- add a separate `async_rl_loop(...)` that keeps the existing sync loop untouched while following an AReaL-style async submit/wait scheduler
- introduce async RL config for `prompt_groups_per_fwd_bkwd`, `prompt_groups_per_step`, `prompt_groups_per_policy`, and `max_head_offpolicy_versions`
- plumb `--hot-load-async-transition` through deployment extra args and add focused unit coverage for async scheduling and resume state

## Test plan
- [x] `python -m pytest tests/unit/test_sdk_compat.py tests/unit/test_checkpoint_utils.py tests/unit/test_async_rl_loop.py tests/unit/test_rl_loop.py`
- [ ] End-to-end RLOR training smoke on a real deployment
- [ ] Manual validation of async hotload transition behavior on serving

## Code Overview Diagram
```mermaid
flowchart TD
  samples[SampleRequests] --> gates[CountGateAndVersionGate]
  gates --> inflight[InflightRequests]
  inflight --> accepted[AcceptedBuffer]
  accepted -->|"groups >= prompt_groups_per_fwd_bkwd"| fwdbwd[ForwardBackward]
  fwdbwd -->|"groups >= prompt_groups_per_step"| step[OptimStep]
  step -->|"groups >= prompt_groups_per_policy"| hotload[HotloadAndVersionBump]
  hotload --> gates
```

Made with [Cursor](https://cursor.com)