### PR TITLE
test(runner): enforce strict protojson structure

### DIFF
--- a/training/tests/unit/test_runner.py
+++ b/training/tests/unit/test_runner.py
@@ -68,6 +68,29 @@ class TestRunnerIOStatus:
         assert data["details"][0]["@type"] == "type.googleapis.com/gateway.JobProgress"
         assert data["details"][0]["percent"] == 30
 
+    def test_status_protojson_strict_structure(self, tmp_path):
+        """Enforce exact protojson shape: google.rpc.Status with JobProgress detail."""
+        path = str(tmp_path / "status.json")
+        runner = RunnerIO(RunnerConfig(status_file=path))
+
+        # 7/20 -> 35%
+        runner.write_status(RunStatus.RUNNING, step=7, total_steps=20, message="training")
+
+        data = json.loads(open(path).read())
+        # Top-level keys: exactly code, message, details
+        assert set(data.keys()) == {"code", "message", "details"}
+        assert isinstance(data["code"], int)
+        assert isinstance(data["message"], str)
+        # Details: list of exactly one element with @type and percent
+        assert isinstance(data["details"], list)
+        assert len(data["details"]) == 1
+        detail = data["details"][0]
+        assert set(detail.keys()) == {"@type", "percent"}
+        assert detail["@type"] == "type.googleapis.com/gateway.JobProgress"
+        assert isinstance(detail["percent"], int)
+        assert 0 <= detail["percent"] <= 100
+        assert detail["percent"] == 35
+
     def test_write_status_with_error(self, tmp_path):
         path = str(tmp_path / "status.json")
         runner = RunnerIO(RunnerConfig(status_file=path))
@@ -101,6 +124,8 @@ class TestRunnerIOStatus:
         runner.write_status(RunStatus.PENDING, step=0, total_steps=0)
 
         data = json.loads(open(path).read())
+        # Exact minimal shape: only code and message, no details
+        assert set(data.keys()) == {"code", "message"}
         assert data["code"] == 0
         assert "details" not in data
 

--- a/training/tests/unit/test_runner.py
+++ b/training/tests/unit/test_runner.py
@@ -63,12 +63,10 @@ class TestRunnerIOStatus:
         runner.write_status(RunStatus.RUNNING, step=3, total_steps=10, message="training")
 
         data = json.loads(open(path).read())
-        assert data["status"] == "running"
-        assert data["step"] == 3
-        assert data["total_steps"] == 10
-        assert data["progress"] == 0.3
+        assert data["code"] == 0
         assert data["message"] == "training"
-        assert "error" not in data
+        assert data["details"][0]["@type"] == "type.googleapis.com/gateway.JobProgress"
+        assert data["details"][0]["percent"] == 30
 
     def test_write_status_with_error(self, tmp_path):
         path = str(tmp_path / "status.json")
@@ -77,8 +75,9 @@ class TestRunnerIOStatus:
         runner.write_status(RunStatus.FAILED, error="OOM")
 
         data = json.loads(open(path).read())
-        assert data["status"] == "failed"
-        assert data["error"] == "OOM"
+        assert data["code"] == 9
+        assert data["message"] == "OOM"
+        assert "details" not in data
 
     def test_write_status_overwrites(self, tmp_path):
         path = str(tmp_path / "status.json")
@@ -88,8 +87,9 @@ class TestRunnerIOStatus:
         runner.write_status(RunStatus.COMPLETED, step=10, total_steps=10, message="done")
 
         data = json.loads(open(path).read())
-        assert data["status"] == "completed"
-        assert data["step"] == 10
+        assert data["code"] == 0
+        assert data["message"] == "done"
+        assert data["details"][0]["percent"] == 100
 
     def test_write_status_noop_when_no_file(self):
         runner = RunnerIO(RunnerConfig())
@@ -101,7 +101,8 @@ class TestRunnerIOStatus:
         runner.write_status(RunStatus.PENDING, step=0, total_steps=0)
 
         data = json.loads(open(path).read())
-        assert data["progress"] == 0.0
+        assert data["code"] == 0
+        assert "details" not in data
 
     def test_all_status_values(self, tmp_path):
         path = str(tmp_path / "status.json")
@@ -110,7 +111,11 @@ class TestRunnerIOStatus:
         for status in RunStatus:
             runner.write_status(status)
             data = json.loads(open(path).read())
-            assert data["status"] == status.value
+            assert data["message"] == status.value
+            if status == RunStatus.FAILED:
+                assert data["code"] == 9
+            else:
+                assert data["code"] == 0
 
 
 # -- RunnerIO: metadata --------------------------------------------------------
@@ -305,10 +310,9 @@ class TestRunnerIOContextManager:
                 raise RuntimeError("boom")
 
         data = json.loads(open(path).read())
-        assert data["status"] == "failed"
-        assert data["error"] == "boom"
-        assert data["step"] == 5
-        assert data["total_steps"] == 10
+        assert data["code"] == 9
+        assert data["message"] == "boom"
+        assert data["details"][0]["percent"] == 50
 
     def test_exception_flushes_metadata(self, tmp_path):
         meta = str(tmp_path / "meta.json")
@@ -338,7 +342,8 @@ class TestRunnerIOContextManager:
             pass  # no exception
 
         data = json.loads(open(path).read())
-        assert data["status"] == "running"  # unchanged by __exit__
+        assert data["code"] == 0
+        assert data["message"] == "running"
 
     def test_noop_runner_context_manager_does_not_raise(self):
         runner = RunnerIO()

--- a/training/utils/runner.py
+++ b/training/utils/runner.py
@@ -12,10 +12,10 @@ Optional inputs (via ``RunnerConfig`` fields or environment variables):
 
 File formats:
 
-``status_file`` (JSON, overwritten each update)::
+``status_file`` (protojson-compatible ``google.rpc.Status``, overwritten each update)::
 
-    {"status": "running", "step": 5, "total_steps": 100,
-     "progress": 0.05, "message": "training"}
+    {"code": 0, "message": "training",
+     "details": [{"@type": "type.googleapis.com/gateway.JobProgress", "percent": 5}]}
 
 ``metadata_file`` (JSON, overwritten each update)::
 
@@ -50,6 +50,18 @@ class RunStatus(str, Enum):
     RUNNING = "running"
     COMPLETED = "completed"
     FAILED = "failed"
+
+
+_GRPC_OK = 0
+_GRPC_FAILED_PRECONDITION = 9
+_JOB_PROGRESS_TYPE_URL = "type.googleapis.com/gateway.JobProgress"
+
+_STATUS_TO_GRPC_CODE: dict[RunStatus, int] = {
+    RunStatus.PENDING: _GRPC_OK,
+    RunStatus.RUNNING: _GRPC_OK,
+    RunStatus.COMPLETED: _GRPC_OK,
+    RunStatus.FAILED: _GRPC_FAILED_PRECONDITION,
+}
 
 
 @dataclass
@@ -135,17 +147,15 @@ class RunnerIO:
         self._last_total_steps = total_steps
         if not self._status_file:
             return
-        progress = step / total_steps if total_steps > 0 else 0.0
+        grpc_code = _STATUS_TO_GRPC_CODE.get(status, _GRPC_OK)
+        status_message = error or message or status.value
         payload: dict[str, Any] = {
-            "status": status.value,
-            "step": step,
-            "total_steps": total_steps,
-            "progress": round(progress, 6),
+            "code": grpc_code,
+            "message": status_message,
         }
-        if message:
-            payload["message"] = message
-        if error:
-            payload["error"] = error
+        if total_steps > 0:
+            percent = int(step / total_steps * 100)
+            payload["details"] = [{"@type": _JOB_PROGRESS_TYPE_URL, "percent": percent}]
         self._write_json(self._status_file, payload)
 
     # -- metadata --------------------------------------------------------------


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This follow-up adds a stricter unit test to enforce the exact protojson shape of the status file emitted by RunnerIO.

What’s covered:
- Verifies top-level keys are exactly {"code", "message", "details"} when progress is present.
- Enforces details is a single-element list containing an object with exactly {"@type", "percent"}.
- Validates the type URL is precisely "type.googleapis.com/gateway.JobProgress" and percent is an int within [0, 100] with the expected computed value.
- Strengthens the zero-progress case to assert the minimal shape {"code", "message"} with no "details" key present.

Files changed:
- training/tests/unit/test_runner.py — adds `test_status_protojson_strict_structure` and tightens assertions in the zero-steps case.

Base branch: json-metadata (companion to PR #313).
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://fireworks-ai.slack.com/archives/C0927VDGNAU/p1775717881870319?thread_ts=1775717881.870319&cid=C0927VDGNAU)

<div><a href="https://cursor.com/agents/bc-ba0b61aa-397c-511e-be9e-4cc5859d412b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba0b61aa-397c-511e-be9e-4cc5859d412b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

