### PR TITLE
fix(training): resolve kimi_k25 renderer for Kimi-K2.6 tokenizers

### DIFF
--- a/training/tests/unit/test_supervised_rendering.py
+++ b/training/tests/unit/test_supervised_rendering.py
@@ -264,6 +264,10 @@ def test_resolve_renderer_name_prefers_kimi_k25_for_kimi_k2_5():
     assert resolve_renderer_name("moonshotai/Kimi-K2.5") == "kimi_k25"
 
 
+def test_resolve_renderer_name_prefers_kimi_k25_for_kimi_k2_6():
+    assert resolve_renderer_name("moonshotai/Kimi-K2.6") == "kimi_k25"
+
+
 def test_resolve_renderer_name_prefers_minimax_m2() -> None:
     """MiniMax M2 tokenizers should resolve to the custom renderer."""
     assert resolve_renderer_name("MiniMaxAI/MiniMax-M2") == "minimax_m2"

--- a/training/utils/supervised.py
+++ b/training/utils/supervised.py
@@ -73,6 +73,12 @@ def resolve_renderer_name(
     normalized_model_name = tokenizer_model.lower()
     if "moonshotai/kimi-k2.5" in normalized_model_name:
         return "kimi_k25"
+    # Kimi-K2.6 ships the same tiktoken vocab and special tokens as K2.5, and its
+    # default chat template output is identical to K2.5's (K2.6 only adds an
+    # opt-in preserve_thinking flag). Reuse the kimi_k25 renderer until a
+    # dedicated kimi_k26 renderer is registered in tinker_cookbook.
+    if "moonshotai/kimi-k2.6" in normalized_model_name:
+        return "kimi_k25"
     if "nemotron" in normalized_model_name:
         return "nemotron"
     if "minimax-m2" in normalized_model_name or "minimax_m2" in normalized_model_name:


### PR DESCRIPTION
## Summary

`training/utils/supervised.py::resolve_renderer_name` had an explicit branch for `moonshotai/Kimi-K2.5` but nothing for K2.6. Callers that leave `renderer_name` empty fell through to `tinker_cookbook.get_recommended_renderer_name(...)`, which raises `KeyError: 'Kimi-K2.6'` because upstream `get_moonshot_info()` only registers K2.5:

```
KeyError: 'Kimi-K2.6'

The above exception was the direct cause of the following exception:
...
  File ".../cookbook/training/recipes/dpo_loop.py", line 600, in main
    renderer = build_renderer(tokenizer, cfg.tokenizer_model, cfg.renderer_name)
  File ".../cookbook/training/utils/supervised.py", line 101, in build_renderer
    resolved_name = resolve_renderer_name(tokenizer_model, renderer_name)
  File ".../cookbook/training/utils/supervised.py", line 89, in resolve_renderer_name
    raise ValueError(
ValueError: Could not infer a renderer for tokenizer_model='moonshotai/Kimi-K2.6'. Set Config.renderer_name explicitly.
```

Reproduced on the single-shape CI run for the new `kimi-k2p6-text-256k-lora-b300-ref-same` shape: stress test passed on a real B300 trainer at 256k seq len, then the harness crashed in `dpo_loop.main → build_renderer` before sending any DPO step.

## Why `kimi_k25` is the correct renderer for K2.6

Checked the HuggingFace artifacts for `moonshotai/Kimi-K2.5` and `moonshotai/Kimi-K2.6` directly:

1. **`tiktoken.model` (BPE vocab)** — byte-identical.
   - K2.5: `size=2795286  sha256=b6c497a7469b33ced9c38afb1ad6e47f03f5e5dc05f15930799210ec050c5103`
   - K2.6: `size=2795286  sha256=b6c497a7469b33ced9c38afb1ad6e47f03f5e5dc05f15930799210ec050c5103`
2. **`tokenizer_config.json`** — byte-identical. Same `TikTokenTokenizer` class, same 163 840 vocab, same special-token IDs (`[BOS]=163584`, `[EOS]=163585`, `<|im_user|>=163587`, `<|im_assistant|>=163588`, all tool-call and media tokens unchanged).
3. **`chat_template.jinja`** — same emitted markup on default settings. K2.6 only adds an opt-in `preserve_thinking` flag (default `false`) and a backward-compatible `message.get('reasoning', message.get('reasoning_content', ''))` rename. For `role`/`content` messages without reasoning traces — which is every shape the SFT/DPO/RL recipes send today — K2.5 and K2.6 templates produce the same token sequence.

So `kimi_k25` is numerically correct for K2.6 SFT/DPO/RL. Once `tinker_cookbook` registers a dedicated `kimi_k26` renderer (needed to expose K2.6's new `preserve_thinking=true` branch for RL with reasoning), this branch can be flipped.

## Changes

- `training/utils/supervised.py`: add a `moonshotai/kimi-k2.6` branch right under the existing K2.5 one, returning `"kimi_k25"`. Additive — no change in behavior for any other tokenizer.
- `training/tests/unit/test_supervised_rendering.py`: mirror the existing `test_resolve_renderer_name_prefers_kimi_k25_for_kimi_k2_5` with a K2.6 case.

## Test plan

- [x] `pytest training/tests/unit/test_supervised_rendering.py -k resolve_renderer_name -v` — all 5 resolver tests pass (existing K2.5/minimax_m2/qwen3_5/gemma4 unchanged, new K2.6 case passes).
- [ ] Re-dispatch `training_single_shape_ci.yml` for `kimi-k2p6-text-256k-lora-b300-ref-same` after this lands + is synced into `fireworks.git` and confirm the DPO phase progresses past `build_renderer`.

Made with [Cursor](https://cursor.com)