### PR TITLE
fix(training_shapes): add fallback passes and diagnostic logging for shape selection

### DIFF
--- a/training/tests/unit/test_training_shapes.py
+++ b/training/tests/unit/test_training_shapes.py
@@ -1,0 +1,359 @@
+"""Tests for training shape auto-selection logic.
+
+Covers the multi-pass fallback in ``auto_select_training_shape``:
+  Pass 1  — exact base_model + trainer_mode server-side filter
+  Pass 1b — relaxed server-side filter (base_model only, mode checked client-side)
+  Pass 1c — account-scoped parent derived from base_model
+  Pass 2  — model_type + parameter_count fallback
+  Pass 2b — relaxed parameter filter (no trainer_mode server-side)
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from training.utils.training_shapes import (
+    auto_select_training_shape,
+    _account_from_base_model,
+    _expected_trainer_mode,
+    _normalize_trainer_mode,
+    _param_count_bounds,
+)
+
+BASE_MODEL = "accounts/fireworks/models/qwen3p5-397b-a17b"
+SHAPE_NAME = "accounts/fireworks/trainingShapes/qwen3p5-397b-a17b-262k-b200"
+SHAPE_VERSION = f"{SHAPE_NAME}/versions/k7sw735k"
+
+
+def _make_shape_version(
+    name: str = SHAPE_VERSION,
+    base_model: str = BASE_MODEL,
+    trainer_mode: str = "POLICY_TRAINER",
+    ctx_len: int = 262144,
+    **extra_snap: Any,
+) -> dict:
+    snap = {
+        "baseModel": base_model,
+        "trainerMode": trainer_mode,
+        "maxSupportedContextLength": ctx_len,
+        **extra_snap,
+    }
+    return {"name": name, "snapshot": snap}
+
+
+class FakeResponse:
+    def __init__(self, data: dict, status_code: int = 200):
+        self._data = data
+        self.status_code = status_code
+        self.is_success = 200 <= status_code < 300
+
+    def json(self):
+        return self._data
+
+
+class FakeTrainerMgr:
+    """Stub TrainerJobManager that returns canned responses."""
+
+    def __init__(self, responses: dict[str, FakeResponse] | None = None):
+        self._responses = responses or {}
+        self.get_calls: list[str] = []
+
+    def _get(self, path: str, timeout: int = 30) -> FakeResponse:
+        self.get_calls.append(path)
+        for prefix, resp in self._responses.items():
+            if prefix in path:
+                return resp
+        return FakeResponse({"trainingShapeVersions": []})
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for helpers
+# ---------------------------------------------------------------------------
+
+
+class TestAccountFromBaseModel:
+    def test_standard_model(self):
+        assert _account_from_base_model("accounts/fireworks/models/qwen3-8b") == "fireworks"
+
+    def test_custom_account(self):
+        assert _account_from_base_model("accounts/my-org/models/custom-7b") == "my-org"
+
+    def test_no_match(self):
+        assert _account_from_base_model("random-string") is None
+
+
+class TestExpectedTrainerMode:
+    def test_lora(self):
+        assert _expected_trainer_mode("policy", lora_rank=16) == "LORA_TRAINER"
+
+    def test_reference(self):
+        assert _expected_trainer_mode("reference", lora_rank=0) == "FORWARD_ONLY"
+
+    def test_policy(self):
+        assert _expected_trainer_mode("policy", lora_rank=0) == "POLICY_TRAINER"
+
+
+class TestNormalizeTrainerMode:
+    def test_string_passthrough(self):
+        assert _normalize_trainer_mode("POLICY_TRAINER") == "POLICY_TRAINER"
+
+    def test_int_code(self):
+        assert _normalize_trainer_mode(1) == "POLICY_TRAINER"
+        assert _normalize_trainer_mode(2) == "FORWARD_ONLY"
+        assert _normalize_trainer_mode(3) == "LORA_TRAINER"
+
+    def test_none(self):
+        assert _normalize_trainer_mode(None) is None
+
+    def test_empty_string(self):
+        assert _normalize_trainer_mode("") is None
+
+
+class TestParamCountBounds:
+    def test_small_model(self):
+        lo, hi = _param_count_bounds(7_000_000_000)
+        assert lo == 7_000_000_000
+        assert hi == 8_000_000_000
+
+    def test_large_model(self):
+        lo, hi = _param_count_bounds(403_000_000_000)
+        assert lo == 400_000_000_000
+        assert hi == 410_000_000_000
+
+
+# ---------------------------------------------------------------------------
+# Integration tests for auto_select_training_shape
+# ---------------------------------------------------------------------------
+
+
+class TestPass1ExactMatch:
+    """Pass 1: server-side filter returns an exact base_model match."""
+
+    def test_single_candidate(self):
+        mgr = FakeTrainerMgr({
+            "versions": FakeResponse({
+                "trainingShapeVersions": [_make_shape_version()],
+            }),
+        })
+        result = auto_select_training_shape(
+            mgr, base_model=BASE_MODEL, max_seq_len=32768,
+        )
+        assert result == SHAPE_NAME
+
+    def test_picks_smallest_sufficient_ctx(self):
+        v32k = _make_shape_version(
+            name="accounts/fireworks/trainingShapes/small-32k/versions/v1",
+            ctx_len=32768,
+        )
+        v262k = _make_shape_version(
+            name="accounts/fireworks/trainingShapes/large-262k/versions/v2",
+            ctx_len=262144,
+        )
+        mgr = FakeTrainerMgr({
+            "versions": FakeResponse({
+                "trainingShapeVersions": [v262k, v32k],
+            }),
+        })
+        result = auto_select_training_shape(
+            mgr, base_model=BASE_MODEL, max_seq_len=32768,
+        )
+        assert result == "accounts/fireworks/trainingShapes/small-32k"
+
+
+class TestPass1bRelaxedFilter:
+    """Pass 1b: full filter returns nothing, relaxed filter finds shapes."""
+
+    def test_mode_filter_stripped_from_server_side(self):
+        call_count = {"n": 0}
+        shape = _make_shape_version()
+
+        class _Mgr(FakeTrainerMgr):
+            def _get(self, path: str, timeout: int = 30) -> FakeResponse:
+                self.get_calls.append(path)
+                if "versions" in path:
+                    call_count["n"] += 1
+                    if call_count["n"] == 1:
+                        return FakeResponse({"trainingShapeVersions": []})
+                    return FakeResponse({"trainingShapeVersions": [shape]})
+                return FakeResponse({})
+
+        mgr = _Mgr()
+        result = auto_select_training_shape(
+            mgr, base_model=BASE_MODEL, max_seq_len=32768,
+        )
+        assert result == SHAPE_NAME
+        assert call_count["n"] >= 2
+
+
+class TestPass1cAccountScoped:
+    """Pass 1c: wildcard parent returns nothing, account-scoped parent works."""
+
+    def test_derives_account_from_base_model(self):
+        call_count = {"n": 0}
+        shape = _make_shape_version()
+
+        class _Mgr(FakeTrainerMgr):
+            def _get(self, path: str, timeout: int = 30) -> FakeResponse:
+                self.get_calls.append(path)
+                if "versions" in path:
+                    call_count["n"] += 1
+                    if "accounts/fireworks/trainingShapes/-" in path:
+                        return FakeResponse({"trainingShapeVersions": [shape]})
+                    return FakeResponse({"trainingShapeVersions": []})
+                return FakeResponse({})
+
+        mgr = _Mgr()
+        result = auto_select_training_shape(
+            mgr, base_model=BASE_MODEL, max_seq_len=32768,
+        )
+        assert result == SHAPE_NAME
+
+    def test_skips_account_scoped_when_shape_account_given(self):
+        """When caller provides shape_account, Pass 1c is skipped."""
+        call_count = {"n": 0}
+
+        class _Mgr(FakeTrainerMgr):
+            def _get(self, path: str, timeout: int = 30) -> FakeResponse:
+                self.get_calls.append(path)
+                if "versions" in path:
+                    call_count["n"] += 1
+                return FakeResponse({"trainingShapeVersions": []})
+
+        mgr = _Mgr()
+        with pytest.raises(ValueError, match="Provide an explicit training_shape_id"):
+            auto_select_training_shape(
+                mgr, base_model=BASE_MODEL,
+                shape_account="explicit-account",
+            )
+
+
+class TestPass2ParameterCountFallback:
+    """Pass 2: model_type + param_count bucket fallback."""
+
+    def test_uses_model_context_for_fallback(self):
+        shape = _make_shape_version(
+            name="accounts/fireworks/trainingShapes/qwen3p5-moe-b200/versions/v1",
+            base_model="accounts/fireworks/models/qwen3p5-other",
+            trainer_mode="POLICY_TRAINER",
+            modelType="qwen3_5_moe",
+            parameterCount=403_000_000_000,
+        )
+        call_count = {"n": 0}
+
+        class _Mgr(FakeTrainerMgr):
+            def _get(self, path: str, timeout: int = 30) -> FakeResponse:
+                self.get_calls.append(path)
+                if "versions" in path:
+                    call_count["n"] += 1
+                    if "parameter_count" in path:
+                        return FakeResponse({"trainingShapeVersions": [shape]})
+                    return FakeResponse({"trainingShapeVersions": []})
+                if f"/v1/{BASE_MODEL}" in path:
+                    return FakeResponse({
+                        "baseModelDetails": {
+                            "modelType": "qwen3_5_moe",
+                            "parameterCount": 403_000_000_000,
+                        },
+                    })
+                return FakeResponse({})
+
+        mgr = _Mgr()
+        result = auto_select_training_shape(
+            mgr, base_model=BASE_MODEL, max_seq_len=32768,
+        )
+        assert result == "accounts/fireworks/trainingShapes/qwen3p5-moe-b200"
+
+
+class TestModelFetch403:
+    """Handles HTTP 403 from model details API gracefully."""
+
+    def test_403_skips_param_fallback(self):
+        class _Mgr(FakeTrainerMgr):
+            def _get(self, path: str, timeout: int = 30) -> FakeResponse:
+                self.get_calls.append(path)
+                if "versions" in path:
+                    return FakeResponse({"trainingShapeVersions": []})
+                if f"/v1/{BASE_MODEL}" in path:
+                    return FakeResponse({}, status_code=403)
+                return FakeResponse({})
+
+        mgr = _Mgr()
+        with pytest.raises(ValueError, match="Provide an explicit training_shape_id"):
+            auto_select_training_shape(
+                mgr, base_model=BASE_MODEL, max_seq_len=32768,
+            )
+
+
+class TestClientSideModeFilter:
+    """Verifies client-side mode filtering catches mismatched modes."""
+
+    def test_filters_wrong_mode(self):
+        lora_shape = _make_shape_version(trainer_mode="LORA_TRAINER")
+
+        mgr = FakeTrainerMgr({
+            "versions": FakeResponse({
+                "trainingShapeVersions": [lora_shape],
+            }),
+        })
+        with pytest.raises(ValueError, match="Provide an explicit training_shape_id"):
+            auto_select_training_shape(
+                mgr, base_model=BASE_MODEL, trainer_role="policy", lora_rank=0,
+            )
+
+    def test_filters_insufficient_ctx(self):
+        small_shape = _make_shape_version(ctx_len=8192)
+
+        mgr = FakeTrainerMgr({
+            "versions": FakeResponse({
+                "trainingShapeVersions": [small_shape],
+            }),
+        })
+        with pytest.raises(ValueError, match="Provide an explicit training_shape_id"):
+            auto_select_training_shape(
+                mgr, base_model=BASE_MODEL, max_seq_len=32768,
+            )
+
+    def test_numeric_mode_normalized(self):
+        """Trainer mode returned as proto enum int (1=POLICY_TRAINER)."""
+        shape = _make_shape_version()
+        shape["snapshot"]["trainerMode"] = 1
+        del shape["snapshot"]["trainerMode"]
+        shape["snapshot"]["trainer_mode"] = 1
+
+        mgr = FakeTrainerMgr({
+            "versions": FakeResponse({
+                "trainingShapeVersions": [shape],
+            }),
+        })
+        result = auto_select_training_shape(
+            mgr, base_model=BASE_MODEL, max_seq_len=32768,
+        )
+        assert result == SHAPE_NAME
+
+
+class TestNoMaxSeqLen:
+    """When max_seq_len is None, picks first candidate (newest)."""
+
+    def test_picks_first(self):
+        v1 = _make_shape_version(
+            name="accounts/fireworks/trainingShapes/newest/versions/v1",
+            ctx_len=262144,
+        )
+        v2 = _make_shape_version(
+            name="accounts/fireworks/trainingShapes/older/versions/v2",
+            ctx_len=32768,
+        )
+        mgr = FakeTrainerMgr({
+            "versions": FakeResponse({
+                "trainingShapeVersions": [v1, v2],
+            }),
+        })
+        result = auto_select_training_shape(
+            mgr, base_model=BASE_MODEL,
+        )
+        assert result == "accounts/fireworks/trainingShapes/newest"

--- a/training/utils/training_shapes.py
+++ b/training/utils/training_shapes.py
@@ -37,6 +37,8 @@ _TRAINER_MODE_BY_CODE = {
     3: "LORA_TRAINER",
 }
 
+_BASE_MODEL_ACCOUNT_RE = re.compile(r"^accounts/([^/]+)/models/")
+
 
 # ---------------------------------------------------------------------------
 # Public API
@@ -68,41 +70,155 @@ def auto_select_training_shape(
         else _TRAINING_SHAPE_VERSION_PARENT
     )
 
-    # Try exact base_model match first.
+    logger.info(
+        "auto_select_training_shape: base_model=%r, mode=%s, max_seq_len=%s, parent=%s",
+        base_model, expected_mode, max_seq_len, parent,
+    )
+
+    # ------------------------------------------------------------------
+    # Pass 1 — exact base_model match with full server-side filter
+    # ------------------------------------------------------------------
+    full_filter = _combine_filters(
+        f'snapshot.base_model="{base_model}"',
+        f'snapshot.trainer_mode="{expected_mode}"',
+        "latest_validated=true",
+        "public=true" if public_only else "",
+    )
     candidates = _list_and_filter(
         trainer_mgr,
         parent=parent,
-        filter_expr=_combine_filters(
-            f'snapshot.base_model="{base_model}"',
-            f'snapshot.trainer_mode="{expected_mode}"',
-            "latest_validated=true",
-            "public=true" if public_only else "",
-        ),
+        filter_expr=full_filter,
         expected_mode=expected_mode,
         max_seq_len=max_seq_len,
     )
     if candidates:
-        return _pick_best(candidates, max_seq_len)
+        chosen = _pick_best(candidates, max_seq_len)
+        logger.info("Pass 1 (exact match) selected: %s", chosen)
+        return chosen
 
-    # Fallback: compatible model_type + parameter_count bucket.
-    model_ctx = _fetch_model_context(trainer_mgr, base_model)
-    lo, hi = _param_count_bounds(model_ctx["parameter_count"])
+    logger.info("Pass 1 (exact match) returned 0 candidates (filter=%r)", full_filter)
+
+    # ------------------------------------------------------------------
+    # Pass 1b — retry with relaxed server-side filter (base_model only)
+    # to diagnose whether the issue is the combined filter or no shapes
+    # ------------------------------------------------------------------
+    relaxed_filter = _combine_filters(
+        f'snapshot.base_model="{base_model}"',
+        "latest_validated=true",
+    )
     candidates = _list_and_filter(
         trainer_mgr,
         parent=parent,
-        filter_expr=_combine_filters(
+        filter_expr=relaxed_filter,
+        expected_mode=expected_mode,
+        max_seq_len=max_seq_len,
+    )
+    if candidates:
+        chosen = _pick_best(candidates, max_seq_len)
+        logger.warning(
+            "Pass 1b (relaxed filter, client-side mode check) selected: %s "
+            "(full server-side filter returned nothing — the API may not "
+            "support filtering by trainer_mode as a string)",
+            chosen,
+        )
+        return chosen
+
+    logger.info(
+        "Pass 1b (relaxed filter) also returned 0 candidates; "
+        "base_model listing may be empty under parent=%s",
+        parent,
+    )
+
+    # ------------------------------------------------------------------
+    # Pass 1c — if using wildcard parent, retry with account-scoped parent
+    # derived from the base_model name
+    # ------------------------------------------------------------------
+    derived_account = _account_from_base_model(base_model)
+    if not shape_account and derived_account:
+        account_parent = f"accounts/{derived_account}/trainingShapes/-"
+        logger.info(
+            "Pass 1c: retrying with account-scoped parent=%s",
+            account_parent,
+        )
+        candidates = _list_and_filter(
+            trainer_mgr,
+            parent=account_parent,
+            filter_expr=relaxed_filter,
+            expected_mode=expected_mode,
+            max_seq_len=max_seq_len,
+        )
+        if candidates:
+            chosen = _pick_best(candidates, max_seq_len)
+            logger.warning(
+                "Pass 1c (account-scoped parent %s) selected: %s "
+                "(wildcard parent returned nothing)",
+                account_parent, chosen,
+            )
+            return chosen
+
+        logger.info(
+            "Pass 1c (account-scoped parent) also returned 0 candidates",
+        )
+
+    # ------------------------------------------------------------------
+    # Pass 2 — fallback by model_type + parameter_count bucket
+    # ------------------------------------------------------------------
+    try:
+        model_ctx = _fetch_model_context(trainer_mgr, base_model)
+    except (RuntimeError, ValueError) as exc:
+        logger.warning(
+            "Could not fetch model details for %r; "
+            "skipping parameter-count fallback: %s",
+            base_model, exc,
+        )
+        model_ctx = None
+
+    if model_ctx is not None:
+        lo, hi = _param_count_bounds(model_ctx["parameter_count"])
+        param_filter = _combine_filters(
             f'snapshot.model_type="{model_ctx["model_type"]}"',
             f"snapshot.parameter_count>={lo}",
             f"snapshot.parameter_count<={hi}",
             f'snapshot.trainer_mode="{expected_mode}"',
             "latest_validated=true",
             "public=true" if public_only else "",
-        ),
-        expected_mode=expected_mode,
-        max_seq_len=max_seq_len,
-    )
-    if candidates:
-        return _pick_best(candidates, max_seq_len)
+        )
+        candidates = _list_and_filter(
+            trainer_mgr,
+            parent=parent,
+            filter_expr=param_filter,
+            expected_mode=expected_mode,
+            max_seq_len=max_seq_len,
+        )
+        if candidates:
+            chosen = _pick_best(candidates, max_seq_len)
+            logger.info("Pass 2 (parameter-count fallback) selected: %s", chosen)
+            return chosen
+
+        logger.info("Pass 2 (parameter-count fallback) returned 0 candidates")
+
+        # Pass 2b — relaxed param filter (no trainer_mode server-side)
+        relaxed_param_filter = _combine_filters(
+            f'snapshot.model_type="{model_ctx["model_type"]}"',
+            f"snapshot.parameter_count>={lo}",
+            f"snapshot.parameter_count<={hi}",
+            "latest_validated=true",
+            "public=true" if public_only else "",
+        )
+        candidates = _list_and_filter(
+            trainer_mgr,
+            parent=parent,
+            filter_expr=relaxed_param_filter,
+            expected_mode=expected_mode,
+            max_seq_len=max_seq_len,
+        )
+        if candidates:
+            chosen = _pick_best(candidates, max_seq_len)
+            logger.warning(
+                "Pass 2b (relaxed param filter) selected: %s",
+                chosen,
+            )
+            return chosen
 
     mode_label = {"LORA_TRAINER": "LoRA", "FORWARD_ONLY": "reference"}.get(
         expected_mode, "full-tune"
@@ -130,6 +246,12 @@ def _expected_trainer_mode(
     return "POLICY_TRAINER"
 
 
+def _account_from_base_model(base_model: str) -> str | None:
+    """Extract the account ID from a base_model resource name."""
+    m = _BASE_MODEL_ACCOUNT_RE.match(base_model)
+    return m.group(1) if m else None
+
+
 def _list_and_filter(
     client: TrainerJobManager,
     *,
@@ -140,20 +262,34 @@ def _list_and_filter(
 ) -> list[dict]:
     """List training shape versions and filter by mode + context length."""
     versions = _list_paginated(client, parent=parent, filter_expr=filter_expr)
+    logger.debug(
+        "_list_and_filter: API returned %d versions for parent=%s filter=%r",
+        len(versions), parent, filter_expr,
+    )
     result = []
+    skipped_mode = 0
+    skipped_ctx = 0
     for v in versions:
         snap = (v.get("snapshot") or {})
         mode = _normalize_trainer_mode(
             snap.get("trainerMode") or snap.get("trainer_mode")
         )
         if mode != expected_mode:
+            skipped_mode += 1
             continue
         ctx_len = _int_val(snap, "maxSupportedContextLength", "max_supported_context_length")
         if max_seq_len is not None and ctx_len < max_seq_len:
+            skipped_ctx += 1
             continue
         name = v.get("name", "")
         shape_id = _TRAINING_SHAPE_VERSION_RE.sub("", name) or name
         result.append({"shape_id": shape_id, "ctx_len": ctx_len})
+    if versions and not result:
+        logger.info(
+            "_list_and_filter: %d versions from API, all filtered out "
+            "(skipped_mode=%d, skipped_ctx=%d)",
+            len(versions), skipped_mode, skipped_ctx,
+        )
     return result
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Training job `rft--pyroworks-dev-ftsy30v1-e19defec7` for model `qwen3p5-397b-a17b` crashed because `auto_select_training_shape` couldn't find any matching shapes, even though validated shapes exist and are visible via `firectl`:

```
accounts/fireworks/trainingShapes/qwen3p5-397b-a17b-32k-b200-lora
accounts/fireworks/trainingShapes/qwen3p5-397b-a17b-262k-b200
```

The function's **Pass 1** (exact base_model + trainer_mode server-side filter) returned zero candidates silently, then **Pass 2** failed because the model API returned HTTP 403 for `accounts/fireworks/models/qwen3p5-397b-a17b`.

There was no logging to help diagnose why the combined server-side filter returned nothing — the shapes exist, are validated and public, yet the API listing returned empty.

## Root Cause Analysis

The most likely causes for Pass 1 returning empty despite shapes existing:

1. **Server-side `trainer_mode` filter mismatch**: The API may store trainer_mode as a numeric proto enum (1, 2, 3) while we filter with the string name (`"POLICY_TRAINER"`). The combined server filter silently returns nothing.
2. **Wildcard parent `accounts/-/trainingShapes/-` not listing cross-account shapes**: On the dev gateway, the wildcard parent may not enumerate shapes from the `fireworks` account.

## Fix

Added progressive fallback passes with diagnostic logging:

| Pass | Strategy | What it catches |
|------|----------|----------------|
| 1 | Exact `base_model` + `trainer_mode` server-side filter | Original behavior (unchanged) |
| 1b | `base_model` only server-side, `trainer_mode` checked client-side | API doesn't support string enum filtering |
| 1c | Account-scoped parent derived from `base_model` name | Wildcard parent doesn't list cross-account shapes |
| 2 | `model_type` + `parameter_count` bucket fallback | Different base_model name, same architecture |
| 2b | Relaxed param filter (no `trainer_mode` server-side) | Same as 1b but for the param-count path |

Also:
- **Graceful 403 handling**: `_fetch_model_context` failures are caught and logged, skipping the param-count fallback instead of crashing
- **Comprehensive logging**: Every pass logs its filter expression and candidate count at INFO level; `_list_and_filter` logs skip reasons (mode mismatch vs context too short) when API returns results but all are filtered client-side
- **`_account_from_base_model` helper**: Extracts the account from `accounts/{account}/models/{model}` for the account-scoped retry

## Testing

- Added 23 new tests in `test_training_shapes.py` covering all passes, helpers, and edge cases
- All 354 existing unit tests continue to pass (331 passed + 23 new = 354; 32 pre-existing skips, 7 pre-existing failures from missing `math_verify`/`eval_protocol` deps)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-49a5e93a-adef-4e44-9797-3c71961a9bef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-49a5e93a-adef-4e44-9797-3c71961a9bef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

