### PR TITLE
fix(infra): warn on ref_training_shape_id + lora_rank, clarify LoRA shared-session in skill docs

### DIFF
--- a/skills/dev/references/rl/custom-loss.md
+++ b/skills/dev/references/rl/custom-loss.md
@@ -33,7 +33,7 @@ All live on `rl_loop.Config`:
 | `policy_loss` | `"grpo"` | `grpo`, `importance_sampling`, `dapo`, `dro`, `gspo`, `reinforce`, `cispo`. Decides server-side vs client-side dispatch. |
 | `completions_per_prompt` | `4` | GRPO group size — responses sampled per prompt. |
 | `prompt_groups_per_step` | `1` | Number of prompt groups per `forward_backward + optim_step` pair. |
-| `kl_beta` | `0.001` | KL-to-reference coefficient (requires `cfg.infra.ref_training_shape_id`). |
+| `kl_beta` | `0.001` | KL-to-reference coefficient. For full-param, requires `cfg.infra.ref_training_shape_id` (provisions a separate forward-only trainer). For LoRA, leave it unset — `setup_infra` uses the shared-session reference on the policy trainer. |
 | `eps_clip`, `eps_clip_high` | `0.2`, `None` | PPO clip for GRPO. |
 | `router_replay` | `False` | Record routing at rollout time and replay during training (MoE models). |
 | `grad_accumulation_normalization` | `NUM_LOSS_TOKENS` | Per-token mean (matches GRPO paper). See [`gradient-accumulation.md`](gradient-accumulation.md). |

--- a/skills/dev/references/shapes.md
+++ b/skills/dev/references/shapes.md
@@ -33,9 +33,11 @@ if not cfg.deployment.deployment_shape and profile.deployment_shape_version:
 
 That is a **versioned** path (`accounts/fw/deploymentShapes/ds-x/versions/abc123`). The `to_deployment_config` helper in `training/utils/config.py` auto-clears manual accelerator fields whenever a shape is present.
 
-## Reference-model shape (RL only)
+## Reference-model shape (RL / DPO)
 
-For RL with a frozen reference, set `cfg.infra.ref_training_shape_id` explicitly — there is no implicit fallback. It can share the same shape as the policy; the control plane appends `--forward-only` automatically.
+For **full-parameter** training with a frozen reference, set `cfg.infra.ref_training_shape_id` explicitly — there is no implicit fallback. It can share the same shape as the policy; the control plane appends `--forward-only` automatically.
+
+For **LoRA** (`lora_rank > 0`), leave `ref_training_shape_id` unset. `setup_infra` uses `policy.create_base_reference()` on the policy trainer for reference logprobs — no separate forward-only trainer, no extra GPUs. Setting `ref_training_shape_id` alongside `lora_rank > 0` logs a warning and still provisions the separate trainer, which defeats LoRA's GPU savings (and can OOM on very large LoRA base models). The CI pattern is `ref_shape = "" if lora_rank > 0 else <explicit shape>`.
 
 ## When to skip validation
 

--- a/training/utils/config.py
+++ b/training/utils/config.py
@@ -72,11 +72,13 @@ class InfraConfig:
     When set, infra config is auto-derived from the shape."""
 
     ref_training_shape_id: str | None = None
-    """Training shape ID for the reference (forward-only) trainer.
-    When set, a reference model is created.  When not set, no reference
-    model is created.  No implicit fallback.  Can be the same value as
-    ``training_shape_id`` -- the control plane auto-appends
-    ``--forward-only`` via ``applyForwardOnlyConfig``."""
+    """Training shape ID for a **separate** forward-only reference trainer.
+    Only relevant for **full-parameter** training — LoRA runs use the
+    shared-session reference (``policy.create_base_reference()``) on the
+    policy trainer, so leave this ``None`` when ``lora_rank > 0``. For
+    full-param, when set, a second trainer is provisioned; when not set,
+    no reference is created. Can be the same value as ``training_shape_id``
+    — the control plane auto-appends ``--forward-only``."""
 
     region: str | None = None
     custom_image_tag: str | None = None

--- a/training/utils/infra.py
+++ b/training/utils/infra.py
@@ -1075,6 +1075,14 @@ def _resolve_reference_shape(
 ) -> tuple[Any | None, str | None]:
     """Return (ref_profile, resolved_ref_shape_id)."""
     if ref_training_shape_id:
+        if lora_rank > 0:
+            logger.warning(
+                "ref_training_shape_id=%r is set alongside lora_rank=%d. This provisions a "
+                "separate full-param forward-only reference trainer, which defeats LoRA's "
+                "GPU savings. For LoRA, leave ref_training_shape_id unset — setup_infra "
+                "will use the shared-session reference (policy.create_base_reference()).",
+                ref_training_shape_id, lora_rank,
+            )
         return rlor_mgr.resolve_training_profile(ref_training_shape_id), ref_training_shape_id
     if not (needs_reference and lora_rank == 0):
         return None, None


### PR DESCRIPTION
## Summary

Motivated by fw-ai/fireworks#23177 — the shape E2E test was passing \`ref_training_shape\` on every row, which OOM'd large LoRA shapes (kimi-k2p5 1T) because \`_resolve_reference_shape\` silently provisions a separate full-param forward-only reference trainer whenever \`ref_training_shape_id\` is set. That PR clears \`ref_shape\` on the CI side for \`lora_rank > 0\`, which is correct, but it papers over the fact that the cookbook never tells users:

- For LoRA, \`setup_infra\` uses \`policy.create_base_reference()\` on the policy trainer for reference logprobs — no separate forward-only trainer, no extra GPUs. That's the \"shared-session\" path.
- Setting \`ref_training_shape_id\` alongside \`lora_rank > 0\` defeats LoRA's whole GPU savings benefit.

Changes:

- **\`training/utils/infra.py\` — \`_resolve_reference_shape\`**: one-line warning when \`ref_training_shape_id\` is set with \`lora_rank > 0\`. Behaviour unchanged, just visible now.
- **\`training/utils/config.py\` — \`InfraConfig.ref_training_shape_id\` docstring**: was \`\"When not set, no reference model is created\"\`, which is wrong for LoRA. Now says: full-param-only knob; for LoRA, leave \`None\`.
- **\`skills/dev/references/rl/custom-loss.md\`**: drop the line that said \`kl_beta\` requires \`cfg.infra.ref_training_shape_id\`. Full-param needs it; LoRA doesn't.
- **\`skills/dev/references/shapes.md\`**: spell out the LoRA shared-session path + the CI pattern \`ref_shape = \"\" if lora_rank > 0 else ...\` so the next caller who writes a shape driver doesn't repeat the fw-ai/fireworks#23177 OOM.

## Test plan

- [x] \`pytest training/tests/unit/test_infra_setup.py training/tests/unit/test_infra.py\` — 37 passed
- [ ] Reviewer skims the three doc edits for tone consistency with the rest of the skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)