### PR TITLE
Retry transient 404 (NotFoundError) in ReconnectableClient

### DIFF
--- a/training/tests/unit/test_client.py
+++ b/training/tests/unit/test_client.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+from unittest.mock import MagicMock
+
 from fireworks.training.sdk.client import GradAccNormalization
 import pytest
+import tinker
 
-from training.utils.client import ReconnectableClient
+from training.utils.client import ReconnectableClient, _retry_on_not_found
 
 
 class _FakeFuture:
@@ -140,3 +143,92 @@ def test_close_drains_telemetry_and_stops_holder_cleanup():
     assert inner.holder._telemetry.flushed == 1
     assert inner.holder._telemetry.drained == 1
     assert inner.holder._telemetry.stopped == 1
+
+
+# ---------------------------------------------------------------------------
+# _retry_on_not_found tests
+# ---------------------------------------------------------------------------
+
+
+def _make_not_found_error(message: str = "Trainer job not found or not running"):
+    """Create a ``tinker.NotFoundError`` with minimal mocking."""
+    mock_response = MagicMock()
+    mock_response.status_code = 404
+    mock_response.json.return_value = {
+        "error": {"message": message, "param": "jobId", "code": "NOT_FOUND"}
+    }
+    mock_response.headers = {}
+    return tinker.NotFoundError(
+        message=message,
+        response=mock_response,
+        body={"error": {"message": message}},
+    )
+
+
+def test_retry_on_not_found_succeeds_immediately():
+    fn = MagicMock(return_value="ok")
+    result = _retry_on_not_found(fn, timeout=60)
+    assert result == "ok"
+    assert fn.call_count == 1
+
+
+def test_retry_on_not_found_retries_then_succeeds(monkeypatch):
+    monkeypatch.setattr("training.utils.client.time.sleep", lambda _: None)
+    call_count = 0
+
+    def fn():
+        nonlocal call_count
+        call_count += 1
+        if call_count < 3:
+            raise _make_not_found_error()
+        return "recovered"
+
+    result = _retry_on_not_found(fn, timeout=60)
+    assert result == "recovered"
+    assert call_count == 3
+
+
+def test_retry_on_not_found_exhausts_retries(monkeypatch):
+    monkeypatch.setattr("training.utils.client.time.sleep", lambda _: None)
+    monkeypatch.setattr("training.utils.client._NOT_FOUND_MAX_RETRIES", 2)
+
+    fn = MagicMock(side_effect=_make_not_found_error())
+    with pytest.raises(tinker.NotFoundError):
+        _retry_on_not_found(fn, timeout=60)
+    assert fn.call_count == 3  # initial + 2 retries
+
+
+def test_retry_on_not_found_propagates_other_errors():
+    fn = MagicMock(side_effect=ValueError("some other error"))
+    with pytest.raises(ValueError, match="some other error"):
+        _retry_on_not_found(fn, timeout=60)
+    assert fn.call_count == 1
+
+
+def test_forward_backward_retries_not_found(monkeypatch):
+    """ReconnectableClient.forward_backward retries transient 404s."""
+    monkeypatch.setattr("training.utils.client.time.sleep", lambda _: None)
+    call_count = 0
+
+    class _RetryFuture:
+        def result(self, timeout=None):
+            nonlocal call_count
+            call_count += 1
+            if call_count < 2:
+                raise _make_not_found_error()
+            return {"ok": True}
+
+    class _RetryInnerClient:
+        def __init__(self):
+            self.holder = None
+
+        def forward_backward(self, data, loss_fn, loss_fn_config=None):
+            return _RetryFuture()
+
+    inner = _RetryInnerClient()
+    client = _make_client(inner)
+    client._client = inner
+
+    result = client.forward_backward(["datum"], "cross_entropy")
+    assert result == {"ok": True}
+    assert call_count == 2

--- a/training/utils/client.py
+++ b/training/utils/client.py
@@ -4,17 +4,22 @@ Provides a clean API surface over the tinker training client.  Each method
 dispatches one request and blocks until the result is ready, with a
 configurable timeout to prevent indefinite hangs.
 
-No explicit retry or reconnect logic -- tinker's internal polling already
-retries transient HTTP errors (408, 5xx).  If the call fails (410, timeout,
-connection error), the exception propagates so the training loop can crash
-cleanly and resume from the last DCP checkpoint.
+Tinker's internal polling already retries transient HTTP errors (408, 5xx).
+However, 404 ("Trainer job not found or not running") can occur transiently
+when the gateway routing hasn't stabilized for a freshly-RUNNING trainer.
+This module adds retry logic for NotFoundError (404) around the dispatch +
+wait cycle so the orchestrator doesn't crash on these transient routing
+hiccups.
 """
 
 from __future__ import annotations
 
 import logging
 import os
+import time
+from typing import Callable, TypeVar
 
+import tinker
 from fireworks.training.sdk.client import (
     FiretitanServiceClient,
     FiretitanTrainingClient,
@@ -26,11 +31,61 @@ from tinker.types.future_retrieve_request import FutureRetrieveRequest as _Futur
 
 logger = logging.getLogger(__name__)
 
+_T = TypeVar("_T")
+
 DEFAULT_TIMEOUT_S: int = 3600
 """Default timeout for forward / forward_backward / optim_step (60 min)."""
 
 DCP_TIMEOUT_S: int = 2700
 """Default timeout for save_state / load_state_with_optimizer (45 min)."""
+
+_NOT_FOUND_MAX_RETRIES: int = 6
+"""Max number of retries when a NotFoundError (404) is raised during result
+retrieval.  Covers transient Tinker API gateway routing gaps that appear
+right after a trainer transitions to JOB_STATE_RUNNING."""
+
+_NOT_FOUND_BASE_DELAY_S: float = 2.0
+"""Base delay (seconds) for exponential back-off on NotFoundError retries."""
+
+_NOT_FOUND_MAX_DELAY_S: float = 30.0
+"""Cap on the back-off delay between NotFoundError retries."""
+
+
+def _retry_on_not_found(fn: Callable[[], _T], *, timeout: int) -> _T:
+    """Execute *fn* and retry on ``tinker.NotFoundError`` with back-off.
+
+    The 404 "Trainer job not found or not running" error can surface
+    transiently when the Tinker gateway hasn't fully registered a
+    freshly-RUNNING trainer.  Rather than crashing immediately (which
+    kills the orchestrator pod and wastes an expensive training step
+    already in flight), this helper retries the full dispatch-then-wait
+    cycle up to ``_NOT_FOUND_MAX_RETRIES`` times with capped exponential
+    back-off.
+
+    Non-404 errors propagate immediately.
+    """
+    last_exc: tinker.NotFoundError | None = None
+    for attempt in range(_NOT_FOUND_MAX_RETRIES + 1):
+        try:
+            return fn()
+        except tinker.NotFoundError as exc:
+            last_exc = exc
+            if attempt >= _NOT_FOUND_MAX_RETRIES:
+                break
+            delay = min(
+                _NOT_FOUND_BASE_DELAY_S * (2 ** attempt),
+                _NOT_FOUND_MAX_DELAY_S,
+            )
+            logger.warning(
+                "Transient 404 on result retrieval (attempt %d/%d), "
+                "retrying in %.1fs: %s",
+                attempt + 1,
+                _NOT_FOUND_MAX_RETRIES,
+                delay,
+                exc,
+            )
+            time.sleep(delay)
+    raise last_exc  # type: ignore[misc]
 
 
 def _install_tinker_future_retrieve_compat() -> None:
@@ -53,8 +108,9 @@ class ReconnectableClient:
     """Training client wrapper: dispatch + wait with timeout.
 
     Each API call dispatches a single request to the trainer and blocks
-    until the result is ready (or the timeout expires).  No retry, no
-    reconnect -- failures propagate to the caller.
+    until the result is ready (or the timeout expires).  Transient 404
+    errors from the Tinker gateway are retried with exponential back-off;
+    all other failures propagate to the caller.
 
     For LoRA GRPO with KL regularisation, a single LoRA trainer can serve
     both policy and reference logprobs.  Use :meth:`create_base_reference`
@@ -126,17 +182,26 @@ class ReconnectableClient:
         return self._job_id
 
     def forward(self, data, loss_fn):
-        return self._client.forward(data, loss_fn).result(
+        return _retry_on_not_found(
+            lambda: self._client.forward(data, loss_fn).result(
+                timeout=self._default_timeout,
+            ),
             timeout=self._default_timeout,
         )
 
     def forward_backward(self, data, loss_fn: str = "cross_entropy", loss_fn_config=None):
-        return self._client.forward_backward(data, loss_fn, loss_fn_config=loss_fn_config).result(
+        return _retry_on_not_found(
+            lambda: self._client.forward_backward(
+                data, loss_fn, loss_fn_config=loss_fn_config,
+            ).result(timeout=self._default_timeout),
             timeout=self._default_timeout,
         )
 
     def forward_backward_custom(self, data, loss_fn):
-        return self._client.forward_backward_custom(data, loss_fn).result(
+        return _retry_on_not_found(
+            lambda: self._client.forward_backward_custom(data, loss_fn).result(
+                timeout=self._default_timeout,
+            ),
             timeout=self._default_timeout,
         )
 
@@ -150,7 +215,10 @@ class ReconnectableClient:
             kwargs["grad_accumulation_normalization"] = _normalize_grad_accumulation_normalization(
                 grad_accumulation_normalization
             )
-        return self._client.optim_step(params, **kwargs).result(
+        return _retry_on_not_found(
+            lambda: self._client.optim_step(params, **kwargs).result(
+                timeout=self._default_timeout,
+            ),
             timeout=self._default_timeout,
         )
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Training job `rft--pyroworks-qmrnnbz9-7b5d129d6` crashed when the orchestrator received a 404 "Trainer job not found or not running" error while polling for `forward_backward` results, only 11 seconds after sending requests to a trainer that had been in `JOB_STATE_RUNNING` for ~18 seconds.

The trainer was fully operational and successfully completed the training batch 3 minutes later — but by then the orchestrator had already crashed.

**Root cause**: Tinker's internal polling (`_result_async` in `api_future_impl`) retries 408 and 5xx errors but does **not** retry 404. When the Tinker API gateway routing hasn't fully stabilized for a freshly-RUNNING trainer, the 404 propagates as a `tinker.NotFoundError` and crashes the orchestrator.

## Fix

Added `_retry_on_not_found()` in `training/utils/client.py` that wraps the dispatch+wait cycle with capped exponential back-off on `tinker.NotFoundError`:

- **Up to 6 retries** (configurable via `_NOT_FOUND_MAX_RETRIES`)
- **Exponential back-off**: 2s, 4s, 8s, 16s, 30s, 30s (capped at `_NOT_FOUND_MAX_DELAY_S`)
- **Total worst-case delay**: ~90 seconds before giving up
- **Non-404 errors propagate immediately** — no change to behavior for other error types

Applied to all training operations in `ReconnectableClient`:
- `forward()`
- `forward_backward()`
- `forward_backward_custom()`
- `optim_step()`

Checkpoint operations (`save_state`, `load_state`, etc.) are left without retry since they don't go through the same gateway routing path.

## Tests

Added 5 new unit tests in `training/tests/unit/test_client.py`:
- `test_retry_on_not_found_succeeds_immediately` — no retry when first call succeeds
- `test_retry_on_not_found_retries_then_succeeds` — retries transient 404s then recovers
- `test_retry_on_not_found_exhausts_retries` — raises after max retries exhausted
- `test_retry_on_not_found_propagates_other_errors` — non-404 errors propagate immediately
- `test_forward_backward_retries_not_found` — end-to-end test through `ReconnectableClient.forward_backward`

All 9 tests pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://fireworks-ai.slack.com/archives/C08FFA581C1/p1776383192270479?thread_ts=1776383192.270479&cid=C08FFA581C1)

<div><a href="https://cursor.com/agents/bc-e44a2dfd-c6f7-5777-b152-fbbf01921df9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e44a2dfd-c6f7-5777-b152-fbbf01921df9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

