### PR TITLE
fix(training): opt into trust_remote_code for Kimi-K2.6 image processor

### DIFF
--- a/training/tests/unit/test_supervised_rendering.py
+++ b/training/tests/unit/test_supervised_rendering.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+
 import pytest
 import torch
 import tinker
@@ -258,6 +260,89 @@ def test_build_renderer_uses_image_processor_for_vl_renderers(monkeypatch):
 
     assert renderer == "renderer"
     assert calls == [("qwen3_vl_instruct", "image-processor")]
+
+
+def test_build_renderer_opts_in_trust_remote_code_for_kimi_k2_6(monkeypatch):
+    """Kimi-K2.6 ships a custom image processor not covered by tinker_cookbook's
+    hardcoded trust_remote_code=True list; build_renderer must set the
+    HF_TRUST_REMOTE_CODE env var before calling get_image_processor so the
+    cached AutoImageProcessor load succeeds non-interactively in CI."""
+    monkeypatch.delenv("HF_TRUST_REMOTE_CODE", raising=False)
+
+    env_at_call: list[str | None] = []
+
+    def fake_get_image_processor(model_name):
+        env_at_call.append(os.environ.get("HF_TRUST_REMOTE_CODE"))
+        return "image-processor"
+
+    def fake_get_renderer(name, tokenizer, image_processor=None):
+        return ("renderer", name, image_processor)
+
+    monkeypatch.setattr(
+        "training.utils.supervised.get_image_processor", fake_get_image_processor
+    )
+    monkeypatch.setattr("training.utils.supervised.get_renderer", fake_get_renderer)
+
+    result = build_renderer(
+        tokenizer="tok",
+        tokenizer_model="moonshotai/Kimi-K2.6",
+    )
+
+    assert env_at_call == ["1"]
+    assert result == ("renderer", "kimi_k25", "image-processor")
+
+
+def test_build_renderer_does_not_touch_trust_remote_code_for_kimi_k2_5(monkeypatch):
+    """K2.5 is already covered by tinker_cookbook's hardcoded trust_remote_code
+    branch, so our opt-in helper must leave HF_TRUST_REMOTE_CODE unset for it."""
+    monkeypatch.delenv("HF_TRUST_REMOTE_CODE", raising=False)
+
+    env_at_call: list[str | None] = []
+
+    def fake_get_image_processor(model_name):
+        env_at_call.append(os.environ.get("HF_TRUST_REMOTE_CODE"))
+        return "image-processor"
+
+    def fake_get_renderer(name, tokenizer, image_processor=None):
+        return "renderer"
+
+    monkeypatch.setattr(
+        "training.utils.supervised.get_image_processor", fake_get_image_processor
+    )
+    monkeypatch.setattr("training.utils.supervised.get_renderer", fake_get_renderer)
+
+    build_renderer(
+        tokenizer="tok",
+        tokenizer_model="moonshotai/Kimi-K2.5",
+    )
+
+    assert env_at_call == [None]
+
+
+def test_build_renderer_preserves_existing_trust_remote_code_value(monkeypatch):
+    """Don't stomp a user-set HF_TRUST_REMOTE_CODE — setdefault semantics."""
+    monkeypatch.setenv("HF_TRUST_REMOTE_CODE", "0")
+
+    env_at_call: list[str | None] = []
+
+    def fake_get_image_processor(model_name):
+        env_at_call.append(os.environ.get("HF_TRUST_REMOTE_CODE"))
+        return "image-processor"
+
+    def fake_get_renderer(name, tokenizer, image_processor=None):
+        return "renderer"
+
+    monkeypatch.setattr(
+        "training.utils.supervised.get_image_processor", fake_get_image_processor
+    )
+    monkeypatch.setattr("training.utils.supervised.get_renderer", fake_get_renderer)
+
+    build_renderer(
+        tokenizer="tok",
+        tokenizer_model="moonshotai/Kimi-K2.6",
+    )
+
+    assert env_at_call == ["0"]
 
 
 def test_resolve_renderer_name_prefers_kimi_k25_for_kimi_k2_5():

--- a/training/utils/supervised.py
+++ b/training/utils/supervised.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import os
 from dataclasses import dataclass
 from typing import Any, Iterable, Mapping, Sequence
 
@@ -106,12 +107,34 @@ def build_renderer(
     """Construct the Tinker renderer used for supervised formatting."""
     resolved_name = resolve_renderer_name(tokenizer_model, renderer_name)
     if get_image_processor is not None and _renderer_uses_images(resolved_name):
+        _ensure_trust_remote_code_for_image_processor(tokenizer_model)
         return get_renderer(
             resolved_name,
             tokenizer,
             image_processor=get_image_processor(tokenizer_model),
         )
     return get_renderer(resolved_name, tokenizer)
+
+
+# tinker_cookbook.image_processing_utils.get_image_processor has a hard-coded
+# trust_remote_code=True branch only for moonshotai/Kimi-K2.5. Other Kimi-family
+# checkpoints that ship a custom image processor (e.g. moonshotai/Kimi-K2.6)
+# also require trust_remote_code, otherwise AutoImageProcessor.from_pretrained
+# raises ValueError in non-interactive environments (CI, service mode). The
+# same module honors HF_TRUST_REMOTE_CODE as an opt-in hook, so set it for
+# those checkpoints before the first (cached) call.
+_MODELS_REQUIRING_TRUST_REMOTE_CODE_FOR_IMAGE_PROCESSOR: tuple[str, ...] = (
+    "moonshotai/kimi-k2.6",
+)
+
+
+def _ensure_trust_remote_code_for_image_processor(tokenizer_model: str) -> None:
+    normalized = tokenizer_model.lower()
+    if any(
+        marker in normalized
+        for marker in _MODELS_REQUIRING_TRUST_REMOTE_CODE_FOR_IMAGE_PROCESSOR
+    ):
+        os.environ.setdefault("HF_TRUST_REMOTE_CODE", "1")
 
 
 def _renderer_uses_images(renderer_name: str) -> bool:


### PR DESCRIPTION
## Summary

Fixes the nightly single-shape training CI for `kimi-k2p6-*` shapes, which was crashing ~42 minutes into every run with:

```
ValueError: The repository moonshotai/Kimi-K2.6 contains custom code which must be
executed to correctly load the model. ... Please pass the argument
`trust_remote_code=True` to allow custom code to be run.
```

…thrown from `AutoImageProcessor.from_pretrained` inside
`tinker_cookbook.image_processing_utils.get_image_processor`, called from
`training/utils/supervised.py::build_renderer` at the top of
`dpo_loop.main` / `sft_loop.main` / `rl_loop.main` / `orpo_loop.main` /
`igpo_loop.main`.

### Root cause

`tinker_cookbook.image_processing_utils.get_image_processor` hard-codes a
`trust_remote_code=True` pass-through for a fixed list of models (e.g.
`Kimi-K2.5`) but falls back to the default prompt-the-user behavior for
anything else. Transformers v4 turns that prompt into a fatal
`ValueError` under non-interactive (CI) stdin, so any new Kimi-family
model whose HF repo ships custom image-processor code blows up on first
load.

Instead of patching `tinker_cookbook` (upstream-owned), we use the
`HF_TRUST_REMOTE_CODE=1` env-var hook it already respects and set it
conditionally for the known-affected models (currently just K2.6).

### Change

`training/utils/supervised.py::build_renderer` now, for a small allow-list
of `tokenizer_model` substrings (currently `moonshotai/kimi-k2.6`), calls
`os.environ.setdefault("HF_TRUST_REMOTE_CODE", "1")` right before invoking
`get_image_processor(tokenizer_model)`. This:

- Is scoped — runs only for renderers that actually need an image processor
  AND for models on the allow-list.
- Uses `setdefault` — never stomps an operator-provided value, just
  supplies a default when unset.
- Leaves K2.5 (already handled by `tinker_cookbook`) and all text-only
  models untouched.

### Also includes: local smoke helper

`training/examples/tools/client_side_smoke.py` — a 7-second standalone
reproducer that runs the exact call chain (`resolve_renderer_name` →
`AutoTokenizer.from_pretrained` → `build_renderer`) offline from a dev
box, so we never again burn 42 minutes of CI trainer-warmup to discover
a pure client-side bug.

```bash
# Reproduce a failure before fixing it (negative control)
python training/examples/tools/client_side_smoke.py \
  --tokenizer moonshotai/Kimi-K2.6 --renderer-name kimi_k25 --disable-fix

# Validate a fix
python training/examples/tools/client_side_smoke.py \
  --tokenizer moonshotai/Kimi-K2.6 --renderer-name kimi_k25
```

## Validation

### Unit tests (19/19 passing)

```
training/tests/unit/test_supervised_rendering.py::
  test_build_renderer_opts_in_trust_remote_code_for_kimi_k2_6      PASSED
  test_build_renderer_does_not_touch_trust_remote_code_for_kimi_k2_5 PASSED
  test_build_renderer_preserves_existing_trust_remote_code_value    PASSED
  ... (16 existing tests, all green)
```

### Local client-side reproduction

| Scenario | Expected | Actual | Time |
|---|---|---|---|
| K2.6, `--disable-fix`, clean env | Reproduce CI `ValueError` | Reproduced from same stack (`image_processing_auto.py:610 → dynamic_module_utils.py:736`) | 26s |
| K2.6, fix enabled, clean env | `KimiK25Renderer` built | Built cleanly | 7s |
| K2.5 regression, fix enabled, clean env | `KimiK25Renderer` built (no change) | Built cleanly | 12s |

### End-to-end CI (fireworks submodule bumped to this branch)

Dispatched `training_single_shape_ci.yml` on fireworks test branch
`renfei/test-kimi-k26-cookbook-fix` (which pins the cookbook submodule to
this branch's HEAD `717db9b`) with the exact failing shape
`fireworks-ml-inf-kimi-k2.6-ho-orig-1028-dev` / `kimi-k2p6-text-256k-lora-b300-ref-same`:
[fw-ai/fireworks/actions/runs/24701469795](https://github.com/fw-ai/fireworks/actions/runs/24701469795)
(in progress — critical `build_renderer` failure point is ~42 min in).

## Follow-up

After this merges, bump the cookbook submodule pointer in `fw-ai/fireworks`
([PR #23080](https://github.com/fw-ai/fireworks/pull/23080)) to this
branch's merge commit on cookbook `main`.

## Related

- Prior fix (now merged): [#357 fix(training): resolve kimi_k25 renderer for Kimi-K2.6 tokenizers](https://github.com/fw-ai/cookbook/pull/357) — added `resolve_renderer_name` mapping.
- `tinker_cookbook` reference: [image_processing_utils.py](https://github.com/thinking-machines-lab/tinker-cookbook/blob/main/tinker_cookbook/image_processing_utils.py) — hard-codes K2.5 but not K2.6 for `trust_remote_code`.

Made with [Cursor](https://cursor.com)