### PR TITLE
fix(adam): default grad_clip_norm to 1.0 for all recipes

### DIFF
--- a/training/examples/sft/train_sft.py
+++ b/training/examples/sft/train_sft.py
@@ -54,7 +54,7 @@ def parse_args():
     parser.add_argument("--renderer-name", default="")
     parser.add_argument("--no-checkpoint", action="store_true",
                         help="Skip final checkpoint save")
-    parser.add_argument("--grad-clip-norm", type=float, default=0.0,
+    parser.add_argument("--grad-clip-norm", type=float, default=1.0,
                         help="Max gradient norm for clipping (0 = no clipping)")
     parser.add_argument("--wandb-project", default="sft-tinker")
     parser.add_argument("--wandb-run-name", default=None)

--- a/training/recipes/sft_loop.py
+++ b/training/recipes/sft_loop.py
@@ -132,7 +132,7 @@ class Config:
     """Load pretrained DCP weights on a fresh dataset. Supports cross-job
     format ``"job_id:checkpoint_name"``."""
 
-    grad_clip_norm: float = 0.0
+    grad_clip_norm: float = 1.0
     """Max gradient norm for clipping. 0 = no clipping."""
 
     trainer_job_id: str | None = None
@@ -460,8 +460,7 @@ def main(
         wandb_log({"train/step": step}, step)
 
         adam_kwargs = dict(DEFAULT_ADAM)
-        if cfg.grad_clip_norm > 0:
-            adam_kwargs["grad_clip_norm"] = cfg.grad_clip_norm
+        adam_kwargs["grad_clip_norm"] = cfg.grad_clip_norm
         adam_params = tinker.AdamParams(learning_rate=cfg.learning_rate, **adam_kwargs)
 
         # -- Training loop (batch-indexed) -------------------------------------

--- a/training/utils/config.py
+++ b/training/utils/config.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from fireworks.training.sdk.client import FiretitanTrainingClient
 from fireworks.training.sdk.deployment import DeploymentConfig
 
-DEFAULT_ADAM = dict(beta1=0.9, beta2=0.999, eps=1e-8, weight_decay=0.01)
+DEFAULT_ADAM = dict(beta1=0.9, beta2=0.999, eps=1e-8, weight_decay=0.01, grad_clip_norm=1.0)
 
 RewardFn = Callable[[str, dict], float]
 """Signature: (completion_text, dataset_row) -> reward_float."""


### PR DESCRIPTION
## Summary

- Add `grad_clip_norm=1.0` to `DEFAULT_ADAM` so DPO/ORPO/IGPO/RL_loop (which all spread `DEFAULT_ADAM` into `tinker.AdamParams`) get gradient clipping by default.
- Update SFT's dedicated `grad_clip_norm` config field to default `1.0` and remove the `> 0` gate so `0.0` now actually disables clipping (previously users couldn't turn it off because the gate ignored 0 and inherited from `DEFAULT_ADAM`).
- Update the `examples/sft/train_sft.py` CLI default to match.

## Why

The cookbook shipped with no gradient clipping by default, which is an outlier vs every reference RL/preference framework:

| Framework | Default `max_grad_norm` |
|---|---|
| TRL `DPOTrainer` (HF Trainer) | **1.0** |
| [slime](https://github.com/THUDM/slime) (`--clip-grad`) | **1.0** |
| [AReaL](https://github.com/inclusionAI/AReaL) (`gradient_clipping`) | **1.0** |
| OpenRLHF / veRL | **1.0** |

### Concrete failure this fixes

On `kimi-k2p5-text-only-256k-lora` DPO (1T-param MoE, nvfp4, 256k context, LoRA rank 256), the CI failed 10 consecutive times with what looked like "trainer disappeared mid-step":

```
tinker.NotFoundError: Error code: 404 - Trainer job not found or not running
RetryableException: Promise expired/broken for request <req-id>
```

GCP trainer pod logs traced this to:

```
08:31:41  optim_step called: lr=1e-5, weight_decay=0.01, grad_clip_norm=0.0
08:34:13  optim_step done in 152.4s
08:34:14  forward (DPO step 2) begins
08:34:27  forward done, "outcome": success
08:34:28  POST /api/v1/retrieve_future → 500
          ValueError: Out of range float values are not JSON compliant: nan
```

The trainer process didn't crash — it kept serving `/healthz` and `/session_heartbeat` 200s for the next 21s. The forward output just contained NaN tensors, and `json.dumps` rejected them. After the SDK gave up, the control plane gracefully recycled the (now-idle) service-mode trainer, producing the misleading 404 the SDK reported.

The unclipped Adam step pushed a small number of LoRA-affected params into Inf; the next forward returned NaN. Setting `grad_clip_norm=1.0` (matching the field standard) prevents this and unblocks DPO on large MoE LoRA configs.

## Test plan

- [x] `python -c "from training.utils.config import DEFAULT_ADAM; print(DEFAULT_ADAM)"` → confirms `grad_clip_norm: 1.0`
- [x] AST-parse all touched files (sft/dpo/rl/orpo/igpo loops, config.py, examples/sft/train_sft.py) — clean
- [ ] Re-run `kimi-k2p5-text-only-256k-lora` Single-Shape CI and confirm Phase 1 DPO passes step 2
- [ ] Spot-check existing SFT runs aren't affected by the now-active default clip

## Follow-up (out of scope)

Trainer FastAPI handler should defensively `json.dumps(..., allow_nan=False)` and return 422 `NAN_DETECTED` so future numerical instabilities surface as a clean error instead of a misleading 500/404 chain. Filing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)