### PR TITLE
feat(training): route rl loop references through training sessions

### DIFF
--- a/training/recipes/rl_loop.py
+++ b/training/recipes/rl_loop.py
@@ -151,10 +151,18 @@ class Config:
     """Base URL for the policy trainer (bypass direct route)."""
 
     reference_job_id: str | None = None
-    """Pre-created RLOR reference trainer job ID (skip creation if set)."""
+    """Legacy dedicated reference trainer job ID.
+
+    `rl_loop` now ignores this and always uses a shared training session for
+    reference logprobs.
+    """
 
     reference_base_url: str | None = None
-    """Base URL for the reference trainer (bypass direct route)."""
+    """Legacy dedicated reference trainer base URL.
+
+    `rl_loop` now ignores this and always uses a shared training session for
+    reference logprobs.
+    """
 
     reference_warm_start_from: str | None = None
     """Optional adapter directory to warm-start the shared reference session."""

--- a/training/recipes/rl_loop.py
+++ b/training/recipes/rl_loop.py
@@ -29,7 +29,6 @@ import asyncio
 import logging
 from typing import List, Optional
 from dataclasses import field, dataclass
-from concurrent.futures import ThreadPoolExecutor
 
 import tinker
 
@@ -43,6 +42,7 @@ from training.utils import (
     DeployConfig,
     WeightSyncConfig,
     ReconnectableClient,
+    TrainingSessionClient,
     RLPromptDataset,
     wandb_log,
     setup_wandb,
@@ -155,6 +155,9 @@ class Config:
 
     reference_base_url: str | None = None
     """Base URL for the reference trainer (bypass direct route)."""
+
+    reference_warm_start_from: str | None = None
+    """Optional adapter directory to warm-start the shared reference session."""
 
     init_from_checkpoint: str | None = None
     """Load pretrained DCP weights on a fresh dataset. Supports cross-job
@@ -311,13 +314,12 @@ def main(
             "(InfraConfig.training_shape_id) to auto-populate it."
         )
 
-    ref_profile = None
-    if cfg.infra.ref_training_shape_id:
-        ref_profile = rlor_mgr.resolve_training_profile(cfg.infra.ref_training_shape_id)
+    if cfg.infra.ref_training_shape_id or cfg.reference_job_id or cfg.reference_base_url:
+        logger.info(
+            "Ignoring dedicated reference trainer config; rl_loop now uses shared training sessions for reference logprobs"
+        )
 
-    use_reference = ref_profile is not None
-    if not use_reference:
-        logger.info("No ref_training_shape_id set, skipping reference model")
+    use_reference = True
 
     import time as _time
 
@@ -334,63 +336,22 @@ def main(
             completions_per_prompt,
         )
 
-        if use_reference:
-            with ThreadPoolExecutor(max_workers=2) as pool:
-                pol_fut = pool.submit(
-                    create_trainer_job,
-                    rlor_mgr,
-                    base_model=cfg.base_model,
-                    infra=cfg.infra,
-                    profile=profile,
-                    lora_rank=cfg.lora_rank,
-                    max_seq_len=cfg.max_seq_len,
-                    learning_rate=cfg.learning_rate,
-                    display_name="grpo-policy",
-                    hot_load_deployment_id=cfg.deployment.deployment_id,  # weight sync target deployment
-                    job_id=cfg.policy_job_id,
-                    base_url_override=cfg.policy_base_url,
-                )
-                ref_fut = pool.submit(
-                    create_trainer_job,
-                    rlor_mgr,
-                    base_model=cfg.base_model,
-                    infra=cfg.infra,
-                    profile=ref_profile,
-                    lora_rank=cfg.lora_rank,
-                    max_seq_len=cfg.max_seq_len,
-                    learning_rate=cfg.learning_rate,
-                    display_name="grpo-reference",
-                    forward_only=True,
-                    job_id=cfg.reference_job_id,
-                    base_url_override=cfg.reference_base_url,
-                )
-                policy_ep = pol_fut.result()
-                policy_job_id = policy_ep.job_id
-                if not cfg.policy_job_id:
-                    cleanup.trainer(policy_job_id)
-                reference_ep = ref_fut.result()
-                reference_job_id = reference_ep.job_id
-                if not cfg.reference_job_id:
-                    cleanup.trainer(reference_job_id)
-        else:
-            policy_ep = create_trainer_job(
-                rlor_mgr,
-                base_model=cfg.base_model,
-                infra=cfg.infra,
-                profile=profile,
-                lora_rank=cfg.lora_rank,
-                max_seq_len=cfg.max_seq_len,
-                learning_rate=cfg.learning_rate,
-                display_name="grpo-policy",
-                hot_load_deployment_id=cfg.deployment.deployment_id,
-                job_id=cfg.policy_job_id,
-                base_url_override=cfg.policy_base_url,
-            )
-            policy_job_id = policy_ep.job_id
-            if not cfg.policy_job_id:
-                cleanup.trainer(policy_job_id)
-            reference_ep = None
-            reference_job_id = None
+        policy_ep = create_trainer_job(
+            rlor_mgr,
+            base_model=cfg.base_model,
+            infra=cfg.infra,
+            profile=profile,
+            lora_rank=cfg.lora_rank,
+            max_seq_len=cfg.max_seq_len,
+            learning_rate=cfg.learning_rate,
+            display_name="grpo-policy",
+            hot_load_deployment_id=cfg.deployment.deployment_id,
+            job_id=cfg.policy_job_id,
+            base_url_override=cfg.policy_base_url,
+        )
+        policy_job_id = policy_ep.job_id
+        if not cfg.policy_job_id:
+            cleanup.trainer(policy_job_id)
 
         policy = ReconnectableClient(
             rlor_mgr,
@@ -400,18 +361,10 @@ def main(
             fw_api_key=api_key,
             endpoint=policy_ep if cfg.policy_base_url else None,
         )
-        reference = (
-            ReconnectableClient(
-                rlor_mgr,
-                reference_ep.job_id,
-                cfg.base_model,
-                cfg.lora_rank,
-                fw_api_key=api_key,
-                endpoint=reference_ep if cfg.reference_base_url else None,
-            )
-            if reference_ep
-            else None
-        )
+        reference = TrainingSessionClient(api_key=api_key, base_url=base_url).create_session(cfg.base_model)
+        reference_job_id = getattr(reference, "_job_id", None)
+        if cfg.reference_warm_start_from:
+            reference.load_state(cfg.reference_warm_start_from)
 
         import transformers
 

--- a/training/tests/unit/test_rl_loop.py
+++ b/training/tests/unit/test_rl_loop.py
@@ -120,7 +120,7 @@ def test_main_requires_deployment_tokenizer_model(monkeypatch):
         module.main(cfg)
 
 
-def test_main_bootstraps_without_reference_and_cleans_up(monkeypatch):
+def test_main_bootstraps_with_shared_reference_session_and_cleans_up(monkeypatch):
     monkeypatch.setenv("FIREWORKS_API_KEY", "test-key")
     monkeypatch.setenv("FIREWORKS_BASE_URL", "https://unit.test")
 
@@ -410,39 +410,12 @@ def test_main_runs_sampling_and_training_with_reference(monkeypatch, tmp_path):
         def scale_to_zero(self, deployment_id):
             events["scaled_deployments"].append(deployment_id)
 
-    class FakeFuture:
-        def __init__(self, value):
-            self._value = value
-
-        def result(self):
-            return self._value
-
-    class FakeThreadPoolExecutor:
-        def __init__(self, max_workers):
-            self.max_workers = max_workers
-
-        def __enter__(self):
-            return self
-
-        def __exit__(self, exc_type, exc, tb):
-            return False
-
-        def submit(self, fn, *args, **kwargs):
-            return FakeFuture(fn(*args, **kwargs))
-
     class FakeClient:
         def __init__(self, _mgr, job_id, *_args, **_kwargs):
             self.job_id = job_id
             self.inner = object()
 
         def forward(self, data, loss_fn):
-            if self.job_id == "reference-job":
-                return SimpleNamespace(
-                    loss_fn_outputs=[
-                        {"logprobs": SimpleNamespace(data=[-0.11, -0.12])}
-                        for _ in data
-                    ]
-                )
             return SimpleNamespace(
                 loss_fn_outputs=[
                     {"logprobs": SimpleNamespace(data=[-0.21, -0.22])}
@@ -712,26 +685,6 @@ def test_custom_policy_loss_falls_back_to_two_pass(monkeypatch, tmp_path):
 
         def scale_to_zero(self, deployment_id):
             events["scaled_deployments"].append(deployment_id)
-
-    class FakeFuture:
-        def __init__(self, value):
-            self._value = value
-
-        def result(self):
-            return self._value
-
-    class FakeThreadPoolExecutor:
-        def __init__(self, max_workers):
-            pass
-
-        def __enter__(self):
-            return self
-
-        def __exit__(self, *args):
-            return False
-
-        def submit(self, fn, *args, **kwargs):
-            return FakeFuture(fn(*args, **kwargs))
 
     class FakeClient:
         def __init__(self, _mgr, job_id, *_args, **_kwargs):

--- a/training/tests/unit/test_rl_loop.py
+++ b/training/tests/unit/test_rl_loop.py
@@ -10,6 +10,36 @@ import training.recipes.rl_loop as module
 from training.utils.rl.losses import PromptGroup
 
 
+class _FakeTrainingSessionHandle:
+    def __init__(
+        self,
+        *,
+        job_id: str = "reference-session-job",
+        forward_result: object | None = None,
+    ):
+        self._job_id = job_id
+        self.forward_result = forward_result or SimpleNamespace(loss_fn_outputs=[])
+        self.forward_calls: list[tuple[object, str]] = []
+        self.load_state_calls: list[str] = []
+
+    def forward(self, data, loss_fn):
+        self.forward_calls.append((data, loss_fn))
+        return self.forward_result
+
+    def load_state(self, path: str) -> None:
+        self.load_state_calls.append(path)
+
+
+class _FakeTrainingSessionClient:
+    def __init__(self, handle: _FakeTrainingSessionHandle):
+        self.handle = handle
+        self.create_session_calls: list[str] = []
+
+    def create_session(self, base_model: str) -> _FakeTrainingSessionHandle:
+        self.create_session_calls.append(base_model)
+        return self.handle
+
+
 def test_extract_answer_reads_digits_from_answer_block():
     assert module.extract_answer("<answer> 42 apples </answer>") == "42"
     assert module.extract_answer("no answer block") is None
@@ -149,6 +179,9 @@ def test_main_bootstraps_without_reference_and_cleans_up(monkeypatch):
         events["run_loop_kwargs"] = kwargs
         return 0
 
+    fake_reference_handle = _FakeTrainingSessionHandle()
+    fake_reference_client = _FakeTrainingSessionClient(fake_reference_handle)
+
     monkeypatch.setattr(module, "setup_wandb", lambda *args, **kwargs: None)
     monkeypatch.setattr(module, "wandb_finish", lambda: events.__setitem__("wandb_finished", 1))
     monkeypatch.setattr(module, "wandb_log", lambda payload, step=0: events["wandb_logs"].append((step, payload)))
@@ -159,6 +192,7 @@ def test_main_bootstraps_without_reference_and_cleans_up(monkeypatch):
         lambda *args, **kwargs: events["create_trainer_job"].append(kwargs) or SimpleNamespace(job_id="policy-job"),
     )
     monkeypatch.setattr(module, "ReconnectableClient", FakePolicyClient)
+    monkeypatch.setattr(module, "TrainingSessionClient", lambda *args, **kwargs: fake_reference_client)
     monkeypatch.setattr(transformers.AutoTokenizer, "from_pretrained", lambda *args, **kwargs: object())
     monkeypatch.setattr(module, "DeploymentSampler", FakeSampler)
     monkeypatch.setattr(module, "WeightSyncer", FakeWeightSyncer)
@@ -191,12 +225,89 @@ def test_main_bootstraps_without_reference_and_cleans_up(monkeypatch):
     assert len(events["create_trainer_job"]) == 1
     assert events["create_trainer_job"][0]["display_name"] == "grpo-policy"
     assert events["create_trainer_job"][0]["hot_load_deployment_id"] == "dep-123"
+    assert fake_reference_client.create_session_calls == ["accounts/test/models/qwen3-4b"]
     assert events["sampler_init"]["model"] == "accounts/test/models/deployed"
     assert events["weight_syncer_init"]["deployment_id"] == "dep-123"
     assert events["run_loop_kwargs"]["prompt_groups_per_step"] == cfg.prompt_groups_per_step
     assert events["deleted_jobs"] == ["policy-job"]
     assert events["scaled_deployments"] == ["dep-123"]
     assert events["wandb_finished"] == 0
+
+
+def test_main_warm_starts_reference_session(monkeypatch):
+    monkeypatch.setenv("FIREWORKS_API_KEY", "test-key")
+    monkeypatch.setenv("FIREWORKS_BASE_URL", "https://unit.test")
+
+    class FakeRlorMgr:
+        def resolve_training_profile(self, shape_id):
+            return SimpleNamespace(
+                deployment_shape="dep-shape-v1",
+                pipeline_parallelism=1,
+                max_supported_context_length=128,
+            )
+
+        def delete(self, job_id):
+            pass
+
+    class FakeDeployMgr:
+        inference_url = "https://inference.unit.test"
+        boot_time_s = 1.0
+
+        def scale_to_zero(self, deployment_id):
+            pass
+
+    class FakePolicyClient:
+        def __init__(self, *args, **kwargs):
+            self.inner = object()
+
+        def save_state(self, name, timeout=None):
+            return SimpleNamespace(path=name)
+
+        def save_weights_for_sampler_ext(self, name, checkpoint_type="base"):
+            return SimpleNamespace(path=name)
+
+        def load_state_with_optimizer(self, path):
+            pass
+
+        def resolve_checkpoint_path(self, name, source_job_id=None):
+            return name
+
+    fake_reference_handle = _FakeTrainingSessionHandle()
+    fake_reference_client = _FakeTrainingSessionClient(fake_reference_handle)
+
+    async def fake_run_rl_loop(**kwargs):
+        return 0
+
+    monkeypatch.setattr(module, "setup_wandb", lambda *args, **kwargs: None)
+    monkeypatch.setattr(module, "wandb_finish", lambda: None)
+    monkeypatch.setattr(module, "wandb_log", lambda *args, **kwargs: None)
+    monkeypatch.setattr(module, "setup_deployment", lambda *args, **kwargs: SimpleNamespace(inference_model="m"))
+    monkeypatch.setattr(module, "create_trainer_job", lambda *args, **kwargs: SimpleNamespace(job_id="policy-job"))
+    monkeypatch.setattr(module, "ReconnectableClient", FakePolicyClient)
+    monkeypatch.setattr(module, "TrainingSessionClient", lambda *args, **kwargs: fake_reference_client)
+    monkeypatch.setattr(transformers.AutoTokenizer, "from_pretrained", lambda *args, **kwargs: object())
+    monkeypatch.setattr(module, "DeploymentSampler", lambda **kwargs: None)
+    monkeypatch.setattr(module, "WeightSyncer", lambda **kwargs: None)
+    monkeypatch.setattr(module, "load_jsonl_dataset", lambda *args, **kwargs: [])
+    monkeypatch.setattr(module, "build_loss_fn", lambda **kwargs: ("loss-builder", kwargs))
+    monkeypatch.setattr(module, "run_rl_loop", fake_run_rl_loop)
+
+    cfg = module.Config(
+        log_path="/tmp/rl_test_logs",
+        base_model="accounts/test/models/qwen3-4b",
+        dataset="/tmp/prompts.jsonl",
+        reference_warm_start_from="gs://bucket/adapters/ref-a",
+        deployment=module.DeployConfig(
+            deployment_id="dep-123",
+            tokenizer_model="Qwen/Qwen3-4B",
+        ),
+        infra=module.InfraConfig(training_shape_id="shape-a"),
+    )
+
+    module.main(cfg, rlor_mgr=FakeRlorMgr(), deploy_mgr=FakeDeployMgr())
+
+    assert fake_reference_client.create_session_calls == ["accounts/test/models/qwen3-4b"]
+    assert fake_reference_handle.load_state_calls == ["gs://bucket/adapters/ref-a"]
 
 
 def test_main_raises_when_builtin_loss_with_pp(monkeypatch):
@@ -223,12 +334,15 @@ def test_main_raises_when_builtin_loss_with_pp(monkeypatch):
         def scale_to_zero(self, deployment_id):
             pass
 
+    fake_reference_client = _FakeTrainingSessionClient(_FakeTrainingSessionHandle())
+
     monkeypatch.setattr(module, "setup_wandb", lambda *args, **kwargs: None)
     monkeypatch.setattr(module, "wandb_finish", lambda: None)
     monkeypatch.setattr(module, "wandb_log", lambda *args, **kwargs: None)
     monkeypatch.setattr(module, "setup_deployment", lambda *args, **kwargs: SimpleNamespace(inference_model="m"))
     monkeypatch.setattr(module, "create_trainer_job", lambda *args, **kwargs: SimpleNamespace(job_id="j"))
     monkeypatch.setattr(module, "ReconnectableClient", lambda *a, **kw: SimpleNamespace(inner=object()))
+    monkeypatch.setattr(module, "TrainingSessionClient", lambda *args, **kwargs: fake_reference_client)
     monkeypatch.setattr(transformers.AutoTokenizer, "from_pretrained", lambda *a, **kw: object())
     monkeypatch.setattr(module, "DeploymentSampler", lambda **kw: None)
     monkeypatch.setattr(module, "WeightSyncer", lambda **kw: None)
@@ -426,9 +540,7 @@ def test_main_runs_sampling_and_training_with_reference(monkeypatch, tmp_path):
 
     def fake_create_trainer_job(*args, **kwargs):
         events["create_trainer_job"].append(kwargs)
-        display_name = kwargs["display_name"]
-        job_id = "policy-job" if display_name == "grpo-policy" else "reference-job"
-        return SimpleNamespace(job_id=job_id)
+        return SimpleNamespace(job_id="policy-job")
 
     def fake_build_loss_fn(**kwargs):
         events["build_loss_fn_kwargs"] = kwargs
@@ -451,9 +563,18 @@ def test_main_runs_sampling_and_training_with_reference(monkeypatch, tmp_path):
     monkeypatch.setattr(module, "wandb_log", lambda payload, step=0: events["wandb_logs"].append((step, payload)))
     monkeypatch.setattr(module, "log_metrics_json", lambda step, **kwargs: events.setdefault("metrics_logs", []).append((step, kwargs)))
     monkeypatch.setattr(module, "setup_deployment", lambda *args, **kwargs: SimpleNamespace(inference_model="accounts/test/models/deployed"))
-    monkeypatch.setattr(module, "ThreadPoolExecutor", FakeThreadPoolExecutor)
     monkeypatch.setattr(module, "create_trainer_job", fake_create_trainer_job)
     monkeypatch.setattr(module, "ReconnectableClient", FakeClient)
+    fake_reference_handle = _FakeTrainingSessionHandle(
+        forward_result=SimpleNamespace(
+            loss_fn_outputs=[
+                {"logprobs": SimpleNamespace(data=[-0.11, -0.12])},
+                {"logprobs": SimpleNamespace(data=[-0.13, -0.14])},
+            ]
+        )
+    )
+    fake_reference_client = _FakeTrainingSessionClient(fake_reference_handle)
+    monkeypatch.setattr(module, "TrainingSessionClient", lambda *args, **kwargs: fake_reference_client)
     monkeypatch.setattr(transformers.AutoTokenizer, "from_pretrained", lambda *args, **kwargs: object())
     monkeypatch.setattr(module, "DeploymentSampler", FakeSampler)
     monkeypatch.setattr(module, "WeightSyncer", FakeWeightSyncer)
@@ -522,14 +643,13 @@ def test_main_runs_sampling_and_training_with_reference(monkeypatch, tmp_path):
     assert result == {
         "steps": 2,
         "policy_job_id": "policy-job",
-        "reference_job_id": "reference-job",
+        "reference_job_id": "reference-session-job",
     }
     assert cfg.max_seq_len == 96
     assert cfg.deployment.deployment_shape == "dep-shape-v2"
-    assert [call["display_name"] for call in events["create_trainer_job"]] == [
-        "grpo-policy",
-        "grpo-reference",
-    ]
+    assert [call["display_name"] for call in events["create_trainer_job"]] == ["grpo-policy"]
+    assert fake_reference_client.create_session_calls == ["accounts/test/models/qwen3-4b"]
+    assert fake_reference_handle.load_state_calls == []
     assert events["sampler_calls"][0]["messages"] == [
         {"role": "system", "content": "sys"},
         {"role": "user", "content": "Solve"},
@@ -554,7 +674,7 @@ def test_main_runs_sampling_and_training_with_reference(monkeypatch, tmp_path):
     )
     assert events["fwd_bwd_call"]["loss_fn"] == expected_kernel
     assert events["fwd_bwd_call"]["loss_fn_config"] == expected_config
-    assert events["deleted_jobs"] == ["reference-job", "policy-job"]
+    assert events["deleted_jobs"] == ["policy-job"]
     assert events["scaled_deployments"] == ["dep-123"]
 
 
@@ -707,9 +827,18 @@ def test_custom_policy_loss_falls_back_to_two_pass(monkeypatch, tmp_path):
     monkeypatch.setattr(module, "wandb_log", lambda *args, **kwargs: None)
     monkeypatch.setattr(module, "log_metrics_json", lambda *args, **kwargs: None)
     monkeypatch.setattr(module, "setup_deployment", lambda *args, **kwargs: SimpleNamespace(inference_model="accounts/test/models/deployed"))
-    monkeypatch.setattr(module, "ThreadPoolExecutor", FakeThreadPoolExecutor)
     monkeypatch.setattr(module, "create_trainer_job", fake_create_trainer_job)
     monkeypatch.setattr(module, "ReconnectableClient", FakeClient)
+    fake_reference_handle = _FakeTrainingSessionHandle(
+        forward_result=SimpleNamespace(
+            loss_fn_outputs=[
+                {"logprobs": SimpleNamespace(data=[-0.11, -0.12])},
+                {"logprobs": SimpleNamespace(data=[-0.13, -0.14])},
+            ]
+        )
+    )
+    fake_reference_client = _FakeTrainingSessionClient(fake_reference_handle)
+    monkeypatch.setattr(module, "TrainingSessionClient", lambda *args, **kwargs: fake_reference_client)
     monkeypatch.setattr(transformers.AutoTokenizer, "from_pretrained", lambda *args, **kwargs: object())
     monkeypatch.setattr(module, "DeploymentSampler", FakeSampler)
     monkeypatch.setattr(module, "WeightSyncer", FakeWeightSyncer)

--- a/training/tests/unit/test_training_session_client.py
+++ b/training/tests/unit/test_training_session_client.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+import requests
+
+from training.utils.training_session_client import TrainingSessionClient, TrainingSessionHandle
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict[str, Any], status_code: int = 200):
+        self._payload = payload
+        self.status_code = status_code
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise requests.HTTPError(f"status={self.status_code}")
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+
+class _FakeManager:
+    def __init__(self, list_payload: dict[str, Any], post_payloads: list[dict[str, Any]]):
+        self.account_id = "acct"
+        self.list_payload = list_payload
+        self.post_payloads = list(post_payloads)
+        self.get_calls: list[tuple[str, int]] = []
+        self.post_calls: list[tuple[str, dict[str, Any], int]] = []
+
+    def _get(self, path: str, timeout: int) -> _FakeResponse:
+        self.get_calls.append((path, timeout))
+        return _FakeResponse(self.list_payload)
+
+    def _post(self, path: str, json: dict[str, Any], timeout: int) -> _FakeResponse:
+        self.post_calls.append((path, json, timeout))
+        payload = self.post_payloads.pop(0)
+        return _FakeResponse(payload)
+
+
+class _FakeHTTPSession:
+    def __init__(self, response: _FakeResponse | Exception):
+        self.headers: dict[str, str] = {}
+        self.response = response
+        self.calls: list[tuple[str, dict[str, Any], int]] = []
+
+    def post(self, url: str, json: dict[str, Any], timeout: int) -> _FakeResponse:
+        self.calls.append((url, json, timeout))
+        if isinstance(self.response, Exception):
+            raise self.response
+        return self.response
+
+
+class _FakeDatum:
+    def __init__(self, payload: dict[str, Any]):
+        self._payload = payload
+
+    def model_dump(self, mode: str = "json", exclude_none: bool = True) -> dict[str, Any]:
+        assert mode == "json"
+        assert exclude_none is True
+        return self._payload
+
+
+def test_create_session_reuses_newest_parent_job() -> None:
+    manager = _FakeManager(
+        list_payload={
+            "trainingSessionJobs": [
+                {"name": "accounts/acct/trainingSessionJobs/job-new"},
+                {"name": "accounts/acct/trainingSessionJobs/job-old"},
+            ]
+        },
+        post_payloads=[
+            {"name": "accounts/acct/trainingSessionJobs/job-new/trainingSessions/session-123"},
+        ],
+    )
+    http_session = _FakeHTTPSession(_FakeResponse({}))
+    client = TrainingSessionClient(
+        api_key="test-key",
+        base_url="https://api.unit.test",
+        manager=manager,
+        request_session=http_session,
+    )
+
+    handle = client.create_session("accounts/fireworks/models/qwen3-8b")
+
+    assert handle._job_id == "job-new"
+    assert handle._training_session_id == "session-123"
+    assert manager.get_calls[0][1] == 30
+    assert "trainingSessionJobs" in manager.get_calls[0][0]
+    assert "base_model%3D%22accounts%2Ffireworks%2Fmodels%2Fqwen3-8b%22" in manager.get_calls[0][0]
+    assert manager.post_calls == [
+        ("/v1/accounts/acct/trainingSessionJobs/job-new/trainingSessions", {}, 30)
+    ]
+
+
+def test_create_session_creates_parent_when_missing() -> None:
+    manager = _FakeManager(
+        list_payload={"trainingSessionJobs": []},
+        post_payloads=[
+            {"name": "accounts/acct/trainingSessionJobs/job-created"},
+            {"name": "accounts/acct/trainingSessionJobs/job-created/trainingSessions/session-456"},
+        ],
+    )
+    client = TrainingSessionClient(
+        api_key="test-key",
+        base_url="https://api.unit.test",
+        manager=manager,
+        request_session=_FakeHTTPSession(_FakeResponse({})),
+    )
+
+    handle = client.create_session("accounts/fireworks/models/qwen3-8b")
+
+    assert handle._job_id == "job-created"
+    assert handle._training_session_id == "session-456"
+    assert manager.post_calls == [
+        (
+            "/v1/accounts/acct/trainingSessionJobs",
+            {"baseModel": "accounts/fireworks/models/qwen3-8b"},
+            30,
+        ),
+        (
+            "/v1/accounts/acct/trainingSessionJobs/job-created/trainingSessions",
+            {},
+            30,
+        ),
+    ]
+
+
+def test_load_state_resets_private_sequence_counter() -> None:
+    manager = _FakeManager(list_payload={"trainingSessionJobs": []}, post_payloads=[{}])
+    handle = TrainingSessionHandle(
+        manager=manager,
+        request_session=_FakeHTTPSession(_FakeResponse({})),
+        base_url="https://api.unit.test",
+        account_id="acct",
+        job_id="job-123",
+        training_session_id="session-123",
+    )
+    handle._next_seq_id = 7
+
+    handle.load_state("/tmp/adapters/ref-a")
+
+    assert handle._next_seq_id == 2
+    assert manager.post_calls == [
+        (
+            "/v1/accounts/acct/trainingSessionJobs/job-123/trainingSessions/session-123:loadState",
+            {
+                "name": "accounts/acct/trainingSessionJobs/job-123/trainingSessions/session-123",
+                "path": "/tmp/adapters/ref-a",
+            },
+            30,
+        )
+    ]
+
+
+def test_forward_uses_session_scoped_path_and_increments_sequence() -> None:
+    http_session = _FakeHTTPSession(
+        _FakeResponse(
+            {
+                "loss_fn_output_type": "forward",
+                "loss_fn_outputs": [
+                    {
+                        "logprobs": {
+                            "data": [-0.5, -0.6],
+                            "dtype": "float32",
+                            "shape": [2],
+                        }
+                    }
+                ],
+                "metrics": {"loss": 1.23},
+            }
+        )
+    )
+    handle = TrainingSessionHandle(
+        manager=_FakeManager(list_payload={"trainingSessionJobs": []}, post_payloads=[]),
+        request_session=http_session,
+        base_url="https://api.unit.test",
+        account_id="acct",
+        job_id="job-123",
+        training_session_id="session-123",
+    )
+
+    result = handle.forward([_FakeDatum({"value": 1})], "cross_entropy")
+
+    assert http_session.calls == [
+        (
+            "https://api.unit.test/training/v1/trainingSessionJobs/acct/job-123/trainingSessions/session-123/forward",
+            {
+                "forward_input": {
+                    "data": [{"value": 1}],
+                    "loss_fn": "cross_entropy",
+                },
+                "seq_id": 1,
+            },
+            600,
+        )
+    ]
+    assert handle._next_seq_id == 2
+    assert result.loss_fn_output_type == "forward"
+    assert result.loss_fn_outputs[0]["logprobs"].data == [-0.5, -0.6]
+
+
+def test_forward_failure_keeps_sequence_and_invalidates_handle() -> None:
+    handle = TrainingSessionHandle(
+        manager=_FakeManager(list_payload={"trainingSessionJobs": []}, post_payloads=[]),
+        request_session=_FakeHTTPSession(requests.Timeout("timed out")),
+        base_url="https://api.unit.test",
+        account_id="acct",
+        job_id="job-123",
+        training_session_id="session-123",
+    )
+    handle._next_seq_id = 3
+
+    with pytest.raises(requests.Timeout):
+        handle.forward([], "cross_entropy")
+
+    assert handle._next_seq_id == 3
+    with pytest.raises(RuntimeError, match="no longer usable"):
+        handle.forward([], "cross_entropy")
+
+
+def test_forward_http_error_keeps_handle_usable() -> None:
+    http_session = _FakeHTTPSession(_FakeResponse({"error": "boom"}, status_code=500))
+    handle = TrainingSessionHandle(
+        manager=_FakeManager(list_payload={"trainingSessionJobs": []}, post_payloads=[]),
+        request_session=http_session,
+        base_url="https://api.unit.test",
+        account_id="acct",
+        job_id="job-123",
+        training_session_id="session-123",
+    )
+    handle._next_seq_id = 4
+
+    with pytest.raises(requests.HTTPError):
+        handle.forward([], "cross_entropy")
+
+    assert handle._next_seq_id == 4
+
+    http_session.response = _FakeResponse(
+        {
+            "loss_fn_output_type": "forward",
+            "loss_fn_outputs": [],
+        }
+    )
+    handle.forward([], "cross_entropy")
+    assert handle._next_seq_id == 5

--- a/training/tests/unit/test_training_session_client.py
+++ b/training/tests/unit/test_training_session_client.py
@@ -64,6 +64,7 @@ class _FakeDatum:
 
 
 def test_create_session_reuses_newest_parent_job() -> None:
+    """Reuse the newest matching parent job before creating a child session."""
     manager = _FakeManager(
         list_payload={
             "trainingSessionJobs": [
@@ -96,6 +97,7 @@ def test_create_session_reuses_newest_parent_job() -> None:
 
 
 def test_create_session_creates_parent_when_missing() -> None:
+    """Create a parent job first when no matching parent exists."""
     manager = _FakeManager(
         list_payload={"trainingSessionJobs": []},
         post_payloads=[
@@ -129,6 +131,7 @@ def test_create_session_creates_parent_when_missing() -> None:
 
 
 def test_load_state_resets_private_sequence_counter() -> None:
+    """Reset the private forward sequence after a successful load_state call."""
     manager = _FakeManager(list_payload={"trainingSessionJobs": []}, post_payloads=[{}])
     handle = TrainingSessionHandle(
         manager=manager,
@@ -156,6 +159,7 @@ def test_load_state_resets_private_sequence_counter() -> None:
 
 
 def test_forward_uses_session_scoped_path_and_increments_sequence() -> None:
+    """Send forwards through the session-scoped gateway path and advance seq_id."""
     http_session = _FakeHTTPSession(
         _FakeResponse(
             {
@@ -203,6 +207,7 @@ def test_forward_uses_session_scoped_path_and_increments_sequence() -> None:
 
 
 def test_forward_failure_keeps_sequence_and_invalidates_handle() -> None:
+    """Keep seq_id unchanged and invalidate the handle after a timeout."""
     handle = TrainingSessionHandle(
         manager=_FakeManager(list_payload={"trainingSessionJobs": []}, post_payloads=[]),
         request_session=_FakeHTTPSession(requests.Timeout("timed out")),
@@ -222,6 +227,7 @@ def test_forward_failure_keeps_sequence_and_invalidates_handle() -> None:
 
 
 def test_forward_http_error_keeps_handle_usable() -> None:
+    """Keep the handle usable after non-timeout HTTP failures."""
     http_session = _FakeHTTPSession(_FakeResponse({"error": "boom"}, status_code=500))
     handle = TrainingSessionHandle(
         manager=_FakeManager(list_payload={"trainingSessionJobs": []}, post_payloads=[]),

--- a/training/utils/__init__.py
+++ b/training/utils/__init__.py
@@ -16,6 +16,8 @@ __all__ = [
     "RewardFn",
     "RLPromptDataset",
     "StepCallback",
+    "TrainingSessionClient",
+    "TrainingSessionHandle",
     "WandBConfig",
     "compute_advantages",
     "compute_pass_at_k",
@@ -74,6 +76,10 @@ from training.utils.infra import (
 )
 from training.utils.timer import timed, timer, flush_timing
 from training.utils.client import ReconnectableClient
+from training.utils.training_session_client import (
+    TrainingSessionClient,
+    TrainingSessionHandle,
+)
 from training.utils.config import (
     DEFAULT_ADAM,
     EvalFn,

--- a/training/utils/config.py
+++ b/training/utils/config.py
@@ -38,11 +38,12 @@ class InfraConfig:
     When set, infra config is auto-derived from the shape."""
 
     ref_training_shape_id: str | None = None
-    """Training shape ID for the reference (forward-only) trainer.
-    When set, a reference model is created.  When not set, no reference
-    model is created.  No implicit fallback.  Can be the same value as
-    ``training_shape_id`` -- the control plane auto-appends
-    ``--forward-only`` via ``applyForwardOnlyConfig``."""
+    """Training shape ID for a dedicated reference (forward-only) trainer.
+    Recipes that still provision a separate reference trainer use this field.
+    `training.recipes.rl_loop` now ignores it and uses shared training sessions
+    for reference logprobs instead. Can be the same value as
+    ``training_shape_id`` -- the control plane auto-appends ``--forward-only``
+    via ``applyForwardOnlyConfig``."""
 
     region: str | None = None
     custom_image_tag: str | None = None
@@ -74,6 +75,8 @@ class DeployConfig:
     Increase for R3 + long completions where responses can be very large."""
     disable_speculative_decoding: bool = True
     """Disable base model's default draft/EAGLE speculation for hotload compatibility."""
+    replica_count: int | None = None
+    """If set, pin the deployment to a fixed replica count."""
     extra_values: dict[str, str] | None = None
     """Extra Helm values for the deployment (e.g. ``{"priorityClass": "deployment"}``)."""
 
@@ -87,6 +90,7 @@ class DeployConfig:
         accel = None if self.deployment_shape else self.deployment_accelerator_type
         if not accel and not self.deployment_shape:
             accel = infra.accelerator_type
+        replica_count = 1 if self.replica_count is None else self.replica_count
         return DeploymentConfig(
             deployment_id=self.deployment_id,
             base_model=base_model,
@@ -95,8 +99,8 @@ class DeployConfig:
             hot_load_bucket_type=self.hot_load_bucket_type,
             skip_shape_validation=skip_validation,
             extra_args=self.deployment_extra_args,
-            min_replica_count=1,
-            max_replica_count=1,
+            min_replica_count=replica_count,
+            max_replica_count=replica_count,
             accelerator_type=accel,
             disable_speculative_decoding=self.disable_speculative_decoding,
             extra_values=self.extra_values,

--- a/training/utils/training_session_client.py
+++ b/training/utils/training_session_client.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from typing import Any
+from urllib.parse import urlencode
+
+import requests
+from fireworks.training.sdk.trainer import TrainerJobManager
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TIMEOUT_S = 600
+
+
+def _to_jsonable(value: Any) -> Any:
+    if hasattr(value, "model_dump"):
+        return value.model_dump(mode="json", exclude_none=True)
+    if isinstance(value, dict):
+        return {key: _to_jsonable(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_to_jsonable(item) for item in value]
+    if isinstance(value, tuple):
+        return [_to_jsonable(item) for item in value]
+    return value
+
+
+def _wrap_forward_leaf(value: Any) -> Any:
+    if isinstance(value, dict) and "data" in value:
+        return SimpleNamespace(**{key: _wrap_forward_leaf(item) for key, item in value.items()})
+    if isinstance(value, list):
+        return [_wrap_forward_leaf(item) for item in value]
+    if isinstance(value, dict):
+        return {key: _wrap_forward_leaf(item) for key, item in value.items()}
+    return value
+
+
+def _to_forward_result(payload: dict[str, Any]) -> SimpleNamespace:
+    loss_fn_outputs = [
+        {key: _wrap_forward_leaf(value) for key, value in output.items()}
+        for output in payload.get("loss_fn_outputs", [])
+    ]
+    result = dict(payload)
+    result["loss_fn_outputs"] = loss_fn_outputs
+    return SimpleNamespace(**result)
+
+
+def _resource_id(name: str) -> str:
+    return name.rstrip("/").split("/")[-1]
+
+
+class TrainingSessionClient:
+    """Cookbook client for shared reference sessions."""
+
+    def __init__(
+        self,
+        api_key: str,
+        base_url: str,
+        *,
+        manager: TrainerJobManager | None = None,
+        request_session: requests.Session | None = None,
+        timeout_s: int = DEFAULT_TIMEOUT_S,
+    ) -> None:
+        self._manager = manager or TrainerJobManager(api_key=api_key, base_url=base_url)
+        self._base_url = base_url.rstrip("/")
+        self._timeout_s = timeout_s
+        self._http = request_session or requests.Session()
+        self._http.headers.update(
+            {
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+            }
+        )
+
+    def create_session(self, base_model: str) -> TrainingSessionHandle:
+        parent_job = self._resolve_or_create_parent_job(base_model)
+        session = self._create_training_session(parent_job["name"])
+        return TrainingSessionHandle(
+            manager=self._manager,
+            request_session=self._http,
+            base_url=self._base_url,
+            account_id=self._manager.account_id,
+            job_id=_resource_id(parent_job["name"]),
+            training_session_id=_resource_id(session["name"]),
+            timeout_s=self._timeout_s,
+        )
+
+    def _resolve_or_create_parent_job(self, base_model: str) -> dict[str, Any]:
+        query = urlencode(
+            {
+                "filter": f'base_model="{base_model}"',
+                "orderBy": "create_time desc",
+                "pageSize": 50,
+            }
+        )
+        path = f"/v1/accounts/{self._manager.account_id}/trainingSessionJobs?{query}"
+        response = self._manager._get(path, timeout=30)
+        response.raise_for_status()
+        jobs = response.json().get("trainingSessionJobs", [])
+        if jobs:
+            return jobs[0]
+
+        create_path = f"/v1/accounts/{self._manager.account_id}/trainingSessionJobs"
+        create_response = self._manager._post(create_path, json={"baseModel": base_model}, timeout=30)
+        create_response.raise_for_status()
+        return create_response.json()
+
+    def _create_training_session(self, parent_name: str) -> dict[str, Any]:
+        path = f"/v1/{parent_name}/trainingSessions"
+        response = self._manager._post(path, json={}, timeout=30)
+        response.raise_for_status()
+        return response.json()
+
+
+class TrainingSessionHandle:
+    """Single-threaded, non-thread-safe handle for one training session."""
+
+    def __init__(
+        self,
+        *,
+        manager: TrainerJobManager,
+        request_session: requests.Session,
+        base_url: str,
+        account_id: str,
+        job_id: str,
+        training_session_id: str,
+        timeout_s: int = DEFAULT_TIMEOUT_S,
+    ) -> None:
+        self._manager = manager
+        self._http = request_session
+        self._base_url = base_url.rstrip("/")
+        self._account_id = account_id
+        self._job_id = job_id
+        self._training_session_id = training_session_id
+        self._timeout_s = timeout_s
+        self._next_seq_id = 1
+        self._usable = True
+
+    def load_state(self, path: str) -> None:
+        self._ensure_usable()
+        response = self._manager._post(
+            f"/v1/{self._session_name}:loadState",
+            json={"name": self._session_name, "path": path},
+            timeout=30,
+        )
+        response.raise_for_status()
+        self._next_seq_id = 2
+
+    def forward(self, data: Any, loss_fn: str) -> SimpleNamespace:
+        self._ensure_usable()
+        payload = {
+            "forward_input": {
+                "data": _to_jsonable(data),
+                "loss_fn": loss_fn,
+            },
+            "seq_id": self._next_seq_id,
+        }
+        try:
+            response = self._http.post(
+                self._forward_url,
+                json=payload,
+                timeout=self._timeout_s,
+            )
+            response.raise_for_status()
+            result = response.json()
+        except requests.Timeout:
+            self._usable = False
+            raise
+        except Exception:
+            raise
+
+        self._next_seq_id += 1
+        return _to_forward_result(result)
+
+    @property
+    def _session_name(self) -> str:
+        return (
+            f"accounts/{self._account_id}/trainingSessionJobs/{self._job_id}"
+            f"/trainingSessions/{self._training_session_id}"
+        )
+
+    @property
+    def _forward_url(self) -> str:
+        return (
+            f"{self._base_url}/training/v1/trainingSessionJobs/{self._account_id}/{self._job_id}"
+            f"/trainingSessions/{self._training_session_id}/forward"
+        )
+
+    def _ensure_usable(self) -> None:
+        if not self._usable:
+            raise RuntimeError("TrainingSessionHandle is no longer usable after a failed forward()")

--- a/training/utils/training_session_client.py
+++ b/training/utils/training_session_client.py
@@ -1,14 +1,11 @@
 from __future__ import annotations
 
-import logging
 from types import SimpleNamespace
 from typing import Any
 from urllib.parse import urlencode
 
 import requests
 from fireworks.training.sdk.trainer import TrainerJobManager
-
-logger = logging.getLogger(__name__)
 
 DEFAULT_TIMEOUT_S = 600
 
@@ -165,8 +162,6 @@ class TrainingSessionHandle:
             result = response.json()
         except requests.Timeout:
             self._usable = False
-            raise
-        except Exception:
             raise
 
         self._next_seq_id += 1


### PR DESCRIPTION
## Summary
- replace dedicated reference trainer provisioning in `rl_loop` with `TrainingSessionClient` and shared training sessions
- add the training session client implementation plus focused unit coverage for session creation, load-state, and forward sequencing
- clarify that `rl_loop` ignores legacy dedicated reference settings while shared config continues to support recipes that still use them

## Architecture / Code Overview Diagram
```mermaid
flowchart LR
    Loop[rl_loop] --> Policy[policy trainer]
    Loop --> Client[TrainingSessionClient]
    Client --> CP[training session APIs]
    CP --> SharedRef[shared reference session]
    Loop --> Handle[TrainingSessionHandle]
    Handle --> Gateway[session-scoped forward route]
    Gateway --> SharedRef
```

## Testing
- `pytest training/tests/unit/test_training_session_client.py training/tests/unit/test_rl_loop.py -q`

## Additional Context
- Pairs with `fw-ai/fireworks#19919`

Made with [Cursor](https://cursor.com)