### PR TITLE
feat(recipes): forward FIREWORKS_API_EXTRA_HEADERS to trainer/deployment clients

### DIFF
--- a/training/recipes/dpo_loop.py
+++ b/training/recipes/dpo_loop.py
@@ -56,6 +56,7 @@ from training.utils import (
     log_metrics_json,
     make_batch_dpo_loss_fn,
     create_trainer_job,
+    read_api_extra_headers_env,
     load_preference_dataset,
     build_renderer,
     auto_select_training_shape,
@@ -453,11 +454,20 @@ def main(
 
     api_key = os.environ["FIREWORKS_API_KEY"]
     base_url = os.environ.get("FIREWORKS_BASE_URL", "https://api.fireworks.ai")
+    additional_headers = read_api_extra_headers_env()
 
     if rlor_mgr is None:
-        rlor_mgr = TrainerJobManager(api_key=api_key, base_url=base_url)
+        rlor_mgr = TrainerJobManager(
+            api_key=api_key,
+            base_url=base_url,
+            additional_headers=additional_headers,
+        )
     if deploy_mgr is None:
-        deploy_mgr = DeploymentManager(api_key=api_key, base_url=base_url)
+        deploy_mgr = DeploymentManager(
+            api_key=api_key,
+            base_url=base_url,
+            additional_headers=additional_headers,
+        )
 
     if not cfg.infra.training_shape_id:
         cfg.infra.training_shape_id = auto_select_training_shape(

--- a/training/recipes/igpo_loop.py
+++ b/training/recipes/igpo_loop.py
@@ -55,6 +55,7 @@ from training.utils import (
     log_metrics_json,
     setup_deployment,
     create_trainer_job,
+    read_api_extra_headers_env,
     load_jsonl_dataset,
     prepare_sampling_messages,
 )
@@ -270,11 +271,20 @@ def main(
 
     api_key = os.environ["FIREWORKS_API_KEY"]
     base_url = os.environ.get("FIREWORKS_BASE_URL", "https://api.fireworks.ai")
+    additional_headers = read_api_extra_headers_env()
 
     if rlor_mgr is None:
-        rlor_mgr = TrainerJobManager(api_key=api_key, base_url=base_url)
+        rlor_mgr = TrainerJobManager(
+            api_key=api_key,
+            base_url=base_url,
+            additional_headers=additional_headers,
+        )
     if deploy_mgr is None:
-        deploy_mgr = DeploymentManager(api_key=api_key, base_url=base_url)
+        deploy_mgr = DeploymentManager(
+            api_key=api_key,
+            base_url=base_url,
+            additional_headers=additional_headers,
+        )
 
     profile = None
     if cfg.infra.training_shape_id:

--- a/training/recipes/orpo_loop.py
+++ b/training/recipes/orpo_loop.py
@@ -62,6 +62,7 @@ from training.utils import (
     log_metrics_json,
     make_batch_orpo_loss_fn,
     create_trainer_job,
+    read_api_extra_headers_env,
     load_preference_dataset,
     build_renderer,
     auto_select_training_shape,
@@ -223,9 +224,14 @@ def main(
 
     api_key = os.environ["FIREWORKS_API_KEY"]
     base_url = os.environ.get("FIREWORKS_BASE_URL", "https://api.fireworks.ai")
+    additional_headers = read_api_extra_headers_env()
 
     if rlor_mgr is None:
-        rlor_mgr = TrainerJobManager(api_key=api_key, base_url=base_url)
+        rlor_mgr = TrainerJobManager(
+            api_key=api_key,
+            base_url=base_url,
+            additional_headers=additional_headers,
+        )
 
     if not cfg.infra.training_shape_id:
         cfg.infra.training_shape_id = auto_select_training_shape(

--- a/training/recipes/rl_loop.py
+++ b/training/recipes/rl_loop.py
@@ -59,6 +59,7 @@ from training.utils import (
     setup_or_reattach_deployment,
     compute_advantages,
     create_trainer_job,
+    read_api_extra_headers_env,
     load_jsonl_dataset,
     prepare_sampling_messages,
     auto_select_training_shape,
@@ -316,11 +317,20 @@ def main(
 
     api_key = os.environ["FIREWORKS_API_KEY"]
     base_url = os.environ.get("FIREWORKS_BASE_URL", "https://api.fireworks.ai")
+    additional_headers = read_api_extra_headers_env()
 
     if rlor_mgr is None:
-        rlor_mgr = TrainerJobManager(api_key=api_key, base_url=base_url)
+        rlor_mgr = TrainerJobManager(
+            api_key=api_key,
+            base_url=base_url,
+            additional_headers=additional_headers,
+        )
     if deploy_mgr is None:
-        deploy_mgr = DeploymentManager(api_key=api_key, base_url=base_url)
+        deploy_mgr = DeploymentManager(
+            api_key=api_key,
+            base_url=base_url,
+            additional_headers=additional_headers,
+        )
 
     # -- Resolve policy training shape -------------------------------------------
     if not cfg.infra.training_shape_id:

--- a/training/recipes/sft_loop.py
+++ b/training/recipes/sft_loop.py
@@ -46,6 +46,7 @@ from training.utils import (
     validate_config,
     log_metrics_json,
     create_trainer_job,
+    read_api_extra_headers_env,
     build_renderer,
     parse_train_on_what,
     auto_select_training_shape,
@@ -302,9 +303,14 @@ def main(
 
     api_key = os.environ.get("FIREWORKS_API_KEY", "")
     base_url = os.environ.get("FIREWORKS_BASE_URL", "https://api.fireworks.ai")
+    additional_headers = read_api_extra_headers_env()
 
     if rlor_mgr is None:
-        rlor_mgr = TrainerJobManager(api_key=api_key, base_url=base_url)
+        rlor_mgr = TrainerJobManager(
+            api_key=api_key,
+            base_url=base_url,
+            additional_headers=additional_headers,
+        )
 
     if _precreated_trainer:
         trainer_infra = cfg.infra

--- a/training/utils/__init__.py
+++ b/training/utils/__init__.py
@@ -50,6 +50,7 @@ __all__ = [
     "compute_advantages",
     "compute_pass_at_k",
     "create_trainer_job",
+    "read_api_extra_headers_env",
     "encode_text",
     "extract_text",
     "find_common_prefix_length",
@@ -104,6 +105,7 @@ from training.utils.infra import (
     setup_deployment,
     setup_or_reattach_deployment,
     create_trainer_job,
+    read_api_extra_headers_env,
     setup_training_client,
 )
 from training.utils.timer import timed, timer, flush_timing

--- a/training/utils/infra.py
+++ b/training/utils/infra.py
@@ -37,6 +37,41 @@ _DEPLOYMENT_ACCELERATOR_REGION_PREFIXES: tuple[tuple[str, str], ...] = (
 _TRAINER_CANCEL_GRACE_ENV = "FW_TRAINER_CANCEL_GRACE_PERIOD_S"
 _TRAINER_DELETE_GRACE_ENV = "FW_TRAINER_DELETE_GRACE_PERIOD_S"
 
+_FIREWORKS_API_EXTRA_HEADERS_ENV = "FIREWORKS_API_EXTRA_HEADERS"
+
+
+def read_api_extra_headers_env() -> dict[str, str] | None:
+    """Parse ``FIREWORKS_API_EXTRA_HEADERS`` into a header dict.
+
+    The env var, when set, must be a JSON object whose values are strings.
+    Used to pass additional HTTP headers (e.g. routing, auth, correlation IDs)
+    to every Fireworks API request. Returns ``None`` when the var is unset or
+    empty.
+    """
+    raw = os.environ.get(_FIREWORKS_API_EXTRA_HEADERS_ENV, "").strip()
+    if not raw:
+        return None
+    import json as _json
+
+    try:
+        parsed = _json.loads(raw)
+    except _json.JSONDecodeError as exc:
+        logger.warning(
+            "Invalid %s (not valid JSON); ignoring: %s",
+            _FIREWORKS_API_EXTRA_HEADERS_ENV,
+            exc,
+        )
+        return None
+    if not isinstance(parsed, dict) or not all(
+        isinstance(k, str) and isinstance(v, str) for k, v in parsed.items()
+    ):
+        logger.warning(
+            "%s must be a JSON object of string->string; ignoring",
+            _FIREWORKS_API_EXTRA_HEADERS_ENV,
+        )
+        return None
+    return parsed or None
+
 
 def _default_trainer_cancel_grace_period_s() -> float:
     raw = os.environ.get(_TRAINER_CANCEL_GRACE_ENV)


### PR DESCRIPTION
## Summary

Adds a new `FIREWORKS_API_EXTRA_HEADERS` env var — a JSON object of string-to-string — that, when set, is parsed and forwarded as `additional_headers` to every `TrainerJobManager` and `DeploymentManager` the recipe loops construct. Opt-in; defaults to no extra headers so existing behavior is unchanged.

The underlying `fireworks-ai-python` SDK already accepts `additional_headers` on all three entrypoints (`_RestClient`, `FireworksClient`, `DeploymentManager`, `TrainerJobManager`). This just wires the env var through so operators don't have to edit Python to pass extra headers.

## Use cases

- Routing headers for test/staging API endpoints.
- Correlation / trace IDs for ops debugging.
- Tenant or feature-flag hints consumed by the API gateway.

## Changes

- `training/utils/infra.py` — new `read_api_extra_headers_env()` helper that parses `FIREWORKS_API_EXTRA_HEADERS`, logs warnings on malformed input, and returns `None` when unset/invalid so callers can pass the result straight through.
- `training/utils/__init__.py` — re-exports the helper.
- Each recipe loop that instantiates `TrainerJobManager` / `DeploymentManager` now passes `additional_headers=` from the helper:
  - `training/recipes/sft_loop.py`
  - `training/recipes/dpo_loop.py`
  - `training/recipes/orpo_loop.py`
  - `training/recipes/igpo_loop.py`
  - `training/recipes/rl_loop.py`

## Example

```bash
export FIREWORKS_API_EXTRA_HEADERS='{"x-my-routing-header":"foo","x-trace-id":"bar"}'
python -m training.recipes.sft_loop ...
```

All outgoing HTTPS requests from the recipe's `TrainerJobManager` / `DeploymentManager` will include those headers.

## Validation

- `python -c "ast.parse(...)"` on all modified files — clean.
- Standalone smoke of `read_api_extra_headers_env()` against: unset, valid JSON, invalid JSON, non-object JSON, non-string values, empty string, empty dict — all produce the expected `None` or parsed dict.

## Backwards compatibility

The env var defaults to unset → helper returns `None` → SDK behavior is identical to before. No recipe config changes required for existing users.