### PR TITLE
feat: checkpoint metadata for auto-promote

### DIFF
--- a/training/examples/promote_checkpoint/train_promote_checkpoint.py
+++ b/training/examples/promote_checkpoint/train_promote_checkpoint.py
@@ -7,19 +7,27 @@ existing DCP checkpoint referenced from cookbook `checkpoints.jsonl`, saves a
 promotable sampler checkpoint, and promotes that checkpoint into a Fireworks
 model.
 
+When checkpoints were saved with ``base_model`` and ``training_shape`` fields,
+``--model`` and ``--shape`` are auto-populated from the checkpoint and can be
+omitted.
+
 Usage:
     export FIREWORKS_API_KEY=...
 
+    # Auto-detect model and shape from checkpoint metadata:
+    python train_promote_checkpoint.py \
+        --checkpoints-jsonl ./sft_logs/checkpoints.jsonl
+
+    # Explicit (overrides checkpoint metadata):
     python train_promote_checkpoint.py \
         --checkpoints-jsonl ./sft_logs/checkpoints.jsonl \
         --model accounts/fireworks/models/qwen3-8b \
         --shape accounts/fireworks/trainingShapes/ts-qwen3-8b-policy
 
+    # Specific step:
     python train_promote_checkpoint.py \
         --checkpoints-jsonl ./sft_logs/checkpoints.jsonl \
-        --step 5 \
-        --model accounts/fireworks/models/qwen3-8b \
-        --shape accounts/fireworks/trainingShapes/ts-qwen3-8b-policy
+        --step 5
 """
 
 from __future__ import annotations
@@ -71,8 +79,8 @@ _VERSIONED_TRAINING_SHAPE_RE = re.compile(
 class PromoteConfig:
     checkpoints_jsonl: str
     step: int | None
-    base_model: str
-    training_shape: str
+    base_model: str | None
+    training_shape: str | None
     lora_rank: int
     output_model_id: str | None
     trainer_timeout_s: float
@@ -85,6 +93,8 @@ class ResolvedCheckpoint:
     checkpoint_ref: str
     checkpoint_name: str
     source_job_id: str | None
+    base_model: str | None = None
+    training_shape: str | None = None
 
 
 def parse_args() -> PromoteConfig:
@@ -106,13 +116,19 @@ def parse_args() -> PromoteConfig:
         help="Training step to promote. Defaults to the latest checkpoint in checkpoints.jsonl.",
     )
     parser.add_argument(
-        "--model", required=True, help="Base model to launch in the temporary trainer"
+        "--model",
+        default=None,
+        help=(
+            "Base model to launch in the temporary trainer. "
+            "Auto-detected from checkpoint metadata when omitted."
+        ),
     )
     parser.add_argument(
         "--shape",
-        required=True,
+        default=None,
         help=(
             "Training shape to use for the temporary trainer. "
+            "Auto-detected from checkpoint metadata when omitted. "
             "Accepts either accounts/<account>/trainingShapes/<shape> or a bare shape ID."
         ),
     )
@@ -238,6 +254,8 @@ def _resolve_checkpoint_from_jsonl(
         checkpoint_ref=checkpoint_ref,
         checkpoint_name=str(chosen.get("name") or _checkpoint_label(checkpoint_ref)),
         source_job_id=chosen.get("source_job_id"),
+        base_model=chosen.get("base_model"),
+        training_shape=chosen.get("training_shape"),
     )
 
 
@@ -263,23 +281,41 @@ def main() -> None:
         cfg.step,
     )
 
+    # Resolve base_model: CLI flag > checkpoint metadata
+    base_model = cfg.base_model or resolved_checkpoint.base_model
+    if not base_model:
+        raise SystemExit(
+            "ERROR: --model is required (checkpoint has no base_model metadata).\n"
+            "Older checkpoints don't store base_model. Pass it explicitly:\n"
+            "  --model accounts/fireworks/models/<model-name>"
+        )
+
+    # Resolve training_shape: CLI flag > checkpoint metadata
+    training_shape_raw = cfg.training_shape or resolved_checkpoint.training_shape
+    if not training_shape_raw:
+        raise SystemExit(
+            "ERROR: --shape is required (checkpoint has no training_shape metadata).\n"
+            "Older checkpoints don't store training_shape. Pass it explicitly:\n"
+            "  --shape accounts/fireworks/trainingShapes/<shape-name>"
+        )
+
     api_key = os.environ["FIREWORKS_API_KEY"]
     base_url = os.environ.get("FIREWORKS_BASE_URL", "https://api.fireworks.ai")
 
     rlor_mgr = TrainerJobManager(api_key=api_key, base_url=base_url)
 
     training_shape = _normalize_training_shape(
-        cfg.training_shape,
+        training_shape_raw,
         rlor_mgr.account_id,
     )
     profile = rlor_mgr.resolve_training_profile(training_shape)
 
     output_model_id = cfg.output_model_id or _default_output_model_id(
-        cfg.base_model,
+        base_model,
         resolved_checkpoint.checkpoint_name,
     )
     display_name = _default_display_name(
-        cfg.base_model,
+        base_model,
         resolved_checkpoint.checkpoint_name,
     )
     sampler_name = _sanitize_resource_id(
@@ -294,8 +330,8 @@ def main() -> None:
     logger.info("Checkpoint name:     %s", resolved_checkpoint.checkpoint_name)
     if resolved_checkpoint.source_job_id:
         logger.info("Source job ID:       %s", resolved_checkpoint.source_job_id)
-    logger.info("Base model:          %s", cfg.base_model)
-    logger.info("Training shape:      %s", training_shape)
+    logger.info("Base model:          %s%s", base_model, " (from checkpoint)" if not cfg.base_model else "")
+    logger.info("Training shape:      %s%s", training_shape, " (from checkpoint)" if not cfg.training_shape else "")
     logger.info("Resolved shape ver.: %s", profile.training_shape_version)
     logger.info("LoRA rank:           %d", cfg.lora_rank)
     logger.info("Output model ID:     %s", output_model_id)
@@ -304,7 +340,7 @@ def main() -> None:
     with cleanup:
         endpoint = create_trainer_job(
             rlor_mgr,
-            base_model=cfg.base_model,
+            base_model=base_model,
             infra=InfraConfig(trainer_timeout_s=cfg.trainer_timeout_s),
             profile=profile,
             lora_rank=cfg.lora_rank,
@@ -315,7 +351,7 @@ def main() -> None:
         client = ReconnectableClient(
             rlor_mgr=rlor_mgr,
             job_id=endpoint.job_id,
-            base_model=cfg.base_model,
+            base_model=base_model,
             lora_rank=cfg.lora_rank,
             fw_api_key=api_key,
             endpoint=endpoint,

--- a/training/recipes/rl_loop.py
+++ b/training/recipes/rl_loop.py
@@ -706,6 +706,8 @@ def main(
                         "source_job_id": policy_job_id,
                     },
                     kind=CheckpointKind.STATE,
+                    base_model=cfg.base_model,
+                    training_shape=cfg.infra.training_shape_id,
                 )
 
             metrics = compute_step_metrics(
@@ -803,6 +805,8 @@ def main(
                         "source_job_id": policy_job_id,
                     },
                     kind=CheckpointKind.BOTH,
+                    base_model=cfg.base_model,
+                    training_shape=cfg.infra.training_shape_id,
                 )
 
                 if getattr(cfg, "output_model_id", None):

--- a/training/recipes/sft_loop.py
+++ b/training/recipes/sft_loop.py
@@ -298,7 +298,9 @@ def main(
                         "step": step,
                         "data_consumed": data_consumed,
                         "source_job_id": job_id,
-                    }, kind=CheckpointKind.STATE)
+                    }, kind=CheckpointKind.STATE,
+                    base_model=cfg.base_model,
+                    training_shape=cfg.infra.training_shape_id)
 
             step_elapsed = time.monotonic() - step_t0
             tokens_per_sec = step_tokens / step_elapsed if step_elapsed > 0 else 0.0
@@ -357,7 +359,9 @@ def main(
                 "step": step,
                 "data_consumed": data_consumed,
                 "source_job_id": job_id,
-            }, kind=CheckpointKind.BOTH)
+            }, kind=CheckpointKind.BOTH,
+            base_model=cfg.base_model,
+            training_shape=cfg.infra.training_shape_id)
             if getattr(cfg, "output_model_id", None):
                 rlor_mgr.promote_checkpoint(
                     job_id,

--- a/training/tests/unit/test_checkpoint_utils.py
+++ b/training/tests/unit/test_checkpoint_utils.py
@@ -142,6 +142,28 @@ class TestSaveCheckpoint:
         assert "sampler_path" in paths
         assert paths["sampler_path"] == "step-5-sampler"
 
+    def test_save_with_base_model_and_training_shape(self, log_dir):
+        client = _make_mock_client(job_id="job-shape")
+        save_checkpoint(
+            client, "step-2", log_dir, {"step": 2},
+            base_model="accounts/fireworks/models/qwen3-8b",
+            training_shape="accounts/fireworks/trainingShapes/ts-qwen3-8b-policy",
+        )
+        ckpt_path = os.path.join(log_dir, CHECKPOINTS_BASE_NAME)
+        with open(ckpt_path) as f:
+            entry = json.loads(f.readline())
+        assert entry["base_model"] == "accounts/fireworks/models/qwen3-8b"
+        assert entry["training_shape"] == "accounts/fireworks/trainingShapes/ts-qwen3-8b-policy"
+
+    def test_save_without_model_metadata_omits_fields(self, log_dir):
+        client = _make_mock_client()
+        save_checkpoint(client, "step-1", log_dir, {"step": 1})
+        ckpt_path = os.path.join(log_dir, CHECKPOINTS_BASE_NAME)
+        with open(ckpt_path) as f:
+            entry = json.loads(f.readline())
+        assert "base_model" not in entry
+        assert "training_shape" not in entry
+
     def test_appends_entries(self, log_dir):
         client = _make_mock_client()
         save_checkpoint(client, "step-1", log_dir, {"step": 1})
@@ -256,3 +278,69 @@ class TestLogPathRequired:
         assert result.step == 3
         assert result.data_consumed == 24
         client2.load_state_with_optimizer.assert_called_once()
+
+
+class TestCheckpointMetadataForPromote:
+    """Verify base_model/training_shape saved in checkpoints are readable
+    by the promote_checkpoint script's _resolve_checkpoint_from_jsonl."""
+
+    def test_metadata_roundtrip_latest(self, log_dir):
+        """Save checkpoints with metadata, read back the latest entry."""
+        client = _make_mock_client(job_id="job-meta")
+        save_checkpoint(client, "step-1", log_dir, {
+            "step": 1, "data_consumed": 8, "source_job_id": "job-meta",
+        }, base_model="accounts/fw/models/qwen3-8b",
+           training_shape="accounts/fw/trainingShapes/ts-qwen3-8b-policy")
+
+        save_checkpoint(client, "step-2", log_dir, {
+            "step": 2, "data_consumed": 16, "source_job_id": "job-meta",
+        }, base_model="accounts/fw/models/qwen3-8b",
+           training_shape="accounts/fw/trainingShapes/ts-qwen3-8b-policy")
+
+        ckpt_path = os.path.join(log_dir, CHECKPOINTS_BASE_NAME)
+        entries = []
+        with open(ckpt_path) as f:
+            for line in f:
+                if line.strip():
+                    entries.append(json.loads(line))
+
+        assert len(entries) == 2
+        latest = entries[-1]
+        assert latest["step"] == 2
+        assert latest["base_model"] == "accounts/fw/models/qwen3-8b"
+        assert latest["training_shape"] == "accounts/fw/trainingShapes/ts-qwen3-8b-policy"
+        assert "state_path" in latest
+        assert latest["state_path"].startswith("cross_job://")
+
+    def test_metadata_absent_for_old_checkpoints(self, log_dir):
+        """Checkpoints saved without metadata lack base_model/training_shape."""
+        client = _make_mock_client(job_id="job-old")
+        save_checkpoint(client, "step-1", log_dir, {
+            "step": 1, "source_job_id": "job-old",
+        })
+
+        ckpt_path = os.path.join(log_dir, CHECKPOINTS_BASE_NAME)
+        with open(ckpt_path) as f:
+            entry = json.loads(f.readline())
+        assert "base_model" not in entry
+        assert "training_shape" not in entry
+
+    def test_select_checkpoint_by_step(self, log_dir):
+        """Verify the right entry is selected when filtering by step."""
+        client = _make_mock_client(job_id="job-step")
+        for step in (1, 2, 3):
+            save_checkpoint(client, f"step-{step}", log_dir, {
+                "step": step, "source_job_id": "job-step",
+            }, base_model=f"model-v{step}",
+               training_shape="shape-a")
+
+        ckpt_path = os.path.join(log_dir, CHECKPOINTS_BASE_NAME)
+        entries = []
+        with open(ckpt_path) as f:
+            for line in f:
+                if line.strip():
+                    entries.append(json.loads(line))
+
+        step2 = [e for e in entries if e.get("step") == 2]
+        assert len(step2) == 1
+        assert step2[0]["base_model"] == "model-v2"

--- a/training/utils/checkpoint_utils.py
+++ b/training/utils/checkpoint_utils.py
@@ -104,11 +104,18 @@ def save_checkpoint(
     log_path: str,
     loop_state: dict[str, Any],
     kind: CheckpointKind = CheckpointKind.STATE,
+    *,
+    base_model: str | None = None,
+    training_shape: str | None = None,
 ) -> dict[str, str]:
     """Save a checkpoint using tinker_cookbook's ``checkpoints.jsonl`` format.
 
     *kind* can be ``CheckpointKind.STATE`` (optimizer + weights), ``CheckpointKind.SAMPLER`` (weights
     only for inference), or ``CheckpointKind.BOTH``.
+
+    *base_model* and *training_shape* are persisted into the checkpoint
+    entry so that downstream tools (e.g. ``train_promote_checkpoint.py``)
+    can auto-detect them without requiring the user to pass them manually.
 
     The ``state_path`` stored is resolved to a cross-job checkpoint
     reference at save time, so any future trainer job can load it
@@ -125,6 +132,10 @@ def save_checkpoint(
         paths["sampler_path"] = get_sampler_checkpoint_id(save_result)
 
     full_dict = {"name": name, **loop_state, **paths}
+    if base_model:
+        full_dict["base_model"] = base_model
+    if training_shape:
+        full_dict["training_shape"] = training_shape
     os.makedirs(log_path, exist_ok=True)
     with open(os.path.join(log_path, CHECKPOINTS_BASE_NAME), "a") as f:
         f.write(json.dumps(full_dict) + "\n")


### PR DESCRIPTION
## Summary
- `save_checkpoint()` now accepts optional `base_model` and `training_shape` kwargs, persisted into `checkpoints.jsonl` entries
- SFT and RL recipes pass these at every checkpoint save
- `train_promote_checkpoint.py` auto-detects `--model` and `--shape` from checkpoint metadata (CLI flags still override for backward compat)
- Unit tests for metadata round-trip and backward compat with old checkpoints

## Test plan
- [x] 220 unit tests passing
- [ ] E2e: verify checkpoint metadata saved and readable by promote script

🤖 Generated with [Claude Code](https://claude.com/claude-code)