### PR TITLE
log: clarify resolve_resume messages — drop 'Fresh start with pretrained'

### DIFF
--- a/training/utils/checkpoint_utils.py
+++ b/training/utils/checkpoint_utils.py
@@ -75,7 +75,10 @@ def resolve_resume(
     if init_from_checkpoint:
         source_job_id, dcp_name = _parse_cross_job(init_from_checkpoint)
         path = client.resolve_checkpoint_path(dcp_name, source_job_id=source_job_id)
-        logger.info("Fresh start with pretrained weights: %s", path)
+        logger.info(
+            "Starting at step 0 with weights loaded from %s (no resume — step counter resets)",
+            path,
+        )
         t0 = time.time()
         client.load_state_with_optimizer(path)
         logger.info("Checkpoint loaded (%.1fs)", time.time() - t0)
@@ -93,7 +96,7 @@ def resolve_resume(
             source_job_id=last.get("source_job_id"),
         )
 
-    logger.info("Fresh start (no checkpoint)")
+    logger.info("Starting at step 0 from base model (no checkpoint)")
     return None
 
 


### PR DESCRIPTION
## Summary

The `resolve_resume` log line when `init_from_checkpoint` is set read as a contradiction:

    INFO Fresh start with pretrained weights: cross_job://job-abc/step-2

'Fresh' suggests no weights loaded; 'pretrained' says the opposite. The intent is: **step counter starts at 0, but weights are initialized from a prior DCP** (the cross-job handoff pattern — the nightly shape-e2e uses it between DPO and DCP-resume phases).

Split the two ideas:

| Case | Old log | New log |
|---|---|---|
| `init_from_checkpoint` set | `Fresh start with pretrained weights: <path>` | `Starting at step 0 with weights loaded from <path> (no resume — step counter resets)` |
| No checkpoint at all | `Fresh start (no checkpoint)` | `Starting at step 0 from base model (no checkpoint)` |
| Local `checkpoints.jsonl` | `Resuming from checkpoints.jsonl: …` | unchanged |

## Test plan

- [x] `pytest training/tests/unit` — 352 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)