### PR TITLE
docs(training): update cookbook install guidance

### DIFF
--- a/training/README.md
+++ b/training/README.md
@@ -29,17 +29,14 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 uv venv --python 3.12
 source .venv/bin/activate
 
-# Install the Fireworks training SDK prerelease that provides
-# `fireworks.training.sdk`.
-uv pip install --pre "fireworks-ai>=1.0.0a36" tinker-cookbook
-
-# Install this package in editable mode
+# Install this package in editable mode.
+# The cookbook's pyproject pins a compatible `fireworks-ai[training]`
+# build plus the tested `tinker-cookbook` revision it expects.
 uv pip install -e .
 
-# If you skip `--pre`, pip may resolve to the stable `0.x` line,
-# which does not include `fireworks.training.sdk` and will cause
-# imports like `from fireworks.training.sdk import DeploymentManager`
-# to fail.
+# Optional: install eval extras for FrozenLake and other
+# `eval-protocol`-based examples.
+uv pip install -e ".[eval]"
 ```
 
 ### 2. Set your credentials

--- a/training/examples/rl/frozen_lake/train_frozen_lake.py
+++ b/training/examples/rl/frozen_lake/train_frozen_lake.py
@@ -8,9 +8,10 @@ Demonstrates reinforcement learning with multi-turn tool-calling:
     it falls back to the client-side custom loss path
 
 Usage:
-    pip install --pre "fireworks-ai>=1.0.0a36" tinker-cookbook eval-protocol
+    # From cookbook/training
+    uv pip install -e ".[eval]"
     export FIREWORKS_API_KEY=...
-    python train_frozen_lake.py --training-shape <shape_id>
+    python examples/rl/frozen_lake/train_frozen_lake.py --training-shape <shape_id>
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- stop telling cookbook users to install the SDK manually with blanket `--pre` flags and a separate `tinker-cookbook` package
- point `training/README.md` at the cookbook package's own editable install so `pyproject.toml` remains the single source of truth for the pinned SDK and cookbook dependencies
- update the FrozenLake example usage block to match the same `.[eval]` install path used for eval-protocol-based examples

## Testing
- `git diff --check`
- reviewed the changed setup guidance against `training/pyproject.toml` to confirm `-e .` and `-e ".[eval]"` match the package's pinned dependencies and optional eval extras
- ran an independent review pass on the final diff

## Architecture / Code Overview Diagram
```mermaid
flowchart LR
  Pyproject[training/pyproject.toml] --> EditableInstall[uv pip install -e . / .[eval]]
  EditableInstall --> README[training/README.md]
  EditableInstall --> FrozenLake[examples/rl/frozen_lake/train_frozen_lake.py]
  README --> Users[Cookbook users]
  FrozenLake --> Users
```

## Checklist
- [x] Kept the diff docs-only and minimal
- [x] Aligned setup guidance with the cookbook's pinned dependencies
- [x] No secrets or credentials added

Made with [Cursor](https://cursor.com)