### PR TITLE
fix(infra): detect UPDATING→READY in reattach settle to avoid timeout

### DIFF
--- a/training/utils/infra.py
+++ b/training/utils/infra.py
@@ -500,8 +500,27 @@ def _wait_for_reattach_settled(
     """
     deadline = time.time() + max(timeout_s, 1)
     saw_pod_gone = prev_identity is None
+    saw_updating = False
     while time.time() < deadline:
         current = _read_replica_identity(deploy_mgr, deployment_id, base_model)
+
+        # Also check the deployment state via the API. If the deployment
+        # transitions through UPDATING and back to READY, the rollout is
+        # complete even if the pod identity didn't change (same ReplicaSet).
+        try:
+            dep_info = deploy_mgr.get(deployment_id)
+            dep_state = dep_info.state if dep_info else None
+        except Exception:  # noqa: BLE001
+            dep_state = None
+        if dep_state == "UPDATING":
+            saw_updating = True
+        if saw_updating and dep_state == "READY" and current is not None:
+            logger.info(
+                "Re-attach settled: deployment READY after UPDATING, pod %s",
+                current,
+            )
+            return
+
         if prev_identity is None:
             if current is not None:
                 logger.info(


### PR DESCRIPTION
## Summary
- `_wait_for_reattach_settled` timed out after 600s when re-attaching a deployment to the same trainer (no-op PATCH) or when the pod identity didn't change after a rolling restart
- Root cause: the settle function only checked for a different pod identity, but Helm skips pod restart when values are unchanged (same trainer → same bucket URL)
- Fix: track the deployment's API state. If it transitions through UPDATING → READY, the server-side reconciliation is complete regardless of pod identity change

## How it works
The server always sets `state=UPDATING` on PATCH and reconciles via Helm. Two cases:
1. **Different trainer**: Helm detects value diff → pod restart → new identity (existing logic handles this)
2. **Same trainer**: Helm detects no diff → no pod restart → state goes UPDATING→READY quickly → new `saw_updating` check exits the wait

## Test plan
- [ ] Re-attach deployment to same trainer — should settle in <10s instead of timing out at 600s
- [ ] Re-attach deployment to different trainer — should still wait for new pod identity as before