### PR TITLE
fix: add orjson to cookbook dependencies for tinker compatibility

### DIFF
--- a/training/pyproject.toml
+++ b/training/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "transformers",
     "python-dotenv",
     "wandb",
+    "orjson",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- `tinker==0.18.1` unconditionally imports `orjson` in `_response.py` but does not declare it as a dependency in its package metadata — a packaging bug on tinker's side.
- This causes `ModuleNotFoundError: No module named 'orjson'` in nightly CI when `test_shape_e2e.py` → `dpo_loop.py` → `import tinker` triggers the import chain.
- Adds `orjson` as an explicit dependency in the cookbook's `pyproject.toml` as a workaround.

Failing run: https://github.com/fw-ai/fireworks/actions/runs/24755616038/job/72428090856

## Test plan
- [ ] Verify nightly CI `Install dependencies` step installs `orjson`
- [ ] Verify `test_shape_e2e.py` imports succeed without `ModuleNotFoundError`

Made with [Cursor](https://cursor.com)