### PR TITLE
test(smoke): nightly e2e workflow + trainer-first and deployment-first deepmath smoke tests

### DIFF
--- a/.github/workflows/training-ci.yml
+++ b/.github/workflows/training-ci.yml
@@ -69,52 +69,5 @@ jobs:
             training/coverage.json
             training/coverage-summary.txt
 
-  qwen3-4b-smoke:
-    name: Qwen3-4B Smoke (${{ matrix.test_target }})
-    needs: unit
-    runs-on: ubuntu-latest
-    timeout-minutes: 180
-    strategy:
-      fail-fast: false
-      max-parallel: 1
-      matrix:
-        test_target:
-          - tests/smoke_test/test_sft_smoke.py
-          - tests/smoke_test/test_dpo_smoke.py
-          - tests/smoke_test/test_grpo_smoke.py
-          - tests/smoke_test/test_grpo_deepmath_smoke.py
-    defaults:
-      run:
-        working-directory: training
-    env:
-      FIREWORKS_API_KEY: ${{ secrets.FIREWORKS_API_KEY }}
-      FIREWORKS_ACCOUNT_ID: ${{ secrets.FIREWORKS_ACCOUNT_ID }}
-      FIREWORKS_BASE_URL: ${{ vars.FIREWORKS_BASE_URL || 'https://dev.api.fireworks.ai' }}
-      FIREWORKS_INFERENCE_URL: ${{ vars.FIREWORKS_INFERENCE_URL || vars.FIREWORKS_BASE_URL || 'https://dev.api.fireworks.ai' }}
-      FIREWORKS_HOTLOAD_API_URL: ${{ vars.FIREWORKS_HOTLOAD_API_URL || vars.FIREWORKS_BASE_URL || 'https://dev.api.fireworks.ai' }}
-      FIREWORKS_GATEWAY_SECRET: ${{ secrets.FIREWORKS_GATEWAY_SECRET }}
-      FIREWORKS_CUSTOM_IMAGE_TAG: ${{ vars.FIREWORKS_CUSTOM_IMAGE_TAG }}
-      FIREWORKS_SMOKE_BASE_MODEL: ${{ vars.FIREWORKS_SMOKE_BASE_MODEL || 'accounts/fireworks/models/qwen3-4b' }}
-      FIREWORKS_SMOKE_TOKENIZER_MODEL: ${{ vars.FIREWORKS_SMOKE_TOKENIZER_MODEL || 'Qwen/Qwen3-4B' }}
-      FIREWORKS_SMOKE_TRAINING_SHAPE: ${{ vars.FIREWORKS_SMOKE_TRAINING_SHAPE || 'ts-qwen3-4b-smoke-v1' }}
-      FIREWORKS_SMOKE_MINIMAL_TRAINING_SHAPE: ${{ vars.FIREWORKS_SMOKE_MINIMAL_TRAINING_SHAPE || 'qwen3-4b-minimum' }}
-      FIREWORKS_SMOKE_MINIMAL_REF_TRAINING_SHAPE: ${{ vars.FIREWORKS_SMOKE_MINIMAL_REF_TRAINING_SHAPE || 'qwen3-4b-minimum-forward-only' }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set Up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-          cache: "pip"
-          cache-dependency-path: training/pyproject.toml
-
-      - name: Install Dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install -e '.[dev]'
-
-      - name: Run Smoke Test
-        run: |
-          pytest -q -s ${{ matrix.test_target }}
+# Smoke matrix moved to .github/workflows/training-smoke.yml
+# (nightly schedule + workflow_dispatch). PRs only run unit tests.

--- a/.github/workflows/training-ci.yml
+++ b/.github/workflows/training-ci.yml
@@ -82,6 +82,7 @@ jobs:
           - tests/smoke_test/test_sft_smoke.py
           - tests/smoke_test/test_dpo_smoke.py
           - tests/smoke_test/test_grpo_smoke.py
+          - tests/smoke_test/test_grpo_deepmath_smoke.py
     defaults:
       run:
         working-directory: training
@@ -96,6 +97,8 @@ jobs:
       FIREWORKS_SMOKE_BASE_MODEL: ${{ vars.FIREWORKS_SMOKE_BASE_MODEL || 'accounts/fireworks/models/qwen3-4b' }}
       FIREWORKS_SMOKE_TOKENIZER_MODEL: ${{ vars.FIREWORKS_SMOKE_TOKENIZER_MODEL || 'Qwen/Qwen3-4B' }}
       FIREWORKS_SMOKE_TRAINING_SHAPE: ${{ vars.FIREWORKS_SMOKE_TRAINING_SHAPE || 'ts-qwen3-4b-smoke-v1' }}
+      FIREWORKS_SMOKE_MINIMAL_TRAINING_SHAPE: ${{ vars.FIREWORKS_SMOKE_MINIMAL_TRAINING_SHAPE || 'qwen3-4b-minimum' }}
+      FIREWORKS_SMOKE_MINIMAL_REF_TRAINING_SHAPE: ${{ vars.FIREWORKS_SMOKE_MINIMAL_REF_TRAINING_SHAPE || 'qwen3-4b-minimum-forward-only' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/training-smoke.yml
+++ b/.github/workflows/training-smoke.yml
@@ -8,11 +8,6 @@ on:
   schedule:
     - cron: "13 8 * * *"  # 08:13 UTC daily (~1:13am PT, off-peak)
   workflow_dispatch:
-    inputs:
-      test_target:
-        description: "Single test file to run (default: full matrix)"
-        required: false
-        default: ""
 
 permissions:
   contents: read
@@ -69,9 +64,4 @@ jobs:
           python -m pip install -e '.[dev]'
 
       - name: Run Smoke Test
-        env:
-          # workflow_dispatch may target a single file; otherwise use matrix entry.
-          TARGET: ${{ github.event.inputs.test_target || matrix.test_target }}
-        run: |
-          if [ -z "$TARGET" ]; then TARGET="${{ matrix.test_target }}"; fi
-          pytest -q -s "$TARGET"
+        run: pytest -q -s "${{ matrix.test_target }}"

--- a/.github/workflows/training-smoke.yml
+++ b/.github/workflows/training-smoke.yml
@@ -1,0 +1,77 @@
+name: Training Smoke
+
+# Real e2e smoke matrix. Hits dev.api.fireworks.ai and provisions GPU
+# trainers/deployments, so it does NOT run on PRs (cost + secret access).
+# Trigger via nightly schedule or manual dispatch from a branch.
+
+on:
+  schedule:
+    - cron: "13 8 * * *"  # 08:13 UTC daily (~1:13am PT, off-peak)
+  workflow_dispatch:
+    inputs:
+      test_target:
+        description: "Single test file to run (default: full matrix)"
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+concurrency:
+  group: training-smoke-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  qwen3-4b-smoke:
+    name: Qwen3-4B Smoke (${{ matrix.test_target }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        test_target:
+          - tests/smoke_test/test_sft_smoke.py
+          - tests/smoke_test/test_dpo_smoke.py
+          - tests/smoke_test/test_grpo_smoke.py
+          - tests/smoke_test/test_grpo_deepmath_trainer_first_smoke.py
+          - tests/smoke_test/test_grpo_deepmath_deployment_first_smoke.py
+    defaults:
+      run:
+        working-directory: training
+    env:
+      FIREWORKS_API_KEY: ${{ secrets.FIREWORKS_API_KEY }}
+      FIREWORKS_ACCOUNT_ID: ${{ secrets.FIREWORKS_ACCOUNT_ID }}
+      FIREWORKS_BASE_URL: ${{ vars.FIREWORKS_BASE_URL || 'https://dev.api.fireworks.ai' }}
+      FIREWORKS_INFERENCE_URL: ${{ vars.FIREWORKS_INFERENCE_URL || vars.FIREWORKS_BASE_URL || 'https://dev.api.fireworks.ai' }}
+      FIREWORKS_HOTLOAD_API_URL: ${{ vars.FIREWORKS_HOTLOAD_API_URL || vars.FIREWORKS_BASE_URL || 'https://dev.api.fireworks.ai' }}
+      FIREWORKS_GATEWAY_SECRET: ${{ secrets.FIREWORKS_GATEWAY_SECRET }}
+      FIREWORKS_CUSTOM_IMAGE_TAG: ${{ vars.FIREWORKS_CUSTOM_IMAGE_TAG }}
+      FIREWORKS_SMOKE_BASE_MODEL: ${{ vars.FIREWORKS_SMOKE_BASE_MODEL || 'accounts/fireworks/models/qwen3-4b' }}
+      FIREWORKS_SMOKE_TOKENIZER_MODEL: ${{ vars.FIREWORKS_SMOKE_TOKENIZER_MODEL || 'Qwen/Qwen3-4B' }}
+      FIREWORKS_SMOKE_TRAINING_SHAPE: ${{ vars.FIREWORKS_SMOKE_TRAINING_SHAPE || 'ts-qwen3-4b-smoke-v1' }}
+      FIREWORKS_SMOKE_MINIMAL_TRAINING_SHAPE: ${{ vars.FIREWORKS_SMOKE_MINIMAL_TRAINING_SHAPE || 'qwen3-4b-minimum' }}
+      FIREWORKS_SMOKE_MINIMAL_REF_TRAINING_SHAPE: ${{ vars.FIREWORKS_SMOKE_MINIMAL_REF_TRAINING_SHAPE || 'qwen3-4b-minimum-forward-only' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set Up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+          cache-dependency-path: training/pyproject.toml
+
+      - name: Install Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e '.[dev]'
+
+      - name: Run Smoke Test
+        env:
+          # workflow_dispatch may target a single file; otherwise use matrix entry.
+          TARGET: ${{ github.event.inputs.test_target || matrix.test_target }}
+        run: |
+          if [ -z "$TARGET" ]; then TARGET="${{ matrix.test_target }}"; fi
+          pytest -q -s "$TARGET"

--- a/training/tests/smoke_test/conftest.py
+++ b/training/tests/smoke_test/conftest.py
@@ -112,6 +112,16 @@ def smoke_minimal_grpo_infra(
 def smoke_sdk_managers():
     api_key = _get_env("FIREWORKS_API_KEY")
     if not api_key:
+        # Inside GitHub Actions a missing FIREWORKS_API_KEY almost always
+        # means the repo secret was never configured -- previously the
+        # smoke matrix silently skipped and was reported green, hiding
+        # the fact that no e2e was actually running. Fail loudly there.
+        if os.environ.get("GITHUB_ACTIONS") == "true":
+            pytest.fail(
+                "FIREWORKS_API_KEY is empty in GitHub Actions. The repo "
+                "secret is not configured -- add it under Settings -> "
+                "Secrets and variables -> Actions."
+            )
         pytest.skip("FIREWORKS_API_KEY not set")
 
     base_url = _get_env("FIREWORKS_BASE_URL", DEFAULT_SMOKE_BASE_URL)

--- a/training/tests/smoke_test/conftest.py
+++ b/training/tests/smoke_test/conftest.py
@@ -16,6 +16,8 @@ logger = logging.getLogger(__name__)
 DEFAULT_SMOKE_BASE_MODEL = "accounts/fireworks/models/qwen3-4b"
 DEFAULT_SMOKE_TOKENIZER_MODEL = "Qwen/Qwen3-4B"
 DEFAULT_SMOKE_TRAINING_SHAPE = "ts-qwen3-4b-smoke-v1"
+DEFAULT_SMOKE_MINIMAL_TRAINING_SHAPE = "qwen3-4b-minimum"
+DEFAULT_SMOKE_MINIMAL_REF_TRAINING_SHAPE = "qwen3-4b-minimum-forward-only"
 DEFAULT_SMOKE_BASE_URL = "https://dev.api.fireworks.ai"
 
 
@@ -72,6 +74,37 @@ def smoke_dpo_infra(smoke_training_shape, smoke_custom_image_tag) -> InfraConfig
     return InfraConfig(
         training_shape_id=smoke_training_shape,
         ref_training_shape_id=smoke_training_shape,
+    )
+
+
+@pytest.fixture(scope="session")
+def smoke_minimal_training_shape() -> str:
+    return _get_env(
+        "FIREWORKS_SMOKE_MINIMAL_TRAINING_SHAPE",
+        DEFAULT_SMOKE_MINIMAL_TRAINING_SHAPE,
+    )
+
+
+@pytest.fixture(scope="session")
+def smoke_minimal_ref_training_shape() -> str:
+    return _get_env(
+        "FIREWORKS_SMOKE_MINIMAL_REF_TRAINING_SHAPE",
+        DEFAULT_SMOKE_MINIMAL_REF_TRAINING_SHAPE,
+    )
+
+
+@pytest.fixture(scope="session")
+def smoke_minimal_grpo_infra(
+    smoke_minimal_training_shape,
+    smoke_minimal_ref_training_shape,
+    smoke_custom_image_tag,
+) -> InfraConfig:
+    """Two minimal 1xGPU training shapes (policy + forward-only reference)."""
+    if smoke_custom_image_tag:
+        return InfraConfig(custom_image_tag=smoke_custom_image_tag)
+    return InfraConfig(
+        training_shape_id=smoke_minimal_training_shape,
+        ref_training_shape_id=smoke_minimal_ref_training_shape,
     )
 
 

--- a/training/tests/smoke_test/test_grpo_deepmath_deployment_first_smoke.py
+++ b/training/tests/smoke_test/test_grpo_deepmath_deployment_first_smoke.py
@@ -1,0 +1,98 @@
+"""DEPRECATED deployment-first creation smoke test on minimal qwen3-4b shapes.
+
+Validates the legacy server contract: create the deployment first, then
+create the trainer with hot_load_deployment_id pointing at it. The
+production cookbook recipe (training/recipes/rl_loop.py) is trainer-first;
+this test exists only to keep the deprecated path from silently breaking.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+import uuid
+
+import httpx
+import pytest
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    force=True,
+)
+
+
+@pytest.mark.e2e
+@pytest.mark.timeout(3600)
+def test_grpo_deepmath_deployment_first_smoke(
+    smoke_sdk_managers,
+    smoke_base_model,
+    smoke_minimal_training_shape,
+):
+    from fireworks.training.sdk.deployment import DeploymentConfig
+    from fireworks.training.sdk.trainer import TrainerJobConfig
+
+    rlor_mgr, deploy_mgr = smoke_sdk_managers
+
+    suffix = uuid.uuid4().hex[:8]
+    deployment_id = f"smoke-depfirst-{suffix}"
+
+    # Resolve the policy training shape so we can pin the trainer to a
+    # validated shape version (the trainer create will reject the manual
+    # path without superuser).
+    profile = rlor_mgr.resolve_training_profile(smoke_minimal_training_shape)
+    deployment_shape = profile.deployment_shape
+    if not deployment_shape:
+        pytest.skip(
+            f"training shape {smoke_minimal_training_shape} has no linked "
+            "deployment_shape; deployment-first smoke needs one"
+        )
+
+    deployment_created = False
+    trainer_job_id: str | None = None
+    try:
+        # Step 1: deployment first (the deprecated order).
+        deploy_cfg = DeploymentConfig(
+            deployment_id=deployment_id,
+            base_model=smoke_base_model,
+            deployment_shape=deployment_shape,
+            min_replica_count=1,
+            max_replica_count=1,
+        )
+        deploy_mgr.create_or_get(deploy_cfg)
+        deployment_created = True
+        deploy_mgr.wait_for_ready(deployment_id, timeout_s=1500)
+
+        # Step 2: trainer with hot_load_deployment_id pointing at the
+        # already-existing deployment. This is the contract under test:
+        # the gateway must accept it and the trainer must reach RUNNING.
+        trainer_cfg = TrainerJobConfig(
+            base_model=smoke_base_model,
+            display_name=f"smoke-depfirst-{suffix}",
+            hot_load_deployment_id=deployment_id,
+            training_shape_ref=profile.training_shape_version,
+        )
+        endpoint = rlor_mgr.create_and_wait(trainer_cfg, timeout_s=1500)
+        trainer_job_id = endpoint.job_id
+        assert endpoint.job_id, "trainer create returned empty job_id"
+    finally:
+        if trainer_job_id:
+            try:
+                rlor_mgr.delete(trainer_job_id)
+            except Exception as e:
+                logging.warning("trainer cleanup failed: %s", e)
+        if deployment_created:
+            try:
+                deploy_mgr.delete(deployment_id)
+            except Exception as e:
+                logging.warning("deployment cleanup failed: %s", e)
+
+    time.sleep(3)
+    if trainer_job_id:
+        try:
+            job = rlor_mgr.get(trainer_job_id)
+            state = job.get("state", "")
+            assert state in ("JOB_STATE_DELETING", "JOB_STATE_DELETED")
+        except httpx.HTTPStatusError as e:
+            assert e.response.status_code == 404

--- a/training/tests/smoke_test/test_grpo_deepmath_deployment_first_smoke.py
+++ b/training/tests/smoke_test/test_grpo_deepmath_deployment_first_smoke.py
@@ -1,4 +1,4 @@
-"""DEPRECATED deployment-first creation smoke test on minimal qwen3-4b shapes.
+"""Smoke test for the DEPRECATED deployment-first creation path on minimal qwen3-4b shapes.
 
 Validates the legacy server contract: create the deployment first, then
 create the trainer with hot_load_deployment_id pointing at it. The
@@ -8,8 +8,8 @@ this test exists only to keep the deprecated path from silently breaking.
 
 from __future__ import annotations
 
+import contextlib
 import logging
-import os
 import time
 import uuid
 
@@ -21,6 +21,35 @@ logging.basicConfig(
     format="%(asctime)s %(levelname)s %(name)s: %(message)s",
     force=True,
 )
+
+# qwen3-4b-minimum cold-start on a fresh dev pod (image pull + checkpoint
+# download + replica become-ready) is ~10-15 min in observed dev runs;
+# 25 min budget gives ~2x slack to absorb pull cache misses without making
+# the smoke timeout a hair trigger.
+_PROVISION_TIMEOUT_S = 1500
+
+# Network errors that are legitimate during best-effort cleanup against
+# a remote dev gateway. We catch these narrowly so genuine programming
+# errors (AttributeError, TypeError, ...) still surface.
+_CLEANUP_NETWORK_ERRORS: tuple[type[BaseException], ...] = (
+    httpx.HTTPError,
+    ConnectionError,
+    TimeoutError,
+)
+
+
+def _delete_deployment_safe(deploy_mgr, deployment_id: str) -> None:
+    try:
+        deploy_mgr.delete(deployment_id)
+    except _CLEANUP_NETWORK_ERRORS as e:
+        logging.warning("deployment %s cleanup failed: %s", deployment_id, e)
+
+
+def _delete_trainer_safe(rlor_mgr, job_id: str) -> None:
+    try:
+        rlor_mgr.delete(job_id)
+    except _CLEANUP_NETWORK_ERRORS as e:
+        logging.warning("trainer %s cleanup failed: %s", job_id, e)
 
 
 @pytest.mark.e2e
@@ -49,10 +78,11 @@ def test_grpo_deepmath_deployment_first_smoke(
             "deployment_shape; deployment-first smoke needs one"
         )
 
-    deployment_created = False
     trainer_job_id: str | None = None
-    try:
-        # Step 1: deployment first (the deprecated order).
+    with contextlib.ExitStack() as stack:
+        # Step 1: deployment first (the deprecated order). Register cleanup
+        # immediately after create_or_get returns so a failure in
+        # wait_for_ready does not leak the deployment.
         deploy_cfg = DeploymentConfig(
             deployment_id=deployment_id,
             base_model=smoke_base_model,
@@ -61,38 +91,42 @@ def test_grpo_deepmath_deployment_first_smoke(
             max_replica_count=1,
         )
         deploy_mgr.create_or_get(deploy_cfg)
-        deployment_created = True
-        deploy_mgr.wait_for_ready(deployment_id, timeout_s=1500)
+        stack.callback(_delete_deployment_safe, deploy_mgr, deployment_id)
+        deploy_mgr.wait_for_ready(deployment_id, timeout_s=_PROVISION_TIMEOUT_S)
 
         # Step 2: trainer with hot_load_deployment_id pointing at the
         # already-existing deployment. This is the contract under test:
         # the gateway must accept it and the trainer must reach RUNNING.
+        # Split create() and wait_for_ready() so cleanup is registered as
+        # soon as the trainer ID exists, not after wait_for_ready returns.
         trainer_cfg = TrainerJobConfig(
             base_model=smoke_base_model,
             display_name=f"smoke-depfirst-{suffix}",
             hot_load_deployment_id=deployment_id,
             training_shape_ref=profile.training_shape_version,
         )
-        endpoint = rlor_mgr.create_and_wait(trainer_cfg, timeout_s=1500)
-        trainer_job_id = endpoint.job_id
-        assert endpoint.job_id, "trainer create returned empty job_id"
-    finally:
-        if trainer_job_id:
-            try:
-                rlor_mgr.delete(trainer_job_id)
-            except Exception as e:
-                logging.warning("trainer cleanup failed: %s", e)
-        if deployment_created:
-            try:
-                deploy_mgr.delete(deployment_id)
-            except Exception as e:
-                logging.warning("deployment cleanup failed: %s", e)
+        created = rlor_mgr.create(trainer_cfg)
+        trainer_job_id = created.job_id
+        assert trainer_job_id, "trainer create returned empty job_id"
+        stack.callback(_delete_trainer_safe, rlor_mgr, trainer_job_id)
+        rlor_mgr.wait_for_ready(
+            trainer_job_id,
+            job_name=created.job_name,
+            timeout_s=_PROVISION_TIMEOUT_S,
+        )
+    # ExitStack fired here in LIFO order: trainer deleted first, then deployment.
 
+    # Verify cleanup actually landed (best-effort: control plane may take a
+    # few seconds to flip state, and the resource may already be 404).
     time.sleep(3)
     if trainer_job_id:
         try:
             job = rlor_mgr.get(trainer_job_id)
             state = job.get("state", "")
-            assert state in ("JOB_STATE_DELETING", "JOB_STATE_DELETED")
+            assert state in ("JOB_STATE_DELETING", "JOB_STATE_DELETED"), (
+                f"trainer {trainer_job_id} cleanup failed: state={state}"
+            )
         except httpx.HTTPStatusError as e:
-            assert e.response.status_code == 404
+            assert e.response.status_code == 404, (
+                f"unexpected error fetching trainer {trainer_job_id}: {e}"
+            )

--- a/training/tests/smoke_test/test_grpo_deepmath_smoke.py
+++ b/training/tests/smoke_test/test_grpo_deepmath_smoke.py
@@ -1,0 +1,112 @@
+"""GRPO deepmath smoke test on minimal 1xGPU qwen3-4b shapes (trainer-first).
+
+40 rows, 4 completions/prompt, 2 prompt groups/step, kl_beta>0. Asserts the
+trainer-first invariant (deployment created with hot_load_trainer_job, not
+hot_load_deployment_id).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+
+import pytest
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    force=True,
+)
+
+_DEEPMATH_DATASET = os.path.abspath(
+    os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "..",
+        "examples",
+        "rl",
+        "deepmath",
+        "dataset.jsonl",
+    )
+)
+
+
+@pytest.mark.e2e
+@pytest.mark.timeout(3600)
+def test_grpo_deepmath_trainer_first_smoke(
+    smoke_sdk_managers,
+    smoke_base_model,
+    smoke_tokenizer_model,
+    smoke_minimal_grpo_infra,
+):
+    # Late imports: module collection must not require FIREWORKS_API_KEY.
+    from training.utils import DeployConfig, WeightSyncConfig, WandBConfig
+    from training.recipes.rl_loop import Config, main
+    import training.recipes.rl_loop as rl_mod
+    from training.examples.rl.deepmath.train_deepmath import deepmath_reward
+
+    if not os.path.exists(_DEEPMATH_DATASET):
+        pytest.skip(f"deepmath dataset not found at {_DEEPMATH_DATASET}")
+
+    rlor_mgr, deploy_mgr = smoke_sdk_managers
+
+    rl_mod.reward_fn = deepmath_reward
+    # Disable zero-variance filter so a 40-row run still produces steps.
+    rl_mod.should_accept = lambda _pg: True
+
+    config = Config(
+        log_path=tempfile.mkdtemp(prefix="grpo_deepmath_smoke_"),
+        base_model=smoke_base_model,
+        dataset=_DEEPMATH_DATASET,
+        learning_rate=1e-5,
+        kl_beta=0.001,
+        completions_per_prompt=4,
+        prompt_groups_per_step=2,
+        max_completion_tokens=256,
+        max_rows=40,
+        epochs=1,
+        infra=smoke_minimal_grpo_infra,
+        deployment=DeployConfig(
+            tokenizer_model=smoke_tokenizer_model,
+            sample_timeout=600,
+        ),
+        weight_sync=WeightSyncConfig(
+            weight_sync_interval=1,
+            first_checkpoint_type="base",
+            weight_sync_before_training=True,
+            weight_sync_timeout=600,
+        ),
+        wandb=WandBConfig(),
+    )
+
+    metrics = main(
+        config,
+        rlor_mgr=rlor_mgr,
+        deploy_mgr=deploy_mgr,
+        cleanup_on_exit=True,
+    )
+
+    assert isinstance(metrics, dict)
+    assert metrics.get("steps", 0) >= 1, f"no training steps: {metrics}"
+    assert metrics.get("reference_job_id"), f"reference trainer not created: {metrics}"
+    assert config.deployment.hot_load_trainer_job, (
+        "trainer-first regression: deployment was not attached via hot_load_trainer_job"
+    )
+
+    import httpx
+    import time
+
+    time.sleep(3)
+    for key in ("policy_job_id", "reference_job_id"):
+        job_id = metrics.get(key)
+        if not job_id:
+            continue
+        try:
+            job = rlor_mgr.get(job_id)
+            state = job.get("state", "")
+            assert state in ("JOB_STATE_DELETING", "JOB_STATE_DELETED"), (
+                f"ResourceCleanup failed: {key} {job_id} still {state}"
+            )
+        except httpx.HTTPStatusError as e:
+            assert e.response.status_code == 404

--- a/training/tests/smoke_test/test_grpo_deepmath_trainer_first_smoke.py
+++ b/training/tests/smoke_test/test_grpo_deepmath_trainer_first_smoke.py
@@ -10,7 +10,9 @@ from __future__ import annotations
 import logging
 import os
 import tempfile
+import time
 
+import httpx
 import pytest
 
 logging.basicConfig(
@@ -39,6 +41,7 @@ def test_grpo_deepmath_trainer_first(
     smoke_base_model,
     smoke_tokenizer_model,
     smoke_minimal_grpo_infra,
+    monkeypatch,
 ):
     # Late imports: module collection must not require FIREWORKS_API_KEY.
     from training.utils import DeployConfig, WeightSyncConfig, WandBConfig
@@ -51,9 +54,12 @@ def test_grpo_deepmath_trainer_first(
 
     rlor_mgr, deploy_mgr = smoke_sdk_managers
 
-    rl_mod.reward_fn = deepmath_reward
+    # monkeypatch (not direct rl_mod.x = ...) so the override is auto-undone
+    # at test exit; otherwise running multiple smoke tests in one pytest
+    # process leaks the patched globals into later tests.
+    monkeypatch.setattr(rl_mod, "reward_fn", deepmath_reward)
     # Disable zero-variance filter so a 40-row run still produces steps.
-    rl_mod.should_accept = lambda _pg: True
+    monkeypatch.setattr(rl_mod, "should_accept", lambda _: True)
 
     config = Config(
         log_path=tempfile.mkdtemp(prefix="grpo_deepmath_smoke_"),
@@ -87,15 +93,14 @@ def test_grpo_deepmath_trainer_first(
         cleanup_on_exit=True,
     )
 
+    # No seed pinning: this is an API contract smoke (steps complete, cleanup
+    # runs, trainer-first invariant holds), not a numerical fidelity check.
     assert isinstance(metrics, dict)
     assert metrics.get("steps", 0) >= 1, f"no training steps: {metrics}"
     assert metrics.get("reference_job_id"), f"reference trainer not created: {metrics}"
     assert config.deployment.hot_load_trainer_job, (
         "trainer-first regression: deployment was not attached via hot_load_trainer_job"
     )
-
-    import httpx
-    import time
 
     time.sleep(3)
     for key in ("policy_job_id", "reference_job_id"):

--- a/training/tests/smoke_test/test_grpo_deepmath_trainer_first_smoke.py
+++ b/training/tests/smoke_test/test_grpo_deepmath_trainer_first_smoke.py
@@ -34,7 +34,7 @@ _DEEPMATH_DATASET = os.path.abspath(
 
 @pytest.mark.e2e
 @pytest.mark.timeout(3600)
-def test_grpo_deepmath_trainer_first_smoke(
+def test_grpo_deepmath_trainer_first(
     smoke_sdk_managers,
     smoke_base_model,
     smoke_tokenizer_model,


### PR DESCRIPTION
## Summary

Three problems with the existing CI:

1. **`qwen3-4b-smoke` matrix has been silently no-op for its entire history** — the workflow references `secrets.FIREWORKS_API_KEY` but the secret is not configured in this repo, so every smoke test pytest-skips and reports green. Verified by inspecting the most recent main run (24162179707): `1 skipped in 0.01s` for every entry.
2. Per-PR e2e is the wrong cadence — burns dev quota on every commit and blocks unrelated PRs when dev is degraded.
3. Only the trainer-first creation flow had a smoke test; the deprecated deployment-first contract had no regression guard.

## Changes

- **New workflow** `.github/workflows/training-smoke.yml` triggered by `schedule:` (08:13 UTC nightly, off-peak) and `workflow_dispatch:` (manual run, optional single-test input). Smoke matrix moved here.
- **`training-ci.yml` trimmed** to unit tests only on PR + push to main.
- **Renamed** `test_grpo_deepmath_smoke.py` → `test_grpo_deepmath_trainer_first_smoke.py` for symmetry.
- **New** `test_grpo_deepmath_deployment_first_smoke.py`: a contract-level smoke that creates the deployment first via the SDK, then creates the trainer with `hot_load_deployment_id` pointing at it. Validates the deprecated server contract still works on the same minimal qwen3-4b shapes.
- **`conftest.smoke_sdk_managers` now fails loudly** when running under GitHub Actions with an empty `FIREWORKS_API_KEY`. Local runs still skip (so devs without dev keys can iterate). This is the only way the maintainer will notice that the secret was never configured.

Smoke matrix entries (all run nightly):
- `tests/smoke_test/test_sft_smoke.py`
- `tests/smoke_test/test_dpo_smoke.py`
- `tests/smoke_test/test_grpo_smoke.py`
- `tests/smoke_test/test_grpo_deepmath_trainer_first_smoke.py`
- `tests/smoke_test/test_grpo_deepmath_deployment_first_smoke.py`

## Required maintainer action before nightly will pass

1. **Configure repo secrets** under Settings → Secrets and variables → Actions:
   - `FIREWORKS_API_KEY` (dev-only key scoped to a dev account, e.g. `pyroworks-dev` on `dev.api.fireworks.ai`)
   - `FIREWORKS_GATEWAY_SECRET` (only if your dev gateway requires it)
   - `FIREWORKS_ACCOUNT_ID` (optional)
2. **Verify the minimal training shapes exist** in the dev account the secret targets:
   - `qwen3-4b-minimum` (policy)
   - `qwen3-4b-minimum-forward-only` (reference)
3. **Consider gating the smoke workflow behind a GitHub Environment with required reviewers** so manual `workflow_dispatch` runs from contributor branches require approval (defense in depth — the secret is dev-only, but environment gating prevents accidental quota burns).

## Security review (public repo)

- Workflow uses `pull_request:` (not `pull_request_target:`) → fork PRs cannot exfiltrate secrets.
- New workflow uses `schedule:` + `workflow_dispatch:` only — no `pull_request:` trigger, so it never runs on untrusted PR code.
- All credentials route through GitHub secrets; nothing hardcoded.
- Test code never logs the API key or any header value.
- Diff scrubbed for `fw_*` API key prefixes, `pyroworks-dev`, `chengxili`, `hec4te`, `workspace_fw`, the gateway secret UUID, `password`, `bearer …` — **no matches**.

## Related

- fw-ai/fireworks#21884 — server-side error message that points users at the trainer-first reference example added here.

## Test plan
- [ ] PR CI: `Unit And Import Tests` job passes (smoke matrix gone from PR triggers, so no false-green skips).
- [ ] Maintainer: configure secrets, then trigger `Training Smoke` workflow manually via `gh workflow run training-smoke.yml --ref chengxili/grpo-deepmath-trainer-first-smoke` and watch it actually exercise the dev API.
- [ ] Iterate on shape-not-found / cleanup / hot_load_deployment_id contract failures.
- [ ] Once the manual run is green, merge → first nightly fires the next morning at 08:13 UTC.