### PR TITLE
fix: auto-reduce batch_size when training examples < batch_size

### DIFF
--- a/training/recipes/sft_loop.py
+++ b/training/recipes/sft_loop.py
@@ -443,9 +443,20 @@ def main(
             else:
                 logger.warning("Dataset too small for auto carve-out, skipping eval")
 
+        effective_batch_size = cfg.batch_size
+        if len(training_data) < effective_batch_size:
+            logger.warning(
+                "Training examples (%d) < batch_size (%d); reducing effective "
+                "batch_size to %d so all examples are trained on.",
+                len(training_data),
+                effective_batch_size,
+                len(training_data),
+            )
+            effective_batch_size = len(training_data)
+
         sft_dataset = SupervisedDatasetFromHFDataset(
             hf_datasets.Dataset.from_dict({"datum_idx": list(range(len(training_data)))}),
-            batch_size=cfg.batch_size,
+            batch_size=effective_batch_size,
             map_fn=lambda row: training_data[row["datum_idx"]],
         )
         total_batches_per_epoch = len(sft_dataset)
@@ -471,7 +482,7 @@ def main(
 
         # -- Training loop (batch-indexed) -------------------------------------
 
-        start_batch = data_consumed // cfg.batch_size
+        start_batch = data_consumed // effective_batch_size
         total_steps_estimate = total_batches_per_epoch * cfg.epochs
 
         def _run_train_step(

--- a/training/tests/unit/test_sft_loop.py
+++ b/training/tests/unit/test_sft_loop.py
@@ -114,6 +114,106 @@ def test_main_raises_when_all_examples_are_filtered(tmp_path, monkeypatch):
     assert deleted_jobs == ["job-sft"]
 
 
+def test_main_reduces_batch_size_when_examples_fewer_than_batch_size(tmp_path, monkeypatch):
+    """When training examples < batch_size, reduce effective batch_size so training proceeds."""
+    dataset_path = _write_dataset(
+        tmp_path,
+        [{"messages": [{"role": "user", "content": "u"}, {"role": "assistant", "content": "a"}]}],
+    )
+    monkeypatch.setenv("FIREWORKS_API_KEY", "test-key")
+    monkeypatch.setenv("FIREWORKS_BASE_URL", "https://unit.test")
+
+    events: dict[str, object] = {"batches": [], "deleted_jobs": []}
+
+    class FakeMgr:
+        def create(self, config):
+            return SimpleNamespace(job_id="job-sft", job_name="jobs/job-sft")
+
+        def wait_for_ready(self, job_id, **kwargs):
+            return SimpleNamespace(job_id=job_id, job_name=f"jobs/{job_id}", base_url="https://unit.test")
+
+        def cancel(self, job_id):
+            events["deleted_jobs"].append(job_id)
+
+        def delete(self, job_id):
+            self.cancel(job_id)
+
+        def resolve_training_profile(self, shape_id):
+            return _fake_profile(shape_id)
+
+    class FakeClient:
+        job_id = "job-sft"
+
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def forward_backward(self, batch, loss_fn="cross_entropy", loss_fn_config=None):
+            events["batches"].append(list(batch))
+            return SimpleNamespace(
+                metrics={"loss:sum": 1.0, "ce_loss_sum": 1.0, "response_tokens": 1}
+            )
+
+        def optim_step(self, _params, **kwargs):
+            return SimpleNamespace(metrics={})
+
+        def save_state(self, name):
+            return SimpleNamespace(path=name)
+
+        def save_weights_for_sampler_ext(self, name, checkpoint_type="base"):
+            return SimpleNamespace(path=f"{name}-sampler")
+
+        def load_state_with_optimizer(self, path):
+            pass
+
+        def resolve_checkpoint_path(self, name, source_job_id=None):
+            return name
+
+    monkeypatch.setattr(module, "setup_wandb", lambda *args, **kwargs: None)
+    monkeypatch.setattr(module, "wandb_finish", lambda: None)
+    monkeypatch.setattr(module, "wandb_log", lambda *args, **kwargs: None)
+    monkeypatch.setattr(module, "log_metrics_json", lambda *args, **kwargs: None)
+    monkeypatch.setattr(module.transformers.AutoTokenizer, "from_pretrained", lambda *args, **kwargs: object())
+    monkeypatch.setattr(module, "build_renderer", lambda *args, **kwargs: object())
+    monkeypatch.setattr(module, "resolve_renderer_name", lambda *args, **kwargs: "unit-renderer")
+    monkeypatch.setattr(
+        module,
+        "auto_select_training_shape",
+        lambda *args, **kwargs: "accounts/test/trainingShapes/sft",
+    )
+    monkeypatch.setattr(
+        module,
+        "render_messages_to_datum",
+        lambda *args, **kwargs: SimpleNamespace(
+            token_ids=[1, 2, 3],
+            datum=SimpleNamespace(
+                model_input=SimpleNamespace(chunks=[SimpleNamespace(tokens=[1, 2, 3])]),
+                loss_fn_inputs={
+                    "target_tokens": SimpleNamespace(data=[2, 3]),
+                    "weights": SimpleNamespace(data=[1.0, 1.0]),
+                },
+            ),
+        ),
+    )
+    monkeypatch.setattr(module, "ReconnectableClient", FakeClient)
+
+    cfg = module.Config(
+        log_path=str(tmp_path / "logs"),
+        base_model="accounts/test/models/custom-sft",
+        dataset=str(dataset_path),
+        tokenizer_model="Qwen/Qwen3-4B",
+        max_seq_len=32,
+        batch_size=999,
+        epochs=1,
+    )
+
+    result = module.main(cfg, rlor_mgr=FakeMgr())
+
+    assert result["steps"] == 1
+    assert len(events["batches"]) == 1
+    assert len(events["batches"][0]) == 1
+    assert events["deleted_jobs"] == ["job-sft"]
+
+
 def test_main_infers_documented_training_shape_for_supported_model(tmp_path, monkeypatch):
     dataset_path = _write_dataset(
         tmp_path,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Training job `rft--pyroworks-dev-b9dr5fi1` showed 18 samples remaining after seq-length filtering (82/100 filtered for len > 32768), but completed with **0 optimizer steps**. The job reported `COMPLETED` status despite doing no training, wasting GPU time.

### Root Cause

`SupervisedDatasetFromHFDataset.__len__` uses **floor division** (`len(hf_dataset) // batch_size`). When the number of remaining training examples (18) is less than `batch_size` (32), `total_batches_per_epoch` evaluates to 0, so the training loop `for i_batch in range(0, 0)` never executes.

Additionally, `get_batch()` uses strict range selection (`index * batch_size` to `(index + 1) * batch_size`), which would fail on a partial last batch anyway — so even if `__len__` used `ceil`, the last incomplete batch would cause an index error.

## Fix

Instead of failing fast with a `RuntimeError` (the approach in PR #335), this PR **automatically reduces the effective batch size** to `len(training_data)` when training examples are fewer than the configured `batch_size`. This way:

- All available examples are trained on, even if there's only 1
- A warning is logged so users know the batch size was adjusted
- No GPU time is wasted on a no-op job

This directly addresses @websterbei's review question on PR #335: *"Is there a minimum number of samples needed? does 1 sample not work?"* — with this fix, 1 sample works fine.

## Changes

- **`training/recipes/sft_loop.py`**: Clamp `effective_batch_size` to `min(cfg.batch_size, len(training_data))` before constructing `SupervisedDatasetFromHFDataset`. Also use `effective_batch_size` for the `start_batch` resume calculation.
- **`training/tests/unit/test_sft_loop.py`**: Added test verifying that 1 training example with `batch_size=999` still produces 1 optimizer step.

## Testing

All 16 unit tests pass, including the new test.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://fireworks-ai.slack.com/archives/C0927VDGNAU/p1776226345691329?thread_ts=1776226345.691329&cid=C0927VDGNAU)

<div><a href="https://cursor.com/agents/bc-e2aa5140-c9fa-5439-a89e-486cc303886c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e2aa5140-c9fa-5439-a89e-486cc303886c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

