### PR TITLE
feat(training): add accelerator_type filtering to training shape selection

### DIFF
--- a/training/tests/unit/test_training_shapes.py
+++ b/training/tests/unit/test_training_shapes.py
@@ -307,7 +307,7 @@ def test_select_validated_launch_shapes_raises_when_no_validated_shape_matches()
         raise AssertionError(f"unexpected path: {path}")
 
     mgr = _FakeSelectorMgr(handler)
-    with pytest.raises(ValueError, match="No validated training shape matched"):
+    with pytest.raises(ValueError, match="No training configuration is available"):
         select_validated_launch_shapes(
             mgr,
             request=ShapeSelectionRequest(
@@ -317,6 +317,134 @@ def test_select_validated_launch_shapes_raises_when_no_validated_shape_matches()
                 needs_deployment=False,
             ),
         )
+
+
+def test_select_validated_launch_shapes_filters_by_accelerator_type():
+    """When accelerator_type is set, only shapes with that accelerator are returned."""
+    h200_shape = _training_shape_version(
+        "accounts/fireworks/trainingShapes/qwen3-8b-h200/versions/v1",
+        trainer_mode="POLICY_TRAINER",
+        max_supported_context_length=131072,
+        accelerator_type="NVIDIA_H200_141GB",
+    )
+    b200_shape = _training_shape_version(
+        "accounts/fireworks/trainingShapes/qwen3-8b-b200/versions/v2",
+        trainer_mode="POLICY_TRAINER",
+        max_supported_context_length=131072,
+        accelerator_type="NVIDIA_B200_180GB",
+    )
+
+    def handler(path: str) -> dict:
+        filt = _filter_for(path)
+        if "/trainingShapes/-/versions" in path:
+            assert 'snapshot.accelerator_type="NVIDIA_B200_180GB"' in filt
+            return {"trainingShapeVersions": [b200_shape]}
+        raise AssertionError(f"unexpected path: {path}")
+
+    mgr = _FakeSelectorMgr(handler)
+    selection = select_validated_launch_shapes(
+        mgr,
+        request=ShapeSelectionRequest(
+            base_model="accounts/fireworks/models/qwen3-8b",
+            trainer_role="policy",
+            accelerator_type="NVIDIA_B200_180GB",
+        ),
+    )
+
+    assert selection.training_shape_id == "accounts/fireworks/trainingShapes/qwen3-8b-b200"
+    assert selection.training_profile.accelerator_type == "NVIDIA_B200_180GB"
+
+
+def test_select_validated_launch_shapes_accelerator_mismatch_raises_generic_error():
+    """When no shapes match the required accelerator, the user sees a generic
+    error while the detailed constraint info is logged."""
+    def handler(path: str) -> dict:
+        if path == "/v1/accounts/fireworks/models/qwen3-8b":
+            return {
+                "baseModelDetails": {
+                    "modelType": "qwen3",
+                    "parameterCount": 8_400_000_000,
+                    "supportsFireattention": False,
+                }
+            }
+        if "/versions" in path:
+            if "trainingShapes" in path:
+                return {"trainingShapeVersions": []}
+            return {"deploymentShapeVersions": []}
+        raise AssertionError(f"unexpected path: {path}")
+
+    mgr = _FakeSelectorMgr(handler)
+    with pytest.raises(ValueError, match="No training configuration is available"):
+        select_validated_launch_shapes(
+            mgr,
+            request=ShapeSelectionRequest(
+                base_model="accounts/fireworks/models/qwen3-8b",
+                trainer_role="policy",
+                accelerator_type="NVIDIA_B200_180GB",
+            ),
+        )
+
+
+def test_select_validated_launch_shapes_client_side_accelerator_filter():
+    """Even if the server returns shapes with mixed accelerators, the client
+    filters to only the requested type."""
+    h200_shape = _training_shape_version(
+        "accounts/fireworks/trainingShapes/qwen3-8b-h200/versions/v1",
+        trainer_mode="POLICY_TRAINER",
+        max_supported_context_length=131072,
+        accelerator_type="NVIDIA_H200_141GB",
+    )
+    b200_shape = _training_shape_version(
+        "accounts/fireworks/trainingShapes/qwen3-8b-b200/versions/v2",
+        trainer_mode="POLICY_TRAINER",
+        max_supported_context_length=131072,
+        accelerator_type="NVIDIA_B200_180GB",
+    )
+
+    def handler(path: str) -> dict:
+        if "/trainingShapes/-/versions" in path:
+            return {"trainingShapeVersions": [h200_shape, b200_shape]}
+        raise AssertionError(f"unexpected path: {path}")
+
+    mgr = _FakeSelectorMgr(handler)
+    selection = select_validated_launch_shapes(
+        mgr,
+        request=ShapeSelectionRequest(
+            base_model="accounts/fireworks/models/qwen3-8b",
+            trainer_role="policy",
+            accelerator_type="NVIDIA_B200_180GB",
+        ),
+    )
+
+    assert selection.training_shape_id == "accounts/fireworks/trainingShapes/qwen3-8b-b200"
+
+
+def test_select_validated_launch_shapes_no_accelerator_filter_returns_any():
+    """When accelerator_type is None, all shapes are eligible (backward compat)."""
+    h200_shape = _training_shape_version(
+        "accounts/fireworks/trainingShapes/qwen3-8b-h200/versions/v1",
+        trainer_mode="POLICY_TRAINER",
+        max_supported_context_length=131072,
+        accelerator_type="NVIDIA_H200_141GB",
+    )
+
+    def handler(path: str) -> dict:
+        filt = _filter_for(path)
+        if "/trainingShapes/-/versions" in path:
+            assert "snapshot.accelerator_type" not in filt
+            return {"trainingShapeVersions": [h200_shape]}
+        raise AssertionError(f"unexpected path: {path}")
+
+    mgr = _FakeSelectorMgr(handler)
+    selection = select_validated_launch_shapes(
+        mgr,
+        request=ShapeSelectionRequest(
+            base_model="accounts/fireworks/models/qwen3-8b",
+            trainer_role="policy",
+        ),
+    )
+
+    assert selection.training_shape_id == "accounts/fireworks/trainingShapes/qwen3-8b-h200"
 
 
 def test_materialize_profile_infra_copies_shape_owned_fields():

--- a/training/utils/training_shapes.py
+++ b/training/utils/training_shapes.py
@@ -48,6 +48,7 @@ class ShapeSelectionRequest:
     explicit_training_shape_id: str | None = None
     explicit_deployment_shape: str | None = None
     public_only: bool = False
+    accelerator_type: str | None = None
 
 
 @dataclass(frozen=True)
@@ -216,6 +217,7 @@ def _select_training_shape_candidate(
                 trainer_mode=expected_mode,
                 deployment_shape=deployment_filter,
                 public_only=request.public_only,
+                accelerator_type=request.accelerator_type,
             ),
         ),
         request=request,
@@ -233,6 +235,7 @@ def _select_training_shape_candidate(
                 trainer_mode=expected_mode,
                 deployment_shape=deployment_filter,
                 public_only=request.public_only,
+                accelerator_type=request.accelerator_type,
             ),
         ),
         request=request,
@@ -241,7 +244,8 @@ def _select_training_shape_candidate(
     if compat_candidates:
         return _choose_training_shape_candidate(compat_candidates, request)
 
-    raise ValueError(_format_training_shape_selection_error(request, expected_mode))
+    logger.error("Training shape selection failed: %s", _format_internal_shape_error(request, expected_mode))
+    raise ValueError(_format_user_facing_shape_error(request))
 
 
 def _select_deployment_shape_candidate(
@@ -290,6 +294,9 @@ def _compatible_training_shape_candidates(
     for candidate in candidates:
         if candidate.trainer_mode != expected_mode:
             continue
+        if request.accelerator_type:
+            if candidate.accelerator_type != request.accelerator_type:
+                continue
         if request.max_seq_len is not None:
             if candidate.max_supported_context_length < request.max_seq_len:
                 continue
@@ -495,10 +502,13 @@ def _build_latest_validated_training_shape_filter(
     trainer_mode: str,
     deployment_shape: str | None,
     public_only: bool = False,
+    accelerator_type: str | None = None,
 ) -> str:
     extras = [f'snapshot.trainer_mode="{trainer_mode}"']
     if deployment_shape:
         extras.extend(_deployment_shape_filters(deployment_shape))
+    if accelerator_type:
+        extras.append(f'snapshot.accelerator_type="{accelerator_type}"')
     return _combine_filters(
         f'snapshot.base_model="{base_model}"',
         "latest_validated=true",
@@ -513,11 +523,14 @@ def _build_compatible_training_shape_filter(
     trainer_mode: str,
     deployment_shape: str | None,
     public_only: bool = False,
+    accelerator_type: str | None = None,
 ) -> str:
     lower_bound, upper_bound = _get_parameter_count_bucket_bounds(model_ctx.parameter_count)
     extras = [f'snapshot.trainer_mode="{trainer_mode}"']
     if deployment_shape:
         extras.extend(_deployment_shape_filters(deployment_shape))
+    if accelerator_type:
+        extras.append(f'snapshot.accelerator_type="{accelerator_type}"')
     return _combine_filters(
         f'snapshot.model_type="{model_ctx.model_type}"',
         f"snapshot.parameter_count>={lower_bound}",
@@ -597,26 +610,31 @@ def _normalize_trainer_mode(value: Any) -> str | None:
     return _TRAINER_MODE_BY_CODE.get(int(value))
 
 
-def _format_training_shape_selection_error(
+def _format_internal_shape_error(
     request: ShapeSelectionRequest,
     trainer_mode: str,
 ) -> str:
+    """Full diagnostic message for internal logs only."""
     mode_label = "LoRA" if trainer_mode == "LORA_TRAINER" else (
         "reference" if trainer_mode == "FORWARD_ONLY" else "full-tune"
-    )
-    suffix = (
-        " Provide explicit shape overrides or lower max_seq_len."
-        if request.max_seq_len is not None
-        else " Provide explicit shape overrides."
     )
     return (
         "No validated training shape matched "
         f"base_model={request.base_model!r}, "
         f"trainer_role={request.trainer_role!r}, "
         f"mode={mode_label!r}, "
+        f"accelerator_type={request.accelerator_type!r}, "
         f"max_seq_len={request.max_seq_len!r}, "
         f"needs_deployment={request.needs_deployment!r}."
-        + suffix
+    )
+
+
+def _format_user_facing_shape_error(request: ShapeSelectionRequest) -> str:
+    """Generic message safe to surface to customers."""
+    return (
+        f"No training configuration is available for "
+        f"base_model={request.base_model!r}. "
+        f"Please contact support or try a different model."
     )
 
 


### PR DESCRIPTION
## Description

Add `accelerator_type` filtering to the training shape selector so jobs forced onto a specific accelerator (e.g. B200 via `UseTrainingV2`) fail fast when no matching shapes exist, instead of silently selecting the wrong accelerator's shapes and failing later with a cryptic 400.

**Companion PR:** https://github.com/fw-ai/fireworks/pull/21714 (updates `training_shape_utils.py` to thread `accelerator_type` from the job config)

### Changes

- `ShapeSelectionRequest`: new optional `accelerator_type` field (backward compatible default `None`)
- `_build_latest_validated_training_shape_filter` / `_build_compatible_training_shape_filter`: add `snapshot.accelerator_type` clause to server-side filter when set
- `_compatible_training_shape_candidates`: client-side accelerator check as belt-and-suspenders
- `_select_training_shape_candidate`: thread `accelerator_type` to both filter builders
- Split error reporting:
  - `_format_internal_shape_error`: full constraint details logged at ERROR (base_model, accelerator_type, mode, seq_len)
  - `_format_user_facing_shape_error`: generic message raised to users ("No training configuration available")
- 4 new unit tests covering server filter, client filter, mismatch error, and backward compat

## Testing

All 12 tests in `test_training_shapes.py` pass.

Made with [Cursor](https://cursor.com)