### PR TITLE
feat: add RLSD (Self-Distilled RLVR) credit assignment

### DIFF
--- a/training/utils/rl/__init__.py
+++ b/training/utils/rl/__init__.py
@@ -1,9 +1,10 @@
-"""RL utilities: losses, training loop, PP recommendation, TIS, router replay."""
+"""RL utilities: losses, training loop, PP recommendation, TIS, RLSD, router replay."""
 
 __all__ = [
     # Losses & algorithms
     "CISPOConfig",
     "DAPOConfig",
+    "RLSDConfig",
     "TISConfig",
     "GSPOConfig",
     "PPBatchRecommendation",
@@ -50,6 +51,7 @@ from training.utils.rl.metrics import (
     add_response_length_stats,
 )
 from training.utils.rl.router_replay import build_r3_routing_matrices
+from training.utils.rl.rlsd import RLSDConfig
 from training.utils.rl.tis import TISConfig
 from training.utils.rl.igpo import (
     IGPOTurnScorer,

--- a/training/utils/rl/common.py
+++ b/training/utils/rl/common.py
@@ -9,6 +9,7 @@ import torch
 import tinker
 
 if TYPE_CHECKING:
+    from training.utils.rl.rlsd import RLSDConfig
     from training.utils.rl.tis import TISConfig
 
 
@@ -95,6 +96,8 @@ class SampleContext:
     """Scalar advantage value (as a 0-d tensor)."""
     tis_weight: torch.Tensor
     """TIS importance weight per token."""
+    rlsd_weight: torch.Tensor
+    """RLSD per-token credit weight (1.0 when RLSD is disabled)."""
 
 
 @dataclass
@@ -130,12 +133,19 @@ def run_loss_loop(
     logprobs_list: List[torch.Tensor],
     policy_loss: str,
     policy_fn: PolicyFn,
+    *,
+    teacher_logprobs: List[List[float]] | None = None,
+    rlsd_config: RLSDConfig | None = None,
 ) -> LossLoopResult:
     """Shared loss loop: tensor setup, TIS weight, inference metrics, KL.
 
     Iterates over ``logprobs_list``, builds a :class:`SampleContext` for each
     sample, and delegates per-token loss computation to ``policy_fn``.
+
+    When ``teacher_logprobs`` and ``rlsd_config`` are provided, RLSD credit
+    weights are computed and made available via ``SampleContext.rlsd_weight``.
     """
+    from training.utils.rl.rlsd import RLSDConfig, compute_rlsd_weights
     from training.utils.rl.tis import compute_tis_weight
 
     total_loss = torch.tensor(0.0, requires_grad=True)
@@ -207,6 +217,27 @@ def run_loss_loop(
 
         adv_t = torch.as_tensor(advantages[i], dtype=resp_pi.dtype, device=resp_pi.device)
 
+        # RLSD credit weight (1.0 when disabled)
+        if teacher_logprobs is not None and rlsd_config is not None and rlsd_config.lam > 0:
+            t_lp = teacher_logprobs[i] if i < len(teacher_logprobs) else []
+            if t_lp:
+                resp_teacher = torch.tensor(
+                    t_lp[:resp_len], dtype=resp_pi.dtype, device=resp_pi.device,
+                )
+                if len(resp_teacher) < resp_len:
+                    resp_teacher = torch.cat([
+                        resp_teacher,
+                        torch.zeros(resp_len - len(resp_teacher), dtype=resp_pi.dtype, device=resp_pi.device),
+                    ])
+                adv_sign = 1.0 if advantages[i] >= 0 else -1.0
+                rlsd_w, rlsd_m = compute_rlsd_weights(pi_detached, resp_teacher, adv_sign, rlsd_config)
+                for k, v in rlsd_m.items():
+                    tis_metrics_agg[k] = tis_metrics_agg.get(k, 0.0) + v
+            else:
+                rlsd_w = torch.ones_like(resp_pi)
+        else:
+            rlsd_w = torch.ones_like(resp_pi)
+
         ctx = SampleContext(
             resp_pi=resp_pi,
             pi_detached=pi_detached,
@@ -216,6 +247,7 @@ def run_loss_loop(
             resp_mask=resp_mask,
             adv=adv_t,
             tis_weight=tis_weight,
+            rlsd_weight=rlsd_w,
         )
         per_token_loss, extra = policy_fn(ctx)
 

--- a/training/utils/rl/grpo.py
+++ b/training/utils/rl/grpo.py
@@ -52,7 +52,7 @@ def make_grpo_loss_fn(
         surr1 = -ratio * ctx.adv
         surr2 = -clipped_ratio * ctx.adv
         kl_penalty = kl_beta * (ctx.pi_detached - ctx.resp_ref)
-        per_token_loss = (torch.maximum(surr1, surr2) * ctx.tis_weight + kl_penalty) * ctx.resp_mask
+        per_token_loss = (torch.maximum(surr1, surr2) * ctx.tis_weight * ctx.rlsd_weight + kl_penalty) * ctx.resp_mask
 
         return per_token_loss, {
             "clip_frac": clip_frac,

--- a/training/utils/rl/rlsd.py
+++ b/training/utils/rl/rlsd.py
@@ -1,0 +1,68 @@
+"""RLSD (RLVR with Self-Distillation) credit assignment.
+
+Per-token credit weight from the evidence ratio between a privileged
+teacher and the student (arXiv 2604.03128, "Self-Distilled RLVR").
+
+Composable with any policy loss (GRPO, DAPO, GSPO, CISPO, etc.) —
+the RLSD weight multiplies into the per-token advantage alongside the
+existing TIS weight.
+
+The teacher is the same model conditioned on privileged information
+(e.g. a reference answer). Only the scalar log-probability of each
+sampled token is needed — no full logits or KL divergence.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import torch
+
+
+@dataclass
+class RLSDConfig:
+    """RLSD credit assignment configuration."""
+
+    eps_w: float = 0.2
+    """Clipping bound for evidence weights.  Limits max per-token credit
+    deviation to ``[1 - eps_w, 1 + eps_w]``."""
+
+    lam: float = 1.0
+    """Interpolation coefficient.  ``0`` = uniform (RLSD disabled),
+    ``1`` = full RLSD credit.  Can be ramped up during training."""
+
+
+def compute_rlsd_weights(
+    resp_student: torch.Tensor,
+    resp_teacher: torch.Tensor,
+    advantage_sign: float,
+    config: RLSDConfig,
+) -> tuple[torch.Tensor, dict[str, float]]:
+    """Compute RLSD per-token credit weights from evidence ratios.
+
+    Args:
+        resp_student: Student (policy) log-probs for response tokens.
+        resp_teacher: Teacher (privileged) log-probs for the same tokens.
+            Must be the same length as ``resp_student``.
+        advantage_sign: ``sign(A)`` for this trajectory (``1.0`` or ``-1.0``).
+        config: RLSD configuration.
+
+    Returns:
+        ``(weights, metrics)`` where ``weights`` has the same shape as the
+        inputs.  When ``A > 0``, tokens that the teacher supports get
+        amplified credit; when ``A < 0``, the ratio is inverted so tokens
+        the teacher disfavors get more blame.
+    """
+    delta = resp_teacher - resp_student
+    w_raw = torch.exp(advantage_sign * delta)
+    w_clipped = torch.clamp(w_raw, min=1.0 - config.eps_w, max=1.0 + config.eps_w)
+    w = 1.0 + config.lam * (w_clipped - 1.0)
+
+    metrics: dict[str, float] = {
+        "rlsd/weight_mean": w.mean().item(),
+        "rlsd/delta_mean": delta.mean().item(),
+        "rlsd/delta_abs_mean": delta.abs().mean().item(),
+        "rlsd/clip_frac": (w_clipped != w_raw).float().mean().item(),
+    }
+    return w, metrics


### PR DESCRIPTION
Adds composable per-token credit weighting from self-distillation evidence ratios (arXiv 2604.03128). RLSD modulates the per-token advantage magnitude using the teacher-student log-prob ratio:

  w_t = clip(exp(sign(A) · (log P_teacher - log P_student)), 1±ε_w)

Key design: RLSD is a weight that composes with any existing loss (GRPO, DAPO, CISPO, etc.) — just like TIS. No new loss function.

Files:
- training/utils/rl/rlsd.py: RLSDConfig + compute_rlsd_weights()
- training/utils/rl/common.py: SampleContext.rlsd_weight + run_loss_loop plumbing
- training/utils/rl/grpo.py: multiply rlsd_weight into surrogate loss
- training/utils/rl/__init__.py: export RLSDConfig