### PR TITLE
compat: align on cancel_* canonical, deprecate cleanup_on_exit + delete_trainer

### DIFF
--- a/training/examples/manual/test_deployment_first_manual.py
+++ b/training/examples/manual/test_deployment_first_manual.py
@@ -162,7 +162,7 @@ def main() -> None:
         config,
         rlor_mgr=rlor_mgr,
         deploy_mgr=deploy_mgr,
-        cleanup_on_exit=not args.keep_resources,
+        cancel_on_exit=not args.keep_resources,
     )
     logger.info("Run metrics: %s", metrics)
 

--- a/training/examples/manual/test_reattach_manual.py
+++ b/training/examples/manual/test_reattach_manual.py
@@ -112,7 +112,7 @@ def _build_config(
     )
 
 
-def _run(cfg: rl_loop.Config, rlor_mgr, deploy_mgr, cleanup_on_exit: bool) -> dict:
+def _run(cfg: rl_loop.Config, rlor_mgr, deploy_mgr, cancel_on_exit: bool) -> dict:
     # Lazy import: train_deepmath reads FIREWORKS_API_KEY at import time, so
     # we defer until main() has already validated the env.
     from training.examples.rl.deepmath.train_deepmath import deepmath_reward
@@ -122,7 +122,7 @@ def _run(cfg: rl_loop.Config, rlor_mgr, deploy_mgr, cleanup_on_exit: bool) -> di
     rl_loop.reward_fn = deepmath_reward
     rl_loop.should_accept = lambda _: True  # avoid zero-variance filter on tiny runs
     return rl_loop.main(
-        cfg, rlor_mgr=rlor_mgr, deploy_mgr=deploy_mgr, cleanup_on_exit=cleanup_on_exit,
+        cfg, rlor_mgr=rlor_mgr, deploy_mgr=deploy_mgr, cancel_on_exit=cancel_on_exit,
     )
 
 
@@ -190,10 +190,10 @@ def main() -> None:
         )
 
     # Run 1: cold start. setup_infra creates both trainer + deployment.
-    # cleanup_on_exit=False so the deployment survives for run 2.
+    # cancel_on_exit=False so the deployment survives for run 2.
     logger.info("--- Run 1: cold start ---")
     cfg1 = _make_cfg("r1")
-    metrics1 = _run(cfg1, rlor_mgr, deploy_mgr, cleanup_on_exit=False)
+    metrics1 = _run(cfg1, rlor_mgr, deploy_mgr, cancel_on_exit=False)
     logger.info("Run 1 metrics: %s", metrics1)
     trainer_r1 = metrics1.get("policy_job_id")
 
@@ -211,7 +211,7 @@ def main() -> None:
     # fresh trainer, PATCHes hot_load_trainer_job, waits for the pod roll.
     logger.info("--- Run 2: re-attach ---")
     cfg2 = _make_cfg("r2")
-    metrics2 = _run(cfg2, rlor_mgr, deploy_mgr, cleanup_on_exit=not args.keep_resources)
+    metrics2 = _run(cfg2, rlor_mgr, deploy_mgr, cancel_on_exit=not args.keep_resources)
     logger.info("Run 2 metrics: %s", metrics2)
 
     trainer_r2 = metrics2.get("policy_job_id")

--- a/training/examples/rl/deepmath/train_deepmath.py
+++ b/training/examples/rl/deepmath/train_deepmath.py
@@ -359,7 +359,7 @@ def main():
         config,
         rlor_mgr=rlor_mgr,
         deploy_mgr=deploy_mgr,
-        cleanup_on_exit=not args.skip_cleanup,
+        cancel_on_exit=not args.skip_cleanup,
     )
 
     logger.info("Training complete. Final metrics: %s", metrics)

--- a/training/recipes/igpo_loop.py
+++ b/training/recipes/igpo_loop.py
@@ -243,8 +243,17 @@ def main(
     config: Config,
     rlor_mgr: TrainerJobManager | None = None,
     deploy_mgr: DeploymentManager | None = None,
-    cleanup_on_exit: bool = False,
+    cancel_on_exit: bool = False,
+    cleanup_on_exit: bool | None = None,
 ):
+    if cleanup_on_exit is not None:
+        import warnings
+        warnings.warn(
+            "igpo_loop.main(cleanup_on_exit=...) is deprecated; use cancel_on_exit=...",
+            DeprecationWarning, stacklevel=2,
+        )
+        cancel_on_exit = cleanup_on_exit
+
     cfg = config
     if cfg.policy_base_url or cfg.reference_base_url:
         logger.warning(
@@ -359,7 +368,7 @@ def main(
         # Create deployment referencing the trainer's hot-load bucket
         cfg.deployment.hot_load_trainer_job = policy_ep.job_name
         dep_info = setup_deployment(deploy_mgr, cfg.deployment, cfg.base_model, cfg.infra)
-        if cleanup_on_exit:
+        if cancel_on_exit:
             cleanup.deployment(cfg.deployment.deployment_id, action="scale_to_zero")
 
         policy_job_id = policy_ep.job_id

--- a/training/recipes/rl_loop.py
+++ b/training/recipes/rl_loop.py
@@ -275,8 +275,17 @@ def main(
     config: Config,
     rlor_mgr: TrainerJobManager | None = None,
     deploy_mgr: DeploymentManager | None = None,
-    cleanup_on_exit: bool = False,
+    cancel_on_exit: bool = False,
+    cleanup_on_exit: bool | None = None,
 ):
+    if cleanup_on_exit is not None:
+        import warnings
+        warnings.warn(
+            "rl_loop.main(cleanup_on_exit=...) is deprecated; use cancel_on_exit=...",
+            DeprecationWarning, stacklevel=2,
+        )
+        cancel_on_exit = cleanup_on_exit
+
     cfg = config
     if cfg.policy_base_url or cfg.reference_base_url:
         logger.warning(
@@ -362,7 +371,7 @@ def main(
             needs_inference=True,
             role_prefix="grpo",
             api_key=api_key,
-            cleanup=cleanup if cleanup_on_exit else None,
+            cleanup=cleanup if cancel_on_exit else None,
             on_status=_on_trainer_status,
         )
         for closeable in infra.closeables:

--- a/training/tests/smoke_test/test_grpo_deepmath_trainer_first_smoke.py
+++ b/training/tests/smoke_test/test_grpo_deepmath_trainer_first_smoke.py
@@ -90,7 +90,7 @@ def test_grpo_deepmath_trainer_first(
         config,
         rlor_mgr=rlor_mgr,
         deploy_mgr=deploy_mgr,
-        cleanup_on_exit=True,
+        cancel_on_exit=True,
     )
 
     # No seed pinning: this is an API contract smoke (steps complete, cleanup

--- a/training/tests/smoke_test/test_grpo_smoke.py
+++ b/training/tests/smoke_test/test_grpo_smoke.py
@@ -96,7 +96,7 @@ def test_grpo_smoke(
             config,
             rlor_mgr=rlor_mgr,
             deploy_mgr=deploy_mgr,
-            cleanup_on_exit=True,
+            cancel_on_exit=True,
         )
 
         assert isinstance(metrics, dict), f"Expected dict, got {type(metrics)}"

--- a/training/utils/checkpoint_utils.py
+++ b/training/utils/checkpoint_utils.py
@@ -75,7 +75,10 @@ def resolve_resume(
     if init_from_checkpoint:
         source_job_id, dcp_name = _parse_cross_job(init_from_checkpoint)
         path = client.resolve_checkpoint_path(dcp_name, source_job_id=source_job_id)
-        logger.info("Fresh start with pretrained weights: %s", path)
+        logger.info(
+            "Starting at step 0 with weights loaded from %s (no resume — step counter resets)",
+            path,
+        )
         t0 = time.time()
         client.load_state_with_optimizer(path)
         logger.info("Checkpoint loaded (%.1fs)", time.time() - t0)
@@ -93,7 +96,7 @@ def resolve_resume(
             source_job_id=last.get("source_job_id"),
         )
 
-    logger.info("Fresh start (no checkpoint)")
+    logger.info("Starting at step 0 from base model (no checkpoint)")
     return None
 
 

--- a/training/utils/infra.py
+++ b/training/utils/infra.py
@@ -1056,6 +1056,12 @@ def setup_infra(
             trainer_job_name=policy_handle.job_name, cleanup=cleanup,
         )
 
+    # Ensure the deploy_cfg fed into wait_deployment carries the resolved
+    # deployment_id (request_deployment auto-generates it on an inner-scope
+    # copy; without this propagation wait_deployment polls /deployments/None).
+    if local_deploy_cfg is not None and resolved_deployment_id is not None:
+        local_deploy_cfg = dataclasses.replace(local_deploy_cfg, deployment_id=resolved_deployment_id)
+
     # Wait for all pending resources in parallel.
     policy_ep, reference_ep, ready_dep_info = _await_in_parallel(
         rlor_mgr=rlor_mgr,


### PR DESCRIPTION
## Summary

After #365 merged, naming was inconsistent between the method and the parameter:

| | Canonical | Deprecated alias |
|---|---|---|
| `ResourceCleanup.cancel_trainer` / `delete_trainer` | `cancel_trainer` | `delete_trainer` (warning) |
| `rl_loop.main` / `igpo_loop.main` kwarg | `cleanup_on_exit` | none (`cancel_on_exit` hard-removed) |

The verb `cancel` was canonical on the method but deprecated-by-removal on the parameter. That's confusing for users and breaks external callers that migrated to #356's `cancel_on_exit` naming (including fw-ai/fireworks `test_shape_e2e.py`).

## Fix

Align everything on the **cancel side** — matches #356's intent, matches the server `:cancel` endpoint, and matches what `cancel_trainer` did post-#253:

- `rl_loop.main` / `igpo_loop.main`: revert `cleanup_on_exit` → `cancel_on_exit` as canonical; accept `cleanup_on_exit` as a deprecated kwarg alias that emits `DeprecationWarning` and forwards into `cancel_on_exit`.
- `ResourceCleanup.cancel_trainer` (+ `delete_trainer` deprecated alias) — unchanged from main post-#365 (already on the cancel side).
- All in-tree callers updated to the canonical name (deepmath, smoke tests, manual scripts).

Pre-#356 callers on `cleanup_on_exit` keep working with a warning; external callers on `cancel_on_exit` (e2e, etc.) work against unpatched main again — **no test-side fix in fw-ai/fireworks needed**.

## Test plan

- [x] `pytest training/tests/unit` — 352 passed, 32 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)