### PR TITLE
feat(runner): emit protojson-compatible status files

### DIFF
--- a/training/tests/unit/test_runner.py
+++ b/training/tests/unit/test_runner.py
@@ -63,12 +63,10 @@ class TestRunnerIOStatus:
         runner.write_status(RunStatus.RUNNING, step=3, total_steps=10, message="training")
 
         data = json.loads(open(path).read())
-        assert data["status"] == "running"
-        assert data["step"] == 3
-        assert data["total_steps"] == 10
-        assert data["progress"] == 0.3
+        assert data["code"] == 0
         assert data["message"] == "training"
-        assert "error" not in data
+        assert data["details"][0]["@type"] == "type.googleapis.com/gateway.JobProgress"
+        assert data["details"][0]["percent"] == 30
 
     def test_write_status_with_error(self, tmp_path):
         path = str(tmp_path / "status.json")
@@ -77,8 +75,9 @@ class TestRunnerIOStatus:
         runner.write_status(RunStatus.FAILED, error="OOM")
 
         data = json.loads(open(path).read())
-        assert data["status"] == "failed"
-        assert data["error"] == "OOM"
+        assert data["code"] == 9
+        assert data["message"] == "OOM"
+        assert "details" not in data
 
     def test_write_status_overwrites(self, tmp_path):
         path = str(tmp_path / "status.json")
@@ -88,8 +87,9 @@ class TestRunnerIOStatus:
         runner.write_status(RunStatus.COMPLETED, step=10, total_steps=10, message="done")
 
         data = json.loads(open(path).read())
-        assert data["status"] == "completed"
-        assert data["step"] == 10
+        assert data["code"] == 0
+        assert data["message"] == "done"
+        assert data["details"][0]["percent"] == 100
 
     def test_write_status_noop_when_no_file(self):
         runner = RunnerIO(RunnerConfig())
@@ -101,7 +101,8 @@ class TestRunnerIOStatus:
         runner.write_status(RunStatus.PENDING, step=0, total_steps=0)
 
         data = json.loads(open(path).read())
-        assert data["progress"] == 0.0
+        assert data["code"] == 0
+        assert "details" not in data
 
     def test_all_status_values(self, tmp_path):
         path = str(tmp_path / "status.json")
@@ -110,7 +111,11 @@ class TestRunnerIOStatus:
         for status in RunStatus:
             runner.write_status(status)
             data = json.loads(open(path).read())
-            assert data["status"] == status.value
+            assert data["message"] == status.value
+            if status == RunStatus.FAILED:
+                assert data["code"] == 9
+            else:
+                assert data["code"] == 0
 
 
 # -- RunnerIO: metadata --------------------------------------------------------
@@ -305,10 +310,9 @@ class TestRunnerIOContextManager:
                 raise RuntimeError("boom")
 
         data = json.loads(open(path).read())
-        assert data["status"] == "failed"
-        assert data["error"] == "boom"
-        assert data["step"] == 5
-        assert data["total_steps"] == 10
+        assert data["code"] == 9
+        assert data["message"] == "boom"
+        assert data["details"][0]["percent"] == 50
 
     def test_exception_flushes_metadata(self, tmp_path):
         meta = str(tmp_path / "meta.json")
@@ -338,7 +342,8 @@ class TestRunnerIOContextManager:
             pass  # no exception
 
         data = json.loads(open(path).read())
-        assert data["status"] == "running"  # unchanged by __exit__
+        assert data["code"] == 0
+        assert data["message"] == "running"
 
     def test_noop_runner_context_manager_does_not_raise(self):
         runner = RunnerIO()

--- a/training/utils/runner.py
+++ b/training/utils/runner.py
@@ -12,10 +12,10 @@ Optional inputs (via ``RunnerConfig`` fields or environment variables):
 
 File formats:
 
-``status_file`` (JSON, overwritten each update)::
+``status_file`` (protojson-compatible ``google.rpc.Status``, overwritten each update)::
 
-    {"status": "running", "step": 5, "total_steps": 100,
-     "progress": 0.05, "message": "training"}
+    {"code": 0, "message": "training",
+     "details": [{"@type": "type.googleapis.com/gateway.JobProgress", "percent": 5}]}
 
 ``metadata_file`` (JSON, overwritten each update)::
 
@@ -50,6 +50,18 @@ class RunStatus(str, Enum):
     RUNNING = "running"
     COMPLETED = "completed"
     FAILED = "failed"
+
+
+_GRPC_OK = 0
+_GRPC_FAILED_PRECONDITION = 9
+_JOB_PROGRESS_TYPE_URL = "type.googleapis.com/gateway.JobProgress"
+
+_STATUS_TO_GRPC_CODE: dict[RunStatus, int] = {
+    RunStatus.PENDING: _GRPC_OK,
+    RunStatus.RUNNING: _GRPC_OK,
+    RunStatus.COMPLETED: _GRPC_OK,
+    RunStatus.FAILED: _GRPC_FAILED_PRECONDITION,
+}
 
 
 @dataclass
@@ -135,17 +147,15 @@ class RunnerIO:
         self._last_total_steps = total_steps
         if not self._status_file:
             return
-        progress = step / total_steps if total_steps > 0 else 0.0
+        grpc_code = _STATUS_TO_GRPC_CODE.get(status, _GRPC_OK)
+        status_message = error or message or status.value
         payload: dict[str, Any] = {
-            "status": status.value,
-            "step": step,
-            "total_steps": total_steps,
-            "progress": round(progress, 6),
+            "code": grpc_code,
+            "message": status_message,
         }
-        if message:
-            payload["message"] = message
-        if error:
-            payload["error"] = error
+        if total_steps > 0:
+            percent = int(step / total_steps * 100)
+            payload["details"] = [{"@type": _JOB_PROGRESS_TYPE_URL, "percent": percent}]
         self._write_json(self._status_file, payload)
 
     # -- metadata --------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Switch `RunnerIO.write_status()` from plain JSON (`{"status": "running", "step": 5, ...}`) to protojson-compatible `google.rpc.Status` format (`{"code": 0, "message": "training", "details": [{"@type": "type.googleapis.com/gateway.JobProgress", "percent": 50}]}`)
- The cookbook stays proto-import-free by constructing the JSON structure manually with gRPC code mapping and `@type` annotations
- All 31 existing runner tests updated to verify the new protojson structure

## Context

The control plane Go reader expects `google.rpc.Status` protobuf in status files, but the cookbook was writing plain JSON -- causing a silent format mismatch that lost all progress and error reporting for V2 training jobs. This change aligns the cookbook output with the control plane's expected schema while keeping the file human-readable.

Companion PR in fw-ai/fireworks adds protojson support to the Go reader and updates the managed Python writer.

## Test plan

- [x] All 31 `test_runner.py` tests pass with updated assertions
- [ ] Integration: deploy Go reader (protojson + binary fallback) first, then this change


Made with [Cursor](https://cursor.com)