### PR TITLE
feat: add deployment_checkpoint_save_interval for periodic deployable checkpoints

### DIFF
--- a/training/recipes/rl_loop.py
+++ b/training/recipes/rl_loop.py
@@ -766,6 +766,27 @@ def main(
                     training_shape=cfg.infra.training_shape_id,
                 )
 
+            if cfg.weight_sync.deployment_checkpoint_save_interval > 0 and step % cfg.weight_sync.deployment_checkpoint_save_interval == 0:
+                logger.info("[step %d] deployment_checkpoint_save...", step)
+                t0 = _time.time()
+                _data_consumed = (resume_info.data_consumed if resume_info else 0) + (
+                    step - step_offset
+                ) * prompt_groups_per_step
+                save_checkpoint(
+                    policy,
+                    f"deploy-step-{step}",
+                    cfg.log_path,
+                    {
+                        "step": step,
+                        "data_consumed": _data_consumed,
+                        "source_job_id": policy_job_id,
+                    },
+                    kind=CheckpointKind.SAMPLER,
+                    base_model=cfg.base_model,
+                    training_shape=cfg.infra.training_shape_id,
+                )
+                logger.info("[step %d] deployment_checkpoint_save: done (%.1fs)", step, _time.time() - t0)
+
             metrics = compute_step_metrics(
                 prompt_groups=prompt_groups,
                 fwd_bwd_results=[fwd_bwd_result],

--- a/training/utils/config.py
+++ b/training/utils/config.py
@@ -147,6 +147,10 @@ class WeightSyncConfig:
     dcp_save_interval: int = 0
     dcp_timeout: int = 2700
     """Timeout in seconds for DCP save_state / load_state_with_optimizer (default 45 min)."""
+    deployment_checkpoint_save_interval: int = 0
+    """Save a deployable (sampler) checkpoint every N training steps.
+    The checkpoint can be promoted to a standalone model or used to create
+    a separate deployment (e.g. for evaluation).  0 = disabled."""
     first_checkpoint_type: str = "base"
     weight_sync_before_training: bool = False
     weight_sync_timeout: int = 600


### PR DESCRIPTION
## Summary
- Adds `deployment_checkpoint_save_interval` to `WeightSyncConfig` (default 0 = disabled)
- When enabled, periodically saves sampler-only (deployable) checkpoints during RL training
- These checkpoints can be promoted to standalone models or used to create separate deployments (e.g. for evaluation) without interfering with the training deployment's hotload delta chain

## Motivation
Users want to run evaluation on a separate deployment during training. Instead of managing a second deployment with synchronized hotloading (which complicates the delta checkpoint chain), this provides a simpler path: save periodic deployable checkpoints that users can independently deploy from.

## Test plan
- [ ] Existing unit tests pass (`pytest tests/unit/test_rl_loop.py`)
- [ ] Run RL loop with `deployment_checkpoint_save_interval=0` (default) — no behavior change
- [ ] Run RL loop with `deployment_checkpoint_save_interval=N` — verify `deploy-step-{step}` sampler checkpoints appear in `checkpoints.jsonl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)