### PR TITLE
fix(training_shapes): handle 403/non-success model fetch gracefully in auto-select

### DIFF
--- a/training/tests/unit/test_training_shapes.py
+++ b/training/tests/unit/test_training_shapes.py
@@ -1,0 +1,92 @@
+"""Tests for training_shapes auto-selection and error handling."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from training.utils.training_shapes import auto_select_training_shape
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, body: dict | None = None):
+        self.status_code = status_code
+        self.is_success = 200 <= status_code < 300
+        self._body = body or {}
+
+    def json(self):
+        return self._body
+
+
+class _FakeMgr:
+    """Minimal stand-in for TrainerJobManager used by shape selection."""
+
+    def __init__(self, *, list_response: dict | None = None, model_response: _FakeResponse | None = None):
+        self._list_response = list_response or {"trainingShapeVersions": []}
+        self._model_response = model_response or _FakeResponse(200, {})
+
+    def _get(self, url: str, **kwargs) -> _FakeResponse:
+        if "/versions" in url:
+            return _FakeResponse(200, self._list_response)
+        return self._model_response
+
+
+class TestModelFetch403FallsThrough:
+    """When the model GET returns 403, auto_select should skip the
+    parameter-count fallback gracefully and raise ValueError (not RuntimeError).
+    """
+
+    def test_403_gives_actionable_value_error(self):
+        mgr = _FakeMgr(
+            list_response={"trainingShapeVersions": []},
+            model_response=_FakeResponse(403),
+        )
+
+        with pytest.raises(ValueError, match="Provide an explicit training_shape_id"):
+            auto_select_training_shape(
+                mgr,
+                base_model="accounts/fireworks/models/qwen3p5-397b-a17b",
+                max_seq_len=32768,
+            )
+
+    def test_404_gives_actionable_value_error(self):
+        mgr = _FakeMgr(
+            list_response={"trainingShapeVersions": []},
+            model_response=_FakeResponse(404),
+        )
+
+        with pytest.raises(ValueError, match="Provide an explicit training_shape_id"):
+            auto_select_training_shape(
+                mgr,
+                base_model="accounts/fireworks/models/nonexistent-model",
+                max_seq_len=32768,
+            )
+
+
+class TestExactMatchSkipsFetch:
+    """When an exact base_model match is found, _fetch_model_context is never
+    called, so a 403 on the model endpoint should not matter."""
+
+    def test_exact_match_returns_without_model_fetch(self):
+        mgr = _FakeMgr(
+            list_response={
+                "trainingShapeVersions": [
+                    {
+                        "name": "accounts/fw/trainingShapes/ts-1/versions/v1",
+                        "snapshot": {
+                            "trainerMode": "POLICY_TRAINER",
+                            "maxSupportedContextLength": 65536,
+                        },
+                    }
+                ]
+            },
+            model_response=_FakeResponse(403),
+        )
+
+        result = auto_select_training_shape(
+            mgr,
+            base_model="accounts/fireworks/models/qwen3p5-397b-a17b",
+            max_seq_len=32768,
+        )
+        assert result == "accounts/fw/trainingShapes/ts-1"

--- a/training/utils/training_shapes.py
+++ b/training/utils/training_shapes.py
@@ -85,24 +85,34 @@ def auto_select_training_shape(
         return _pick_best(candidates, max_seq_len)
 
     # Fallback: compatible model_type + parameter_count bucket.
-    model_ctx = _fetch_model_context(trainer_mgr, base_model)
-    lo, hi = _param_count_bounds(model_ctx["parameter_count"])
-    candidates = _list_and_filter(
-        trainer_mgr,
-        parent=parent,
-        filter_expr=_combine_filters(
-            f'snapshot.model_type="{model_ctx["model_type"]}"',
-            f"snapshot.parameter_count>={lo}",
-            f"snapshot.parameter_count<={hi}",
-            f'snapshot.trainer_mode="{expected_mode}"',
-            "latest_validated=true",
-            "public=true" if public_only else "",
-        ),
-        expected_mode=expected_mode,
-        max_seq_len=max_seq_len,
-    )
-    if candidates:
-        return _pick_best(candidates, max_seq_len)
+    try:
+        model_ctx = _fetch_model_context(trainer_mgr, base_model)
+    except RuntimeError:
+        logger.warning(
+            "Could not fetch model details for %r; "
+            "skipping parameter-count fallback.",
+            base_model,
+        )
+        model_ctx = None
+
+    if model_ctx is not None:
+        lo, hi = _param_count_bounds(model_ctx["parameter_count"])
+        candidates = _list_and_filter(
+            trainer_mgr,
+            parent=parent,
+            filter_expr=_combine_filters(
+                f'snapshot.model_type="{model_ctx["model_type"]}"',
+                f"snapshot.parameter_count>={lo}",
+                f"snapshot.parameter_count<={hi}",
+                f'snapshot.trainer_mode="{expected_mode}"',
+                "latest_validated=true",
+                "public=true" if public_only else "",
+            ),
+            expected_mode=expected_mode,
+            max_seq_len=max_seq_len,
+        )
+        if candidates:
+            return _pick_best(candidates, max_seq_len)
 
     mode_label = {"LORA_TRAINER": "LoRA", "FORWARD_ONLY": "reference"}.get(
         expected_mode, "full-tune"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Training job `rft--pyroworks-dev-ftsy30v1-e19defec7` crashed with:

```
RuntimeError: Failed to fetch model details for 'accounts/fireworks/models/qwen3p5-397b-a17b' (HTTP 403)
```

This happens in `auto_select_training_shape` when:
1. No exact `base_model` match is found in validated training shapes
2. The fallback path calls `GET /v1/accounts/fireworks/models/qwen3p5-397b-a17b` to get model type and parameter count for a broader search
3. That API call returns **HTTP 403** (the model may be restricted or not yet public)

The `RuntimeError` is unrecoverable and provides no actionable guidance.

## Fix

Catch the `RuntimeError` from `_fetch_model_context`, log a warning, and skip the parameter-count fallback. The function then falls through to raise a `ValueError` with the message **"Provide an explicit training_shape_id"**, which tells the user exactly what to do.

This is the right behavior because:
- If the exact match found nothing **and** the model details are inaccessible, there's nothing more the auto-select can do
- A `ValueError` with an actionable message is more useful than a `RuntimeError` about an HTTP status code
- The training job gets a clear error up front instead of a cryptic crash

## Changes

- **`training/utils/training_shapes.py`**: Wrap `_fetch_model_context` call in try/except to handle 403 and other HTTP errors gracefully
- **`training/tests/unit/test_training_shapes.py`**: New test file with 3 tests:
  - 403 response produces actionable `ValueError` (not `RuntimeError`)
  - 404 response produces actionable `ValueError`
  - Exact match path skips model fetch entirely (403 doesn't matter)

## Testing

All 336 unit tests pass (32 skipped), including the 3 new ones.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://fireworks-ai.slack.com/archives/C0927VDGNAU/p1776226345691329?thread_ts=1776226345.691329&cid=C0927VDGNAU)

<div><a href="https://cursor.com/agents/bc-dc65c72e-3511-5457-a1cd-1d87de03b042"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc65c72e-3511-5457-a1cd-1d87de03b042"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

