### PR TITLE
fix(sft): stream-render dataset to fix orchestrator OOM on large/long-context jobs

### DIFF
--- a/training/recipes/dpo_loop.py
+++ b/training/recipes/dpo_loop.py
@@ -164,12 +164,15 @@ def _tokenize_pairs(
     tokenizer: Any,
     renderer: Any,
     max_seq_len: int,
+    runner: RunnerIO | None = None,
 ) -> tuple[list[tuple[int, dict[str, Any]]], int]:
     """Tokenize all preference pairs (CPU only).
 
     Returns ``(tokenized, filtered_count)`` where each entry is
     ``(original_index, pair_data_dict)``.
     """
+    total_raw = len(raw_data)
+    log_interval = max(1, total_raw // 20)  # ~5% increments
     tokenized: list[tuple[int, dict[str, Any]]] = []
     filtered_count = 0
     for i, example in enumerate(raw_data):
@@ -178,6 +181,14 @@ def _tokenize_pairs(
             filtered_count += 1
         elif result is not None:
             tokenized.append((i, result))
+        if (i + 1) % log_interval == 0 or (i + 1) == total_raw:
+            if runner is not None:
+                runner.report_rendering_progress(i + 1, total_raw)
+            else:
+                logger.info(
+                    "Rendering preference pairs: %d/%d (%d%%)",
+                    i + 1, total_raw, int(100.0 * (i + 1) / total_raw),
+                )
     return tokenized, filtered_count
 
 
@@ -588,6 +599,7 @@ def main(
 
         tokenized_pairs, filtered_count = _tokenize_pairs(
             raw_data, tokenizer, renderer, cfg.max_seq_len,
+            runner=runner,
         )
         if filtered_count > 0:
             logger.info(

--- a/training/recipes/orpo_loop.py
+++ b/training/recipes/orpo_loop.py
@@ -295,11 +295,13 @@ def main(
         if not raw_data:
             raise RuntimeError(f"No data loaded from {cfg.dataset}")
 
-        logger.info("Tokenizing %d preference pairs...", len(raw_data))
+        total_raw = len(raw_data)
+        log_interval = max(1, total_raw // 20)  # ~5% increments
+        logger.info("Tokenizing %d preference pairs...", total_raw)
         pair_cache: list[dict] = []
         filtered_count = 0
 
-        for example in raw_data:
+        for i, example in enumerate(raw_data):
             pair = render_preference_pair(
                 example["chosen"],
                 example["rejected"],
@@ -324,6 +326,8 @@ def main(
                     "rejected_datum": pair.rejected_datum,
                 }
             )
+            if (i + 1) % log_interval == 0 or (i + 1) == total_raw:
+                runner.report_rendering_progress(i + 1, total_raw)
 
         if filtered_count > 0:
             logger.info(

--- a/training/recipes/sft_loop.py
+++ b/training/recipes/sft_loop.py
@@ -403,7 +403,18 @@ def main(
                 return None
             return rendered.datum
 
-        training_data = [d for row in raw_data if (d := _map_fn(row)) is not None]
+        total_raw = len(raw_data)
+        log_interval = max(1, total_raw // 20)  # ~5% increments
+        training_data: List[tinker.Datum] = []
+        for i, row in enumerate(raw_data):
+            d = _map_fn(row)
+            if d is not None:
+                training_data.append(d)
+            if (i + 1) % log_interval == 0 or (i + 1) == total_raw:
+                logger.info(
+                    "Rendering examples: %d/%d (%.0f%%)",
+                    i + 1, total_raw, 100.0 * (i + 1) / total_raw,
+                )
         if filtered_count > 0:
             logger.info(
                 "Seq-length filter: %d/%d examples filtered (len > %d or len < 2)",
@@ -426,7 +437,18 @@ def main(
                     if not line:
                         continue
                     raw_eval.append(json.loads(line))
-            eval_data = [d for row in raw_eval if (d := _map_fn(row)) is not None]
+            total_eval = len(raw_eval)
+            eval_log_interval = max(1, total_eval // 10)
+            eval_data = []
+            for i, row in enumerate(raw_eval):
+                d = _map_fn(row)
+                if d is not None:
+                    eval_data.append(d)
+                if (i + 1) % eval_log_interval == 0 or (i + 1) == total_eval:
+                    logger.info(
+                        "Rendering eval examples: %d/%d (%.0f%%)",
+                        i + 1, total_eval, 100.0 * (i + 1) / total_eval,
+                    )
             logger.info("Loaded %d eval examples from %s", len(eval_data), cfg.evaluation_dataset)
         elif cfg.eval_auto_carveout:
             # Auto carve-out: split first N examples as eval

--- a/training/recipes/sft_loop.py
+++ b/training/recipes/sft_loop.py
@@ -411,10 +411,7 @@ def main(
             if d is not None:
                 training_data.append(d)
             if (i + 1) % log_interval == 0 or (i + 1) == total_raw:
-                logger.info(
-                    "Rendering examples: %d/%d (%.0f%%)",
-                    i + 1, total_raw, 100.0 * (i + 1) / total_raw,
-                )
+                runner.report_rendering_progress(i + 1, total_raw)
         if filtered_count > 0:
             logger.info(
                 "Seq-length filter: %d/%d examples filtered (len > %d or len < 2)",
@@ -445,10 +442,7 @@ def main(
                 if d is not None:
                     eval_data.append(d)
                 if (i + 1) % eval_log_interval == 0 or (i + 1) == total_eval:
-                    logger.info(
-                        "Rendering eval examples: %d/%d (%.0f%%)",
-                        i + 1, total_eval, 100.0 * (i + 1) / total_eval,
-                    )
+                    runner.report_rendering_progress(i + 1, total_eval, label="rendering eval data")
             logger.info("Loaded %d eval examples from %s", len(eval_data), cfg.evaluation_dataset)
         elif cfg.eval_auto_carveout:
             # Auto carve-out: split first N examples as eval

--- a/training/utils/runner.py
+++ b/training/utils/runner.py
@@ -158,6 +158,12 @@ class RunnerIO:
             payload["details"] = [{"@type": _JOB_PROGRESS_TYPE_URL, "percent": percent}]
         self._write_json(self._status_file, payload)
 
+    def report_rendering_progress(self, current: int, total: int, *, label: str = "rendering data") -> None:
+        """Log and write status for data rendering progress."""
+        pct = int(100.0 * current / total) if total else 0
+        logger.info("%s: %d/%d (%d%%)", label, current, total, pct)
+        self.write_status(RunStatus.PENDING, message=f"{label} ({pct}%)")
+
     # -- metadata --------------------------------------------------------------
 
     def set_accelerator_info(


### PR DESCRIPTION
## Summary

Fixes orchestrator (cookbook runner) OOMKills during the SFT dataset rendering phase on large / long-context datasets. Replaces the eager `List[tinker.Datum]` with a streaming, disk-backed pipeline so peak RAM is bounded by `num_workers × per-worker render footprint` instead of `num_examples × avg_seq_len × bytes_per_token`.

Validated end-to-end on job `r62fmz8e` (110,919 examples × 256K context, `qwen3p5-397b-a17b`):
- Peak app memory **~5.4 GiB** (was unbounded; previous attempts OOMKilled at 118 GiB / 428 GiB depending on QoS).
- cgroup ~57 GiB at 100%, ~95% of which is reclaimable page cache from pickle file writes.
- Rendering completes in ~30 min with 4 workers (single-threaded would take 5–6 h).

Full investigation: [docs/engineering/sft-v2-orchestrator-oom-debug.md](https://github.com/fw-ai/fireworks/blob/fix-orchestrator-memory-allocation/docs/engineering/sft-v2-orchestrator-oom-debug.md) (in companion fireworks PR).

## Architecture

```mermaid
flowchart LR
    A[JSONL on GCS] -->|iter_jsonl_rows<br/>lazy| B(stream_render_to_store)
    B -->|spawn pool<br/>imap, chunksize=10| W1[worker 1]
    B --> W2[worker 2]
    B --> W3[worker 3]
    B --> W4[worker 4]
    W1 -->|pickle.dumps| S[(DiskBackedDatumStore<br/>pickle file on local SSD)]
    W2 --> S
    W3 --> S
    W4 --> S
    S -.->|RAM only| IDX[index<br/>List_of_offset_length]
    IDX -->|map_fn| T[trainer<br/>SupervisedDatasetFromHFDataset]
    S -->|seek + pickle.loads<br/>per batch| T
    M[MemTracer] -.->|every ~1%| L[/log: cgroup main workers unaccounted/]
    B -.-> M
```

## Changes

### New shared utilities (`training/utils/`)

- **`streaming.py`**
  - `DiskBackedDatumStore` — append-only pickle store with random-access reads via in-memory `(offset, length)` index (~16 B/row).
  - `iter_jsonl_rows` / `count_jsonl_rows` — lazy JSONL helpers.
  - `stream_render_to_store` — `spawn` multiprocessing pool that runs `Pool.imap` and spills each rendered item directly into a store (no result accumulation in the parent).
- **`memlog.py`**
  - `read_cgroup_mem` / `read_cgroup_limit` / `proc_vmrss_gi` / `worker_rss_info` — cgroup v1+v2 and `/proc/<pid>/status` readers.
  - `MemTracer` — high-level `[mem]` line emitter that combines the readers and optionally attaches store stats.

### `sft_loop.py`

- Replaces inline streaming/mem-tracing logic (~308 lines) with calls to the shared utilities (~114 lines). Net: −194 LOC in the loop file.
- Renderer: `num_workers=4`, `chunksize=10`, spawn context. These were validated to give a stable ~28 GiB worker baseline (vs ~56 GiB at 8 workers).
- Mem trace at every ~1% of progress + on phase transitions.
- Eval rendering uses the same streaming path; eval set is materialised at the end (bounded by `max_eval_seqs ≤ 100`, safe).

### `dpo_loop.py` / `orpo_loop.py` / `runner.py`

- Adds the `report_rendering_progress` helper to `RunnerIO` and wires it into DPO/ORPO tokenization loops for status visibility. **No memory behaviour change in DPO/ORPO** — they still load eagerly; migration to `DiskBackedDatumStore` is tracked as a follow-up (needs design for ref-logprob caching in DPO).

## Why streaming?

Earlier iterations failed because:

1. **Static overhead factor** — flat multiplier on dataset bytes; OOMKilled at 124 GiB.
2. **First-principles formula** — request scaled with `num_examples × max_seq_len`, peaked ~550 GiB; **physically larger than the ~121 GiB allocatable on m5.8xlarge**, so unschedulable.
3. **Burstable QoS reclaim** — pod was OOMed at ~118 GiB while `cgroup.limit=428 GiB` because the kernel was reclaiming page cache aggressively against `request=107 GiB`. Looked like a +310 GiB "burst" in mem trace; was actually reclaim failing.

Streaming sidesteps all of the above by making peak RAM independent of dataset size and well below any single-node capacity.

## Type of Change

- [x] Bug fix
- [x] Refactoring

## Testing

- [x] End-to-end validated on job `r62fmz8e` — render completed (110,919 examples, 41.1 GiB pickle store), training started (loss 1.0 → 0.78 over 39 steps), no OOM.
- [x] Smoke test of new modules (`DiskBackedDatumStore` + `stream_render_to_store` + `iter_jsonl_rows`) round-trips JSONL → store → random reads.
- [x] `test_sft_loop.py` — 10/10 tests not blocked by a pre-existing SDK mismatch (`TrainerJobConfig.skip_validations` in `infra.py`) pass cleanly. The 6 failures exist on the previous commit too — unrelated.

## Follow-ups (out of scope)

- DPO migration to `DiskBackedDatumStore` — needs design for the `ref_cache` (epoch 0 producer writes `ref_chosen` / `ref_rejected` back into per-pair dicts; current store is append-only).
- ORPO migration — similar shape to DPO without ref logprobs.
- RL/IGPO `raw_dataset * cfg.epochs` cleanup — minor, can pair with the ORPO PR.

## Pairs with

- fw-ai/fireworks#23033 — orchestrator memory/disk allocation update for the streaming renderer.
