### PR TITLE
infra: map NVIDIA_B300 deployments to NA_BRITISHCOLUMBIA_1

### DIFF
--- a/training/utils/infra.py
+++ b/training/utils/infra.py
@@ -32,6 +32,7 @@ logger = logging.getLogger(__name__)
 _DEPLOYMENT_ACCELERATOR_REGION_PREFIXES: tuple[tuple[str, str], ...] = (
     ("NVIDIA_H200", "US_VIRGINIA_1"),
     ("NVIDIA_B200", "US_OHIO_1"),
+    ("NVIDIA_B300", "NA_BRITISHCOLUMBIA_1"),
 )
 
 _TRAINER_CANCEL_GRACE_ENV = "FW_TRAINER_CANCEL_GRACE_PERIOD_S"


### PR DESCRIPTION
## Description

`_infer_region_from_deployment_shape()` in `training/utils/infra.py` maps accelerator type to a deployment region so the Fireworks control plane places pods in a region that actually has the hardware. The table covered `NVIDIA_H200 -> US_VIRGINIA_1` and `NVIDIA_B200 -> US_OHIO_1`, but was **missing `NVIDIA_B300`**.

For B300 shapes the lookup fell through to "auto placement" (`Placement.Multi Region = GLOBAL`, `Region = REGION_UNSPECIFIED`). The control plane's global router was resolving that to `AP_MALAYSIA_1` — a region without available B300 capacity — so deployments got stuck in `CREATING` (`Pending Scheduling Replica Count = 1`) for hours and ultimately timed out.

Affected callers include the `train-firetitan-py` E2E suite (RL phase in `test_shape_e2e.py`) and any cookbook consumer that creates a deployment from a B300 shape without an explicit region.

This PR adds one entry to the existing table, mirroring the H200/B200 convention.

## Architecture / Code Overview Diagram

```mermaid
flowchart LR
    A[DeployConfig<br/>no explicit region] --> B["_infer_region_from_deployment_shape()"]
    B -->|H200| C[US_VIRGINIA_1]
    B -->|B200| D[US_OHIO_1]
    B -->|B300 NEW| E[NA_BRITISHCOLUMBIA_1]
    B -->|unknown| F[GLOBAL auto<br/>→ AP_MALAYSIA_1<br/>❌ no B300]
    C --> G[Deployment created in<br/>correct region]
    D --> G
    E --> G
    F --> H[Stuck in CREATING]
```

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Infrastructure/DevOps

## Testing

- Reproduced the original bug end-to-end against `qwen3p5-397b-a17b-256k-lora-b300` in the `pyroworks` account: deployment stuck in CREATING (`Region: AP_MALAYSIA_1`, `Pending Scheduling Replica Count: 1`) until this change.
- With the fix, new B300 deployments land in `NA_BRITISHCOLUMBIA_1` and successfully reach `READY` (verified via `firectl get deployment` and k8s pod scheduling on the BC cluster).
- Existing `test_to_deployment_config_*` unit tests under `training/tests/unit/` remain green (no behavior change for H200/B200 paths).

- [ ] Added/updated tests
- [x] Tested manually
- [ ] No testing needed

## Surface Consistency

- No customer-facing API / SDK / CLI surface change. Purely internal routing heuristic used by cookbook recipes and the E2E test pipeline.

- [x] No customer-facing surface impact
- [ ] Related surfaces checked — all consistent or follow-up filed
- [ ] Inline "keep in sync" comments followed

## Deployment Notes

After this cookbook PR merges, a follow-up submodule-pointer bump in `fw-ai/fireworks` is needed for the `training_single_shape_ci.yml` workflow on `main` (and other main-branch callers) to pick up the new cookbook commit.

- [ ] Requires database migration
- [ ] Requires config/env changes
- [ ] Requires Terraform/K8s changes
- [x] Requires follow-up: bump cookbook submodule pointer in `fw-ai/fireworks`

## Change Size

- [x] Small (< 200 LOC)  — 1 line added
- [ ] Medium (200–999 LOC)
- [ ] Large (≥ 1,000 LOC)

## Checklist

- [x] Self-reviewed my code
- [x] Change is the **minimum necessary** diff (one entry in a constant tuple)
- [ ] Added tests for my changes  — behavior is covered by the existing accelerator-prefix lookup tests; no new branches to exercise
- [x] No new linter warnings/errors
- [x] No secrets or credentials in the diff

## Additional Context

Observed symptom before the fix:
```
firectl -a pyroworks get deployment qwen3p5-397b-a17b-<id>
State: CREATING
Placement:
  Region: REGION_UNSPECIFIED
  Multi Region: GLOBAL
Region: AP_MALAYSIA_1
Replica Stats:
  Pending Scheduling Replica Count: 1
```

After the fix:
```
State: READY
Placement:
  Region: NA_BRITISHCOLUMBIA_1
  Multi Region: MULTI_REGION_UNSPECIFIED
Region: NA_BRITISHCOLUMBIA_1
```

Made with [Cursor](https://cursor.com)