### PR TITLE
Move max_concurrent from WeightSyncConfig to ConcurrencyConfig

### DIFF
--- a/training/examples/frozen_lake/train_frozen_lake.py
+++ b/training/examples/frozen_lake/train_frozen_lake.py
@@ -824,7 +824,6 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
                 metrics_callback=_filtered_step_callback,
                 weight_sync_fn=_weight_sync if weight_sync_cfg.weight_sync_interval > 0 else None,
                 weight_sync_interval=weight_sync_cfg.weight_sync_interval,
-                max_concurrent=weight_sync_cfg.max_concurrent,
             ))
 
             # -- Final checkpoint -----------------------------------------------

--- a/training/recipes/rl_loop.py
+++ b/training/recipes/rl_loop.py
@@ -838,7 +838,6 @@ def main(
                     metrics_callback=_loop_metrics_callback,
                     weight_sync_fn=_weight_sync if cfg.weight_sync.weight_sync_interval > 0 else None,
                     weight_sync_interval=cfg.weight_sync.weight_sync_interval,
-                    max_concurrent=cfg.weight_sync.max_concurrent,
                 )
             )
 

--- a/training/tests/unit/test_train_frozen_lake.py
+++ b/training/tests/unit/test_train_frozen_lake.py
@@ -324,7 +324,6 @@ def test_main_bootstraps_without_reference_and_cleans_up(monkeypatch, tmp_path):
     assert events["rollout_processor_init"]["allow_plaintext_action_fallback"] is True
     assert events["run_rl_loop_kwargs"]["prompt_groups_per_step"] == 4
     assert "train_fns" in events["run_rl_loop_kwargs"]
-    assert events["run_rl_loop_kwargs"]["max_concurrent"] == 0
     assert events["run_rl_loop_kwargs"]["weight_sync_interval"] == 1
     assert events["run_rl_loop_kwargs"]["weight_sync_fn"] is not None
     assert events["deleted_jobs"] == ["policy-job"]

--- a/training/utils/config.py
+++ b/training/utils/config.py
@@ -150,10 +150,6 @@ class WeightSyncConfig:
     first_checkpoint_type: str = "base"
     weight_sync_before_training: bool = False
     weight_sync_timeout: int = 600
-    max_concurrent: int = 0
-    """Cap concurrent sampling requests.  Passed to both
-    DeploymentSampler(max_concurrency=...) for HTTP-level gating and to
-    run_rl_loop for coroutine-level gating.  0 = unlimited."""
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- Remove `max_concurrent` from `WeightSyncConfig` — sampling concurrency is the sampler's responsibility, not the weight syncer's
- Drop the redundant coroutine-level `max_concurrent` arg from `run_rl_loop` calls in `rl_loop.py` and `train_frozen_lake.py` — concurrency is now managed by `DeploymentSampler`'s `concurrency_controller` (adaptive/fixed via `ConcurrencyConfig`)
- Update frozen lake test assertion accordingly

Follow-up to #244 which introduced the pipeline overlap. PR #244 added `max_concurrent` to `WeightSyncConfig` for convenience, but it belongs in the sampling layer which now has proper `ConcurrencyConfig` with adaptive and fixed modes.

## Test plan
- [x] E2E deepmath_rl test (qwen3-4b, 10+ steps) passed with all pipeline stages working: sampling, ref_forward, fwd_bwd, optim_step, weight_sync, hotload
- [ ] Unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)