### PR TITLE
fix(supervised): add Qwen3.5 and Gemma4 renderer resolution

### DIFF
--- a/training/tests/unit/test_supervised_rendering.py
+++ b/training/tests/unit/test_supervised_rendering.py
@@ -269,6 +269,21 @@ def test_resolve_renderer_name_prefers_minimax_m2() -> None:
     assert resolve_renderer_name("MiniMaxAI/MiniMax-M2") == "minimax_m2"
 
 
+def test_resolve_renderer_name_prefers_qwen3_5() -> None:
+    """Qwen3.5 models should resolve to the qwen3_5 renderer."""
+    assert resolve_renderer_name("Qwen/Qwen3.5-9B") == "qwen3_5"
+    assert resolve_renderer_name("Qwen/Qwen3.5-4B") == "qwen3_5"
+    assert resolve_renderer_name("Qwen/Qwen3.5-27B") == "qwen3_5"
+    assert resolve_renderer_name("Qwen/Qwen3.5-35B-A3B") == "qwen3_5"
+    assert resolve_renderer_name("Qwen/Qwen3.5-397B-A17B") == "qwen3_5"
+
+
+def test_resolve_renderer_name_prefers_gemma4() -> None:
+    """Gemma 4 models should resolve to the gemma4 renderer."""
+    assert resolve_renderer_name("google/gemma-4-12b-it") == "gemma4"
+    assert resolve_renderer_name("google/gemma-4-27b-it") == "gemma4"
+
+
 def test_build_renderer_resolves_minimax_m2(monkeypatch) -> None:
     """build_renderer should resolve minimax_m2 and dispatch to get_renderer."""
     calls: list[tuple[str, object]] = []

--- a/training/utils/supervised.py
+++ b/training/utils/supervised.py
@@ -33,6 +33,7 @@ from tinker_cookbook.image_processing_utils import get_image_processor
 from tinker_cookbook.supervised.common import datum_from_model_input_weights
 import training.renderer.nemotron as _nemotron_renderer  # noqa: F401 — triggers register_renderer
 import training.renderer.minimax_m2 as _minimax_m2_renderer  # noqa: F401 — triggers register_renderer
+import training.renderer.gemma4 as _gemma4_renderer  # noqa: F401 — triggers register_renderer
 
 
 @dataclass(frozen=True)
@@ -78,6 +79,10 @@ def resolve_renderer_name(
         return "minimax_m2"
     if "qwen3-vl" in normalized_model_name:
         return "qwen3_vl_instruct"
+    if "qwen3.5" in normalized_model_name or "qwen3_5" in normalized_model_name:
+        return "qwen3_5"
+    if "gemma-4" in normalized_model_name or "gemma4" in normalized_model_name:
+        return "gemma4"
     try:
         return get_recommended_renderer_name(tokenizer_model)
     except Exception as exc:  # pragma: no cover - message only


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the `KeyError: 'Qwen3.5-9B'` / `ValueError: Could not infer a renderer for tokenizer_model='Qwen/Qwen3.5-9B'` crash that occurred when running V2 SFT on Qwen3.5 models.

The root cause was that `resolve_renderer_name()` in `training/utils/supervised.py` had no prefix match for Qwen3.5 model names, and `tinker_cookbook`'s model registry doesn't include all Qwen3.5 sizes (e.g. `Qwen3.5-9B` is missing). The function fell through to `get_recommended_renderer_name()` which raised a `KeyError`.

Similarly, Gemma4 models had a custom `Gemma4Renderer` registered in this repo (`training/renderer/gemma4.py`) but no prefix fallback in `resolve_renderer_name()`, making it dependent on tinker_cookbook's registry (which also lacks Gemma4).

## Changes

**`training/utils/supervised.py`**:
- Add `qwen3.5` / `qwen3_5` prefix match → `qwen3_5` renderer
- Add `gemma-4` / `gemma4` prefix match → `gemma4` renderer
- Import `training.renderer.gemma4` to trigger `register_renderer("gemma4", ...)` side-effect (matching the existing pattern for nemotron and minimax_m2)

**`training/tests/unit/test_supervised_rendering.py`**:
- Add `test_resolve_renderer_name_prefers_qwen3_5` covering all known Qwen3.5 variants (9B, 4B, 27B, 35B-A3B, 397B-A17B)
- Add `test_resolve_renderer_name_prefers_gemma4` covering Gemma4 variants

## Test results

All 331 unit tests pass (32 skipped), including 15 supervised rendering tests.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d801bc8c-fa56-434e-b11e-3a09d0aba88d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d801bc8c-fa56-434e-b11e-3a09d0aba88d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

