### PR TITLE
chore: bump fireworks-ai SDK to >=1.0.0a61

### DIFF
--- a/training/pyproject.toml
+++ b/training/pyproject.toml
@@ -7,7 +7,7 @@ name = "fireworks-training-cookbook"
 version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [
-    "fireworks-ai[training]>=1.0.0a61,<2",
+    "fireworks-ai[training]>=1.0.0a60,<2",
     "tqdm",
     "torch",
     "datasets",

--- a/training/pyproject.toml
+++ b/training/pyproject.toml
@@ -7,7 +7,7 @@ name = "fireworks-training-cookbook"
 version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [
-    "fireworks-ai[training]>=1.0.0a59,<2",
+    "fireworks-ai[training]>=1.0.0a61,<2",
     "tqdm",
     "torch",
     "datasets",

--- a/training/pyproject.toml
+++ b/training/pyproject.toml
@@ -7,7 +7,7 @@ name = "fireworks-training-cookbook"
 version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [
-    "fireworks-ai[training]>=1.0.0a60,<2",
+    "fireworks-ai[training]>=1.0.0a61,<2",
     "tqdm",
     "torch",
     "datasets",


### PR DESCRIPTION
## Summary

- Bump `fireworks-ai[training]` minimum from `1.0.0a59` to `1.0.0a61`

## Motivation

Release a61 includes:
- `DeploymentManager.update` for partial deployment PATCH
- `WeightSyncer.reset_delta_chain` for re-attach support
- Stale `stage=error` handling in `wait_for_hotload` (ignores errors from previous snapshots after re-attach)

These are required by `setup_or_reattach_deployment` added in PR #301.

## Test plan

- [x] CI unit tests pass with a61
- [x] E2E re-attach test passed on prod (6 hotloads: T1 base+2 deltas, T2 base+2 deltas)

🤖 Generated with [Claude Code](https://claude.com/claude-code)