### PR TITLE
fix(training): retry with backoff on 429 when creating RLOR trainer job

### DIFF
--- a/training/tests/unit/test_infra.py
+++ b/training/tests/unit/test_infra.py
@@ -403,3 +403,86 @@ class TestFetchJobFailureReason:
         })
         reason = _fetch_job_failure_reason(mgr, "job-1")
         assert "Pod evicted" in reason
+
+
+# ---------------------------------------------------------------------------
+# create_trainer_job: retry on 429
+# ---------------------------------------------------------------------------
+
+
+class _CountingRlorMgr(_FakeRlorMgr):
+    """Fake that raises on the first *fail_count* create() calls, then succeeds."""
+
+    def __init__(self, *, fail_count: int, error: Exception, **kwargs):
+        super().__init__(**kwargs)
+        self._fail_count = fail_count
+        self._error = error
+        self.create_calls = 0
+
+    def create(self, config):
+        self.create_calls += 1
+        if self.create_calls <= self._fail_count:
+            raise self._error
+        return super().create(config)
+
+
+class TestCreateTrainerJobRetry:
+    def test_429_retried_then_succeeds(self, monkeypatch):
+        monkeypatch.setattr("training.utils.infra._TRAINER_CREATE_MAX_RETRIES", 3)
+        monkeypatch.setattr("training.utils.infra.time.sleep", lambda _: None)
+
+        mgr = _CountingRlorMgr(
+            fail_count=2,
+            error=RuntimeError("Client error '429 Too Many Requests' for url '...'"),
+        )
+        endpoint = create_trainer_job(
+            mgr, base_model="model", infra=InfraConfig(), display_name="test"
+        )
+        assert endpoint.job_id == "job-123"
+        assert mgr.create_calls == 3
+
+    def test_429_exhausts_retries_then_fails(self, monkeypatch):
+        monkeypatch.setattr("training.utils.infra._TRAINER_CREATE_MAX_RETRIES", 2)
+        monkeypatch.setattr("training.utils.infra.time.sleep", lambda _: None)
+
+        mgr = _CountingRlorMgr(
+            fail_count=99,
+            error=RuntimeError("Client error '429 Too Many Requests' for url '...'"),
+        )
+        with pytest.raises(RuntimeError, match="429 Too Many Requests"):
+            create_trainer_job(
+                mgr, base_model="model", infra=InfraConfig(), display_name="test"
+            )
+        assert mgr.create_calls == 3  # initial + 2 retries
+
+    def test_non_retryable_error_not_retried(self, monkeypatch):
+        monkeypatch.setattr("training.utils.infra._TRAINER_CREATE_MAX_RETRIES", 3)
+        monkeypatch.setattr("training.utils.infra.time.sleep", lambda _: None)
+
+        mgr = _CountingRlorMgr(
+            fail_count=99,
+            error=ValueError("invalid accelerator type"),
+        )
+        with pytest.raises(RuntimeError, match="invalid accelerator type"):
+            create_trainer_job(
+                mgr, base_model="model", infra=InfraConfig(), display_name="test"
+            )
+        assert mgr.create_calls == 1
+
+    def test_429_retry_emits_status(self, monkeypatch):
+        monkeypatch.setattr("training.utils.infra._TRAINER_CREATE_MAX_RETRIES", 3)
+        monkeypatch.setattr("training.utils.infra.time.sleep", lambda _: None)
+
+        messages: list[str] = []
+        mgr = _CountingRlorMgr(
+            fail_count=1,
+            error=RuntimeError("Client error '429 Too Many Requests'"),
+        )
+        create_trainer_job(
+            mgr,
+            base_model="model",
+            infra=InfraConfig(),
+            display_name="test",
+            on_status=messages.append,
+        )
+        assert any("rate-limited" in m for m in messages)

--- a/training/utils/infra.py
+++ b/training/utils/infra.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import random
 import time
 import logging
 from typing import TYPE_CHECKING, Any
@@ -28,6 +29,16 @@ if TYPE_CHECKING:
     from fireworks.training.sdk.weight_syncer import WeightSyncer
 
 logger = logging.getLogger(__name__)
+
+_TRAINER_CREATE_MAX_RETRIES = int(os.environ.get("FW_TRAINER_CREATE_MAX_RETRIES", "5"))
+_TRAINER_CREATE_BACKOFF_BASE_S = 10
+_TRAINER_CREATE_BACKOFF_CAP_S = 120
+
+
+def _is_retryable_create_error(exc: Exception) -> bool:
+    """Return True for transient HTTP errors that are safe to retry on job create."""
+    return "429" in str(exc)
+
 
 _DEPLOYMENT_ACCELERATOR_REGION_PREFIXES: tuple[tuple[str, str], ...] = (
     ("NVIDIA_H200", "US_VIRGINIA_1"),
@@ -309,7 +320,31 @@ def create_trainer_job(
 
     created_job_id: str | None = None
     try:
-        created_job = rlor_mgr.create(config)
+        for _attempt in range(_TRAINER_CREATE_MAX_RETRIES + 1):
+            try:
+                created_job = rlor_mgr.create(config)
+                break
+            except Exception as create_exc:
+                if not _is_retryable_create_error(create_exc) or _attempt >= _TRAINER_CREATE_MAX_RETRIES:
+                    raise
+                delay = min(
+                    _TRAINER_CREATE_BACKOFF_BASE_S * (2 ** _attempt),
+                    _TRAINER_CREATE_BACKOFF_CAP_S,
+                ) * (0.5 + random.random() * 0.5)
+                logger.warning(
+                    "Trainer create returned retryable error (attempt %d/%d), "
+                    "retrying in %.0fs: %s",
+                    _attempt + 1,
+                    _TRAINER_CREATE_MAX_RETRIES,
+                    delay,
+                    create_exc,
+                )
+                _emit(
+                    f"trainer create rate-limited, retrying in {int(delay)}s "
+                    f"(attempt {_attempt + 1}/{_TRAINER_CREATE_MAX_RETRIES})"
+                )
+                time.sleep(delay)
+
         created_job_id = created_job.job_id
         if cleanup:
             cleanup.trainer(created_job.job_id)


### PR DESCRIPTION
## Summary

- Adds exponential backoff retry (up to 5 attempts, 10s–120s delays with jitter) around `rlor_mgr.create()` in `create_trainer_job()` so that HTTP 429 (Too Many Requests) errors during RLOR trainer creation don't immediately fail the entire SFT job.
- Non-retryable errors (400, 401, etc.) still fail immediately.
- Retry count configurable via `FW_TRAINER_CREATE_MAX_RETRIES` env var (default: 5).

## Context

`accounts/youfychenbc5000-70d70d/supervisedFineTuningJobs/prcvvafl` failed because the trainer creation POST got a 429 while B300 capacity was occupied by another job. The entire SFT job died instead of waiting and retrying.

## Test plan

- [x] Added unit tests: 429 retried then succeeds, 429 exhausts retries, non-retryable error not retried, status callback emits retry messages
- [ ] CI passes

Made with [Cursor](https://cursor.com)