### PR TITLE
fix(rl): share FiretitanServiceClient for LoRA shared-reference (fixes #343)

### DIFF
--- a/training/recipes/rl_loop.py
+++ b/training/recipes/rl_loop.py
@@ -360,21 +360,20 @@ def main(
         )
 
     # -- Resolve reference training shape ------------------------------------------
-    # When kl_beta > 0 we need reference logprobs from a frozen base model.
-    # Always provision a *separate* forward-only reference trainer with
-    # lora_rank=0 (full-param frozen base) — including for LoRA policy.
-    # Sharing the policy trainer for reference would require trainer
-    # multi-session mode (--max-lora-modules-gpu>=2), which is currently
-    # SUPERUSER_ONLY in the control plane API.
+    # ref_profile is non-None only when a *separate* reference trainer is needed.
+    # LoRA + kl_beta > 0 without an explicit ref shape: the policy trainer
+    # serves reference logprobs via a base-only model handle (no extra GPU job).
+    # See create_base_reference() in utils/client.py — both clients share one
+    # FiretitanServiceClient (one session) so they don't reset each other.
     ref_profile = None
     if cfg.infra.ref_training_shape_id:
         ref_profile = rlor_mgr.resolve_training_profile(cfg.infra.ref_training_shape_id)
-    elif cfg.kl_beta > 0:
+    elif cfg.kl_beta > 0 and cfg.lora_rank == 0:
         cfg.infra.ref_training_shape_id = auto_select_training_shape(
             rlor_mgr,
             base_model=cfg.base_model,
             trainer_role="reference",
-            lora_rank=0,
+            lora_rank=cfg.lora_rank,
             max_seq_len=cfg.max_seq_len,
         )
         logger.info("Auto-selected reference training shape: %s", cfg.infra.ref_training_shape_id)
@@ -407,7 +406,7 @@ def main(
                 base_model=cfg.base_model,
                 infra=cfg.infra,
                 profile=profile,
-                lora_rank=0 if is_ref else cfg.lora_rank,
+                lora_rank=cfg.lora_rank,
                 max_seq_len=cfg.max_seq_len,
                 learning_rate=cfg.learning_rate,
                 display_name=f"grpo-{role}",
@@ -456,10 +455,10 @@ def main(
 
         _timeout = cfg.step_timeout or DEFAULT_TIMEOUT_S
 
-        def _make_client(ep, *, lora_rank):
+        def _make_client(ep):
             c = ReconnectableClient(
                 rlor_mgr, ep.job_id, cfg.base_model,
-                lora_rank=lora_rank,
+                lora_rank=cfg.lora_rank,
                 fw_api_key=api_key,
                 default_timeout=_timeout,
                 endpoint=ep if (cfg.policy_base_url or cfg.reference_base_url) else None,
@@ -468,8 +467,18 @@ def main(
                 stack.callback(c.close)
             return c
 
-        policy = _make_client(policy_ep, lora_rank=cfg.lora_rank)
-        reference = _make_client(reference_ep, lora_rank=0) if reference_ep is not None else None
+        policy = _make_client(policy_ep)
+
+        if reference_ep is not None:
+            reference = _make_client(reference_ep)
+        elif cfg.lora_rank > 0 and cfg.kl_beta > 0:
+            # Share the policy trainer's session: base-only model handle, no
+            # second trainer, no second create_session (which would unload the
+            # policy LoRA).
+            reference = policy.create_base_reference()
+            stack.callback(reference.close)
+        else:
+            reference = None
 
         import transformers
 

--- a/training/tests/unit/test_client.py
+++ b/training/tests/unit/test_client.py
@@ -33,6 +33,8 @@ def _make_client(inner: _FakeInnerClient) -> ReconnectableClient:
     client._closed = False
     client._endpoint = None
     client._job_id = "job-test"
+    client._service = None
+    client._owns_service = True
     return client
 
 

--- a/training/tests/unit/test_rl_loop.py
+++ b/training/tests/unit/test_rl_loop.py
@@ -208,18 +208,22 @@ def test_main_bootstraps_without_reference_and_cleans_up(monkeypatch):
     assert events["wandb_finished"] == 0
 
 
-def test_lora_with_kl_provisions_separate_reference_trainer(monkeypatch):
-    """LoRA + kl_beta > 0 must provision a *separate* forward-only reference
-    trainer with lora_rank=0, not piggyback on the policy trainer.
+def test_lora_shared_reference_creates_single_trainer(monkeypatch):
+    """LoRA + kl_beta > 0 + no ref shape → one trainer; reference comes from a
+    base-only handle on the *same* FiretitanServiceClient (shared session).
 
-    Sharing the policy trainer for reference would require trainer multi-session
-    mode (--max-lora-modules-gpu>=2), which is currently SUPERUSER_ONLY in the
-    control plane API.
+    Creating a second service client (or re-creating the trainer session) would
+    unload the policy LoRA — the `base-` handle must share the policy session.
     """
     monkeypatch.setenv("FIREWORKS_API_KEY", "test-key")
     monkeypatch.setenv("FIREWORKS_BASE_URL", "https://unit.test")
 
-    events: dict[str, object] = {"trainer_calls": []}
+    events: dict[str, object] = {
+        "trainer_calls": [],
+        "deleted_jobs": [],
+        "scaled_deployments": [],
+        "base_ref_created": False,
+    }
 
     class FakeRlorMgr:
         def resolve_training_profile(self, shape_id):
@@ -233,22 +237,36 @@ def test_lora_with_kl_provisions_separate_reference_trainer(monkeypatch):
             )
 
         def cancel(self, job_id):
-            pass
+            events["deleted_jobs"].append(job_id)
 
         def delete(self, job_id):
-            pass
+            self.cancel(job_id)
 
     class FakeDeployMgr:
         inference_url = "https://inference.unit.test"
         boot_time_s = 1.0
 
         def scale_to_zero(self, deployment_id):
+            events["scaled_deployments"].append(deployment_id)
+
+    class FakeBaseRef:
+        job_id = "policy-job"
+        inner = object()
+
+        def forward(self, data, loss_fn):
+            return SimpleNamespace(loss_fn_outputs=[])
+
+        def close(self, timeout=5.0):
             pass
 
     class FakeClient:
         def __init__(self, *args, **kwargs):
-            self.job_id = kwargs.get("job_id", "job-x")
+            self.job_id = "policy-job"
             self.inner = object()
+
+        def create_base_reference(self):
+            events["base_ref_created"] = True
+            return FakeBaseRef()
 
         def save_state(self, name, timeout=None):
             return SimpleNamespace(path=name)
@@ -262,18 +280,17 @@ def test_lora_with_kl_provisions_separate_reference_trainer(monkeypatch):
         def resolve_checkpoint_path(self, name, source_job_id=None):
             return name
 
+        def close(self, timeout=5.0):
+            pass
+
     def fake_create_trainer_job(*args, **kwargs):
-        name = kwargs.get("display_name")
-        events["trainer_calls"].append({
-            "name": name,
-            "lora_rank": kwargs.get("lora_rank"),
-            "forward_only": kwargs.get("forward_only", False),
-        })
+        events["trainer_calls"].append(kwargs.get("display_name"))
         return SimpleNamespace(
-            job_id=f"{name}-job", job_name=f"jobs/{name}-job", base_url="https://unit.test",
+            job_id="policy-job", job_name="jobs/policy-job", base_url="https://unit.test",
         )
 
     async def fake_run_rl_loop(**kwargs):
+        events["run_loop_kwargs"] = kwargs
         return 0
 
     monkeypatch.setattr(module, "setup_wandb", lambda *a, **kw: None)
@@ -290,33 +307,23 @@ def test_lora_with_kl_provisions_separate_reference_trainer(monkeypatch):
     monkeypatch.setattr(module, "run_rl_loop", fake_run_rl_loop)
 
     cfg = module.Config(
-        log_path="/tmp/lora_kl_ref_test",
+        log_path="/tmp/lora_shared_ref_test",
         base_model="accounts/test/models/qwen3-4b",
         dataset="/tmp/prompts.jsonl",
         kl_beta=0.1,
         lora_rank=64,
         deployment=module.DeployConfig(deployment_id="dep-1", tokenizer_model="Qwen/Qwen3-4B"),
-        infra=module.InfraConfig(
-            training_shape_id="ts-lora",
-            ref_training_shape_id="ts-ref",
-        ),
+        infra=module.InfraConfig(training_shape_id="ts-lora"),
     )
 
     module.main(cfg, rlor_mgr=FakeRlorMgr(), deploy_mgr=FakeDeployMgr(), cleanup_on_exit=True)
 
-    names = sorted(c["name"] for c in events["trainer_calls"])
-    assert names == ["grpo-policy", "grpo-reference"], (
-        f"LoRA + KL must provision both policy and reference trainers, got: {names}"
+    assert events["trainer_calls"] == ["grpo-policy"], (
+        "LoRA shared ref should provision exactly one trainer (policy only)"
     )
-
-    by_name = {c["name"]: c for c in events["trainer_calls"]}
-    assert by_name["grpo-policy"]["lora_rank"] == 64
-    assert by_name["grpo-policy"]["forward_only"] is False
-    assert by_name["grpo-reference"]["lora_rank"] == 0, (
-        "Reference trainer must use lora_rank=0 (full-param forward-only), "
-        "even when policy is LoRA"
+    assert events["base_ref_created"] is True, (
+        "create_base_reference() must be called for shared LoRA reference"
     )
-    assert by_name["grpo-reference"]["forward_only"] is True
 
 
 def test_main_raises_when_builtin_loss_with_pp(monkeypatch):

--- a/training/utils/client.py
+++ b/training/utils/client.py
@@ -55,6 +55,18 @@ class ReconnectableClient:
     Each API call dispatches a single request to the trainer and blocks
     until the result is ready (or the timeout expires).  No retry, no
     reconnect -- failures propagate to the caller.
+
+    For LoRA GRPO with KL regularisation, a single LoRA trainer can serve
+    both policy and reference logprobs.  Use :meth:`create_base_reference`
+    to obtain a second ``ReconnectableClient`` that shares the same trainer
+    job *and the same session* but operates on a ``base-<hex>`` model handle
+    (no LoRA adapter).  Sharing the service client is essential — creating
+    a second :class:`FiretitanServiceClient` would create a second session
+    and reset the trainer, unloading the policy LoRA.
+
+    The two clients must not dispatch concurrent requests; the trainer
+    serialises ops per session.  The cookbook RL loop already alternates
+    policy and reference forward passes synchronously.
     """
 
     def __init__(
@@ -66,20 +78,53 @@ class ReconnectableClient:
         fw_api_key: str | None = None,
         default_timeout: int = DEFAULT_TIMEOUT_S,
         endpoint: TrainerServiceEndpoint | None = None,
+        *,
+        service: FiretitanServiceClient | None = None,
+        base_only: bool = False,
     ):
         self._rlor_mgr = rlor_mgr
         self._job_id = job_id
         self._base_model = base_model
         self._lora_rank = lora_rank
+        self._base_only = base_only
         self._fw_api_key = fw_api_key or os.environ.get("FIREWORKS_API_KEY")
         self._default_timeout = default_timeout
         self._endpoint: TrainerServiceEndpoint | None = None
+        self._service: FiretitanServiceClient | None = service
         self._client: FiretitanTrainingClient | None = None
+        self._owns_service = service is None
         self._closed = False
         if endpoint:
             self._use_endpoint(endpoint)
         else:
             self._connect()
+
+    def create_base_reference(self) -> ReconnectableClient:
+        """Create a base-only reference client sharing this trainer's session.
+
+        Returns a new :class:`ReconnectableClient` that reuses the same
+        :class:`FiretitanServiceClient` (and therefore the same session) as
+        this client, but issues forward passes against a ``base-<hex>``
+        model handle (LoRA adapter disabled).
+
+        The returned client must NOT be used concurrently with the policy
+        client; calls are serialised through the shared session.  Do not
+        call ``forward_backward`` or ``optim_step`` on it.
+        """
+        assert self._endpoint is not None and self._service is not None, (
+            "policy client must be connected before creating a base reference"
+        )
+        return ReconnectableClient(
+            rlor_mgr=self._rlor_mgr,
+            job_id=self._job_id,
+            base_model=self._base_model,
+            lora_rank=0,
+            fw_api_key=self._fw_api_key,
+            default_timeout=self._default_timeout,
+            endpoint=self._endpoint,
+            service=self._service,
+            base_only=True,
+        )
 
     @property
     def inner(self) -> FiretitanTrainingClient:
@@ -158,6 +203,12 @@ class ReconnectableClient:
         Best-effort flush queued telemetry, then stop those tasks before remote
         trainer cleanup so local tasks do not continue talking to a trainer
         that has already been deleted.
+
+        When this client shares its :class:`FiretitanServiceClient` with
+        another :class:`ReconnectableClient` (e.g. created via
+        :meth:`create_base_reference`), this client does not own the holder
+        and skips the holder/telemetry teardown — the owning client will
+        clean it up.
         """
         if self._closed:
             return
@@ -166,7 +217,7 @@ class ReconnectableClient:
         client = self._client
         self._client = None
         self._endpoint = None
-        if client is None:
+        if client is None or not self._owns_service:
             return
 
         holder = client.holder
@@ -214,14 +265,20 @@ class ReconnectableClient:
     # -- Internal --------------------------------------------------------------
 
     def _use_endpoint(self, ep: TrainerServiceEndpoint) -> None:
-        svc = FiretitanServiceClient(
-            base_url=ep.base_url,
-            api_key=self._fw_api_key,
-        )
-        self._client = svc.create_training_client(
-            base_model=self._base_model,
-            lora_rank=self._lora_rank,
-        )
+        if self._service is None:
+            self._service = FiretitanServiceClient(
+                base_url=ep.base_url,
+                api_key=self._fw_api_key,
+            )
+        if self._base_only:
+            self._client = self._service.create_base_training_client(
+                base_model=self._base_model,
+            )
+        else:
+            self._client = self._service.create_training_client(
+                base_model=self._base_model,
+                lora_rank=self._lora_rank,
+            )
         self._endpoint = ep
 
     def _connect(self) -> None:


### PR DESCRIPTION
## Summary

Fixes a hang introduced by #343 (LoRA single-trainer reference). The previous implementation used a base-only model handle for reference logprobs but created the handle on a **second** \`FiretitanServiceClient\`. Each service client owns its own holder, which means a separate \`/api/v1/create_session\` call to the trainer. The trainer's \`create_session\` is destructive in the default mode — it enqueues UnloadModelOps for all existing model_ids, evicting the policy LoRA session from CUDA. The first \`save_weights_for_sampler\` then hangs forever (Rank 0 raises \`No LoRA session found for model_id=rlor-...\` and the future never resolves).

## Fix

Reuse the policy \`ReconnectableClient\`'s \`FiretitanServiceClient\` when constructing the base-only reference. One service client → one holder → one \`session_id\` → one \`create_session\` call. The base-only handle is added to the same session via \`create_base_training_client\` — the trainer short-circuits \`LoraManager.activate_for_model\` for \`base-\` IDs, so the policy LoRA session stays loaded.

The two clients share the trainer's IPC queue, so requests must be serialised; the cookbook RL loop already alternates policy and reference forward passes synchronously.

## Customer-facing command (tested working)

The previously-merged PR #343 documented \`qwen3p5-32b\` as the example model — that has no validated LoRA training shape. Use a model with a validated LoRA RFT shape, e.g. **qwen3-8b** with \`qwen3-8b-125k-lora\`:

\`\`\`bash
git clone -b zhiweiz/lora-shared-session-fix https://github.com/fw-ai/cookbook.git
cd cookbook/training
uv venv --python 3.12 && source .venv/bin/activate
uv pip install --pre -e .

export FIREWORKS_API_KEY="..."
python -m examples.rl.deepmath.train_deepmath \\
    --base-model accounts/fireworks/models/qwen3-8b \\
    --tokenizer-model Qwen/Qwen3-8B \\
    --training-shape accounts/fireworks/trainingShapes/qwen3-8b-125k-lora \\
    --lora-rank 64 \\
    --kl-beta 0.001 \\
    --max-rows 50 \\
    --epochs 1 \\
    --completions-per-prompt 4 \\
    --prompt-groups-per-step 4 \\
    --learning-rate 1e-5 \\
    --region US_OHIO_1 \\
    --output-model-id grpo-lora-shared-fix-\$(date +%Y%m%d%H%M)
\`\`\`

Drop \`--lora-rank 64\` for full-param GRPO (that path is unaffected by either of these PRs).

Unit test:
\`\`\`bash
cd training
pytest tests/unit/test_rl_loop.py::test_lora_shared_reference_creates_single_trainer -xvs
\`\`\`

## Changes

- \`utils/client.py\`: \`ReconnectableClient\` accepts an optional \`service\` kwarg and tracks ownership via \`_owns_service\` so \`close()\` only tears the holder down once. \`create_base_reference()\` passes \`service=self._service\` to the new client.
- \`recipes/rl_loop.py\`: register a stack callback for the shared reference so cleanup ordering is correct; clarifying comment.
- \`tests/unit/test_rl_loop.py\`: assert exactly one trainer is created and \`create_base_reference\` is invoked.

## End-to-end validation (aialabs account)

Live run on \`accounts/aialabs/rlorTrainerJobs/jzbja5sizj5zbwcv\` with \`accounts/fireworks/trainingShapes/qwen3-8b-125k-lora\` (qwen3-8b, LoRA rank 64, kl_beta=0.001), 2× B200 trainer + 1× B200 hot-load deployment, 3 training steps completed.

### Session-creation evidence (the bug)

Cookbook stdout shows **only one** \`ServiceClient initialized\` line (broken run had two — the second wiped the first):

\`\`\`
21:48:07 [INFO] ServiceClient initialized for session deb69f13f3184c7a848b4dfc993ed986
21:48:07 [INFO] Created model rlor-7dfb4f5de93c (lora_rank=64)
21:48:08 [INFO] Created base-only model base-caa85fd6ef9f (reference)   ← reuses same svc
\`\`\`

Trainer pod logs confirm: **two** \`LoraManager Created session rlor-7dfb4f5de93c\` (Rank 0 + Rank 1), and **zero** \`Removed session\` entries. The policy LoRA session stays loaded for the entire run.

### Save operations (the previously-hung step) ✅

| Step | model_id | duration | outcome | adapter location |
|---|---|---:|---|---|
| 0 (base) | rlor-7dfb4f5de93c | 18.43s | success | gs://…/step-0-base-d921c904 |
| 1 (delta) | rlor-7dfb4f5de93c | 18.16s | success | gs://…/step-1-d921c904 |
| 2 (delta) | rlor-7dfb4f5de93c | 17.99s | success | gs://…/step-2-d921c904 |

Each emits \`outcome: success, error: ""\` in \`tinker_future_result\` telemetry, followed by \`LoRA adapter save completed: gs://fireworks-artifacts-aialabs-3f126a/rl-checkpoints/aialabs/trainer-jzbja5sizj5zbwcv/<step>\`.

### Forward routing (policy LoRA + base-only reference) ✅

Trainer logs confirm both handles are dispatched correctly on the same session:

\`\`\`
[API] /api/v1/forward received: model_id=base-caa85fd6ef9f, seq_id=1   ← reference
operation=forward, model_id=base-caa85fd6ef9f, outcome=success, duration=6915ms
[API] /api/v1/forward received: model_id=rlor-7dfb4f5de93c, seq_id=2   ← policy
operation=forward, model_id=rlor-7dfb4f5de93c, outcome=success, duration=735ms
operation=forward_backward, model_id=rlor-7dfb4f5de93c, outcome=success, duration=2643ms
operation=optim_step, model_id=rlor-7dfb4f5de93c, outcome=success, duration=540ms
\`\`\`

### Hot-load (full inference path) ✅

| Snapshot | Stage progression | Total |
|---|---|---:|
| step-0-base-d921c904 | downloading → loading → ready | 15s |
| step-1-d921c904 | downloading → loading → ready | 16s |
| step-2-d921c904 | downloading → loading → ready | 16s |

### Step metrics ✅

| Step | Reward | Acc | KL | Cadence (sample / fwd-bwd-optim / sync+hotload) |
|---:|---:|---:|---:|---|
| 1 | 0.750 | 75.0% | 0.0000 | 88.6s / 16s / 36s |
| 2 | 0.250 | 25.0% | 0.0000 | similar |
| 3 | (in progress when stopped) | | | |

KL=0 is expected at step 1: LoRA \`B\` matrix initialises to zero so policy logprobs equal base logprobs; for this tiny 4-prompt × 4-completion batch, adapter movement is small for the first couple of steps.

### One known cosmetic warning

\`create_model(base_only=True)\` overwrites global \`state.is_lora=False, state.lora_rank=0\` (these fields are server-side global state, not per-model). The trainer logs:

\`\`\`
WARNING [save_weights_for_sampler] state.is_lora is false, but trainer has LoRA config. Forcing adapter export.
\`\`\`

The save still produces the correct LoRA adapter (the warning is followed by \`LoRA adapter save completed\`). It's noisy but harmless. A follow-up could fix the trainer to make \`state.is_lora\`/\`state.lora_rank\` per-model rather than global, eliminating the warning.

## Test plan

- [x] Unit test passes (\`test_lora_shared_reference_creates_single_trainer\`)
- [x] Live LoRA + KL run on aialabs — 3 training steps with both ref_forward (base-only handle) and policy_forward (LoRA handle) on the same trainer; all saves and hotloads succeed
- [x] Trainer logs verified: only one \`create_session\`, no \`Removed session\` entries, both forward routes work
- [ ] Long stability run (optional follow-up)

## Alternative

The companion PR #350 (\`zhiweiz/lora-two-trainers-fallback\`) reverts to provisioning a separate forward-only reference trainer with \`lora_rank=0\` (matches the pre-#343 production CI behaviour). Pick whichever you trust; this one is the smarter design (1 trainer instead of 2).