### PR TITLE
Add cookbook release workflows and runbook

### DIFF
--- a/.github/ISSUE_TEMPLATE/cookbook-release.yml
+++ b/.github/ISSUE_TEMPLATE/cookbook-release.yml
@@ -1,0 +1,139 @@
+name: Cookbook release record
+description: Track one public cookbook release from candidate tag through final go or no-go.
+title: "Cookbook release: vX.Y.Z"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this issue as the single release record for one cookbook release.
+
+        Final publication is blocked until the required evidence is attached here and the release owner records an explicit go decision.
+
+  - type: input
+    id: version
+    attributes:
+      label: Target version
+      description: Stable release version in vX.Y.Z format.
+      placeholder: v0.3.0
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Release scope
+      description: Summarize the user-visible cookbook changes and note whether packaging is in scope.
+      placeholder: |
+        - Runnable cookbook behavior:
+        - Package or install flow:
+        - Renderer, shape, image, service, or backend assumptions:
+    validations:
+      required: true
+
+  - type: input
+    id: release_owner
+    attributes:
+      label: Release owner
+      placeholder: "@owner"
+    validations:
+      required: true
+
+  - type: input
+    id: reviewer
+    attributes:
+      label: Reviewer
+      placeholder: "@reviewer"
+    validations:
+      required: true
+
+  - type: input
+    id: internal_test_owner
+    attributes:
+      label: Internal test owner
+      placeholder: "@internal-tester"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: backend_coupled
+    attributes:
+      label: Backend-coupled release?
+      description: Start with the safer choice when the scope is unclear.
+      options:
+        - "No"
+        - "Yes"
+        - "Unclear - default to yes until waived"
+    validations:
+      required: true
+
+  - type: input
+    id: candidate_sha
+    attributes:
+      label: Candidate commit SHA
+      placeholder: 0123456789abcdef0123456789abcdef01234567
+    validations:
+      required: true
+
+  - type: input
+    id: candidate_tag
+    attributes:
+      label: Candidate tag
+      description: Candidate tag in vX.Y.Z-alpha.N format.
+      placeholder: v0.3.0-alpha.1
+    validations:
+      required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence links
+      description: Add the repository-owned CI run plus the external validation evidence required for this release.
+      value: |
+        - Training CI:
+        - Candidate workflow run:
+        - Cookbook smoke tests:
+        - Fireworks internal tests:
+        - Control-plane smoke test (if required):
+        - Managed-service validation (if required):
+        - Draft release notes:
+
+  - type: textarea
+    id: rollback
+    attributes:
+      label: Rollback plan
+      description: Describe the rollback path before cutting the stable tag.
+      placeholder: |
+        - If the release regresses:
+        - Which tag or artifact to roll back to:
+        - Who owns rollback execution:
+    validations:
+      required: true
+
+  - type: textarea
+    id: go_no_go
+    attributes:
+      label: Final go or no-go readout
+      description: Record the explicit decision once all blockers are green.
+      placeholder: |
+        Go/no-go:
+        Reviewer sign-off:
+        Notes:
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Final release checklist
+      options:
+        - label: Release owner is named.
+        - label: Scope and version are defined.
+        - label: Candidate commit is merged to main.
+        - label: Candidate tag exists.
+        - label: Training CI is green on the exact candidate commit.
+        - label: Cookbook smoke tests passed.
+        - label: Fireworks internal tests passed.
+        - label: Control-plane smoke test passed when required.
+        - label: Managed-service validation passed when required.
+        - label: Reviewer sign-off is recorded.
+        - label: Rollback plan is recorded.

--- a/.github/ISSUE_TEMPLATE/cookbook-release.yml
+++ b/.github/ISSUE_TEMPLATE/cookbook-release.yml
@@ -1,6 +1,8 @@
 name: Cookbook release record
 description: Track one public cookbook release from candidate tag through final go or no-go.
 title: "Cookbook release: vX.Y.Z"
+labels:
+  - cookbook-release
 body:
   - type: markdown
     attributes:
@@ -118,6 +120,22 @@ body:
         Go/no-go:
         Reviewer sign-off:
         Notes:
+    validations:
+      required: true
+
+  - type: textarea
+    id: automation_metadata
+    attributes:
+      label: Automation metadata
+      description: Keep the marker lines intact and update the values as the release progresses.
+      value: |
+        <!-- cookbook-release-metadata
+        version: vX.Y.Z
+        candidate-tag: vX.Y.Z-alpha.N
+        candidate-sha: 0123456789abcdef0123456789abcdef01234567
+        backend-validation-required: false
+        go-approved: false
+        -->
     validations:
       required: true
 

--- a/.github/scripts/cookbook_release.py
+++ b/.github/scripts/cookbook_release.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Helpers for validating cookbook release tags inside GitHub Actions."""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import subprocess
+import sys
+import tomllib
+
+
+CANDIDATE_TAG_RE = re.compile(r"^v(?P<version>\d+\.\d+\.\d+)-alpha\.(?P<iteration>\d+)$")
+FINAL_TAG_RE = re.compile(r"^v(?P<version>\d+\.\d+\.\d+)$")
+
+
+class ReleaseTagError(ValueError):
+    """Raised when a tag does not match the cookbook release contract."""
+
+
+def parse_tag(tag: str, kind: str) -> dict[str, str]:
+    if kind == "candidate":
+        match = CANDIDATE_TAG_RE.fullmatch(tag)
+        if not match:
+            raise ReleaseTagError(
+                f"Candidate tag {tag!r} must match vX.Y.Z-alpha.N."
+            )
+    elif kind == "final":
+        match = FINAL_TAG_RE.fullmatch(tag)
+        if not match:
+            raise ReleaseTagError(f"Final tag {tag!r} must match vX.Y.Z.")
+    else:
+        raise ReleaseTagError(f"Unsupported tag kind: {kind}")
+
+    version = match.group("version")
+    metadata = {
+        "tag": tag,
+        "kind": kind,
+        "version": version,
+        "stable_tag": f"v{version}",
+        "artifact_name": f"cookbook-release-{tag}",
+    }
+
+    if kind == "candidate":
+        metadata["candidate_iteration"] = match.group("iteration")
+
+    return metadata
+
+
+def write_github_output(output_file: pathlib.Path, metadata: dict[str, str]) -> None:
+    with output_file.open("a", encoding="utf-8") as handle:
+        for key, value in metadata.items():
+            handle.write(f"{key}={value}\n")
+
+
+def load_pyproject_version(pyproject_path: pathlib.Path) -> str:
+    with pyproject_path.open("rb") as handle:
+        document = tomllib.load(handle)
+
+    try:
+        return document["project"]["version"]
+    except KeyError as exc:
+        raise ReleaseTagError(
+            f"Unable to locate [project].version in {pyproject_path}."
+        ) from exc
+
+
+def assert_pyproject_version(tag: str, kind: str, pyproject_path: pathlib.Path) -> None:
+    metadata = parse_tag(tag, kind)
+    actual = load_pyproject_version(pyproject_path)
+    expected = metadata["version"]
+    if actual != expected:
+        raise ReleaseTagError(
+            f"{pyproject_path} version is {actual}, but {tag} requires {expected}."
+        )
+
+
+def candidate_sort_key(tag: str) -> tuple[int, str]:
+    match = CANDIDATE_TAG_RE.fullmatch(tag)
+    if not match:
+        raise ReleaseTagError(f"Tag {tag!r} is not a valid candidate tag.")
+    return (int(match.group("iteration")), tag)
+
+
+def list_candidate_tags(version: str, sha: str) -> list[str]:
+    result = subprocess.run(
+        ["git", "tag", "--points-at", sha, "--list", f"v{version}-alpha.*"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    tags = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+    return sorted(tags, key=candidate_sort_key)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    github_output = subparsers.add_parser(
+        "github-output", help="Write parsed tag metadata to a GitHub Actions output file."
+    )
+    github_output.add_argument("--tag", required=True)
+    github_output.add_argument("--kind", choices=("candidate", "final"), required=True)
+    github_output.add_argument("--output-file", required=True, type=pathlib.Path)
+
+    version_check = subparsers.add_parser(
+        "assert-pyproject-version",
+        help="Ensure training/pyproject.toml matches the version encoded in the tag.",
+    )
+    version_check.add_argument("--tag", required=True)
+    version_check.add_argument("--kind", choices=("candidate", "final"), required=True)
+    version_check.add_argument("--pyproject", required=True, type=pathlib.Path)
+
+    candidates = subparsers.add_parser(
+        "list-candidate-tags",
+        help="List candidate tags for a version that point at one exact SHA.",
+    )
+    candidates.add_argument("--version", required=True)
+    candidates.add_argument("--sha", required=True)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        if args.command == "github-output":
+            metadata = parse_tag(args.tag, args.kind)
+            write_github_output(args.output_file, metadata)
+            return 0
+
+        if args.command == "assert-pyproject-version":
+            assert_pyproject_version(args.tag, args.kind, args.pyproject)
+            return 0
+
+        if args.command == "list-candidate-tags":
+            for tag in list_candidate_tags(args.version, args.sha):
+                print(tag)
+            return 0
+    except ReleaseTagError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    parser.error(f"Unhandled command: {args.command}")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/cookbook_release.py
+++ b/.github/scripts/cookbook_release.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import pathlib
 import re
 import subprocess
@@ -13,6 +14,11 @@ import tomllib
 
 CANDIDATE_TAG_RE = re.compile(r"^v(?P<version>\d+\.\d+\.\d+)-alpha\.(?P<iteration>\d+)$")
 FINAL_TAG_RE = re.compile(r"^v(?P<version>\d+\.\d+\.\d+)$")
+RELEASE_METADATA_RE = re.compile(
+    r"<!--\s*cookbook-release-metadata\s*\n(?P<body>.*?)\n-->",
+    re.DOTALL,
+)
+METADATA_LINE_RE = re.compile(r"^\s*(?P<key>[a-z0-9_-]+)\s*:\s*(?P<value>.*?)\s*$")
 
 
 class ReleaseTagError(ValueError):
@@ -94,6 +100,138 @@ def list_candidate_tags(version: str, sha: str) -> list[str]:
     return sorted(tags, key=candidate_sort_key)
 
 
+def run_git(*args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def render_release_notes(version: str, candidate_tag: str) -> str:
+    previous = previous_stable_tag(candidate_tag)
+    revspec = f"{previous}..{candidate_tag}" if previous else candidate_tag
+    result = subprocess.run(
+        ["git", "log", "--pretty=format:%H%x09%s", revspec],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        log_output = run_git("log", "--pretty=format:%H%x09%s", "HEAD~20..HEAD")
+    else:
+        log_output = result.stdout.strip()
+    commits = [line.split("\t", 1) for line in log_output.splitlines() if line.strip()]
+
+    lines = [
+        f"# Draft release notes for v{version}",
+        "",
+        f"- Candidate tag: `{candidate_tag}`",
+        f"- Previous stable tag: `{previous or 'none'}`",
+        "",
+        "## Changes since last stable release",
+    ]
+    if commits:
+        for sha, subject in commits:
+            short_sha = sha[:7]
+            lines.append(f"- {subject} (`{short_sha}`)")
+    else:
+        lines.append("- No commits found between the previous stable tag and this candidate.")
+    lines.extend(
+        [
+            "",
+            "## Release checklist reminders",
+            "",
+            "- Link Fireworks internal test evidence",
+            "- Link backend validation evidence when required",
+            "- Confirm reviewer sign-off and rollback plan in the release record",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def previous_stable_tag(candidate_tag: str) -> str:
+    result = subprocess.run(
+        [
+            "git",
+            "describe",
+            "--tags",
+            "--abbrev=0",
+            "--match",
+            "v[0-9]*.[0-9]*.[0-9]*",
+            f"{candidate_tag}^",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return ""
+    return result.stdout.strip()
+
+
+def parse_release_metadata(issue_body: str) -> dict[str, str]:
+    match = RELEASE_METADATA_RE.search(issue_body)
+    if not match:
+        raise ReleaseTagError(
+            "Release record is missing the cookbook-release-metadata block."
+        )
+
+    metadata: dict[str, str] = {}
+    for raw_line in match.group("body").splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        parsed = METADATA_LINE_RE.fullmatch(line)
+        if not parsed:
+            raise ReleaseTagError(
+                f"Malformed release metadata line: {raw_line!r}."
+            )
+        metadata[parsed.group("key")] = parsed.group("value")
+    return metadata
+
+
+def normalize_boolean_text(value: str) -> str:
+    lowered = value.strip().lower()
+    if lowered in {"true", "yes", "y"}:
+        return "true"
+    if lowered in {"false", "no", "n"}:
+        return "false"
+    raise ReleaseTagError(f"Expected boolean-like value, got {value!r}.")
+
+
+def assert_release_record(
+    *,
+    issue_body_path: pathlib.Path,
+    version: str,
+    candidate_tag: str,
+    sha: str,
+) -> dict[str, str]:
+    metadata = parse_release_metadata(issue_body_path.read_text(encoding="utf-8"))
+    stable_tag = f"v{version}"
+    expected = {
+        "version": stable_tag,
+        "candidate-tag": candidate_tag,
+        "candidate-sha": sha,
+        "go-approved": "true",
+    }
+    for key, value in expected.items():
+        actual = metadata.get(key)
+        if actual != value:
+            raise ReleaseTagError(
+                f"Release record metadata has {key}={actual!r}, expected {value!r}."
+            )
+
+    backend_required = normalize_boolean_text(
+        metadata.get("backend-validation-required", "false")
+    )
+    return {
+        "backend_validation_required": backend_required,
+    }
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -120,6 +258,25 @@ def build_parser() -> argparse.ArgumentParser:
     candidates.add_argument("--version", required=True)
     candidates.add_argument("--sha", required=True)
 
+    notes = subparsers.add_parser(
+        "draft-release-notes",
+        help="Generate draft release notes for one candidate tag.",
+    )
+    notes.add_argument("--version", required=True)
+    notes.add_argument("--candidate-tag", required=True)
+    notes.add_argument("--notes-file", required=True, type=pathlib.Path)
+    notes.add_argument("--github-output", required=False, type=pathlib.Path)
+
+    record = subparsers.add_parser(
+        "assert-release-record",
+        help="Verify that a release record issue matches the stable release inputs.",
+    )
+    record.add_argument("--issue-body-file", required=True, type=pathlib.Path)
+    record.add_argument("--version", required=True)
+    record.add_argument("--candidate-tag", required=True)
+    record.add_argument("--candidate-sha", required=True)
+    record.add_argument("--github-output", required=False, type=pathlib.Path)
+
     return parser
 
 
@@ -140,6 +297,27 @@ def main(argv: list[str] | None = None) -> int:
         if args.command == "list-candidate-tags":
             for tag in list_candidate_tags(args.version, args.sha):
                 print(tag)
+            return 0
+
+        if args.command == "draft-release-notes":
+            rendered = render_release_notes(args.version, args.candidate_tag)
+            args.notes_file.write_text(rendered, encoding="utf-8")
+            if args.github_output:
+                write_github_output(
+                    args.github_output,
+                    {"previous_tag": previous_stable_tag(args.candidate_tag)},
+                )
+            return 0
+
+        if args.command == "assert-release-record":
+            metadata = assert_release_record(
+                issue_body_path=args.issue_body_file,
+                version=args.version,
+                candidate_tag=args.candidate_tag,
+                sha=args.candidate_sha,
+            )
+            if args.github_output:
+                write_github_output(args.github_output, metadata)
             return 0
     except ReleaseTagError as exc:
         print(f"error: {exc}", file=sys.stderr)

--- a/.github/workflows/cookbook-release-candidate.yml
+++ b/.github/workflows/cookbook-release-candidate.yml
@@ -1,0 +1,134 @@
+name: Validate Cookbook Release Candidate
+
+on:
+  push:
+    tags:
+      - "v*-alpha.*"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cookbook-release-candidate-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    name: Validate Candidate Tag
+    runs-on: ubuntu-latest
+    outputs:
+      artifact_name: ${{ steps.tag.outputs.artifact_name }}
+      stable_tag: ${{ steps.tag.outputs.stable_tag }}
+      tag: ${{ steps.tag.outputs.tag }}
+      version: ${{ steps.tag.outputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set Up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Parse Candidate Tag
+        id: tag
+        run: |
+          python .github/scripts/cookbook_release.py github-output \
+            --tag "${GITHUB_REF_NAME}" \
+            --kind candidate \
+            --output-file "${GITHUB_OUTPUT}"
+
+      - name: Confirm Candidate Commit Is Reachable From Main
+        run: |
+          git fetch origin main --depth=1
+          git merge-base --is-ancestor "${GITHUB_SHA}" "origin/main"
+
+      - name: Confirm training/pyproject.toml Matches Candidate Version
+        run: |
+          python .github/scripts/cookbook_release.py assert-pyproject-version \
+            --tag "${GITHUB_REF_NAME}" \
+            --kind candidate \
+            --pyproject training/pyproject.toml
+
+  training-ci:
+    name: Run Training CI
+    needs: prepare
+    uses: ./.github/workflows/training-ci.yml
+    secrets: inherit
+
+  build-package:
+    name: Build Candidate Package Artifact
+    needs:
+      - prepare
+      - training-ci
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set Up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+          cache-dependency-path: training/pyproject.toml
+
+      - name: Install Build Tooling
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build
+
+      - name: Build Package
+        working-directory: training
+        run: |
+          python -m build --sdist --wheel --outdir ../dist
+
+      - name: Write Candidate Manifest
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          manifest = {
+              "tag": os.environ["GITHUB_REF_NAME"],
+              "stable_tag": "${{ needs.prepare.outputs.stable_tag }}",
+              "version": "${{ needs.prepare.outputs.version }}",
+              "sha": os.environ["GITHUB_SHA"],
+          }
+          Path("dist/release-manifest.json").write_text(
+              json.dumps(manifest, indent=2) + "\n",
+              encoding="utf-8",
+          )
+          PY
+
+      - name: Upload Candidate Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ needs.prepare.outputs.artifact_name }}
+          path: |
+            dist/*.whl
+            dist/*.tar.gz
+            dist/release-manifest.json
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Summarize Candidate Evidence
+        run: |
+          {
+            echo "## Cookbook release candidate"
+            echo "- Candidate tag: \`${{ needs.prepare.outputs.tag }}\`"
+            echo "- Stable tag target: \`${{ needs.prepare.outputs.stable_tag }}\`"
+            echo "- Candidate SHA: \`${GITHUB_SHA}\`"
+            echo "- Candidate artifact: \`${{ needs.prepare.outputs.artifact_name }}\`"
+            echo
+            echo "Repository-owned checks are complete. The release record still needs:"
+            echo "- Fireworks internal test evidence"
+            echo "- Backend validation evidence when the release is backend-coupled"
+            echo "- Reviewer sign-off"
+            echo "- Rollback plan"
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/cookbook-release-candidate.yml
+++ b/.github/workflows/cookbook-release-candidate.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       artifact_name: ${{ steps.tag.outputs.artifact_name }}
+      candidate_previous_tag: ${{ steps.notes.outputs.previous_tag }}
       stable_tag: ${{ steps.tag.outputs.stable_tag }}
       tag: ${{ steps.tag.outputs.tag }}
       version: ${{ steps.tag.outputs.version }}
@@ -51,6 +52,15 @@ jobs:
             --tag "${GITHUB_REF_NAME}" \
             --kind candidate \
             --pyproject training/pyproject.toml
+
+      - name: Draft Release Notes
+        id: notes
+        run: |
+          python .github/scripts/cookbook_release.py draft-release-notes \
+            --version "${{ steps.tag.outputs.version }}" \
+            --candidate-tag "${GITHUB_REF_NAME}" \
+            --notes-file /tmp/candidate-release-notes.md \
+            --github-output "${GITHUB_OUTPUT}"
 
   training-ci:
     name: Run Training CI
@@ -87,6 +97,13 @@ jobs:
         run: |
           python -m build --sdist --wheel --outdir ../dist
 
+      - name: Draft Release Notes
+        run: |
+          python .github/scripts/cookbook_release.py draft-release-notes \
+            --version "${{ needs.prepare.outputs.version }}" \
+            --candidate-tag "${GITHUB_REF_NAME}" \
+            --notes-file candidate-release-notes.md
+
       - name: Write Candidate Manifest
         run: |
           python - <<'PY'
@@ -114,6 +131,7 @@ jobs:
             dist/*.whl
             dist/*.tar.gz
             dist/release-manifest.json
+            candidate-release-notes.md
           if-no-files-found: error
           retention-days: 30
 
@@ -125,10 +143,17 @@ jobs:
             echo "- Stable tag target: \`${{ needs.prepare.outputs.stable_tag }}\`"
             echo "- Candidate SHA: \`${GITHUB_SHA}\`"
             echo "- Candidate artifact: \`${{ needs.prepare.outputs.artifact_name }}\`"
+            if [ -n "${{ needs.prepare.outputs.candidate_previous_tag }}" ]; then
+              echo "- Draft release notes compare base: \`${{ needs.prepare.outputs.candidate_previous_tag }}\`"
+            else
+              echo "- Draft release notes compare base: repository history start"
+            fi
             echo
             echo "Repository-owned checks are complete. The release record still needs:"
             echo "- Fireworks internal test evidence"
             echo "- Backend validation evidence when the release is backend-coupled"
             echo "- Reviewer sign-off"
             echo "- Rollback plan"
+            echo
+            echo "Draft release notes are attached to the candidate artifact as \`candidate-release-notes.md\`."
           } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/cookbook-release-publish.yml
+++ b/.github/workflows/cookbook-release-publish.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   actions: read
   contents: write
+  issues: read
 
 concurrency:
   group: cookbook-release-publish-${{ github.ref }}
@@ -21,6 +22,7 @@ jobs:
     outputs:
       artifact_name: ${{ steps.candidate.outputs.artifact_name }}
       candidate_tag: ${{ steps.candidate.outputs.tag }}
+      release_issue_number: ${{ steps.release_record.outputs.issue_number }}
       stable_tag: ${{ steps.tag.outputs.stable_tag }}
       version: ${{ steps.tag.outputs.version }}
     steps:
@@ -74,6 +76,78 @@ jobs:
           )"
           echo "tag=${candidate_tag}" >> "${GITHUB_OUTPUT}"
           echo "artifact_name=cookbook-release-${candidate_tag}" >> "${GITHUB_OUTPUT}"
+
+      - name: Validate Matching Release Record
+        id: release_record
+        uses: actions/github-script@v7
+        env:
+          EXPECTED_STABLE_TAG: ${{ steps.tag.outputs.stable_tag }}
+        with:
+          script: |
+            const expectedStableTag = process.env.EXPECTED_STABLE_TAG;
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "open",
+              labels: "cookbook-release",
+              per_page: 100,
+            });
+
+            const marker = "<!-- cookbook-release-metadata";
+            const matches = [];
+
+            for (const issue of issues) {
+              const body = issue.body || "";
+              if (!body.includes(marker)) {
+                continue;
+              }
+
+              const title = issue.title || "";
+              if (!title.includes(expectedStableTag)) {
+                continue;
+              }
+
+              matches.push({
+                number: issue.number,
+                title,
+                body,
+              });
+            }
+
+            if (matches.length === 0) {
+              core.setFailed(
+                `No open cookbook-release issue with metadata found for ${expectedStableTag}.`,
+              );
+              return;
+            }
+
+            if (matches.length > 1) {
+              core.setFailed(
+                `Multiple cookbook-release issues match ${expectedStableTag}: ${matches.map((item) => `#${item.number}`).join(", ")}`,
+              );
+              return;
+            }
+
+            const issue = matches[0];
+            const fs = require("fs");
+            const os = require("os");
+            const path = require("path");
+            const metadataPath = path.join(os.tmpdir(), `cookbook-release-issue-${issue.number}.md`);
+            fs.writeFileSync(metadataPath, issue.body || "", "utf8");
+
+            core.setOutput("issue_number", String(issue.number));
+            core.setOutput("issue_body_path", metadataPath);
+
+      - name: Assert Release Record Metadata Matches Stable Publish
+        env:
+          RELEASE_RECORD_PATH: ${{ steps.release_record.outputs.issue_body_path }}
+        run: |
+          python .github/scripts/cookbook_release.py assert-release-record \
+            --issue-body-file "${RELEASE_RECORD_PATH}" \
+            --version "${{ steps.tag.outputs.version }}" \
+            --candidate-tag "${{ steps.candidate.outputs.tag }}" \
+            --candidate-sha "${GITHUB_SHA}" \
+            --github-output "${GITHUB_OUTPUT}"
 
   candidate-artifact:
     name: Locate Validated Candidate Artifact
@@ -179,7 +253,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref_name }}
-          generate_release_notes: true
+          body_path: release-assets/draft-release-notes.md
           files: |
             release-assets/*.whl
             release-assets/*.tar.gz
@@ -192,6 +266,7 @@ jobs:
             echo "- Stable tag: \`${GITHUB_REF_NAME}\`"
             echo "- Candidate tag: \`${{ needs.prepare.outputs.candidate_tag }}\`"
             echo "- Release SHA: \`${GITHUB_SHA}\`"
+            echo "- Release record: #${{ needs.prepare.outputs.release_issue_number }}"
             echo
             echo "This release reused the exact candidate artifact that was validated on the matching SHA."
           } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/cookbook-release-publish.yml
+++ b/.github/workflows/cookbook-release-publish.yml
@@ -1,0 +1,197 @@
+name: Publish Cookbook Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+      - "!v*-alpha.*"
+
+permissions:
+  actions: read
+  contents: write
+
+concurrency:
+  group: cookbook-release-publish-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    name: Verify Stable Release Tag
+    runs-on: ubuntu-latest
+    outputs:
+      artifact_name: ${{ steps.candidate.outputs.artifact_name }}
+      candidate_tag: ${{ steps.candidate.outputs.tag }}
+      stable_tag: ${{ steps.tag.outputs.stable_tag }}
+      version: ${{ steps.tag.outputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set Up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Parse Stable Tag
+        id: tag
+        run: |
+          python .github/scripts/cookbook_release.py github-output \
+            --tag "${GITHUB_REF_NAME}" \
+            --kind final \
+            --output-file "${GITHUB_OUTPUT}"
+
+      - name: Confirm Stable Commit Is Reachable From Main
+        run: |
+          git fetch origin main --depth=1
+          git merge-base --is-ancestor "${GITHUB_SHA}" "origin/main"
+
+      - name: Confirm training/pyproject.toml Matches Stable Version
+        run: |
+          python .github/scripts/cookbook_release.py assert-pyproject-version \
+            --tag "${GITHUB_REF_NAME}" \
+            --kind final \
+            --pyproject training/pyproject.toml
+
+      - name: Resolve Candidate Tag For This SHA
+        id: candidate
+        run: |
+          candidate_tags="$(python .github/scripts/cookbook_release.py list-candidate-tags \
+            --version "${{ steps.tag.outputs.version }}" \
+            --sha "${GITHUB_SHA}")"
+          if [ -z "${candidate_tags}" ]; then
+            echo "No candidate tag v${{ steps.tag.outputs.version }}-alpha.N points at ${GITHUB_SHA}." >&2
+            exit 1
+          fi
+          export CANDIDATE_TAGS="${candidate_tags}"
+          candidate_tag="$(python - <<'PY'
+          import os
+
+          tags = [line for line in os.environ["CANDIDATE_TAGS"].splitlines() if line.strip()]
+          print(tags[-1])
+          PY
+          )"
+          echo "tag=${candidate_tag}" >> "${GITHUB_OUTPUT}"
+          echo "artifact_name=cookbook-release-${candidate_tag}" >> "${GITHUB_OUTPUT}"
+
+  candidate-artifact:
+    name: Locate Validated Candidate Artifact
+    needs: prepare
+    runs-on: ubuntu-latest
+    outputs:
+      run_id: ${{ steps.locate.outputs.run_id }}
+    steps:
+      - name: Find Successful Candidate Workflow Run
+        id: locate
+        uses: actions/github-script@v7
+        env:
+          ARTIFACT_NAME: ${{ needs.prepare.outputs.artifact_name }}
+          CANDIDATE_SHA: ${{ github.sha }}
+        with:
+          script: |
+            const artifactName = process.env.ARTIFACT_NAME;
+            const candidateSha = process.env.CANDIDATE_SHA;
+            const runs = await github.paginate(github.rest.actions.listWorkflowRuns, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: "cookbook-release-candidate.yml",
+              event: "push",
+              status: "completed",
+              per_page: 100,
+            });
+
+            for (const run of runs) {
+              if (run.head_sha !== candidateSha || run.conclusion !== "success") {
+                continue;
+              }
+
+              const artifacts = await github.paginate(
+                github.rest.actions.listWorkflowRunArtifacts,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  run_id: run.id,
+                  per_page: 100,
+                },
+              );
+
+              const artifact = artifacts.find(
+                (item) => item.name === artifactName && !item.expired,
+              );
+
+              if (artifact) {
+                core.setOutput("run_id", String(run.id));
+                return;
+              }
+            }
+
+            core.setFailed(
+              `No successful candidate workflow run found for ${candidateSha} with artifact ${artifactName}.`,
+            );
+
+      - name: Download Candidate Artifact
+        uses: actions/download-artifact@v4
+        with:
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ steps.locate.outputs.run_id }}
+          name: ${{ needs.prepare.outputs.artifact_name }}
+          path: candidate-dist
+
+      - name: Verify Candidate Manifest
+        env:
+          EXPECTED_CANDIDATE_TAG: ${{ needs.prepare.outputs.candidate_tag }}
+          EXPECTED_SHA: ${{ github.sha }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          manifest = json.loads(Path("candidate-dist/release-manifest.json").read_text())
+          assert manifest["tag"] == os.environ["EXPECTED_CANDIDATE_TAG"], manifest
+          assert manifest["sha"] == os.environ["EXPECTED_SHA"], manifest
+          PY
+
+      - name: Upload Release Assets For Publish Job
+        uses: actions/upload-artifact@v4
+        with:
+          name: stable-release-assets
+          path: candidate-dist/*
+          if-no-files-found: error
+          retention-days: 7
+
+  publish:
+    name: Publish GitHub Release
+    needs:
+      - prepare
+      - candidate-artifact
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Validated Release Assets
+        uses: actions/download-artifact@v4
+        with:
+          name: stable-release-assets
+          path: release-assets
+
+      - name: Publish GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          generate_release_notes: true
+          files: |
+            release-assets/*.whl
+            release-assets/*.tar.gz
+            release-assets/release-manifest.json
+
+      - name: Summarize Stable Release
+        run: |
+          {
+            echo "## Cookbook release published"
+            echo "- Stable tag: \`${GITHUB_REF_NAME}\`"
+            echo "- Candidate tag: \`${{ needs.prepare.outputs.candidate_tag }}\`"
+            echo "- Release SHA: \`${GITHUB_SHA}\`"
+            echo
+            echo "This release reused the exact candidate artifact that was validated on the matching SHA."
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/training-ci.yml
+++ b/.github/workflows/training-ci.yml
@@ -1,6 +1,7 @@
 name: Training CI
 
 on:
+  workflow_call:
   pull_request:
     paths:
       - "training/**"

--- a/Contribution.md
+++ b/Contribution.md
@@ -24,4 +24,12 @@ Thank you for your interest in contributing to the Fireworks repository! We welc
 
 If you're planning a larger or more complex change, please open a new issue first to discuss your proposal. This will help us ensure your work aligns with the repo's goals and avoid redundant efforts.
 
+## Cookbook releases
+
+Public cookbook releases are maintainer-run and follow the workflow in
+[`RELEASING.md`](./RELEASING.md). If your change affects runnable cookbook
+behavior, packaging, or backend-coupled behavior, call that out clearly in your
+pull request so the release owner can decide whether a versioned release is
+required.
+
 We truly appreciate your contributions and collaboration in improving this community resource!

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ All previous cookbook material — learning tutorials, integration examples, sho
 
 We welcome contributions! See the [Contribution Guide](./Contribution.md) for how to get started.
 
+Maintainers should use the [cookbook release guide](./RELEASING.md) for
+candidate tags, release records, and stable publication.
+
 ## Feedback & Support
 
 - [Fireworks Documentation](https://fireworks.ai/docs)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -42,6 +42,7 @@ candidate tags and:
 - confirms `training/pyproject.toml` matches `X.Y.Z`
 - runs the reusable `Training CI` workflow
 - builds a source distribution and wheel for the exact candidate commit
+- generates draft release notes from the git history since the previous stable tag
 - uploads the candidate artifact plus a small release manifest
 
 ### Stable publish workflow
@@ -54,8 +55,10 @@ tags and:
 - confirms `training/pyproject.toml` matches `X.Y.Z`
 - confirms there is a candidate tag for the same `X.Y.Z` on the exact same SHA
 - locates a successful candidate validation run for that SHA
+- requires a matching cookbook release-record issue with explicit release metadata
+- requires the release record to contain a recorded `go` decision
 - reuses the exact candidate artifact
-- publishes the GitHub release with the validated wheel and sdist attached
+- publishes the GitHub release with the validated wheel, sdist, and candidate-generated notes
 
 This workflow intentionally refuses to publish if the stable tag does not map
 back to a previously validated candidate artifact.
@@ -74,6 +77,10 @@ Use it as the single release record for:
 - reviewer sign-off
 - rollback plan
 - final go or no-go readout
+
+The issue template includes a machine-readable metadata block. Keep that block
+updated when the candidate SHA or candidate tag changes, because the stable
+publish workflow validates it directly.
 
 ## End-to-end release checklist
 
@@ -99,7 +106,7 @@ Before tagging:
 
 - merge the intended release commit to `main`
 - open the cookbook release record issue
-- draft release notes
+- let the candidate workflow generate the first draft of the release notes
 - record the exact candidate SHA in the issue
 
 ### 4. Create the candidate tag
@@ -121,6 +128,7 @@ artifact for that SHA.
 Record all required evidence in the release issue:
 
 - candidate workflow run
+- candidate draft release notes artifact
 - `Training CI` result
 - cookbook smoke-test result
 - Fireworks internal test result or written sign-off
@@ -136,7 +144,7 @@ attached to the release record manually.
 ### 6. Hold the go or no-go call
 
 Do not create the stable tag until the release owner records an explicit go
-decision in the release issue.
+decision in the release issue and updates the metadata block accordingly.
 
 ### 7. Create the stable tag
 
@@ -153,6 +161,7 @@ The stable publish workflow will fail if:
 - the tagged SHA is not on `main`
 - no candidate tag for `vX.Y.Z-alpha.N` points to that SHA
 - no successful candidate workflow run exists for the same artifact
+- no matching release-record issue contains the expected metadata and `go` state
 
 ### 8. Verify after publication
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,181 @@
+# Cookbook release process
+
+This document is the maintainer-facing release guide for the public cookbook.
+It mirrors the operator runbook in Notion and describes the GitHub automation
+that now backs the process.
+
+## What counts as a cookbook release
+
+Use this process for changes that affect runnable cookbook behavior, packaging,
+or the supported backend path, including:
+
+- `training/` package code
+- recipe behavior
+- packaging or versioning
+- install or setup flow
+- cookbook smoke-test behavior
+- renderer, shape, image, service, or managed-service assumptions
+
+Docs-only changes that do not change runnable cookbook behavior usually do not
+need a versioned cookbook release.
+
+## Release model
+
+Every public release is a two-step flow:
+
+1. create a candidate tag `vX.Y.Z-alpha.N`
+2. cut the final stable tag `vX.Y.Z` only after blockers are green
+
+The stable tag should point to the exact same validated commit as the candidate.
+If the release commit changes after candidate validation, treat it as a new
+candidate and rerun validation.
+
+## Repo-owned release automation
+
+### Candidate workflow
+
+`.github/workflows/cookbook-release-candidate.yml` runs automatically on
+candidate tags and:
+
+- validates `vX.Y.Z-alpha.N` format
+- confirms the tagged commit is reachable from `main`
+- confirms `training/pyproject.toml` matches `X.Y.Z`
+- runs the reusable `Training CI` workflow
+- builds a source distribution and wheel for the exact candidate commit
+- uploads the candidate artifact plus a small release manifest
+
+### Stable publish workflow
+
+`.github/workflows/cookbook-release-publish.yml` runs automatically on stable
+tags and:
+
+- validates `vX.Y.Z` format
+- confirms the tagged commit is reachable from `main`
+- confirms `training/pyproject.toml` matches `X.Y.Z`
+- confirms there is a candidate tag for the same `X.Y.Z` on the exact same SHA
+- locates a successful candidate validation run for that SHA
+- reuses the exact candidate artifact
+- publishes the GitHub release with the validated wheel and sdist attached
+
+This workflow intentionally refuses to publish if the stable tag does not map
+back to a previously validated candidate artifact.
+
+## Release record
+
+Open a release record issue from
+`.github/ISSUE_TEMPLATE/cookbook-release.yml` before cutting the final tag.
+Use it as the single release record for:
+
+- target version
+- candidate commit SHA
+- candidate tag
+- backend-coupled yes/no decision
+- evidence links
+- reviewer sign-off
+- rollback plan
+- final go or no-go readout
+
+## End-to-end release checklist
+
+### 1. Decide whether a public release is needed
+
+Confirm that the change affects runnable cookbook behavior, packaging, or the
+supported backend path.
+
+### 2. Choose the version
+
+Use normal semver:
+
+- major for breaking changes
+- minor for backward-compatible features
+- patch for fixes only
+
+If packaging is in scope, update `training/pyproject.toml` so
+`[project].version` matches the stable release version `X.Y.Z` before tagging.
+
+### 3. Prepare the candidate commit
+
+Before tagging:
+
+- merge the intended release commit to `main`
+- open the cookbook release record issue
+- draft release notes
+- record the exact candidate SHA in the issue
+
+### 4. Create the candidate tag
+
+Tag the exact release commit:
+
+```bash
+git checkout main
+git pull origin main
+git tag vX.Y.Z-alpha.N <candidate-sha>
+git push origin vX.Y.Z-alpha.N
+```
+
+The candidate workflow will run automatically and produce the validated build
+artifact for that SHA.
+
+### 5. Attach required evidence
+
+Record all required evidence in the release issue:
+
+- candidate workflow run
+- `Training CI` result
+- cookbook smoke-test result
+- Fireworks internal test result or written sign-off
+- control-plane smoke-test result when required
+- managed-service validation when required
+- reviewer sign-off
+- rollback plan
+
+Fireworks internal tests and backend validation are still external blockers.
+The repo automation does not synthesize those signals yet, so they must be
+attached to the release record manually.
+
+### 6. Hold the go or no-go call
+
+Do not create the stable tag until the release owner records an explicit go
+decision in the release issue.
+
+### 7. Create the stable tag
+
+Create the stable tag on the exact same SHA as the validated candidate:
+
+```bash
+git tag vX.Y.Z <candidate-sha>
+git push origin vX.Y.Z
+```
+
+The stable publish workflow will fail if:
+
+- the tag version does not match `training/pyproject.toml`
+- the tagged SHA is not on `main`
+- no candidate tag for `vX.Y.Z-alpha.N` points to that SHA
+- no successful candidate workflow run exists for the same artifact
+
+### 8. Verify after publication
+
+After the workflow publishes the GitHub release:
+
+- confirm the generated release notes look correct
+- confirm the wheel and sdist are attached
+- confirm installability if the release depends on packaging changes
+- monitor for regressions and open follow-up issues if needed
+
+## Decision matrix
+
+| Change type | Candidate tag required | Training CI | Cookbook smoke tests | Fireworks internal tests | Control-plane smoke test | Managed-service validation |
+| --- | --- | --- | --- | --- | --- | --- |
+| Docs-only, no runnable behavior change | Usually no public release | No release-specific run | No | No | No | No |
+| Recipe, package, install, or runnable UX change | Yes | Yes | Yes | Yes | Usually no | Usually no |
+| Renderer, shape, image, service, or backend-coupled behavior change | Yes | Yes | Yes | Yes | Yes | Yes |
+| Unclear scope | Yes | Yes | Yes | Yes | Default to yes until waived | Default to yes until waived |
+
+## Common mistakes to avoid
+
+- cutting the stable tag before Fireworks internal tests are green
+- validating one commit and releasing another
+- skipping backend validation for renderer or shape changes
+- tagging a commit that is not on `main`
+- forgetting to bump `training/pyproject.toml` before tagging

--- a/training/README.md
+++ b/training/README.md
@@ -115,6 +115,10 @@ For detailed guides, configuration reference, and examples, see the official doc
 - [Cookbook recipes (SFT, RL, DPO, ORPO)](https://docs.fireworks.ai/fine-tuning/training-sdk/cookbook/overview)
 - [Configuration reference](https://docs.fireworks.ai/fine-tuning/training-sdk/cookbook/reference)
 
+For maintainers cutting a public cookbook release, follow
+[`../RELEASING.md`](../RELEASING.md) and keep `training/pyproject.toml`
+aligned with the stable tag version.
+
 ## Directory layout
 
 ```


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a structured cookbook release record issue form and a maintainer-facing `RELEASING.md`
- add candidate and stable tag GitHub Actions workflows plus shared tag/version validation helpers
- make `training-ci.yml` reusable and link the new release process from the main contributor docs
- generate draft release notes from candidate-tag history and publish the stable release with those candidate-generated notes
- require a matching open `cookbook-release` issue with machine-readable metadata and an explicit `go-approved: true` gate before stable publish

## Validation
- `python3 .github/scripts/cookbook_release.py github-output --tag v0.1.0-alpha.1 --kind candidate --output-file /tmp/candidate.out`
- `python3 .github/scripts/cookbook_release.py assert-pyproject-version --tag v0.1.0-alpha.1 --kind candidate --pyproject training/pyproject.toml`
- `python3 .github/scripts/cookbook_release.py github-output --tag v0.1.0 --kind final --output-file /tmp/final.out`
- `python3 .github/scripts/cookbook_release.py assert-pyproject-version --tag v0.1.0 --kind final --pyproject training/pyproject.toml`
- `python3 .github/scripts/cookbook_release.py draft-release-notes --version 0.1.0 --candidate-tag v0.1.0-alpha.1 --notes-file /tmp/candidate-release-notes.md --github-output /tmp/candidate-notes.out`
- `python3 .github/scripts/cookbook_release.py assert-release-record --issue-body-file /tmp/release-record.md --version 0.1.0 --candidate-tag v0.1.0-alpha.1 --candidate-sha 9041b03 --github-output /tmp/release-record.out`
- `"$(go env GOPATH)/bin/actionlint" .github/workflows/training-ci.yml .github/workflows/cookbook-release-candidate.yml .github/workflows/cookbook-release-publish.yml`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-decf05ac-9f27-4651-a705-dace6007f662"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-decf05ac-9f27-4651-a705-dace6007f662"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

