### PR TITLE
training: bound sampler checkpoint export

### DIFF
--- a/training/tests/unit/test_checkpoint_utils.py
+++ b/training/tests/unit/test_checkpoint_utils.py
@@ -1,6 +1,7 @@
 """Unit tests for checkpoint_utils -- resume, save."""
 
 import json
+import logging
 import os
 import tempfile
 from unittest.mock import MagicMock
@@ -141,6 +142,17 @@ class TestSaveCheckpoint:
         assert "state_path" in paths
         assert "sampler_path" in paths
         assert paths["sampler_path"] == "step-5-sampler"
+
+    def test_save_both_logs_checkpoint_phases(self, log_dir, caplog):
+        client = _make_mock_client()
+        caplog.set_level(logging.INFO)
+
+        save_checkpoint(client, "step-5", log_dir, {"step": 5}, kind=CheckpointKind.BOTH)
+
+        assert "Saving DCP checkpoint 'step-5'..." in caplog.messages
+        assert "Saved DCP checkpoint 'step-5'" in " ".join(caplog.messages)
+        assert "Exporting sampler checkpoint 'step-5'..." in caplog.messages
+        assert "Exported sampler checkpoint 'step-5'" in " ".join(caplog.messages)
 
     def test_save_with_base_model_and_training_shape(self, log_dir):
         client = _make_mock_client(job_id="job-shape")

--- a/training/tests/unit/test_client.py
+++ b/training/tests/unit/test_client.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import threading
+
 from fireworks.training.sdk.client import GradAccNormalization
 import pytest
 
@@ -20,10 +22,28 @@ class _FakeInnerClient:
         self.calls = []
         self.future = _FakeFuture()
         self.holder = None
+        self.sampler_calls = []
 
     def optim_step(self, params, **kwargs):
         self.calls.append((params, kwargs))
         return self.future
+
+    def save_weights_for_sampler_ext(self, name, checkpoint_type=None):
+        self.sampler_calls.append((name, checkpoint_type))
+        return {"name": name, "checkpoint_type": checkpoint_type}
+
+
+class _BlockingSamplerInner(_FakeInnerClient):
+    def __init__(self):
+        super().__init__()
+        self.started = threading.Event()
+        self.release = threading.Event()
+
+    def save_weights_for_sampler_ext(self, name, checkpoint_type=None):
+        self.sampler_calls.append((name, checkpoint_type))
+        self.started.set()
+        self.release.wait()
+        return {"name": name, "checkpoint_type": checkpoint_type}
 
 
 def _make_client(inner: _FakeInnerClient) -> ReconnectableClient:
@@ -120,6 +140,35 @@ def test_optim_step_rejects_unknown_normalization():
 
     with pytest.raises(ValueError, match="Unknown grad_accumulation_normalization"):
         client.optim_step("adam", grad_accumulation_normalization="not-a-real-mode")
+
+
+def test_save_weights_for_sampler_ext_returns_inner_result():
+    inner = _FakeInnerClient()
+    client = _make_client(inner)
+
+    result = client.save_weights_for_sampler_ext(
+        "step-2",
+        checkpoint_type="base",
+        timeout=5,
+    )
+
+    assert result == {"name": "step-2", "checkpoint_type": "base"}
+    assert inner.sampler_calls == [("step-2", "base")]
+
+
+def test_save_weights_for_sampler_ext_honors_timeout():
+    inner = _BlockingSamplerInner()
+    client = _make_client(inner)
+
+    with pytest.raises(TimeoutError, match="did not complete within 0.01s"):
+        client.save_weights_for_sampler_ext(
+            "step-3",
+            checkpoint_type="base",
+            timeout=0.01,
+        )
+
+    assert inner.started.wait(0.2)
+    inner.release.set()
 
 
 def test_close_drains_telemetry_and_stops_holder_cleanup():

--- a/training/utils/checkpoint_utils.py
+++ b/training/utils/checkpoint_utils.py
@@ -123,13 +123,29 @@ def save_checkpoint(
     """
     paths: dict[str, str] = {}
     if kind in (CheckpointKind.STATE, CheckpointKind.BOTH):
+        dcp_start = time.monotonic()
+        logger.info("Saving DCP checkpoint '%s'...", name)
         client.save_state(name)
         paths["state_path"] = client.resolve_checkpoint_path(
             name, source_job_id=client.job_id,
         )
+        logger.info(
+            "Saved DCP checkpoint '%s' in %.1fs -> %s",
+            name,
+            time.monotonic() - dcp_start,
+            paths["state_path"],
+        )
     if kind in (CheckpointKind.SAMPLER, CheckpointKind.BOTH):
+        sampler_start = time.monotonic()
+        logger.info("Exporting sampler checkpoint '%s'...", name)
         save_result = client.save_weights_for_sampler_ext(name, checkpoint_type="base")
         paths["sampler_path"] = get_sampler_checkpoint_id(save_result)
+        logger.info(
+            "Exported sampler checkpoint '%s' in %.1fs -> %s",
+            name,
+            time.monotonic() - sampler_start,
+            paths["sampler_path"],
+        )
 
     full_dict = {"name": name, **loop_state, **paths}
     if base_model:

--- a/training/utils/client.py
+++ b/training/utils/client.py
@@ -14,6 +14,9 @@ from __future__ import annotations
 
 import logging
 import os
+import queue
+import threading
+import time
 
 from fireworks.training.sdk.client import (
     FiretitanServiceClient,
@@ -141,9 +144,62 @@ class ReconnectableClient:
         return self._client.load_state_with_optimizer(path).result(timeout=timeout)
 
     def save_weights_for_sampler_ext(
-        self, name: str, checkpoint_type: str | None = None, timeout: int = DCP_TIMEOUT_S
+        self, name: str, checkpoint_type: str | None = None, timeout: int | None = DCP_TIMEOUT_S
     ):
-        return self.inner.save_weights_for_sampler_ext(name, checkpoint_type=checkpoint_type)
+        logger.info(
+            "Starting sampler checkpoint export '%s' (checkpoint_type=%s, timeout=%s)",
+            name,
+            checkpoint_type or "default",
+            timeout if timeout is not None else "none",
+        )
+        start = time.monotonic()
+        results: queue.Queue[object] = queue.Queue(maxsize=1)
+        errors: queue.Queue[BaseException] = queue.Queue(maxsize=1)
+
+        def _save_sampler_checkpoint() -> None:
+            try:
+                results.put(
+                    self.inner.save_weights_for_sampler_ext(
+                        name,
+                        checkpoint_type=checkpoint_type,
+                    )
+                )
+            except BaseException as exc:
+                errors.put(exc)
+
+        worker = threading.Thread(
+            target=_save_sampler_checkpoint,
+            name=f"sampler-export-{self._job_id}",
+            daemon=True,
+        )
+        worker.start()
+        worker.join(timeout=timeout)
+
+        elapsed = time.monotonic() - start
+        if worker.is_alive():
+            logger.error(
+                "Sampler checkpoint export '%s' timed out after %.1fs",
+                name,
+                elapsed,
+            )
+            raise TimeoutError(
+                f"Sampler checkpoint export '{name}' did not complete within {timeout}s. "
+                "The trainer may still be exporting weights on the server."
+            )
+
+        if not errors.empty():
+            exc = errors.get()
+            logger.error(
+                "Sampler checkpoint export '%s' failed after %.1fs: %s",
+                name,
+                elapsed,
+                exc,
+            )
+            raise exc
+
+        result = results.get()
+        logger.info("Completed sampler checkpoint export '%s' in %.1fs", name, elapsed)
+        return result
 
     def resolve_checkpoint_path(self, name: str, source_job_id: str | None = None) -> str:
         return self.inner.resolve_checkpoint_path(name, source_job_id=source_job_id)


### PR DESCRIPTION
## Summary
- honor `ReconnectableClient.save_weights_for_sampler_ext(...)` timeouts instead of blocking indefinitely
- add phase-specific timing logs for DCP save vs sampler export in `save_checkpoint(...)`
- add focused unit coverage for sampler export timeout handling and checkpoint phase logging

## Why
We reproduced multiple training runs that completed optimization steps and then stalled at `Saving final checkpoint...` before promotion. The cookbook is not the root cause of the server-side export stall, but it currently makes the failure opaque:
- `save_weights_for_sampler_ext(...)` advertises a timeout and ignores it
- `save_checkpoint(...)` does not distinguish DCP save from sampler export in logs

This patch makes the cookbook fail clearly and leaves cleaner evidence for backend debugging.

## Testing
- `training/.venv/bin/pytest training/tests/unit/test_client.py -q`
- `training/.venv/bin/pytest training/tests/unit/test_checkpoint_utils.py -q -k TestSaveCheckpoint`
