### PR TITLE
feat(sft): add eval_steps for periodic mid-epoch eval

### DIFF
--- a/training/recipes/sft_loop.py
+++ b/training/recipes/sft_loop.py
@@ -162,6 +162,11 @@ class Config:
     max_eval_seqs: int = DEFAULT_MAX_EVAL_SEQS
     """Max number of eval sequences for carve-out."""
 
+    eval_steps: int = 0
+    """Run eval every N training steps (0 = off, eval only at end of each epoch).
+    When > 0, eval also runs at the end of each epoch so the final step is
+    always covered."""
+
     infra: InfraConfig = field(default_factory=InfraConfig)
     wandb: WandBConfig = field(default_factory=lambda: WandBConfig(project="sft-tinker"))
     runner: RunnerConfig = field(default_factory=RunnerConfig)
@@ -561,6 +566,25 @@ def main(
         runner.start_training()
         runner.write_status(RunStatus.RUNNING, total_steps=total_steps_estimate, message="training")
 
+        def _maybe_run_eval(step: int, epoch: int, where: str) -> None:
+            if not eval_data:
+                return
+            try:
+                eval_loss = run_eval(
+                    eval_data=eval_data,
+                    client=client,
+                    batch_size=cfg.batch_size,
+                    step=step,
+                    epoch=epoch,
+                )
+                if eval_loss is not None:
+                    runner.append_metrics(
+                        step,
+                        {"eval/loss": eval_loss, "eval/ppl": torch.exp(torch.tensor(eval_loss)).item()},
+                    )
+            except Exception as e:
+                logger.warning("Eval failed %s, continuing: %s", where, e)
+
         for epoch in range(cfg.epochs):
             sft_dataset.set_epoch(epoch)
             epoch_start = start_batch if epoch == 0 else 0
@@ -569,23 +593,13 @@ def main(
                 data_consumed += len(batch)
                 step = _run_train_step(batch, step)
 
-            # Run eval after each epoch
-            if eval_data:
-                try:
-                    eval_loss = run_eval(
-                        eval_data=eval_data,
-                        client=client,
-                        batch_size=cfg.batch_size,
-                        step=step,
-                        epoch=epoch,
-                    )
-                    if eval_loss is not None:
-                        runner.append_metrics(
-                            step,
-                            {"eval/loss": eval_loss, "eval/ppl": torch.exp(torch.tensor(eval_loss)).item()},
-                        )
-                except Exception as e:
-                    logger.warning("Eval failed at epoch %d, continuing: %s", epoch + 1, e)
+                # Optional mid-epoch eval every N steps. The end-of-epoch eval
+                # below still runs unconditionally so the final step is always
+                # covered regardless of whether step % eval_steps lines up.
+                if cfg.eval_steps > 0 and step > 0 and step % cfg.eval_steps == 0:
+                    _maybe_run_eval(step, epoch, f"at step {step}")
+
+            _maybe_run_eval(step, epoch, f"at end of epoch {epoch + 1}")
 
         # -- Final checkpoint --------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Adds `Config.eval_steps` (default **0 = off**) to run eval every N training steps during the inner training loop.
- Preserves existing post-epoch eval — it still runs unconditionally when an eval dataset is present, so the final step of each epoch is always covered.
- Refactors the eval invocation into a local `_maybe_run_eval` helper so in-loop and post-epoch calls share the same try/except + metrics-append boilerplate.

## Why

With the current per-epoch-only eval, a single-epoch run produces a single eval point at the end of training. The dashboard charts `train/loss` densely and `eval/loss` sparsely — you can't see whether the model is overfitting until it's done. Setting `eval_steps=5` (or whatever interval suits the run) gives a proper eval curve alongside the train curve without changing the default behavior for anyone who hasn't opted in.

## Behavior

| `eval_steps` | Mid-epoch eval | Post-epoch eval |
|---|---|---|
| `0` (default) | — | ✅ (unchanged) |
| `> 0` | every N steps | ✅ (still runs) |

## Testing

- Default path (`eval_steps=0`) exercises the same code path as before — no behavioral change for existing callers.
- Will land this alongside [fw-ai/fireworks#22702](https://github.com/fw-ai/fireworks/pull/22702) (which fixes GCS staging of `evaluation_dataset` in the orchestrator). End-to-end test plan: run an SFT V2 job with `evaluation_dataset` + `eval_steps=5` and confirm multiple `eval/loss` entries in the metrics file.