### PR TITLE
fix(dpo): construct reference client with lora_rank=0

### DIFF
--- a/training/recipes/dpo_loop.py
+++ b/training/recipes/dpo_loop.py
@@ -547,7 +547,8 @@ def main(
         reference_job_id = reference_ep.job_id
 
         policy = ReconnectableClient(rlor_mgr, policy_ep.job_id, cfg.base_model, cfg.lora_rank)
-        reference = ReconnectableClient(rlor_mgr, reference_ep.job_id, cfg.base_model, cfg.lora_rank)
+        # Match the ref trainer's lora_rank=0 (set above).
+        reference = ReconnectableClient(rlor_mgr, reference_ep.job_id, cfg.base_model, 0)
         if hasattr(policy, "close"):
             stack.callback(policy.close)
         if hasattr(reference, "close"):


### PR DESCRIPTION
## Summary

Companion to #326. That PR fixed the reference *trainer* creation to use `lora_rank=0` (the ref trainer only runs base-model forward passes, no adapters), but the matching `ReconnectableClient` was still constructed with `cfg.lora_rank`, so the client's `create_model` call requests LoRA mode on a trainer initialized with `--lora-rank=0`:

```
tinker.RequestFailedError: create_model requested LoRA mode, but trainer
was initialized without LoRA config. Check RLOR startup args include --lora-rank.
```

Reproduced on [run 24419618895](https://github.com/fw-ai/fireworks/actions/runs/24419618895) for kimi-k2p5-text-only-256k-lora.

## Fix

One line — pin the reference `ReconnectableClient`'s `lora_rank` to `0` so client and trainer agree.

## Test plan

- [ ] Re-run the kimi-k2p5-text-only-256k-lora single-shape CI; should now reach DPO step 1