### PR TITLE
Reduce cleanup grace period from 30s to 5s

### DIFF
--- a/training/utils/infra.py
+++ b/training/utils/infra.py
@@ -36,17 +36,17 @@ def _default_trainer_cancel_grace_period_s() -> float:
     raw = os.environ.get(_TRAINER_CANCEL_GRACE_ENV)
     source_env = _TRAINER_CANCEL_GRACE_ENV
     if raw is None:
-        raw = os.environ.get(_TRAINER_DELETE_GRACE_ENV, "30")
+        raw = os.environ.get(_TRAINER_DELETE_GRACE_ENV, "5")
         source_env = _TRAINER_DELETE_GRACE_ENV
     try:
         return max(0.0, float(raw))
     except ValueError:
         logger.warning(
-            "Invalid %s=%r; falling back to 30s trainer cancel grace period",
+            "Invalid %s=%r; falling back to 5s trainer cancel grace period",
             source_env,
             raw,
         )
-        return 30.0
+        return 5.0
 
 
 class ResourceCleanup:


### PR DESCRIPTION
## Summary
- Reduce the default trainer cleanup grace period from 30 seconds to 5 seconds in `training/utils/infra.py`
- Updates the default fallback value, warning message, and error fallback return value

## Test plan
- [ ] Verify cleanup completes within the new 5s grace period
- [ ] Confirm the `FW_TRAINER_CANCEL_GRACE_PERIOD_S` and `FW_TRAINER_DELETE_GRACE_PERIOD_S` env var overrides still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)