### PR TITLE
Preflight training smoke secret setup

### DIFF
--- a/.github/workflows/training-smoke.yml
+++ b/.github/workflows/training-smoke.yml
@@ -51,6 +51,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Validate smoke CI configuration
+        run: |
+          if [ -z "${FIREWORKS_API_KEY}" ]; then
+            echo "::error title=Missing FIREWORKS_API_KEY secret::Set the FIREWORKS_API_KEY GitHub Actions secret for fw-ai/cookbook before running Training Smoke. A pyroworks or pyroworks-dev API key is sufficient."
+            exit 1
+          fi
+
       - name: Set Up Python
         uses: actions/setup-python@v5
         with:

--- a/training/README.md
+++ b/training/README.md
@@ -136,6 +136,32 @@ uv pip install -e ".[dev]"
 pytest tests/
 ```
 
+### GitHub Actions smoke CI setup
+
+The repo has two separate training workflows:
+
+- `.github/workflows/training-ci.yml` runs unit/import coverage on PRs and
+  pushes with no Fireworks credentials.
+- `.github/workflows/training-smoke.yml` runs remote end-to-end smoke tests
+  against `https://dev.api.fireworks.ai` on nightly/manual dispatch.
+
+For `training-smoke.yml`, configure the following in GitHub under
+**Settings -> Secrets and variables -> Actions**:
+
+- **Required secret:** `FIREWORKS_API_KEY`
+  - Use a key that can create training/deployment resources in dev.
+  - A `pyroworks` key works; a `pyroworks-dev` key is safer if available.
+- **Optional secret:** `FIREWORKS_GATEWAY_SECRET`
+  - Only needed when the dev endpoint requires the gateway header.
+- **Optional variables:** `FIREWORKS_BASE_URL`,
+  `FIREWORKS_INFERENCE_URL`, `FIREWORKS_HOTLOAD_API_URL`,
+  `FIREWORKS_CUSTOM_IMAGE_TAG`, `FIREWORKS_SMOKE_BASE_MODEL`,
+  `FIREWORKS_SMOKE_TOKENIZER_MODEL`, `FIREWORKS_SMOKE_TRAINING_SHAPE`,
+  `FIREWORKS_SMOKE_MINIMAL_TRAINING_SHAPE`,
+  `FIREWORKS_SMOKE_MINIMAL_REF_TRAINING_SHAPE`
+  - If unset, the workflow defaults to the current dev URLs and small
+    Qwen3-4B smoke shapes shown in `.github/workflows/training-smoke.yml`.
+
 Coverage for the training entrypoints:
 
 ```bash


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add an early preflight step to `training-smoke.yml` that fails immediately when `FIREWORKS_API_KEY` is missing
- document the required and optional GitHub Actions secrets/variables for the training smoke workflow in `training/README.md`
- clarify that a `pyroworks` or `pyroworks-dev` key can be used for the smoke workflow

## Testing
- `git diff --check -- .github/workflows/training-smoke.yml training/README.md`

## Notes
- I could not create or upload the API key directly from this environment because mutating `firectl` usage is disallowed in this workspace and GitHub secret management is not available through my configured write tools.
- Current repo observation: `gh secret list` returns no configured Actions secrets for `fw-ai/cookbook`, so an admin still needs to add `FIREWORKS_API_KEY` in GitHub.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ec39ab83-742b-4dfa-89be-c6a0381f6cf4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec39ab83-742b-4dfa-89be-c6a0381f6cf4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

