### PR TITLE
feat(rl): skip separate reference trainer for LoRA GRPO

### DIFF
--- a/training/README.md
+++ b/training/README.md
@@ -1,65 +1,165 @@
 # Fireworks Training Cookbook
 
 Ready-to-run training recipes for reinforcement learning, preference optimization, and supervised fine-tuning on [Fireworks](https://fireworks.ai).
+Each recipe is a single Python file you can fork and customize.
 
-> **Full documentation**: [Training SDK docs](https://docs.fireworks.ai/fine-tuning/training-sdk/introduction)
-
-## Setup
-
-See [`skills/dev/references/setup.md`](../skills/dev/references/setup.md) for install, credentials, and verification.
-
-Quick version:
-
-```bash
-cd cookbook/training
-conda create -n cookbook python=3.12 -y && conda activate cookbook
-pip install --pre -e .
-```
+> **Full documentation**: For detailed guides on each recipe, configuration reference, and the Training SDK, see the [Training SDK documentation](https://docs.fireworks.ai/fine-tuning/training-sdk/introduction).
 
 ## Recipes
 
 | Recipe | File | Description |
 | --- | --- | --- |
-| GRPO / IS / DAPO / DRO / GSPO / CISPO | `recipes/rl_loop.py` | On-policy RL with streaming rollouts |
-| DPO | `recipes/dpo_loop.py` | Direct preference optimization |
-| ORPO | `recipes/orpo_loop.py` | Odds-ratio preference optimization |
-| SFT | `recipes/sft_loop.py` | Supervised fine-tuning |
+| GRPO / IS / DAPO / DRO / GSPO / CISPO | `recipes/rl_loop.py` | On-policy RL with streaming rollouts. Set `policy_loss="grpo"`, `"importance_sampling"`, `"dapo"`, `"dro"`, `"gspo"`, or `"cispo"`. |
+| DPO | `recipes/dpo_loop.py` | Direct preference optimization with cached reference logprobs. |
+| ORPO | `recipes/orpo_loop.py` | Odds-ratio preference optimization -- no reference model needed. |
+| SFT | `recipes/sft_loop.py` | Supervised fine-tuning with response-only cross-entropy loss. |
 
-Each recipe has a `Config` dataclass — edit it and run `python -m recipes.<name>`.
+## Getting started
 
-**Quick start** — run the SFT example end-to-end:
+### 1. Clone and install
 
 ```bash
-export FIREWORKS_API_KEY="your-api-key"
-python examples/sft/train_sft.py \
-    --base-model accounts/fireworks/models/qwen3-8b \
-    --tokenizer-model Qwen/Qwen3-8B \
-    --dataset-path examples/sft/text2sql_dataset.jsonl \
-    --region US_VIRGINIA_1 \
-    --max-examples 100 \
-    --epochs 3 \
-    --batch-size 32 \
-    --learning-rate 1e-5 \
-    --output-model-id sft-text-qwen3-8b-$(date +%Y%m%d%H%M)
+git clone https://github.com/fw-ai/cookbook.git
+cd cookbook/training
+
+# Install uv (skip if already installed)
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Create and activate a virtual environment
+uv venv --python 3.12
+source .venv/bin/activate
+
+# Install the Fireworks training SDK prerelease that provides
+# `fireworks.training.sdk`.
+uv pip install --pre "fireworks-ai>=1.0.0a36" tinker-cookbook
+
+# Install this package in editable mode
+uv pip install -e .
+
+# If you skip `--pre`, pip may resolve to the stable `0.x` line,
+# which does not include `fireworks.training.sdk` and will cause
+# imports like `from fireworks.training.sdk import DeploymentManager`
+# to fail.
 ```
 
-See [`skills/dev/references/examples.md`](../skills/dev/references/examples.md) for all worked examples.
+### 2. Set your credentials
 
-## Directory Layout
+Create a `.env` file in the `training/` directory (picked up automatically via `python-dotenv`):
 
-```
-recipes/              Training loop scripts (fork these)
-utils/                Shared config, data loading, losses, metrics
-examples/
-  rl/deepmath/        Worked example: math reasoning with GRPO
-  rl/frozen_lake/     Worked example: Frozen Lake with tool-use RL
-  orpo/ifeval/        Worked example: IFEval with ORPO
-  sft/                Worked example: SFT getting started
-  dpo/                Worked example: DPO
-  tools/              Standalone utility scripts
-tests/                Unit and end-to-end tests
+```bash
+FIREWORKS_API_KEY="your-api-key"
 ```
 
-## Skills (primary reference)
+Or export it directly:
 
-For configuration, debugging, shapes, hotload, checkpoints, and all task-specific guidance, see **[`skills/dev/SKILL.md`](../skills/dev/SKILL.md)** — it is the single source of truth and maps every task to its reference doc.
+```bash
+export FIREWORKS_API_KEY="..."
+```
+
+### 3. Configure your recipe
+
+Each recipe has a `Config` dataclass at the top of the file. Open the recipe you want to run and edit the `if __name__ == "__main__"` block at the bottom. Here are the fields you **must** set:
+
+**All recipes:**
+
+| Field | What to set |
+| --- | --- |
+| `dataset` | Path to your JSONL training data |
+| `base_model` | Fireworks model ID (e.g. `"accounts/fireworks/models/qwen3-8b"`) |
+| `max_seq_len` | Max token length for training examples |
+| `infra` | `InfraConfig()` to auto-select validated shapes from Fireworks control-plane data, or `InfraConfig(training_shape_id="your-shape")` to override them |
+
+**SFT** (`recipes/sft_loop.py`) -- also requires:
+
+| Field | What to set |
+| --- | --- |
+| `tokenizer_model` | HuggingFace model name matching your base model (e.g. `"Qwen/Qwen3-8B"`) |
+
+**RL** (`recipes/rl_loop.py`) -- also requires:
+
+| Field | What to set |
+| --- | --- |
+| `deployment` | `DeployConfig(tokenizer_model="Qwen/Qwen3-8B")` for inference rollouts |
+| `weight_sync` | `WeightSyncConfig(weight_sync_interval=1)` to sync weights to the deployment |
+
+When `training_shape_id` is not set, the cookbook auto-selects validated
+trainer shapes at runtime from Fireworks control-plane data. RL-family
+recipes also auto-select a validated deployment shape, and DPO / KL
+flows request a validated forward-only reference shape. Explicit
+`training_shape_id`, `ref_training_shape_id`, and deployment-shape
+overrides still take precedence.
+
+**LoRA RL** -- for LoRA GRPO with KL regularisation (`kl_beta > 0`), set `lora_rank`:
+
+| Field | What to set |
+| --- | --- |
+| `lora_rank` | Rank of the LoRA adapter (e.g. `64`, `128`) |
+
+When `lora_rank > 0` and no explicit `ref_training_shape_id` is given,
+the RL loop automatically reuses the policy trainer for reference
+logprobs by creating a base-only model handle (adapters disabled).
+This halves GPU cost compared to provisioning a separate reference
+trainer.
+
+**DPO / ORPO** -- also requires:
+
+| Field | What to set |
+| --- | --- |
+| `tokenizer_model` | HuggingFace model name matching your base model |
+
+### 4. Run
+
+```bash
+cd cookbook/training
+python -m recipes.sft_loop      # or whichever recipe you configured
+```
+
+## Useful examples
+
+- `examples/snippets/promote_checkpoint.py` reads `checkpoints.jsonl` (produced by cookbook recipes), finds the sampler checkpoint ID and source trainer job, and calls the promotion API to promote it to a deployable Fireworks model. No temporary trainer needed.
+- `examples/snippets/reconnect_and_adjust_lr.py` shows how to reconnect to an already-running trainer job and resume training with a different learning rate.
+
+## Documentation
+
+For detailed guides, configuration reference, and examples, see the official documentation:
+
+- [Introduction & Quickstart](https://docs.fireworks.ai/fine-tuning/training-sdk/introduction)
+- [Cookbook recipes (SFT, RL, DPO, ORPO)](https://docs.fireworks.ai/fine-tuning/training-sdk/cookbook/overview)
+- [Configuration reference](https://docs.fireworks.ai/fine-tuning/training-sdk/cookbook/reference)
+
+## Directory layout
+
+```
+recipes/                 Training loop scripts (fork these)
+utils/                   Shared config, data loading, loss functions, metrics
+examples/rl/deepmath/    Worked example: math reasoning with GRPO
+examples/rl/frozen_lake/ Worked example: Frozen Lake with tool-use RL
+examples/orpo/ifeval/    Worked example: IFEval with ORPO
+examples/sft/            Worked example: SFT getting started
+examples/dpo/            Worked example: DPO
+examples/snippets/       Standalone utility scripts
+tests/                   Unit and end-to-end tests
+```
+
+## Tests
+
+```bash
+uv pip install -e ".[dev]"
+pytest tests/
+```
+
+Coverage for the training entrypoints:
+
+```bash
+cd training
+pytest -q tests/unit tests/test_smoke_imports.py examples/rl/frozen_lake/test_masking.py \
+  --cov=. \
+  --cov-report=term-missing \
+  --cov-report=json:coverage.json
+python tests/coverage_summary.py coverage.json
+```
+
+See [issues/training-script-coverage-baseline.md](./issues/training-script-coverage-baseline.md)
+for the current baseline and
+[issues/training-script-coverage-roadmap.md](./issues/training-script-coverage-roadmap.md)
+for the expansion plan.

--- a/training/examples/rl/deepmath/train_deepmath.py
+++ b/training/examples/rl/deepmath/train_deepmath.py
@@ -73,6 +73,10 @@ class TrainArgs:
     temperature: float = 1.0
     max_completion_tokens: int = 30 * 1024
     prompt_groups_per_step: int = 32
+    lora_rank: int = 0
+    """LoRA rank (0 = full-param).  When > 0, auto_select_training_shape
+    picks a LoRA training shape and the reference model reuses the policy
+    trainer (no extra GPUs)."""
     router_replay: bool = False
     trajectory_dir: str | None = None
     """Directory to save per-step trajectory JSONL files."""
@@ -118,6 +122,8 @@ def parse_args() -> TrainArgs:
     parser.add_argument("--max-completion-tokens", type=int)
 
     parser.add_argument("--prompt-groups-per-step", type=int)
+    parser.add_argument("--lora-rank", type=int,
+                        help="LoRA rank (0 = full-param, e.g. 64 or 128 for LoRA)")
 
     parser.add_argument("--trajectory-dir",
                         help="Directory to save per-step trajectory JSONL files")
@@ -291,6 +297,7 @@ def main():
         temperature=args.temperature,
         epochs=args.epochs,
         max_rows=args.max_rows,
+        lora_rank=args.lora_rank,
         prompt_groups_per_step=args.prompt_groups_per_step,
         trajectory_dir=args.trajectory_dir,
         tis=TISConfig(cap=2.0),

--- a/training/pyproject.toml
+++ b/training/pyproject.toml
@@ -7,7 +7,7 @@ name = "fireworks-training-cookbook"
 version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [
-    "fireworks-ai[training]>=1.0.0a62,<2",
+    "fireworks-ai[training]>=1.0.0a62,<2",  # >=a60 for create_base_training_client
     "tqdm",
     "torch",
     "datasets",

--- a/training/recipes/rl_loop.py
+++ b/training/recipes/rl_loop.py
@@ -91,6 +91,7 @@ from training.utils.rl.router_replay import build_r3_routing_matrices
 
 logger = logging.getLogger(__name__)
 
+
 # ---------------------------------------------------------------------------
 # Config
 # ---------------------------------------------------------------------------
@@ -358,24 +359,23 @@ def main(
             "(InfraConfig.training_shape_id) to auto-populate it."
         )
 
-    # -- Resolve reference training shape --------------------------------------
-    reference_needed = cfg.kl_beta > 0 or cfg.infra.ref_training_shape_id is not None
+    # -- Resolve reference training shape ------------------------------------------
+    # ref_profile is non-None only when a *separate* reference trainer is needed.
+    # LoRA + kl_beta > 0 without an explicit ref shape: the policy trainer
+    # serves reference logprobs via a base-only handle (no extra GPU job).
     ref_profile = None
-    if reference_needed:
-        if not cfg.infra.ref_training_shape_id:
-            cfg.infra.ref_training_shape_id = auto_select_training_shape(
-                rlor_mgr,
-                base_model=cfg.base_model,
-                trainer_role="reference",
-                lora_rank=cfg.lora_rank,
-                max_seq_len=cfg.max_seq_len,
-            )
-            logger.info("Auto-selected reference training shape: %s", cfg.infra.ref_training_shape_id)
+    if cfg.infra.ref_training_shape_id:
         ref_profile = rlor_mgr.resolve_training_profile(cfg.infra.ref_training_shape_id)
-
-    use_reference = ref_profile is not None
-    if not use_reference:
-        logger.info("No ref_training_shape_id set, skipping reference model")
+    elif cfg.kl_beta > 0 and cfg.lora_rank == 0:
+        cfg.infra.ref_training_shape_id = auto_select_training_shape(
+            rlor_mgr,
+            base_model=cfg.base_model,
+            trainer_role="reference",
+            lora_rank=cfg.lora_rank,
+            max_seq_len=cfg.max_seq_len,
+        )
+        logger.info("Auto-selected reference training shape: %s", cfg.infra.ref_training_shape_id)
+        ref_profile = rlor_mgr.resolve_training_profile(cfg.infra.ref_training_shape_id)
 
     import time as _time
 
@@ -388,49 +388,40 @@ def main(
     _infra_start = _time.time()
 
     with runner, ResourceCleanup(rlor_mgr, deploy_mgr) as cleanup, ExitStack() as stack:
-        # -- Create trainer jobs first (trainer owns the hot-load bucket) ------
+        # -- Provision trainer jobs ------------------------------------------------
         logger.info(
             "Training: prompt_groups_per_step=%d | completions_per_prompt=%d",
             prompt_groups_per_step,
             completions_per_prompt,
         )
 
-        if use_reference:
+        _cleanup = cleanup if cleanup_on_exit else None
+
+        def _make_trainer(role: str, profile, *, forward_only: bool = False):
+            is_ref = role == "reference"
+            return create_trainer_job(
+                rlor_mgr,
+                base_model=cfg.base_model,
+                infra=cfg.infra,
+                profile=profile,
+                lora_rank=cfg.lora_rank,
+                max_seq_len=cfg.max_seq_len,
+                learning_rate=cfg.learning_rate,
+                display_name=f"grpo-{role}",
+                forward_only=forward_only,
+                job_id=cfg.reference_job_id if is_ref else cfg.policy_job_id,
+                base_url_override=cfg.reference_base_url if is_ref else cfg.policy_base_url,
+                cleanup=_cleanup,
+                on_status=_on_trainer_status,
+            )
+
+        if ref_profile is not None:
             _on_trainer_status("provisioning policy and reference trainers")
             with ThreadPoolExecutor(max_workers=2) as pool:
-                pol_fut = pool.submit(
-                    create_trainer_job,
-                    rlor_mgr,
-                    base_model=cfg.base_model,
-                    infra=cfg.infra,
-                    profile=policy_profile,
-                    lora_rank=cfg.lora_rank,
-                    max_seq_len=cfg.max_seq_len,
-                    learning_rate=cfg.learning_rate,
-                    display_name="grpo-policy",
-                    job_id=cfg.policy_job_id,
-                    base_url_override=cfg.policy_base_url,
-                    cleanup=cleanup if cleanup_on_exit else None,
-                    on_status=_on_trainer_status,
-                )
+                pol_fut = pool.submit(_make_trainer, "policy", policy_profile)
                 ref_fut = pool.submit(
-                    create_trainer_job,
-                    rlor_mgr,
-                    base_model=cfg.base_model,
-                    infra=cfg.infra,
-                    profile=ref_profile,
-                    lora_rank=cfg.lora_rank,
-                    max_seq_len=cfg.max_seq_len,
-                    learning_rate=cfg.learning_rate,
-                    display_name="grpo-reference",
-                    forward_only=True,
-                    job_id=cfg.reference_job_id,
-                    base_url_override=cfg.reference_base_url,
-                    cleanup=cleanup if cleanup_on_exit else None,
-                    on_status=_on_trainer_status,
+                    _make_trainer, "reference", ref_profile, forward_only=True,
                 )
-                # Collect both results so that if both fail we report
-                # both errors instead of swallowing the second one.
                 errors: list[str] = []
                 policy_ep = reference_ep = None
                 try:
@@ -445,26 +436,13 @@ def main(
                     raise RuntimeError(
                         "Trainer creation failed:\n" + "\n".join(errors)
                     )
-                policy_job_id = policy_ep.job_id
-                reference_job_id = reference_ep.job_id
         else:
-            policy_ep = create_trainer_job(
-                rlor_mgr,
-                base_model=cfg.base_model,
-                infra=cfg.infra,
-                profile=policy_profile,
-                lora_rank=cfg.lora_rank,
-                max_seq_len=cfg.max_seq_len,
-                learning_rate=cfg.learning_rate,
-                display_name="grpo-policy",
-                job_id=cfg.policy_job_id,
-                base_url_override=cfg.policy_base_url,
-                cleanup=cleanup if cleanup_on_exit else None,
-                on_status=_on_trainer_status,
-            )
-            policy_job_id = policy_ep.job_id
+            _on_trainer_status("provisioning policy trainer")
+            policy_ep = _make_trainer("policy", policy_profile)
             reference_ep = None
-            reference_job_id = None
+
+        policy_job_id = policy_ep.job_id
+        reference_job_id = reference_ep.job_id if reference_ep else policy_ep.job_id
 
         # -- Connect deployment to the trainer's hot-load bucket ----------------
         dep_info = setup_or_reattach_deployment(
@@ -474,32 +452,28 @@ def main(
             cleanup.deployment(cfg.deployment.deployment_id, action="scale_to_zero")
 
         _timeout = cfg.step_timeout or DEFAULT_TIMEOUT_S
-        policy = ReconnectableClient(
-            rlor_mgr,
-            policy_ep.job_id,
-            cfg.base_model,
-            cfg.lora_rank,
-            fw_api_key=api_key,
-            default_timeout=_timeout,
-            endpoint=policy_ep if cfg.policy_base_url else None,
-        )
-        if hasattr(policy, "close"):
-            stack.callback(policy.close)
-        reference = (
-            ReconnectableClient(
-                rlor_mgr,
-                reference_ep.job_id,
-                cfg.base_model,
-                cfg.lora_rank,
+
+        def _make_client(ep, *, base_only=False):
+            c = ReconnectableClient(
+                rlor_mgr, ep.job_id, cfg.base_model,
+                lora_rank=0 if base_only else cfg.lora_rank,
                 fw_api_key=api_key,
                 default_timeout=_timeout,
-                endpoint=reference_ep if cfg.reference_base_url else None,
+                endpoint=ep if (cfg.policy_base_url or cfg.reference_base_url) else None,
+                base_only=base_only,
             )
-            if reference_ep
-            else None
-        )
-        if reference is not None and hasattr(reference, "close"):
-            stack.callback(reference.close)
+            if hasattr(c, "close"):
+                stack.callback(c.close)
+            return c
+
+        policy = _make_client(policy_ep)
+
+        if reference_ep is not None:
+            reference = _make_client(reference_ep)
+        elif cfg.lora_rank > 0 and cfg.kl_beta > 0:
+            reference = policy.create_base_reference()
+        else:
+            reference = None
 
         import transformers
 
@@ -667,7 +641,7 @@ def main(
                 )
                 policy_data.append(policy_datum)
 
-                if use_reference:
+                if reference is not None:
                     reference_datum = tinker.Datum(
                         model_input=tinker.ModelInput.from_ints(tokens[:-1]),
                         loss_fn_inputs={
@@ -715,7 +689,7 @@ def main(
 
         def ref_forward(groups: list[PromptGroup]) -> None:
             """Compute reference logprobs for all prompt groups (one call)."""
-            if not use_reference:
+            if reference is None:
                 return
             all_ref_data = [d for pg in groups for d in pg.ref_data]
             try:

--- a/training/tests/unit/test_rl_loop.py
+++ b/training/tests/unit/test_rl_loop.py
@@ -208,6 +208,115 @@ def test_main_bootstraps_without_reference_and_cleans_up(monkeypatch):
     assert events["wandb_finished"] == 0
 
 
+def test_lora_shared_reference_creates_single_trainer(monkeypatch):
+    """LoRA + kl_beta > 0 + no ref shape → one trainer, base-only reference handle."""
+    monkeypatch.setenv("FIREWORKS_API_KEY", "test-key")
+    monkeypatch.setenv("FIREWORKS_BASE_URL", "https://unit.test")
+
+    events: dict[str, object] = {
+        "trainer_calls": [],
+        "deleted_jobs": [],
+        "scaled_deployments": [],
+        "base_ref_created": False,
+    }
+
+    class FakeRlorMgr:
+        def resolve_training_profile(self, shape_id):
+            return SimpleNamespace(
+                deployment_shape_version="accounts/test/deploymentShapes/dep/versions/1",
+                pipeline_parallelism=1,
+                max_supported_context_length=128,
+                training_shape_version="accounts/test/trainingShapes/ts/versions/1",
+                accelerator_type="NVIDIA_B200",
+                accelerator_count=8,
+            )
+
+        def cancel(self, job_id):
+            events["deleted_jobs"].append(job_id)
+
+        def delete(self, job_id):
+            self.cancel(job_id)
+
+    class FakeDeployMgr:
+        inference_url = "https://inference.unit.test"
+        boot_time_s = 1.0
+
+        def scale_to_zero(self, deployment_id):
+            events["scaled_deployments"].append(deployment_id)
+
+    class FakeBaseRef:
+        job_id = "policy-job"
+        inner = object()
+
+        def forward(self, data, loss_fn):
+            return SimpleNamespace(loss_fn_outputs=[])
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            self.job_id = "policy-job"
+            self.inner = object()
+
+        def create_base_reference(self):
+            events["base_ref_created"] = True
+            return FakeBaseRef()
+
+        def save_state(self, name, timeout=None):
+            return SimpleNamespace(path=name)
+
+        def save_weights_for_sampler_ext(self, name, checkpoint_type="base"):
+            return SimpleNamespace(path=name, snapshot_name=name)
+
+        def load_state_with_optimizer(self, path):
+            pass
+
+        def resolve_checkpoint_path(self, name, source_job_id=None):
+            return name
+
+    def fake_create_trainer_job(*args, **kwargs):
+        events["trainer_calls"].append(kwargs.get("display_name"))
+        return SimpleNamespace(
+            job_id="policy-job", job_name="jobs/policy-job", base_url="https://unit.test",
+        )
+
+    async def fake_run_rl_loop(**kwargs):
+        events["run_loop_kwargs"] = kwargs
+        return 0
+
+    monkeypatch.setattr(module, "setup_wandb", lambda *a, **kw: None)
+    monkeypatch.setattr(module, "wandb_finish", lambda: None)
+    monkeypatch.setattr(module, "wandb_log", lambda *a, **kw: None)
+    monkeypatch.setattr(module, "setup_or_reattach_deployment", lambda *a, **kw: SimpleNamespace(inference_model="m"))
+    monkeypatch.setattr(module, "create_trainer_job", fake_create_trainer_job)
+    monkeypatch.setattr(module, "ReconnectableClient", FakeClient)
+    monkeypatch.setattr(transformers.AutoTokenizer, "from_pretrained", lambda *a, **kw: object())
+    monkeypatch.setattr(module, "DeploymentSampler", lambda **kw: None)
+    monkeypatch.setattr(module, "WeightSyncer", lambda **kw: None)
+    monkeypatch.setattr(module, "load_jsonl_dataset", lambda *a, **kw: [])
+    monkeypatch.setattr(module, "build_loss_fn", lambda **kw: ("builder", kw))
+    monkeypatch.setattr(module, "run_rl_loop", fake_run_rl_loop)
+
+    cfg = module.Config(
+        log_path="/tmp/lora_shared_ref_test",
+        base_model="accounts/test/models/qwen3-4b",
+        dataset="/tmp/prompts.jsonl",
+        kl_beta=0.1,
+        lora_rank=64,
+        deployment=module.DeployConfig(deployment_id="dep-1", tokenizer_model="Qwen/Qwen3-4B"),
+        infra=module.InfraConfig(training_shape_id="ts-lora"),
+    )
+
+    result = module.main(
+        cfg, rlor_mgr=FakeRlorMgr(), deploy_mgr=FakeDeployMgr(), cleanup_on_exit=True,
+    )
+
+    assert events["trainer_calls"] == ["grpo-policy"], (
+        "LoRA shared ref should provision exactly one trainer (policy only)"
+    )
+    assert events["base_ref_created"] is True, (
+        "create_base_reference() must be called for shared LoRA reference"
+    )
+
+
 def test_main_raises_when_builtin_loss_with_pp(monkeypatch):
     """Builtin policy_loss + PP>1 should raise immediately."""
     monkeypatch.setenv("FIREWORKS_API_KEY", "test-key")

--- a/training/utils/client.py
+++ b/training/utils/client.py
@@ -55,6 +55,13 @@ class ReconnectableClient:
     Each API call dispatches a single request to the trainer and blocks
     until the result is ready (or the timeout expires).  No retry, no
     reconnect -- failures propagate to the caller.
+
+    For LoRA GRPO with KL regularisation, a single LoRA trainer can serve
+    both policy and reference logprobs.  Use :meth:`create_base_reference`
+    to obtain a second ``ReconnectableClient`` that shares the same trainer
+    job but creates a ``base-<hex>`` model handle (adapters disabled).
+    This avoids provisioning a second trainer purely for reference forward
+    passes.
     """
 
     def __init__(
@@ -66,11 +73,14 @@ class ReconnectableClient:
         fw_api_key: str | None = None,
         default_timeout: int = DEFAULT_TIMEOUT_S,
         endpoint: TrainerServiceEndpoint | None = None,
+        *,
+        base_only: bool = False,
     ):
         self._rlor_mgr = rlor_mgr
         self._job_id = job_id
         self._base_model = base_model
         self._lora_rank = lora_rank
+        self._base_only = base_only
         self._fw_api_key = fw_api_key or os.environ.get("FIREWORKS_API_KEY")
         self._default_timeout = default_timeout
         self._endpoint: TrainerServiceEndpoint | None = None
@@ -80,6 +90,26 @@ class ReconnectableClient:
             self._use_endpoint(endpoint)
         else:
             self._connect()
+
+    def create_base_reference(self) -> ReconnectableClient:
+        """Create a reference client sharing this trainer's job.
+
+        Returns a new ``ReconnectableClient`` backed by a ``base-<hex>``
+        model handle on the same trainer.  Forward passes through the
+        returned client run with all LoRA adapters disabled, giving
+        base-model logprobs without a second GPU allocation.
+        """
+        assert self._endpoint is not None, "policy client must be connected first"
+        return ReconnectableClient(
+            rlor_mgr=self._rlor_mgr,
+            job_id=self._job_id,
+            base_model=self._base_model,
+            lora_rank=0,
+            fw_api_key=self._fw_api_key,
+            default_timeout=self._default_timeout,
+            endpoint=self._endpoint,
+            base_only=True,
+        )
 
     @property
     def inner(self) -> FiretitanTrainingClient:
@@ -218,10 +248,15 @@ class ReconnectableClient:
             base_url=ep.base_url,
             api_key=self._fw_api_key,
         )
-        self._client = svc.create_training_client(
-            base_model=self._base_model,
-            lora_rank=self._lora_rank,
-        )
+        if self._base_only:
+            self._client = svc.create_base_training_client(
+                base_model=self._base_model,
+            )
+        else:
+            self._client = svc.create_training_client(
+                base_model=self._base_model,
+                lora_rank=self._lora_rank,
+            )
         self._endpoint = ep
 
     def _connect(self) -> None:


### PR DESCRIPTION
## Summary

When running LoRA GRPO with KL regularisation (`kl_beta > 0`), reference logprobs can come from the **same trainer** via a base-only model handle (adapters disabled). This eliminates provisioning a second forward-only trainer job, halving GPU cost for LoRA RL.

### What changed

**`training/recipes/rl_loop.py`**
- Reference resolution uses direct config checks (`cfg.kl_beta`, `cfg.lora_rank`, `cfg.infra.ref_training_shape_id`) — no intermediate enums or booleans
- `_make_client()` helper deduplicates trainer client creation (incorporates `cfg.step_timeout`)
- LoRA + `kl_beta > 0` without explicit ref shape: calls `policy.create_base_reference()` — no second job
- Explicit `ref_training_shape_id` or full-param KL: provisions a separate forward-only trainer
- `kl_beta=0`: no reference at all

**`training/utils/client.py`**
- `ReconnectableClient.create_base_reference()` returns a new client sharing the same trainer with a `base-<hex>` model handle
- Uses SDK's `FiretitanServiceClient.create_base_training_client()` (`fireworks-ai>=1.0.0a60`) — no raw HTTP workaround
- Added `base_only` parameter to `ReconnectableClient`

**`training/examples/rl/deepmath/train_deepmath.py`**
- Added `--lora-rank` CLI argument so customers can run LoRA GRPO directly

**`training/tests/unit/test_rl_loop.py`**
- Added `test_lora_shared_reference_creates_single_trainer` — validates only one trainer job is provisioned and `create_base_reference()` is called for LoRA + KL

### Customer usage

```bash
python -m examples.rl.deepmath.train_deepmath \
    --base-model accounts/fireworks/models/qwen3p5-32b \
    --lora-rank 64 \
    --dataset my_math_prompts.jsonl
```

The cookbook auto-selects the policy training shape. When `lora_rank > 0` and no explicit `ref_training_shape_id` is set, reference logprobs come from the policy trainer via a base-only handle.

### Before / After

| | Before | After |
|---|---|---|
| LoRA GRPO trainers | 2 (policy + reference) | 1 (policy only) |
| GPU cost | 2× | 1× |
| Control flow | scattered booleans | direct config checks in if/elif/else |

## Test plan

- [ ] LoRA + `kl_beta > 0`, no `ref_training_shape_id` → single trainer, `create_base_reference()` called
- [ ] Full-param + `kl_beta > 0` → separate reference trainer provisioned
- [ ] Explicit `ref_training_shape_id` → separate reference trainer provisioned
- [ ] `kl_beta=0` → no reference client created
- [ ] `--lora-rank` flag works in `train_deepmath.py`
- [ ] Unit test passes: `test_lora_shared_reference_creates_single_trainer`