### PR TITLE
docs: simplify install to one command, clean up READMEs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -296,6 +296,8 @@ cython_debug/
 wandb/
 *_dev.sh
 sft_logs/
+deepmath_logs/
+verify_logs/
 
 # dev scripts
 *_dev.sh

--- a/README.md
+++ b/README.md
@@ -13,16 +13,15 @@ conda create -n cookbook python=3.12 -y && conda activate cookbook
 pip install --pre -e .
 ```
 
-Set your API key and run a recipe:
+See [`training/README.md`](./training/README.md) for configuration, recipes, and examples.
 
-```bash
-export FIREWORKS_API_KEY="your-api-key"
-python -m recipes.sft_loop
-```
+## For AI Agents
 
-See [`training/README.md`](./training/README.md) for recipe configuration and examples.
+The primary reference for agents working in this repo is **[`skills/dev/SKILL.md`](skills/dev/SKILL.md)** — it maps tasks and error signals to specific reference files. Start there, not the READMEs.
 
 ## Repository Structure
+
+Only `training/` is actively developed. Other top-level directories (`integrations/`, `multimedia/`, `archived/`) are kept for backward compatibility.
 
 ```
 training/           Training SDK recipes, utilities, and examples
@@ -30,10 +29,8 @@ training/           Training SDK recipes, utilities, and examples
   utils/            Shared config, data loading, losses, metrics
   examples/         Worked examples (RL, SFT, DPO, ORPO)
   tests/            Unit and end-to-end tests
-archived/           Legacy cookbook content
+skills/             Agent skills and reference docs
 ```
-
-The `integrations/`, `multimedia/`, and `archived/` directories contain older content kept for backward compatibility.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ training/           Training SDK recipes, utilities, and examples
   utils/            Shared config, data loading, losses, metrics
   examples/         Worked examples (RL, SFT, DPO, ORPO)
   tests/            Unit and end-to-end tests
-integrations/       Third-party integrations (AgentCore, SageMaker)
-multimedia/         Video and VLM notebooks
 archived/           Legacy cookbook content
 ```
+
+The `integrations/`, `multimedia/`, and `archived/` directories contain older content kept for backward compatibility.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,26 @@
 # Fireworks AI Cookbook
 
-The Fireworks AI Cookbook provides ready-to-run recipes and utilities for training models on [Fireworks](https://fireworks.ai). It covers supervised fine-tuning (SFT), reinforcement learning (GRPO, DAPO, GSPO, CISPO), and preference optimization (DPO, ORPO) — all driven by the Fireworks Training SDK.
+Ready-to-run training recipes for reinforcement learning (GRPO, DAPO, GSPO, CISPO), preference optimization (DPO, ORPO), and supervised fine-tuning (SFT) on [Fireworks](https://fireworks.ai).
 
-For full SDK documentation, see the [Fireworks Training SDK Reference](https://docs.fireworks.ai/fine-tuning/training-sdk/introduction).
+> **Full documentation**: [Fireworks Training SDK Reference](https://docs.fireworks.ai/fine-tuning/training-sdk/introduction)
 
-## Getting Started
+## Quick Start
 
-Head to the [`training/`](./training) directory for installation instructions, recipe configuration, and runnable examples.
+```bash
+git clone https://github.com/fw-ai/cookbook.git
+cd cookbook/training
+conda create -n cookbook python=3.12 -y && conda activate cookbook
+pip install --pre -e .
+```
+
+Set your API key and run a recipe:
+
+```bash
+export FIREWORKS_API_KEY="your-api-key"
+python -m recipes.sft_loop
+```
+
+See [`training/README.md`](./training/README.md) for recipe configuration and examples.
 
 ## Repository Structure
 
@@ -14,21 +28,19 @@ Head to the [`training/`](./training) directory for installation instructions, r
 training/           Training SDK recipes, utilities, and examples
   recipes/          Fork-and-customize training loop scripts
   utils/            Shared config, data loading, losses, metrics
-  examples/         Worked examples (e.g. deepmath GRPO)
+  examples/         Worked examples (RL, SFT, DPO, ORPO)
   tests/            Unit and end-to-end tests
-archived/           Legacy cookbook content (see below)
+integrations/       Third-party integrations (AgentCore, SageMaker)
+multimedia/         Video and VLM notebooks
+archived/           Legacy cookbook content
 ```
-
-## Archived Content
-
-All previous cookbook material — learning tutorials, integration examples, showcase projects, evaluation recipes, and more — has been moved to [`archived/`](./archived). See the [archived README](./archived/README.md) for details on what's there.
 
 ## Contributing
 
-We welcome contributions! See the [Contribution Guide](./Contribution.md) for how to get started.
+See the [Contribution Guide](./Contribution.md).
 
-## Feedback & Support
+## Support
 
-- [Fireworks Documentation](https://fireworks.ai/docs)
+- [Documentation](https://fireworks.ai/docs)
 - [Discord](https://discord.gg/9nKGzdCk)
 - [Open an issue](https://github.com/fw-ai/cookbook/issues/new)

--- a/skills/dev/SKILL.md
+++ b/skills/dev/SKILL.md
@@ -13,6 +13,7 @@ The cookbook is the reference implementation of the Fireworks Training SDK. Fork
 
 | Task or signal | Reference |
 |----------------|-----------|
+| "How do I set up / install the cookbook?" | [`references/setup.md`](references/setup.md) |
 | "I want to run something out of the box" | [`references/examples.md`](references/examples.md) |
 | "I want to fork a recipe and edit the Config" | [`references/recipes.md`](references/recipes.md) |
 | "How do I set the training / deployment shape?" | [`references/shapes.md`](references/shapes.md) |

--- a/skills/dev/references/setup.md
+++ b/skills/dev/references/setup.md
@@ -1,0 +1,59 @@
+# Environment Setup
+
+## Install
+
+```bash
+git clone https://github.com/fw-ai/cookbook.git
+cd cookbook/training
+
+# Option A: conda
+conda create -n cookbook python=3.12 -y && conda activate cookbook
+pip install --pre -e .
+
+# Option B: uv
+uv venv --python 3.12 && source .venv/bin/activate
+uv pip install --pre -e .
+```
+
+`--pre` is required — the SDK (`fireworks-ai[training]`) is a prerelease. All dependencies (including `tinker-cookbook`) are pulled in automatically via `pyproject.toml`.
+
+## Credentials
+
+Set your API key via `.env` (auto-loaded by `python-dotenv`) or environment variable:
+
+```bash
+# Option A: .env file in training/
+echo 'FIREWORKS_API_KEY="your-api-key"' > .env
+
+# Option B: export
+export FIREWORKS_API_KEY="your-api-key"
+```
+
+## Verify
+
+```bash
+python -c "from fireworks.training.sdk import TrainerJobManager; print('SDK OK')"
+python -c "from training.utils.config import InfraConfig; print('Cookbook OK')"
+```
+
+## Dev dependencies (tests, coverage)
+
+```bash
+pip install --pre -e ".[dev]"
+pytest tests/
+```
+
+## Upgrading the SDK
+
+The required SDK version is pinned in `training/pyproject.toml`. To upgrade:
+
+```bash
+pip install --pre --upgrade "fireworks-ai[training]"
+```
+
+Then verify the installed version satisfies the pin:
+
+```bash
+grep 'fireworks-ai\[training\]' training/pyproject.toml
+pip show fireworks-ai | grep Version
+```

--- a/training/README.md
+++ b/training/README.md
@@ -34,7 +34,13 @@ export FIREWORKS_API_KEY="your-api-key"
 python examples/sft/train_sft.py \
     --base-model accounts/fireworks/models/qwen3-8b \
     --tokenizer-model Qwen/Qwen3-8B \
-    --output-model-id my-sft-test
+    --dataset-path examples/sft/text2sql_dataset.jsonl \
+    --region US_VIRGINIA_1 \
+    --max-examples 100 \
+    --epochs 3 \
+    --batch-size 32 \
+    --learning-rate 1e-5 \
+    --output-model-id sft-text-qwen3-8b-$(date +%Y%m%d%H%M)
 ```
 
 See [`skills/dev/references/examples.md`](../skills/dev/references/examples.md) for all worked examples.

--- a/training/README.md
+++ b/training/README.md
@@ -22,25 +22,17 @@ Each recipe is a single Python file you can fork and customize.
 git clone https://github.com/fw-ai/cookbook.git
 cd cookbook/training
 
-# Install uv (skip if already installed)
-curl -LsSf https://astral.sh/uv/install.sh | sh
+# Option A: conda
+conda create -n cookbook python=3.12 -y && conda activate cookbook
+pip install --pre -e .
 
-# Create and activate a virtual environment
-uv venv --python 3.12
-source .venv/bin/activate
-
-# Install the Fireworks training SDK prerelease that provides
-# `fireworks.training.sdk`.
-uv pip install --pre "fireworks-ai>=1.0.0a36" tinker-cookbook
-
-# Install this package in editable mode
-uv pip install -e .
-
-# If you skip `--pre`, pip may resolve to the stable `0.x` line,
-# which does not include `fireworks.training.sdk` and will cause
-# imports like `from fireworks.training.sdk import DeploymentManager`
-# to fail.
+# Option B: uv
+uv venv --python 3.12 && source .venv/bin/activate
+uv pip install --pre -e .
 ```
+
+> **Note**: `--pre` is required to resolve the `fireworks-ai` prerelease SDK.
+> All dependencies (including `tinker-cookbook`) are pulled in automatically via `pyproject.toml`.
 
 ### 2. Set your credentials
 

--- a/training/README.md
+++ b/training/README.md
@@ -31,7 +31,10 @@ Each recipe has a `Config` dataclass — edit it and run `python -m recipes.<nam
 
 ```bash
 export FIREWORKS_API_KEY="your-api-key"
-cd examples/sft && bash run.sh
+python examples/sft/train_sft.py \
+    --base-model accounts/fireworks/models/qwen3-8b \
+    --tokenizer-model Qwen/Qwen3-8B \
+    --output-model-id my-sft-test
 ```
 
 See [`skills/dev/references/examples.md`](../skills/dev/references/examples.md) for all worked examples.

--- a/training/README.md
+++ b/training/README.md
@@ -27,6 +27,15 @@ pip install --pre -e .
 
 Each recipe has a `Config` dataclass — edit it and run `python -m recipes.<name>`.
 
+**Quick start** — run the SFT example end-to-end:
+
+```bash
+export FIREWORKS_API_KEY="your-api-key"
+cd examples/sft && bash run.sh
+```
+
+See [`skills/dev/references/examples.md`](../skills/dev/references/examples.md) for all worked examples.
+
 ## Directory Layout
 
 ```

--- a/training/README.md
+++ b/training/README.md
@@ -1,146 +1,47 @@
 # Fireworks Training Cookbook
 
 Ready-to-run training recipes for reinforcement learning, preference optimization, and supervised fine-tuning on [Fireworks](https://fireworks.ai).
-Each recipe is a single Python file you can fork and customize.
 
-> **Full documentation**: For detailed guides on each recipe, configuration reference, and the Training SDK, see the [Training SDK documentation](https://docs.fireworks.ai/fine-tuning/training-sdk/introduction).
+> **Full documentation**: [Training SDK docs](https://docs.fireworks.ai/fine-tuning/training-sdk/introduction)
+
+## Setup
+
+See [`skills/dev/references/setup.md`](../skills/dev/references/setup.md) for install, credentials, and verification.
+
+Quick version:
+
+```bash
+cd cookbook/training
+conda create -n cookbook python=3.12 -y && conda activate cookbook
+pip install --pre -e .
+```
 
 ## Recipes
 
 | Recipe | File | Description |
 | --- | --- | --- |
-| GRPO / IS / DAPO / DRO / GSPO / CISPO | `recipes/rl_loop.py` | On-policy RL with streaming rollouts. Set `policy_loss="grpo"`, `"importance_sampling"`, `"dapo"`, `"dro"`, `"gspo"`, or `"cispo"`. |
-| DPO | `recipes/dpo_loop.py` | Direct preference optimization with cached reference logprobs. |
-| ORPO | `recipes/orpo_loop.py` | Odds-ratio preference optimization -- no reference model needed. |
-| SFT | `recipes/sft_loop.py` | Supervised fine-tuning with response-only cross-entropy loss. |
+| GRPO / IS / DAPO / DRO / GSPO / CISPO | `recipes/rl_loop.py` | On-policy RL with streaming rollouts |
+| DPO | `recipes/dpo_loop.py` | Direct preference optimization |
+| ORPO | `recipes/orpo_loop.py` | Odds-ratio preference optimization |
+| SFT | `recipes/sft_loop.py` | Supervised fine-tuning |
 
-## Getting started
+Each recipe has a `Config` dataclass — edit it and run `python -m recipes.<name>`.
 
-### 1. Clone and install
-
-```bash
-git clone https://github.com/fw-ai/cookbook.git
-cd cookbook/training
-
-# Option A: conda
-conda create -n cookbook python=3.12 -y && conda activate cookbook
-pip install --pre -e .
-
-# Option B: uv
-uv venv --python 3.12 && source .venv/bin/activate
-uv pip install --pre -e .
-```
-
-> **Note**: `--pre` is required to resolve the `fireworks-ai` prerelease SDK.
-> All dependencies (including `tinker-cookbook`) are pulled in automatically via `pyproject.toml`.
-
-### 2. Set your credentials
-
-Create a `.env` file in the `training/` directory (picked up automatically via `python-dotenv`):
-
-```bash
-FIREWORKS_API_KEY="your-api-key"
-```
-
-Or export it directly:
-
-```bash
-export FIREWORKS_API_KEY="..."
-```
-
-### 3. Configure your recipe
-
-Each recipe has a `Config` dataclass at the top of the file. Open the recipe you want to run and edit the `if __name__ == "__main__"` block at the bottom. Here are the fields you **must** set:
-
-**All recipes:**
-
-| Field | What to set |
-| --- | --- |
-| `dataset` | Path to your JSONL training data |
-| `base_model` | Fireworks model ID (e.g. `"accounts/fireworks/models/qwen3-8b"`) |
-| `max_seq_len` | Max token length for training examples |
-| `infra` | `InfraConfig()` to auto-select validated shapes from Fireworks control-plane data, or `InfraConfig(training_shape_id="your-shape")` to override them |
-
-**SFT** (`recipes/sft_loop.py`) -- also requires:
-
-| Field | What to set |
-| --- | --- |
-| `tokenizer_model` | HuggingFace model name matching your base model (e.g. `"Qwen/Qwen3-8B"`) |
-
-**RL** (`recipes/rl_loop.py`) -- also requires:
-
-| Field | What to set |
-| --- | --- |
-| `deployment` | `DeployConfig(tokenizer_model="Qwen/Qwen3-8B")` for inference rollouts |
-| `weight_sync` | `WeightSyncConfig(weight_sync_interval=1)` to sync weights to the deployment |
-
-When `training_shape_id` is not set, the cookbook auto-selects validated
-trainer shapes at runtime from Fireworks control-plane data. RL-family
-recipes also auto-select a validated deployment shape, and DPO / KL
-flows request a validated forward-only reference shape. Explicit
-`training_shape_id`, `ref_training_shape_id`, and deployment-shape
-overrides still take precedence.
-
-**DPO / ORPO** -- also requires:
-
-| Field | What to set |
-| --- | --- |
-| `tokenizer_model` | HuggingFace model name matching your base model |
-
-### 4. Run
-
-```bash
-cd cookbook/training
-python -m recipes.sft_loop      # or whichever recipe you configured
-```
-
-## Useful examples
-
-- `examples/tools/promote_checkpoint.py` reads `checkpoints.jsonl` (produced by cookbook recipes), finds the sampler checkpoint ID and source trainer job, and calls the promotion API to promote it to a deployable Fireworks model. No temporary trainer needed.
-- `examples/tools/list_checkpoints.py` lists the server's authoritative view of checkpoints for a trainer job (sampler + DCP, promotable or not). Thin wrapper over `FireworksClient.list_checkpoints()`.
-- `examples/tools/reconnect_and_adjust_lr.py` shows how to reconnect to an already-running trainer job and resume training with a different learning rate.
-
-## Documentation
-
-For detailed guides, configuration reference, and examples, see the official documentation:
-
-- [Introduction & Quickstart](https://docs.fireworks.ai/fine-tuning/training-sdk/introduction)
-- [Cookbook recipes (SFT, RL, DPO, ORPO)](https://docs.fireworks.ai/fine-tuning/training-sdk/cookbook/overview)
-- [Configuration reference](https://docs.fireworks.ai/fine-tuning/training-sdk/cookbook/reference)
-
-## Directory layout
+## Directory Layout
 
 ```
-recipes/                 Training loop scripts (fork these)
-utils/                   Shared config, data loading, loss functions, metrics
-examples/rl/deepmath/    Worked example: math reasoning with GRPO
-examples/rl/frozen_lake/ Worked example: Frozen Lake with tool-use RL
-examples/orpo/ifeval/    Worked example: IFEval with ORPO
-examples/sft/            Worked example: SFT getting started
-examples/dpo/            Worked example: DPO
-examples/tools/          Standalone utility scripts
-tests/                   Unit and end-to-end tests
+recipes/              Training loop scripts (fork these)
+utils/                Shared config, data loading, losses, metrics
+examples/
+  rl/deepmath/        Worked example: math reasoning with GRPO
+  rl/frozen_lake/     Worked example: Frozen Lake with tool-use RL
+  orpo/ifeval/        Worked example: IFEval with ORPO
+  sft/                Worked example: SFT getting started
+  dpo/                Worked example: DPO
+  tools/              Standalone utility scripts
+tests/                Unit and end-to-end tests
 ```
 
-## Tests
+## Skills (primary reference)
 
-```bash
-uv pip install -e ".[dev]"
-pytest tests/
-```
-
-Coverage for the training entrypoints:
-
-```bash
-cd training
-pytest -q tests/unit tests/test_smoke_imports.py examples/rl/frozen_lake/test_masking.py \
-  --cov=. \
-  --cov-report=term-missing \
-  --cov-report=json:coverage.json
-python tests/coverage_summary.py coverage.json
-```
-
-See [issues/training-script-coverage-baseline.md](./issues/training-script-coverage-baseline.md)
-for the current baseline and
-[issues/training-script-coverage-roadmap.md](./issues/training-script-coverage-roadmap.md)
-for the expansion plan.
+For configuration, debugging, shapes, hotload, checkpoints, and all task-specific guidance, see **[`skills/dev/SKILL.md`](../skills/dev/SKILL.md)** — it is the single source of truth and maps every task to its reference doc.


### PR DESCRIPTION
## Summary
- Simplify install from 3 steps (install uv, install tinker-cookbook, install editable) to one `pip install --pre -e .` — all deps including tinker-cookbook come transitively via `fireworks-ai[training]` in pyproject.toml
- Clean up top-level README: add quick start with copy-paste install, list all top-level dirs (integrations, multimedia, archived)
- Gitignore local artifact dirs (`deepmath_logs/`, `verify_logs/`)

## Test plan
- [x] Verified in fresh `conda create -n cookbook-test python=3.12` — `pip install --pre -e .` installs everything, all key imports (`fireworks.training.sdk`, `training.utils`, `tinker_cookbook`) work

🤖 Generated with [Claude Code](https://claude.com/claude-code)