### PR TITLE
test(infra_setup): fix flaky test_parallel_wait_timing on CI

### DIFF
--- a/training/tests/unit/test_infra_setup.py
+++ b/training/tests/unit/test_infra_setup.py
@@ -523,7 +523,7 @@ def test_parallel_request_phase_precedes_wait_phase(monkeypatch):
 def test_parallel_wait_timing(monkeypatch):
     """Both trainer waits run in parallel; total wall time ≈ max(N), not sum(N)."""
     _FakeClient.instances = []
-    SLEEP_S = 0.15  # each wait sleeps this long; sum would be 0.30
+    SLEEP_S = 0.5  # each wait sleeps this long; serial would be 2*SLEEP_S = 1.0s
 
     def fake_request_trainer(_rlor, *, display_name, forward_only=False, **kwargs):
         job_id = "ref-job" if "reference" in display_name else "policy-job"
@@ -564,9 +564,12 @@ def test_parallel_wait_timing(monkeypatch):
     elapsed = time.monotonic() - t0
 
     # Parallel: elapsed ≈ SLEEP_S (max of two). Serial would be 2*SLEEP_S.
-    # Allow up to 1.5x to avoid flakes on slow CI.
-    assert elapsed < SLEEP_S * 1.5, (
-        f"Waits appear serial: {elapsed:.3f}s ≥ {SLEEP_S * 1.5:.3f}s (sum would be {SLEEP_S * 2:.3f}s)"
+    # Threshold is 1.5*SLEEP_S (midpoint between parallel and serial), which
+    # cleanly distinguishes the two even with hundreds of ms of fixture/CI
+    # overhead. Using SLEEP_S=0.5s keeps that overhead as noise, not signal.
+    threshold = SLEEP_S * 1.5
+    assert elapsed < threshold, (
+        f"Waits appear serial: {elapsed:.3f}s ≥ {threshold:.3f}s (sum would be {SLEEP_S * 2:.3f}s)"
     )
 
 


### PR DESCRIPTION
## Summary

Bumps `SLEEP_S` in `test_parallel_wait_timing` from 0.15s to 0.5s so the parallel-vs-serial distinction remains ≫ the GHA runner's fixture/executor-startup overhead.

## Why

The test asserts the two trainer waits in `setup_infra` run in parallel (elapsed ≈ max instead of sum). With `SLEEP_S=0.15` and a 1.5× threshold (0.225s), fixture + `ThreadPoolExecutor` startup contributed ~200ms regardless of parallelism, so CI landed around 0.36s and the assertion fired false positives consistently.

Observed on PR #347 CI runs (24757323518):
```
AssertionError: Waits appear serial: 0.381s ≥ 0.225s
AssertionError: Waits appear serial: 0.361s ≥ 0.225s
```

## Fix

`SLEEP_S = 0.5`. Parallel elapsed ≈ 0.5s, serial ≈ 1.0s, threshold 0.75s. CI overhead becomes noise; the test still actually checks that both waits happen concurrently.

## Cost

Local runtime goes from ~2.0s to ~2.5s. Negligible.

## Test plan

- [x] `pytest training/tests/unit/test_infra_setup.py::test_parallel_wait_timing` passes locally.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)