### PR TITLE
fix(rl): provision separate forward-only reference trainer for LoRA + KL (fixes #343, fallback)

### DIFF
--- a/training/README.md
+++ b/training/README.md
@@ -95,11 +95,11 @@ overrides still take precedence.
 | --- | --- |
 | `lora_rank` | Rank of the LoRA adapter (e.g. `64`, `128`) |
 
-When `lora_rank > 0` and no explicit `ref_training_shape_id` is given,
-the RL loop automatically reuses the policy trainer for reference
-logprobs by creating a base-only model handle (adapters disabled).
-This halves GPU cost compared to provisioning a separate reference
-trainer.
+When `kl_beta > 0` the RL loop provisions a separate forward-only
+reference trainer (with `lora_rank=0`, full-param frozen base) in
+addition to the LoRA policy trainer. Auto-selection picks an
+appropriate validated reference shape unless `ref_training_shape_id`
+is set explicitly.
 
 **DPO / ORPO** -- also requires:
 

--- a/training/pyproject.toml
+++ b/training/pyproject.toml
@@ -7,7 +7,7 @@ name = "fireworks-training-cookbook"
 version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [
-    "fireworks-ai[training]>=1.0.0a62,<2",  # >=a60 for create_base_training_client
+    "fireworks-ai[training]>=1.0.0a62,<2",
     "tqdm",
     "torch",
     "datasets",

--- a/training/recipes/rl_loop.py
+++ b/training/recipes/rl_loop.py
@@ -360,18 +360,21 @@ def main(
         )
 
     # -- Resolve reference training shape ------------------------------------------
-    # ref_profile is non-None only when a *separate* reference trainer is needed.
-    # LoRA + kl_beta > 0 without an explicit ref shape: the policy trainer
-    # serves reference logprobs via a base-only handle (no extra GPU job).
+    # When kl_beta > 0 we need reference logprobs from a frozen base model.
+    # Always provision a *separate* forward-only reference trainer with
+    # lora_rank=0 (full-param frozen base) — including for LoRA policy.
+    # Sharing the policy trainer for reference would require trainer
+    # multi-session mode (--max-lora-modules-gpu>=2), which is currently
+    # SUPERUSER_ONLY in the control plane API.
     ref_profile = None
     if cfg.infra.ref_training_shape_id:
         ref_profile = rlor_mgr.resolve_training_profile(cfg.infra.ref_training_shape_id)
-    elif cfg.kl_beta > 0 and cfg.lora_rank == 0:
+    elif cfg.kl_beta > 0:
         cfg.infra.ref_training_shape_id = auto_select_training_shape(
             rlor_mgr,
             base_model=cfg.base_model,
             trainer_role="reference",
-            lora_rank=cfg.lora_rank,
+            lora_rank=0,
             max_seq_len=cfg.max_seq_len,
         )
         logger.info("Auto-selected reference training shape: %s", cfg.infra.ref_training_shape_id)
@@ -404,7 +407,7 @@ def main(
                 base_model=cfg.base_model,
                 infra=cfg.infra,
                 profile=profile,
-                lora_rank=cfg.lora_rank,
+                lora_rank=0 if is_ref else cfg.lora_rank,
                 max_seq_len=cfg.max_seq_len,
                 learning_rate=cfg.learning_rate,
                 display_name=f"grpo-{role}",
@@ -453,27 +456,20 @@ def main(
 
         _timeout = cfg.step_timeout or DEFAULT_TIMEOUT_S
 
-        def _make_client(ep, *, base_only=False):
+        def _make_client(ep, *, lora_rank):
             c = ReconnectableClient(
                 rlor_mgr, ep.job_id, cfg.base_model,
-                lora_rank=0 if base_only else cfg.lora_rank,
+                lora_rank=lora_rank,
                 fw_api_key=api_key,
                 default_timeout=_timeout,
                 endpoint=ep if (cfg.policy_base_url or cfg.reference_base_url) else None,
-                base_only=base_only,
             )
             if hasattr(c, "close"):
                 stack.callback(c.close)
             return c
 
-        policy = _make_client(policy_ep)
-
-        if reference_ep is not None:
-            reference = _make_client(reference_ep)
-        elif cfg.lora_rank > 0 and cfg.kl_beta > 0:
-            reference = policy.create_base_reference()
-        else:
-            reference = None
+        policy = _make_client(policy_ep, lora_rank=cfg.lora_rank)
+        reference = _make_client(reference_ep, lora_rank=0) if reference_ep is not None else None
 
         import transformers
 

--- a/training/tests/unit/test_rl_loop.py
+++ b/training/tests/unit/test_rl_loop.py
@@ -208,17 +208,18 @@ def test_main_bootstraps_without_reference_and_cleans_up(monkeypatch):
     assert events["wandb_finished"] == 0
 
 
-def test_lora_shared_reference_creates_single_trainer(monkeypatch):
-    """LoRA + kl_beta > 0 + no ref shape → one trainer, base-only reference handle."""
+def test_lora_with_kl_provisions_separate_reference_trainer(monkeypatch):
+    """LoRA + kl_beta > 0 must provision a *separate* forward-only reference
+    trainer with lora_rank=0, not piggyback on the policy trainer.
+
+    Sharing the policy trainer for reference would require trainer multi-session
+    mode (--max-lora-modules-gpu>=2), which is currently SUPERUSER_ONLY in the
+    control plane API.
+    """
     monkeypatch.setenv("FIREWORKS_API_KEY", "test-key")
     monkeypatch.setenv("FIREWORKS_BASE_URL", "https://unit.test")
 
-    events: dict[str, object] = {
-        "trainer_calls": [],
-        "deleted_jobs": [],
-        "scaled_deployments": [],
-        "base_ref_created": False,
-    }
+    events: dict[str, object] = {"trainer_calls": []}
 
     class FakeRlorMgr:
         def resolve_training_profile(self, shape_id):
@@ -232,33 +233,22 @@ def test_lora_shared_reference_creates_single_trainer(monkeypatch):
             )
 
         def cancel(self, job_id):
-            events["deleted_jobs"].append(job_id)
+            pass
 
         def delete(self, job_id):
-            self.cancel(job_id)
+            pass
 
     class FakeDeployMgr:
         inference_url = "https://inference.unit.test"
         boot_time_s = 1.0
 
         def scale_to_zero(self, deployment_id):
-            events["scaled_deployments"].append(deployment_id)
-
-    class FakeBaseRef:
-        job_id = "policy-job"
-        inner = object()
-
-        def forward(self, data, loss_fn):
-            return SimpleNamespace(loss_fn_outputs=[])
+            pass
 
     class FakeClient:
         def __init__(self, *args, **kwargs):
-            self.job_id = "policy-job"
+            self.job_id = kwargs.get("job_id", "job-x")
             self.inner = object()
-
-        def create_base_reference(self):
-            events["base_ref_created"] = True
-            return FakeBaseRef()
 
         def save_state(self, name, timeout=None):
             return SimpleNamespace(path=name)
@@ -273,13 +263,17 @@ def test_lora_shared_reference_creates_single_trainer(monkeypatch):
             return name
 
     def fake_create_trainer_job(*args, **kwargs):
-        events["trainer_calls"].append(kwargs.get("display_name"))
+        name = kwargs.get("display_name")
+        events["trainer_calls"].append({
+            "name": name,
+            "lora_rank": kwargs.get("lora_rank"),
+            "forward_only": kwargs.get("forward_only", False),
+        })
         return SimpleNamespace(
-            job_id="policy-job", job_name="jobs/policy-job", base_url="https://unit.test",
+            job_id=f"{name}-job", job_name=f"jobs/{name}-job", base_url="https://unit.test",
         )
 
     async def fake_run_rl_loop(**kwargs):
-        events["run_loop_kwargs"] = kwargs
         return 0
 
     monkeypatch.setattr(module, "setup_wandb", lambda *a, **kw: None)
@@ -296,25 +290,33 @@ def test_lora_shared_reference_creates_single_trainer(monkeypatch):
     monkeypatch.setattr(module, "run_rl_loop", fake_run_rl_loop)
 
     cfg = module.Config(
-        log_path="/tmp/lora_shared_ref_test",
+        log_path="/tmp/lora_kl_ref_test",
         base_model="accounts/test/models/qwen3-4b",
         dataset="/tmp/prompts.jsonl",
         kl_beta=0.1,
         lora_rank=64,
         deployment=module.DeployConfig(deployment_id="dep-1", tokenizer_model="Qwen/Qwen3-4B"),
-        infra=module.InfraConfig(training_shape_id="ts-lora"),
+        infra=module.InfraConfig(
+            training_shape_id="ts-lora",
+            ref_training_shape_id="ts-ref",
+        ),
     )
 
-    result = module.main(
-        cfg, rlor_mgr=FakeRlorMgr(), deploy_mgr=FakeDeployMgr(), cleanup_on_exit=True,
+    module.main(cfg, rlor_mgr=FakeRlorMgr(), deploy_mgr=FakeDeployMgr(), cleanup_on_exit=True)
+
+    names = sorted(c["name"] for c in events["trainer_calls"])
+    assert names == ["grpo-policy", "grpo-reference"], (
+        f"LoRA + KL must provision both policy and reference trainers, got: {names}"
     )
 
-    assert events["trainer_calls"] == ["grpo-policy"], (
-        "LoRA shared ref should provision exactly one trainer (policy only)"
+    by_name = {c["name"]: c for c in events["trainer_calls"]}
+    assert by_name["grpo-policy"]["lora_rank"] == 64
+    assert by_name["grpo-policy"]["forward_only"] is False
+    assert by_name["grpo-reference"]["lora_rank"] == 0, (
+        "Reference trainer must use lora_rank=0 (full-param forward-only), "
+        "even when policy is LoRA"
     )
-    assert events["base_ref_created"] is True, (
-        "create_base_reference() must be called for shared LoRA reference"
-    )
+    assert by_name["grpo-reference"]["forward_only"] is True
 
 
 def test_main_raises_when_builtin_loss_with_pp(monkeypatch):

--- a/training/utils/client.py
+++ b/training/utils/client.py
@@ -55,13 +55,6 @@ class ReconnectableClient:
     Each API call dispatches a single request to the trainer and blocks
     until the result is ready (or the timeout expires).  No retry, no
     reconnect -- failures propagate to the caller.
-
-    For LoRA GRPO with KL regularisation, a single LoRA trainer can serve
-    both policy and reference logprobs.  Use :meth:`create_base_reference`
-    to obtain a second ``ReconnectableClient`` that shares the same trainer
-    job but creates a ``base-<hex>`` model handle (adapters disabled).
-    This avoids provisioning a second trainer purely for reference forward
-    passes.
     """
 
     def __init__(
@@ -73,14 +66,11 @@ class ReconnectableClient:
         fw_api_key: str | None = None,
         default_timeout: int = DEFAULT_TIMEOUT_S,
         endpoint: TrainerServiceEndpoint | None = None,
-        *,
-        base_only: bool = False,
     ):
         self._rlor_mgr = rlor_mgr
         self._job_id = job_id
         self._base_model = base_model
         self._lora_rank = lora_rank
-        self._base_only = base_only
         self._fw_api_key = fw_api_key or os.environ.get("FIREWORKS_API_KEY")
         self._default_timeout = default_timeout
         self._endpoint: TrainerServiceEndpoint | None = None
@@ -90,26 +80,6 @@ class ReconnectableClient:
             self._use_endpoint(endpoint)
         else:
             self._connect()
-
-    def create_base_reference(self) -> ReconnectableClient:
-        """Create a reference client sharing this trainer's job.
-
-        Returns a new ``ReconnectableClient`` backed by a ``base-<hex>``
-        model handle on the same trainer.  Forward passes through the
-        returned client run with all LoRA adapters disabled, giving
-        base-model logprobs without a second GPU allocation.
-        """
-        assert self._endpoint is not None, "policy client must be connected first"
-        return ReconnectableClient(
-            rlor_mgr=self._rlor_mgr,
-            job_id=self._job_id,
-            base_model=self._base_model,
-            lora_rank=0,
-            fw_api_key=self._fw_api_key,
-            default_timeout=self._default_timeout,
-            endpoint=self._endpoint,
-            base_only=True,
-        )
 
     @property
     def inner(self) -> FiretitanTrainingClient:
@@ -248,15 +218,10 @@ class ReconnectableClient:
             base_url=ep.base_url,
             api_key=self._fw_api_key,
         )
-        if self._base_only:
-            self._client = svc.create_base_training_client(
-                base_model=self._base_model,
-            )
-        else:
-            self._client = svc.create_training_client(
-                base_model=self._base_model,
-                lora_rank=self._lora_rank,
-            )
+        self._client = svc.create_training_client(
+            base_model=self._base_model,
+            lora_rank=self._lora_rank,
+        )
         self._endpoint = ep
 
     def _connect(self) -> None:


### PR DESCRIPTION
## Summary

**Fallback** for the hang introduced by #343. Reverts to provisioning a separate forward-only reference trainer with \`lora_rank=0\` whenever \`kl_beta > 0\`, including when the policy is LoRA.

The companion PR #349 (\`zhiweiz/lora-shared-session-fix\`) takes the smarter approach: share the policy trainer's session via a base-only model handle, no extra GPU job. **Pick that one if you trust the shared-session approach; this PR is the safer revert that matches the pre-#343 production CI behaviour.**

## Why the original optimisation broke

#343 added a base-only model handle for reference logprobs on the policy trainer. The implementation created a **second** \`FiretitanServiceClient\`, which created a **second** trainer session. The trainer's \`create_session\` is destructive without \`--max-lora-modules-gpu>=2\` (which is \`SUPERUSER_ONLY\` in the gateway proto):

\`\`\`
04:14:24.804: create_session reset (cleared models=['rlor-5b8f4d016cb7'])  ← unloaded policy LoRA
04:14:28.311: ERROR: No LoRA session found for model_id=rlor-5b8f4d016cb7
\`\`\`

\`save_weights_for_sampler\` then hangs forever on the policy trainer.

## Customer-facing command (tested working)

The previously-merged PR #343 documented \`qwen3p5-32b\` as the example model — that has no validated LoRA training shape. Use a model with a validated LoRA RFT shape, e.g. **qwen3-8b** with \`qwen3-8b-125k-lora\`:

\`\`\`bash
git clone -b zhiweiz/lora-two-trainers-fallback https://github.com/fw-ai/cookbook.git
cd cookbook/training
uv venv --python 3.12 && source .venv/bin/activate
uv pip install --pre -e .

export FIREWORKS_API_KEY="..."
python -m examples.rl.deepmath.train_deepmath \\
    --base-model accounts/fireworks/models/qwen3-8b \\
    --tokenizer-model Qwen/Qwen3-8B \\
    --training-shape accounts/fireworks/trainingShapes/qwen3-8b-125k-lora \\
    --lora-rank 64 \\
    --kl-beta 0.001 \\
    --max-rows 50 \\
    --epochs 1 \\
    --completions-per-prompt 4 \\
    --prompt-groups-per-step 4 \\
    --learning-rate 1e-5 \\
    --region US_OHIO_1 \\
    --output-model-id grpo-lora-two-trainers-\$(date +%Y%m%d%H%M)
\`\`\`

The cookbook auto-selects a forward-only reference shape (e.g. \`accounts/fireworks/trainingShapes/qwen3-8b-128k-forward-only\`); set \`--ref-training-shape\` to override. Drop \`--lora-rank 64\` for full-param GRPO.

Unit test:
\`\`\`bash
cd training
pytest tests/unit/test_rl_loop.py::test_lora_with_kl_provisions_separate_reference_trainer -xvs
\`\`\`

## Changes

- \`recipes/rl_loop.py\`: auto-select reference shape whenever \`kl_beta > 0\` (regardless of \`lora_rank\`); pass \`lora_rank=0\` for the reference trainer in \`_make_trainer\`. Refactor \`_make_client\` to take \`lora_rank\` directly.
- \`utils/client.py\`: drop \`create_base_reference\` and \`base_only\` handling.
- \`README.md\`: document the 2-trainer behaviour for LoRA + KL.
- \`tests/unit/test_rl_loop.py\`: assert both trainers are created with the right \`lora_rank\` (64 for policy, 0 for reference).

## Cost

Doubles GPU usage for LoRA + KL runs (one extra forward-only trainer). Acceptable while \`max_lora_modules_gpu\` remains \`SUPERUSER_ONLY\` in the gateway proto.

## End-to-end validation (aialabs account)

Live run on aialabs with \`accounts/fireworks/trainingShapes/qwen3-8b-125k-lora\` (qwen3-8b, LoRA rank 64, kl_beta=0.001), 2 trainers + 1 hot-load deployment, 2 training steps completed.

### Trainer provisioning ✅

| Role | Job ID | Shape | loraRank | forwardOnly | Ready in |
|---|---|---|---:|---|---:|
| Policy | \`hdj5oiakmincipe9\` | \`qwen3-8b-125k-lora\` | 64 | false | 184s |
| Reference | \`dwnqkhke7uf0uges\` | \`qwen3-8b-128k-forward-only\` (auto-selected) | 0 | true | 361s |

\`\`\`
22:00:00 [INFO] Auto-selected reference training shape: accounts/fireworks/trainingShapes/qwen3-8b-128k-forward-only
22:00:00 [INFO] Creating policy trainer job 'grpo-policy' (forward_only=False)...      ← loraRank=64
22:00:00 [INFO] Creating reference trainer job 'grpo-reference' (forward_only=True)... ← loraRank=0
\`\`\`

### Save operations (policy trainer) ✅

| Step | model_id | duration | outcome |
|---|---|---:|---|
| 0 (base)  | rlor-4fa8b88df4cd | 18.23s | success |
| 1 (delta) | rlor-4fa8b88df4cd | 18.48s | success |
| 2 (delta) | rlor-4fa8b88df4cd | 18.01s | success |

All saves on \`hdj5oiakmincipe9\` emit \`outcome: success, error: ""\` — and **no \`Forcing adapter export\` warnings** (unlike PR #349, since the policy trainer's \`state.is_lora\` is never overwritten by a base-only handle).

### Hot-load (full inference path) ✅

| Snapshot | Stage progression | Total |
|---|---|---:|
| step-0-base-895fac26 | downloading → loading → completed | 20s |
| step-1-895fac26      | downloading → loading → completed | 17s |

### Step metrics ✅

| Step | Reward | Acc | KL | ref_forward | policy_forward | fwd_bwd | optim_step | weight_sync |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 1 | 0.250 | 25.0% | 0.0000 | 2.6s | 8.6s | 6.0s | 0.7s | 36.5s |
| 2 | 0.375 | 37.5% | 0.0000 | 2.8s | 3.3s | 7.3s | 0.4s | (in flight) |

KL=0 is expected at step 1 (LoRA \`B\` initialised to zero so policy ≡ base); for this 4-prompt × 4-completion micro-batch, the adapter doesn't move much in the first couple of steps.

### Pattern matches pre-#343 production CI

This 2-trainer pattern matches the **pre-#343 production CI behaviour** (e.g. run [24494316954](https://github.com/fw-ai/fireworks/actions/runs/24494316954)) which used the same shape with \`loraRank=128\` for policy + \`loraRank=0, forwardOnly=true\` for reference and successfully completed Phase 0 / Phase 1 / Phase 2.

## Test plan

- [x] Unit test passes (\`test_lora_with_kl_provisions_separate_reference_trainer\`)
- [x] Live LoRA + KL run on aialabs — 2 trainers provisioned (policy LoRA + reference forward-only), 2 training steps completed with all 3 saves \`outcome: success\` on the policy trainer
- [x] No \`Forcing adapter export\` warnings (vs PR #349 where the base-only handle overwrites global \`state.is_lora\`)

## When to merge this instead of #349

- If #349 turns out to have edge cases under heavier batch sizes or different LoRA configs
- If you want to revert the cookbook to its known-good 2-trainer behaviour while #349 is being reviewed
- If trainer's global \`state.is_lora\` overwrite (the harmless warning in #349's logs) is considered too risky to ship without a server-side fix

## Follow-up

Long-term fix is to lift the \`SUPERUSER_ONLY\` restriction on \`RlorTrainerMultiLoraConfig.max_lora_modules_gpu\` (in \`control_plane/protos/gateway/rlor_trainer_job.proto\` and \`training.proto\`) and expose it via the SDK. Then the cookbook can pass \`max_lora_modules_gpu=2\` on the policy trainer and use a base-only handle without resetting the session — making both this PR and #349 obsolete.