### PR TITLE
fix: increase forward_backward timeout from 600s to 3600s for long-context SFT

### DIFF
--- a/training/recipes/sft_loop.py
+++ b/training/recipes/sft_loop.py
@@ -52,6 +52,7 @@ from training.utils import (
     render_messages_to_datum,
     resolve_renderer_name,
 )
+from training.utils.client import DEFAULT_TIMEOUT_S
 from training.utils.checkpoint_utils import (
     resolve_resume,
     save_checkpoint,
@@ -134,6 +135,10 @@ class Config:
 
     grad_clip_norm: float = 1.0
     """Max gradient norm for clipping. 0 = no clipping."""
+
+    step_timeout: int = 0
+    """Timeout in seconds for forward_backward / optim_step calls.
+    0 = use DEFAULT_TIMEOUT_S from training.utils.client."""
 
     trainer_job_id: str | None = None
     """Pre-created RLOR trainer job ID. When set, skips trainer creation."""
@@ -352,6 +357,7 @@ def main(
         job_id = endpoint.job_id
         client = ReconnectableClient(
             rlor_mgr, job_id, cfg.base_model, cfg.lora_rank, fw_api_key=api_key,
+            default_timeout=cfg.step_timeout or DEFAULT_TIMEOUT_S,
             endpoint=endpoint if cfg.trainer_base_url else None,
         )
         if hasattr(client, "close"):

--- a/training/utils/client.py
+++ b/training/utils/client.py
@@ -26,8 +26,8 @@ from tinker.types.future_retrieve_request import FutureRetrieveRequest as _Futur
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_TIMEOUT_S: int = 600
-"""Default timeout for forward / forward_backward / optim_step (10 min)."""
+DEFAULT_TIMEOUT_S: int = 3600
+"""Default timeout for forward / forward_backward / optim_step (60 min)."""
 
 DCP_TIMEOUT_S: int = 2700
 """Default timeout for save_state / load_state_with_optimizer (45 min)."""


### PR DESCRIPTION
## Summary

- Increase `DEFAULT_TIMEOUT_S` from 600s (10 min) to 3600s (1 hour) in `ReconnectableClient` — 256k context SFT jobs on large MoE models (e.g. qwen3p5-397b-a17b) exceed the 10-minute timeout during `forward_backward` on the first training step
- Add `step_timeout` field to `sft_loop.Config` so callers can override the default per-job without code changes
- Import `DEFAULT_TIMEOUT_S` in `sft_loop.py` and pass `cfg.step_timeout or DEFAULT_TIMEOUT_S` to the `ReconnectableClient` constructor

### Evidence

| Job | Context | GPU | Step Time |
|-----|---------|-----|-----------|
| `xq17o8ha` | 65k | 8x B200 | ~6.5 min (observed) |
| `hutnwgvv` | 65k | 8x B300 | ~6 min (observed) |
| `pi3nb2tp` | 256k | 8x H200 | >10 min (**timed out at 600s**, step never completed) |

The 256k job timed out after 10 minutes without completing the first step. The trainer was still healthy (no OOM, no NCCL errors) — the orchestrator's `ReconnectableClient` killed it via the hardcoded 600s `DEFAULT_TIMEOUT_S`.

### Why cookbook, not the SDK?

The `ReconnectableClient` (in the cookbook) is the layer that imposes the timeout by calling `.result(timeout=...)` on the tinker SDK's `ApiFuture`. The SDK and tinker themselves don't set a default timeout — they wait indefinitely unless the caller passes one. The managed orchestrator (`sft_orchestrator.py`) uses tinker directly with no timeout and is unaffected. The cookbook is the correct place for this fix.

## Test plan

- [ ] Deploy an SFT job with `qwen3p5-397b-a17b` at 256k context and verify it no longer times out during `forward_backward`
- [ ] Verify `step_timeout=0` (default) falls back to `DEFAULT_TIMEOUT_S` (3600)
- [ ] Verify explicit `step_timeout` override works when set via `CookbookTrainingConfig`