### PR TITLE
fix(sft): stream-render dataset to fix orchestrator OOM on large/long-context jobs

### DIFF
--- a/skills/dev/references/shapes.md
+++ b/skills/dev/references/shapes.md
@@ -37,7 +37,11 @@ That is a **versioned** path (`accounts/fw/deploymentShapes/ds-x/versions/abc123
 
 For **full-parameter** training with a frozen reference, set `cfg.infra.ref_training_shape_id` explicitly — there is no implicit fallback. It can share the same shape as the policy; the control plane appends `--forward-only` automatically.
 
-For **LoRA** (`lora_rank > 0`), leave `ref_training_shape_id` unset. `setup_infra` uses `policy.create_base_reference()` on the policy trainer for reference logprobs — no separate forward-only trainer, no extra GPUs. Setting `ref_training_shape_id` alongside `lora_rank > 0` logs a warning and still provisions the separate trainer, which defeats LoRA's GPU savings (and can OOM on very large LoRA base models). The CI pattern is `ref_shape = "" if lora_rank > 0 else <explicit shape>`.
+For **LoRA** (`lora_rank > 0`), two valid options:
+- **Shared session (recommended, saves GPUs)**: leave `ref_training_shape_id` unset. `setup_infra` uses `policy.create_base_reference()` on the policy trainer for reference logprobs — no separate trainer, no extra GPUs.
+- **Separate LoRA-capable ref trainer**: set `ref_training_shape_id` to a `LORA_TRAINER` shape (typically the same as the policy shape). `setup_infra` provisions a forward-only LoRA ref trainer (its own GPUs) and forwards `lora_rank` to both the trainer request and the ref client so the gateway infers `trainer_mode=LORA_TRAINER` and matches the shape. CP's V2 DPO auto-resolver picks this path by default for LoRA DPO.
+
+The CI pattern for the saves-GPUs variant is `ref_shape = "" if lora_rank > 0 else <explicit shape>`.
 
 ## When to skip validation
 

--- a/training/recipes/dpo_loop.py
+++ b/training/recipes/dpo_loop.py
@@ -3,19 +3,28 @@
 
 Optimisations:
 
+  - **Streaming render**: preference rows are rendered to Datums on the fly
+    inside DataLoader workers (PyTorch ``spawn``), so the orchestrator
+    never holds the full tokenized dataset in RAM. Same machinery as
+    ``sft_loop``; see fw-ai/cookbook#371.
   - **Pipelined ref/training**: reference logprobs are computed
     concurrently with policy training via a producer/consumer pipeline.
     The reference trainer is deleted as soon as all ref forwards
     complete -- even while training continues.
+  - **Append-only ref cache**: for multi-epoch runs, enriched pairs
+    (datums + ref logprobs) are spilled to a tiny pickle log on disk so
+    epochs 1+ stream them sequentially without re-running the reference
+    forward. The log is sequential-only -- no random access, no offset
+    table -- which is sufficient for "iterate front-to-back per epoch".
   - **Client-side fused train steps**: all datums for one optimizer window
-    are sent in a single ``forward_backward_custom`` call so the backend can
-    batch the whole step more efficiently.
+    are sent in a single ``forward_backward_custom`` call so the backend
+    can batch the whole step more efficiently.
 
 Architecture:
     - Policy RLOR job:    forward_backward_custom + optim_step (trainable)
     - Reference RLOR job: forward only (frozen base model, for KL baseline)
-    - Epoch 0: ref forward and training overlap via unbounded asyncio.Queue
-    - Epochs 1+: ref logprobs cached from epoch 0, no ref GPU needed
+    - Epoch 0: DataLoader → ref forward → train via unbounded asyncio.Queue
+    - Epochs 1+: ref logprobs streamed from AppendOnlyPickleLog, no ref GPU
 
 Usage:
     export FIREWORKS_API_KEY=...
@@ -24,54 +33,60 @@ Usage:
 
 from __future__ import annotations
 
-import os
-import random
-import time
-import signal
+import array
 import asyncio
+import functools
 import logging
+import os
+import signal
+import tempfile
+import time
 from contextlib import ExitStack
+from dataclasses import dataclass, field
 from typing import Any, Callable
-import dataclasses
-from dataclasses import field, dataclass
-from concurrent.futures import ThreadPoolExecutor
 
 import tinker
+import transformers
 from tqdm import tqdm
 
 from fireworks.training.sdk import DeploymentManager, TrainerJobManager
 from training.utils import (
+    AppendOnlyPickleLog,
     DEFAULT_ADAM,
+    DEFAULT_RENDER_WORKERS,
+    DeployConfig,
     InfraConfig,
+    JsonlRenderDataset,
+    ReconnectableClient,
     ResourceCleanup,
+    RunStatus,
     RunnerConfig,
     RunnerIO,
-    RunStatus,
     WandBConfig,
-    DeployConfig,
-    ReconnectableClient,
-    wandb_log,
-    setup_wandb,
-    wandb_finish,
-    validate_config,
+    build_renderer,
     log_metrics_json,
     make_batch_dpo_loss_fn,
+    make_render_dataloader,
     read_api_extra_headers_env,
-    load_preference_dataset,
-    build_renderer,
     render_preference_pair,
     resolve_renderer_name,
+    setup_wandb,
+    validate_config,
+    wandb_finish,
+    wandb_log,
 )
 from training.utils.checkpoint_utils import (
+    CheckpointKind,
     resolve_resume,
     save_checkpoint,
     validate_warm_start_config,
-    CheckpointKind,
 )
+from training.utils.data import _normalize_preference_row
 from training.utils.rl import setup_infra
-from training.utils.timer import timer, flush_timing
+from training.utils.timer import flush_timing, timer
 
 logger = logging.getLogger(__name__)
+
 
 # ---------------------------------------------------------------------------
 # Config
@@ -97,15 +112,15 @@ class Config:
     """Deprecated. Ignored. Use ``batch_size`` to control the effective batch."""
     max_seq_len: int | None = None
     max_pairs: int | None = None
+    """Cap on *valid rendered pairs* after schema/length filtering."""
     lora_rank: int = 0
 
     ref_cache_concurrency: int = 16
     """Max concurrent reference forward passes during cache warm-up."""
     ref_cache_batch_size: int = 1
     """Number of preference pairs per reference forward call during caching."""
-
-    seed: int = 0
-    """Seed for deterministic per-epoch data shuffling (epochs >= 1)."""
+    render_workers: int = DEFAULT_RENDER_WORKERS
+    """Number of DataLoader workers for streaming render. <=1 = in-process."""
 
     step_timeout: int = 0
     """Timeout in seconds for forward_backward / optim_step calls.
@@ -126,102 +141,96 @@ class Config:
     output_model_id: str | None = None
     save_final_checkpoint: bool = True
     runner: RunnerConfig = field(default_factory=RunnerConfig)
-    """Optional orchestration outputs written during training.
-
-    Paths can be set here or via environment variables:
-      COOKBOOK_STATUS_FILE      -- training status + progress (JSON, overwritten each step)
-      COOKBOOK_METADATA_FILE    -- tokens processed + accelerator-seconds (JSON)
-      COOKBOOK_METRICS_FILE     -- per-step metrics (JSONL, appended each step)
-      COOKBOOK_OUTPUT_MODEL_PATH -- final model info written on completion (JSON)
-
-    All paths are optional; unset paths are silently skipped.
-    See training/utils/runner.py for file format details.
-    """
 
 
 # ---------------------------------------------------------------------------
-# Tokenization and reference forward
+# Per-worker render: tokenizer + renderer cached in module-level state
 # ---------------------------------------------------------------------------
 
 
-def _tokenize_pair(
-    example: dict[str, Any],
-    tokenizer: Any,
-    renderer: Any,
+# Populated once per process: in the parent (for num_workers <= 1 fallback)
+# and in each spawn worker via ``_init_pair_worker``. Mirrors sft_loop.py.
+_pair_worker_state: dict = {}
+
+
+def _init_pair_worker(
+    tokenizer_model: str,
+    renderer_name: str,
     max_seq_len: int,
-) -> dict[str, Any] | None:
-    """Tokenize a single preference pair. Returns None if invalid, 'filtered' if too long."""
-    pair = render_preference_pair(
-        example["chosen"],
-        example["rejected"],
-        renderer=renderer,
-        tokenizer=tokenizer,
+    _worker_id: int | None = None,
+) -> None:
+    """Populate ``_pair_worker_state`` with a tokenizer + renderer.
+
+    ``_worker_id`` is accepted (and ignored) so this function can be used
+    directly as a DataLoader ``worker_init_fn`` after binding the other
+    args via ``functools.partial``.
+    """
+    tokenizer = transformers.AutoTokenizer.from_pretrained(
+        tokenizer_model, trust_remote_code=True,
     )
+    _pair_worker_state.update(
+        renderer=build_renderer(tokenizer, tokenizer_model, renderer_name),
+        tokenizer=tokenizer,
+        max_seq_len=max_seq_len,
+    )
+
+
+def _render_pair_worker(row: dict[str, Any]) -> dict[str, Any] | None:
+    """Render one JSONL row to a Datum-pair dict, or ``None`` to drop.
+
+    Combines schema normalisation (chosen / rejected / samples / OpenAI),
+    rendering, and over-length filtering. Returning ``None`` covers all
+    drop reasons; the DataLoader's collate filters Nones out of each batch.
+    """
+    pair = _normalize_preference_row(row)
     if pair is None:
         return None
-    if len(pair.chosen_tokens) > max_seq_len or len(pair.rejected_tokens) > max_seq_len:
-        return "filtered"
-
+    rendered = render_preference_pair(
+        pair["chosen"], pair["rejected"],
+        renderer=_pair_worker_state["renderer"],
+        tokenizer=_pair_worker_state["tokenizer"],
+    )
+    if rendered is None:
+        return None
+    max_seq_len = _pair_worker_state["max_seq_len"]
+    if (
+        len(rendered.chosen_tokens) > max_seq_len
+        or len(rendered.rejected_tokens) > max_seq_len
+    ):
+        return None
     return {
-        "chosen_tokens": pair.chosen_tokens,
-        "rejected_tokens": pair.rejected_tokens,
-        "response_start": pair.response_start,
-        "chosen_datum": pair.chosen_datum,
-        "rejected_datum": pair.rejected_datum,
+        "chosen_tokens_len": len(rendered.chosen_tokens),
+        "rejected_tokens_len": len(rendered.rejected_tokens),
+        "response_start": rendered.response_start,
+        "chosen_datum": rendered.chosen_datum,
+        "rejected_datum": rendered.rejected_datum,
     }
 
 
-def _tokenize_pairs(
-    raw_data: list[dict[str, Any]],
-    tokenizer: Any,
-    renderer: Any,
-    max_seq_len: int,
-    runner: RunnerIO | None = None,
-) -> tuple[list[tuple[int, dict[str, Any]]], int]:
-    """Tokenize all preference pairs (CPU only).
-
-    Returns ``(tokenized, filtered_count)`` where each entry is
-    ``(original_index, pair_data_dict)``.
-    """
-    total_raw = len(raw_data)
-    log_interval = max(1, total_raw // 20)  # ~5% increments
-    tokenized: list[tuple[int, dict[str, Any]]] = []
-    filtered_count = 0
-    for i, example in enumerate(raw_data):
-        result = _tokenize_pair(example, tokenizer, renderer, max_seq_len)
-        if result == "filtered":
-            filtered_count += 1
-        elif result is not None:
-            tokenized.append((i, result))
-        if (i + 1) % log_interval == 0 or (i + 1) == total_raw:
-            if runner is not None:
-                runner.report_rendering_progress(i + 1, total_raw)
-            else:
-                logger.info(
-                    "Rendering preference pairs: %d/%d (%d%%)",
-                    i + 1, total_raw, int(100.0 * (i + 1) / total_raw),
-                )
-    return tokenized, filtered_count
+# ---------------------------------------------------------------------------
+# Reference forward
+# ---------------------------------------------------------------------------
 
 
 async def _ref_forward_batch(
-    pairs: list[tuple[int, dict[str, Any]]],
+    pairs: list[dict[str, Any]],
     reference: ReconnectableClient,
     semaphore: asyncio.Semaphore,
     ref_batch_size: int,
-) -> list[tuple[int, dict[str, Any]]]:
+) -> list[dict[str, Any]]:
     """Compute reference logprobs for *pairs*, sub-batched by *ref_batch_size*.
 
-    Uses the semaphore for concurrency control.  Returns enriched pairs
-    with ``ref_chosen`` / ``ref_rejected`` logprobs attached.
+    Returns enriched pairs with ``ref_chosen`` / ``ref_rejected`` logprobs
+    attached as :class:`array.array` of ``'f'`` (4 bytes/token vs 28+ for a
+    Python ``list[float]``) — both ``torch.tensor`` and pickle handle them
+    natively. Returned pairs preserve input order so multi-epoch ref-cache
+    iteration keeps producer-order consistent with epoch 0.
     """
     sub_batches = [pairs[i:i + ref_batch_size] for i in range(0, len(pairs), ref_batch_size)]
 
-    async def _process_sub_batch(
-        batch: list[tuple[int, dict[str, Any]]],
-    ) -> list[tuple[int, dict[str, Any]]]:
+    async def _process_sub_batch(batch: list[dict[str, Any]]) -> list[dict[str, Any]]:
         datums: list[tinker.Datum] = []
-        for _, pair_data in batch:
+        for pair_data in batch:
             datums.append(pair_data["chosen_datum"])
             datums.append(pair_data["rejected_datum"])
 
@@ -230,17 +239,17 @@ async def _ref_forward_batch(
                 lambda d=datums: reference.forward(d, "cross_entropy")
             )
 
-        results: list[tuple[int, dict[str, Any]]] = []
-        for j, (idx, pair_data) in enumerate(batch):
-            results.append((idx, {
-                "chosen_tokens": pair_data["chosen_tokens"],
-                "rejected_tokens": pair_data["rejected_tokens"],
+        results: list[dict[str, Any]] = []
+        for j, pair_data in enumerate(batch):
+            results.append({
+                "chosen_tokens_len": pair_data["chosen_tokens_len"],
+                "rejected_tokens_len": pair_data["rejected_tokens_len"],
                 "chosen_datum": pair_data["chosen_datum"],
                 "rejected_datum": pair_data["rejected_datum"],
-                "ref_chosen": fwd.loss_fn_outputs[2 * j]["logprobs"].data,
-                "ref_rejected": fwd.loss_fn_outputs[2 * j + 1]["logprobs"].data,
+                "ref_chosen": array.array("f", fwd.loss_fn_outputs[2 * j]["logprobs"].data),
+                "ref_rejected": array.array("f", fwd.loss_fn_outputs[2 * j + 1]["logprobs"].data),
                 "response_start": pair_data["response_start"],
-            }))
+            })
         return results
 
     batch_results = await asyncio.gather(*[_process_sub_batch(b) for b in sub_batches])
@@ -274,10 +283,7 @@ def _forward_backward_pairs(
         response_starts.append(cached["response_start"])
 
     loss_fn = make_batch_dpo_loss_fn(
-        ref_chosen_list,
-        ref_rejected_list,
-        response_starts,
-        beta,
+        ref_chosen_list, ref_rejected_list, response_starts, beta,
     )
     return policy.forward_backward_custom(datums, loss_fn)
 
@@ -286,42 +292,53 @@ _DONE = object()
 
 
 async def _train_loop(
-    tokenized_pairs: list[tuple[int, dict[str, Any]]],
+    pair_dataset: JsonlRenderDataset,
+    ref_cache_log: AppendOnlyPickleLog | None,
     reference: ReconnectableClient,
     policy: ReconnectableClient,
     adam_params: tinker.AdamParams,
     cfg: Config,
     step_offset: int,
+    *,
+    worker_init_fn: Callable[[int], None] | None = None,
     on_ref_done: Callable[[], None] | None = None,
     runner: RunnerIO | None = None,
     training_shape_id: str | None = None,
 ) -> int:
-    """Pipelined DPO training -- ref forward overlaps with policy training.
+    """Pipelined DPO training -- streaming render + ref forward overlap policy.
 
     Epoch 0 runs a producer/consumer pipeline with an unbounded queue:
-    the producer computes reference logprobs at full speed (concurrent
-    via semaphore) while the consumer trains.  Once the producer finishes,
-    *on_ref_done* fires to delete the reference trainer immediately --
-    even while training continues.
+    a DataLoader streams rendered preference batches; the producer
+    computes reference logprobs at full speed (concurrent via semaphore)
+    and pushes enriched batches to the consumer that runs train steps.
+    Once the producer finishes, *on_ref_done* fires to delete the
+    reference trainer immediately -- even while training continues.
 
-    Epochs 1+ reuse cached ref logprobs (no ref GPU needed).
+    For multi-epoch runs, ``ref_cache_log`` (must be opened by the caller)
+    captures every enriched pair in producer order so epochs 1+ stream
+    them sequentially without holding the cache in RAM.
     """
+    multi_epoch = cfg.epochs > 1
+    if multi_epoch and ref_cache_log is None:
+        raise ValueError("ref_cache_log is required when cfg.epochs > 1")
+
     batch_size = cfg.batch_size
     step = step_offset
-    n_batches_per_epoch = (len(tokenized_pairs) + batch_size - 1) // batch_size
-    total_steps = n_batches_per_epoch * cfg.epochs
-
-    # Shuffle once before epoch 0 so file-ordered customer datasets (sorted
-    # by source/difficulty/date) don't bias the single-epoch gradient
-    # schedule. ref_cache is keyed by the original dataset index carried
-    # inside the (idx, pair) tuple, so shuffling the outer list preserves
-    # ref-cache correctness and makes epoch 0 consistent with epochs >= 1.
-    tokenized_pairs = list(tokenized_pairs)
-    random.Random(cfg.seed).shuffle(tokenized_pairs)
+    rough_pairs_per_epoch = (
+        min(len(pair_dataset), cfg.max_pairs)
+        if cfg.max_pairs is not None
+        else len(pair_dataset)
+    )
+    total_steps = ((rough_pairs_per_epoch + batch_size - 1) // batch_size) * cfg.epochs
+    total_raw_rows = len(pair_dataset)
+    total_raw_batches = (total_raw_rows + batch_size - 1) // batch_size
+    progress_interval = max(1, total_raw_batches // 20) if total_raw_batches else 1
+    raw_rows_consumed = 0
+    rendered_pairs = 0
+    pairs_per_epoch = 0
 
     if runner is None:
         runner = RunnerIO()
-    ref_cache: dict[int, dict[str, Any]] = {}
     pipe: asyncio.Queue = asyncio.Queue()
     sem = asyncio.Semaphore(cfg.ref_cache_concurrency)
 
@@ -329,7 +346,7 @@ async def _train_loop(
         nonlocal step
         step_t0 = time.monotonic()
         step_tokens = sum(
-            len(p["chosen_tokens"]) + len(p["rejected_tokens"])
+            p["chosen_tokens_len"] + p["rejected_tokens_len"]
             for p in step_pairs
         )
         # Epoch 0: ref model processed these same sequences; epochs 1+ use cached ref logprobs.
@@ -394,23 +411,73 @@ async def _train_loop(
         runner.write_status(RunStatus.RUNNING, step=step, total_steps=total_steps, message="training")
         runner.write_metadata()
 
-    # -- Epoch 0: pipelined ref forward + training -----------------------------
+    # -- Epoch 0: stream render → ref forward → training -----------------------
 
-    multi_epoch = cfg.epochs > 1
-
-    n_batches_epoch0 = n_batches_per_epoch
     pbar = tqdm(total=total_steps, desc="DPO training", unit="step")
+    loader = make_render_dataloader(
+        pair_dataset,
+        batch_size=batch_size,
+        num_workers=cfg.render_workers,
+        shuffle=False,  # ref-cache iteration depends on stable producer order
+        worker_init_fn=worker_init_fn,
+    )
 
     async def _ref_producer() -> None:
-        for start in range(0, len(tokenized_pairs), batch_size):
-            chunk = tokenized_pairs[start:start + batch_size]
+        nonlocal raw_rows_consumed, rendered_pairs, pairs_per_epoch
+        # The DataLoader is synchronous; pull each batch via to_thread so
+        # render workers and ref forwards can overlap on the event loop.
+        loader_iter = iter(loader)
+        sentinel = object()
+        batches_consumed = 0
+        pending_pairs: list[dict[str, Any]] = []
+
+        async def _emit_enriched(chunk: list[dict[str, Any]]) -> None:
+            nonlocal pairs_per_epoch
             enriched = await _ref_forward_batch(
                 chunk, reference, sem, cfg.ref_cache_batch_size,
             )
+            pairs_per_epoch += len(enriched)
             if multi_epoch:
-                for idx, pair in enriched:
-                    ref_cache[idx] = pair
-            await pipe.put([pair for _, pair in enriched])
+                for pair in enriched:
+                    ref_cache_log.append(pair)
+            await pipe.put(enriched)
+
+        while True:
+            batch = await asyncio.to_thread(next, loader_iter, sentinel)
+            if batch is sentinel:
+                break
+            batches_consumed += 1
+            raw_rows_consumed = min(batches_consumed * batch_size, total_raw_rows)
+            if (
+                total_raw_rows > 0
+                and (
+                    batches_consumed % progress_interval == 0
+                    or raw_rows_consumed == total_raw_rows
+                )
+            ):
+                runner.report_rendering_progress(
+                    raw_rows_consumed,
+                    total_raw_rows,
+                    label="rendering/ref cache",
+                )
+            rendered_pairs += len(batch)
+            if not batch:  # all rows in this DataLoader batch rendered to None
+                continue
+            if cfg.max_pairs is not None:
+                remaining = cfg.max_pairs - pairs_per_epoch - len(pending_pairs)
+                if remaining <= 0:
+                    break
+                batch = batch[:remaining]
+                if not batch:
+                    break
+            pending_pairs.extend(batch)
+            while len(pending_pairs) >= batch_size:
+                await _emit_enriched(pending_pairs[:batch_size])
+                pending_pairs = pending_pairs[batch_size:]
+            if cfg.max_pairs is not None and pairs_per_epoch + len(pending_pairs) >= cfg.max_pairs:
+                break
+        if pending_pairs:
+            await _emit_enriched(pending_pairs)
         await pipe.put(_DONE)
 
     async def _trainer() -> None:
@@ -428,21 +495,42 @@ async def _train_loop(
         await asyncio.to_thread(on_ref_done)
     await consumer
 
-    # -- Epochs 1+: iterate cached ref logprobs --------------------------------
+    filtered_count = max(0, raw_rows_consumed - rendered_pairs)
+    if filtered_count > 0:
+        logger.info(
+            "Seq-length / format filter: %d/%d raw rows filtered",
+            filtered_count,
+            raw_rows_consumed,
+        )
+    if rendered_pairs == 0 or pairs_per_epoch == 0:
+        raise RuntimeError("No valid pairs after tokenization")
 
-    for epoch in range(1, cfg.epochs):
-        ordered_pairs = [ref_cache[idx] for idx, _ in tokenized_pairs]
-        # Without this, every epoch >= 1 visits pairs in the exact same order
-        # as epoch 0, which compounds a biased data schedule across the run.
-        rng = random.Random(cfg.seed + epoch)
-        rng.shuffle(ordered_pairs)
-        for start in range(0, len(ordered_pairs), batch_size):
-            chunk = ordered_pairs[start:start + batch_size]
-            _run_train_step(epoch, chunk)
-            pbar.update(1)
+    total_steps = ((pairs_per_epoch + batch_size - 1) // batch_size) * cfg.epochs
+    pbar.total = total_steps
+    pbar.refresh()
+
+    # -- Epochs 1+: stream cached ref logprobs from disk -----------------------
+
+    if multi_epoch:
+        ref_cache_log.close_write()
+        n_cached = len(ref_cache_log)
+        logger.info(
+            "Ref cache built: %d pairs / %.1f GiB on disk",
+            n_cached, ref_cache_log.disk_size_bytes() / (1024 ** 3),
+        )
+        for epoch in range(1, cfg.epochs):
+            chunk: list[dict[str, Any]] = []
+            for pair in ref_cache_log:
+                chunk.append(pair)
+                if len(chunk) == batch_size:
+                    _run_train_step(epoch, chunk)
+                    pbar.update(1)
+                    chunk = []
+            if chunk:
+                _run_train_step(epoch, chunk)
+                pbar.update(1)
 
     pbar.close()
-    ref_cache.clear()
     return step
 
 
@@ -504,15 +592,11 @@ def main(
 
     if rlor_mgr is None:
         rlor_mgr = TrainerJobManager(
-            api_key=api_key,
-            base_url=base_url,
-            additional_headers=additional_headers,
+            api_key=api_key, base_url=base_url, additional_headers=additional_headers,
         )
     if deploy_mgr is None:
         deploy_mgr = DeploymentManager(
-            api_key=api_key,
-            base_url=base_url,
-            additional_headers=additional_headers,
+            api_key=api_key, base_url=base_url, additional_headers=additional_headers,
         )
 
     runner = RunnerIO(cfg.runner)
@@ -564,33 +648,46 @@ def main(
         wandb_log({"train/step": step_offset}, step_offset)
         adam_params = tinker.AdamParams(learning_rate=cfg.learning_rate, **DEFAULT_ADAM)
 
-        # -- Tokenize + pipelined training -------------------------------------
+        # -- Stream-render dataset + (optional) ref cache ---------------------
+        #
+        # Render preference rows on the fly inside DataLoader workers so the
+        # orchestrator never holds the full tokenized dataset in RAM. For
+        # multi-epoch runs we additionally spool enriched pairs (datums +
+        # ref logprobs) to a small append-only pickle log so the reference
+        # trainer can be released after epoch 0 and epochs 1+ stream the
+        # cache from disk. See fw-ai/cookbook#371 / #373 for OOM context.
 
-        import transformers
+        max_seq_len = infra.max_seq_len
+        init_args = (cfg.tokenizer_model, cfg.renderer_name, max_seq_len)
+        # Initialise in the parent so the num_workers <= 1 fallback uses
+        # the same render_fn as the spawn workers.
+        _init_pair_worker(*init_args)
+        worker_init_fn = functools.partial(_init_pair_worker, *init_args)
 
-        tokenizer = transformers.AutoTokenizer.from_pretrained(cfg.tokenizer_model, trust_remote_code=True)
-        renderer = build_renderer(tokenizer, cfg.tokenizer_model, cfg.renderer_name)
+        pair_dataset = JsonlRenderDataset(cfg.dataset, _render_pair_worker)
+        if len(pair_dataset) == 0:
+            raise RuntimeError(f"No data found in {cfg.dataset}")
+
         logger.info(
-            "Using renderer=%s for preference tokenization",
+            "Streaming %d raw preference rows from %s (renderer=%s, workers=%d%s)",
+            len(pair_dataset), cfg.dataset,
             resolve_renderer_name(cfg.tokenizer_model, cfg.renderer_name),
+            cfg.render_workers,
+            (
+                f", max_pairs={cfg.max_pairs}"
+                if cfg.max_pairs is not None
+                else ""
+            ),
         )
 
-        raw_data = load_preference_dataset(cfg.dataset, cfg.max_pairs)
-        if not raw_data:
-            raise RuntimeError(f"No data loaded from {cfg.dataset}")
-
-        tokenized_pairs, filtered_count = _tokenize_pairs(
-            raw_data, tokenizer, renderer, infra.max_seq_len,
-            runner=runner,
-        )
-        if filtered_count > 0:
-            logger.info(
-                "Seq-length filter: %d/%d pairs filtered (chosen or rejected > %d tokens)",
-                filtered_count, len(raw_data), infra.max_seq_len,
+        ref_cache_log: AppendOnlyPickleLog | None = None
+        if cfg.epochs > 1:
+            ref_cache_dir = stack.enter_context(
+                tempfile.TemporaryDirectory(prefix="dpo_ref_")
             )
-        logger.info("Prepared %d preference pairs", len(tokenized_pairs))
-        if not tokenized_pairs:
-            raise RuntimeError("No valid pairs after tokenization")
+            ref_cache_log = stack.enter_context(
+                AppendOnlyPickleLog(os.path.join(ref_cache_dir, "ref_cache.pkl"))
+            )
 
         def _on_ref_done():
             nonlocal reference_job_id
@@ -611,7 +708,9 @@ def main(
         runner.start_training()
         step = asyncio.run(
             _train_loop(
-                tokenized_pairs, reference, policy, adam_params, cfg, step_offset,
+                pair_dataset, ref_cache_log,
+                reference, policy, adam_params, cfg, step_offset,
+                worker_init_fn=worker_init_fn,
                 on_ref_done=_on_ref_done,
                 runner=runner,
                 training_shape_id=infra.training_shape_id,
@@ -647,7 +746,7 @@ def main(
                     model_id=cfg.output_model_id, checkpoint=cp_name, job_id=policy_job_id,
                 )
 
-        total_steps = ((len(tokenized_pairs) + cfg.batch_size - 1) // cfg.batch_size) * cfg.epochs
+        total_steps = step
         runner.write_status(RunStatus.COMPLETED, step=step, total_steps=total_steps, message="done")
         runner.write_metadata()
         logger.info("Training complete: %d optimizer steps (%d new)", step, step - step_offset)

--- a/training/recipes/sft_loop.py
+++ b/training/recipes/sft_loop.py
@@ -14,9 +14,11 @@ Usage:
 
 from __future__ import annotations
 
+import functools
 import os
 import signal
 import logging
+import tempfile
 from contextlib import ExitStack
 from typing import Any, Dict, List
 from dataclasses import field, dataclass
@@ -24,7 +26,6 @@ from dataclasses import field, dataclass
 import torch
 import tinker
 
-import json
 import datasets as hf_datasets
 import transformers
 from dotenv import load_dotenv
@@ -33,13 +34,20 @@ from fireworks.training.sdk import TrainerJobManager
 from tinker_cookbook.supervised.data import SupervisedDatasetFromHFDataset
 from training.utils import (
     DEFAULT_ADAM,
+    DEFAULT_RENDER_CHUNKSIZE,
+    DEFAULT_RENDER_WORKERS,
+    DiskBackedDatumStore,
     InfraConfig,
+    MemTracer,
     ResourceCleanup,
     RunnerConfig,
     RunnerIO,
     RunStatus,
     WandBConfig,
     ReconnectableClient,
+    count_jsonl_rows,
+    iter_jsonl_rows,
+    stream_render_to_store,
     wandb_log,
     setup_wandb,
     wandb_finish,
@@ -65,6 +73,52 @@ from training.utils.timer import timer, flush_timing
 
 load_dotenv()
 logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Per-worker render state (multiprocessing) -- module-level so the spawn
+# pool initializer can populate it before each worker starts consuming rows.
+# ---------------------------------------------------------------------------
+
+_worker_renderer = None
+_worker_train_on_what = None
+_worker_max_seq_len = None
+
+
+def _init_render_worker(tokenizer_model, renderer_name, train_on_what_str, max_seq_len):
+    """Build a renderer per worker (avoids pickling the tokenizer)."""
+    global _worker_renderer, _worker_train_on_what, _worker_max_seq_len
+    tokenizer = transformers.AutoTokenizer.from_pretrained(
+        tokenizer_model, trust_remote_code=True,
+    )
+    _worker_renderer = build_renderer(tokenizer, tokenizer_model, renderer_name)
+    _worker_train_on_what = parse_train_on_what(train_on_what_str)
+    _worker_max_seq_len = max_seq_len
+
+
+def _render_messages(
+    row: dict, *, renderer, train_on_what, max_seq_len: int,
+) -> tinker.Datum | None:
+    """Render a chat row to a Datum, filtering empty / out-of-range sequences."""
+    messages = row.get("messages", [])
+    if not messages:
+        return None
+    rendered = render_messages_to_datum(
+        messages, renderer=renderer, train_on_what=train_on_what,
+    )
+    if len(rendered.token_ids) > max_seq_len or len(rendered.token_ids) < 2:
+        return None
+    return rendered.datum
+
+
+def _render_one_worker(row: dict) -> tinker.Datum | None:
+    """Render a single chat example in a worker process."""
+    return _render_messages(
+        row,
+        renderer=_worker_renderer,
+        train_on_what=_worker_train_on_what,
+        max_seq_len=_worker_max_seq_len,
+    )
+
 
 # ---------------------------------------------------------------------------
 # Eval auto carve-out defaults
@@ -426,112 +480,171 @@ def main(
             train_on_what.value,
         )
 
-        raw_data: List[Dict[str, Any]] = []
-        with open(cfg.dataset) as f:
-            for line in f:
-                line = line.strip()
-                if not line:
-                    continue
-                raw_data.append(json.loads(line))
-                if cfg.max_examples and len(raw_data) >= cfg.max_examples:
-                    break
-        logger.info("Loaded %d examples from %s", len(raw_data), cfg.dataset)
+        # Stream-render the dataset: JSONL rows are read lazily and each
+        # rendered Datum is spilled to a disk-backed store so peak RAM stays
+        # bounded (O(num_workers * per_worker_render_footprint) instead of
+        # O(num_examples * avg_seq_len * bytes_per_token)).
+        # See docs/engineering/sft-v2-orchestrator-oom-debug.md for the
+        # investigation that led to this design.
+        total_raw = count_jsonl_rows(cfg.dataset, cfg.max_examples)
+        if total_raw == 0:
+            raise RuntimeError(f"No examples found in {cfg.dataset}")
+        logger.info("Streaming %d examples from %s", total_raw, cfg.dataset)
 
         max_seq_len = cfg.max_seq_len
-        filtered_count = 0
+        log_interval = max(1, total_raw // 20)  # ~5% increments for runner progress
+        mem_log_interval = max(1, total_raw // 200)  # ~0.5% for memory tracing
+        render_cache_dir = stack.enter_context(
+            tempfile.TemporaryDirectory(prefix="sft_render_")
+        )
+        training_store = stack.enter_context(
+            DiskBackedDatumStore(os.path.join(render_cache_dir, "training.bin"))
+        )
 
-        def _map_fn(row: dict) -> tinker.Datum | None:
-            nonlocal filtered_count
-            messages = row.get("messages", [])
-            if not messages:
-                filtered_count += 1
-                return None
-            rendered = render_messages_to_datum(
-                messages,
-                renderer=renderer,
-                train_on_what=train_on_what,
-            )
-            if len(rendered.token_ids) > max_seq_len or len(rendered.token_ids) < 2:
-                filtered_count += 1
-                return None
-            return rendered.datum
+        mem_tracer = MemTracer(
+            store_callback=lambda: (
+                len(training_store), training_store.disk_size_bytes(),
+            ),
+            log=logger,
+        )
+        mem_tracer.log("before_rendering", 0, total_raw)
 
-        total_raw = len(raw_data)
-        log_interval = max(1, total_raw // 20)  # ~5% increments
-        training_data: List[tinker.Datum] = []
-        for i, row in enumerate(raw_data):
-            d = _map_fn(row)
-            if d is not None:
-                training_data.append(d)
-            if (i + 1) % log_interval == 0 or (i + 1) == total_raw:
-                runner.report_rendering_progress(i + 1, total_raw)
+        num_workers = min(os.cpu_count() or 1, DEFAULT_RENDER_WORKERS)
+        use_parallel = num_workers > 1 and total_raw > num_workers
+        logger.info(
+            "Rendering %d examples (%s, workers=%d, chunksize=%d)",
+            total_raw,
+            "parallel spawn" if use_parallel else "single-process",
+            num_workers if use_parallel else 1,
+            DEFAULT_RENDER_CHUNKSIZE if use_parallel else 1,
+        )
+
+        def _on_render_progress(i: int, _datum: tinker.Datum | None) -> None:
+            if i % log_interval == 0 or i == total_raw:
+                runner.report_rendering_progress(i, total_raw)
+            if i % mem_log_interval == 0 or i == total_raw:
+                mem_tracer.log("rendering", i, total_raw)
+
+        filtered_count = stream_render_to_store(
+            iter_jsonl_rows(cfg.dataset, cfg.max_examples),
+            render_fn=(
+                _render_one_worker if use_parallel
+                else functools.partial(
+                    _render_messages,
+                    renderer=renderer,
+                    train_on_what=train_on_what,
+                    max_seq_len=max_seq_len,
+                )
+            ),
+            store=training_store,
+            num_workers=num_workers if use_parallel else 1,
+            chunksize=DEFAULT_RENDER_CHUNKSIZE,
+            initializer=_init_render_worker if use_parallel else None,
+            initargs=(
+                cfg.tokenizer_model, cfg.renderer_name,
+                cfg.train_on_what, max_seq_len,
+            ) if use_parallel else (),
+            on_progress=_on_render_progress,
+        )
+        training_store.close_write()
+        mem_tracer.log("after_rendering", total_raw, total_raw)
+
         if filtered_count > 0:
             logger.info(
                 "Seq-length filter: %d/%d examples filtered (len > %d or len < 2)",
-                filtered_count,
-                len(raw_data),
-                max_seq_len,
+                filtered_count, total_raw, max_seq_len,
             )
-        logger.info("Prepared %d training examples", len(training_data))
-        if not training_data:
+        logger.info("Prepared %d training examples", len(training_store))
+        if len(training_store) == 0:
             raise RuntimeError("No valid training examples after tokenization")
 
         # -- Eval dataset (explicit or auto carve-out) -------------------------
+        # eval_data is a small list of Datums (max_eval_seqs <= 100 typical).
+        # For explicit eval_dataset we also stream rendering to a disk store,
+        # then materialise a bounded list for the eval loop.
         eval_data: List[tinker.Datum] = []
+        training_start_idx = 0
         if cfg.evaluation_dataset:
-            # Explicit eval dataset
-            raw_eval: List[Dict[str, Any]] = []
-            with open(cfg.evaluation_dataset) as f:
-                for line in f:
-                    line = line.strip()
-                    if not line:
-                        continue
-                    raw_eval.append(json.loads(line))
-            total_eval = len(raw_eval)
+            total_eval = count_jsonl_rows(cfg.evaluation_dataset)
             eval_log_interval = max(1, total_eval // 10)
-            eval_data = []
-            for i, row in enumerate(raw_eval):
-                d = _map_fn(row)
-                if d is not None:
-                    eval_data.append(d)
-                if (i + 1) % eval_log_interval == 0 or (i + 1) == total_eval:
-                    runner.report_rendering_progress(i + 1, total_eval, label="rendering eval data")
-            logger.info("Loaded %d eval examples from %s", len(eval_data), cfg.evaluation_dataset)
+            eval_store = stack.enter_context(
+                DiskBackedDatumStore(os.path.join(render_cache_dir, "eval.bin"))
+            )
+
+            def _on_eval_progress(i: int, _datum: tinker.Datum | None) -> None:
+                if i % eval_log_interval == 0 or i == total_eval:
+                    runner.report_rendering_progress(
+                        i, total_eval, label="rendering eval data",
+                    )
+
+            stream_render_to_store(
+                iter_jsonl_rows(cfg.evaluation_dataset),
+                render_fn=(
+                    _render_one_worker if use_parallel
+                    else functools.partial(
+                        _render_messages,
+                        renderer=renderer,
+                        train_on_what=train_on_what,
+                        max_seq_len=max_seq_len,
+                    )
+                ),
+                store=eval_store,
+                num_workers=num_workers if use_parallel else 1,
+                chunksize=DEFAULT_RENDER_CHUNKSIZE,
+                initializer=_init_render_worker if use_parallel else None,
+                initargs=(
+                    cfg.tokenizer_model, cfg.renderer_name,
+                    cfg.train_on_what, max_seq_len,
+                ) if use_parallel else (),
+                on_progress=_on_eval_progress,
+            )
+            eval_store.close_write()
+            # Eval set is bounded (max_eval_seqs ~ 100), safe to materialise.
+            eval_data = list(eval_store)
+            logger.info(
+                "Loaded %d eval examples from %s",
+                len(eval_data), cfg.evaluation_dataset,
+            )
         elif cfg.eval_auto_carveout:
-            # Auto carve-out: split first N examples as eval
+            # Auto carve-out: split first N examples as eval. The backing file
+            # stays intact; we materialise a small eval list and advance the
+            # training index window past the carveout range.
             carveout_count = compute_eval_carveout(
-                len(training_data), cfg.eval_carve_ratio, cfg.max_eval_seqs,
+                len(training_store), cfg.eval_carve_ratio, cfg.max_eval_seqs,
             )
             if carveout_count > 0:
-                eval_data = training_data[:carveout_count]
-                training_data = training_data[carveout_count:]
+                eval_data = [training_store[i] for i in range(carveout_count)]
+                training_start_idx = carveout_count
                 logger.info(
                     "Auto carve-out: %d eval examples, %d training examples",
-                    len(eval_data), len(training_data),
+                    len(eval_data), len(training_store) - training_start_idx,
                 )
             else:
                 logger.warning("Dataset too small for auto carve-out, skipping eval")
 
+        training_count = len(training_store) - training_start_idx
         effective_batch_size = cfg.batch_size
-        if len(training_data) < effective_batch_size:
+        if training_count < effective_batch_size:
             logger.warning(
                 "Training examples (%d) < batch_size (%d); reducing effective "
                 "batch_size to %d so all examples are trained on.",
-                len(training_data),
+                training_count,
                 effective_batch_size,
-                len(training_data),
+                training_count,
             )
-            effective_batch_size = len(training_data)
+            effective_batch_size = training_count
 
         sft_dataset = SupervisedDatasetFromHFDataset(
-            hf_datasets.Dataset.from_dict({"datum_idx": list(range(len(training_data)))}),
+            hf_datasets.Dataset.from_dict(
+                {"datum_idx": list(range(training_start_idx, len(training_store)))}
+            ),
             batch_size=effective_batch_size,
-            map_fn=lambda row: training_data[row["datum_idx"]],
+            map_fn=lambda row: training_store[row["datum_idx"]],
         )
         total_batches_per_epoch = len(sft_dataset)
         logger.info(
             "Dataset: %d examples, %d batches/epoch, %d epochs",
-            len(training_data),
+            training_count,
             total_batches_per_epoch,
             cfg.epochs,
         )

--- a/training/recipes/sft_loop.py
+++ b/training/recipes/sft_loop.py
@@ -237,6 +237,13 @@ class Config:
     """Linear LR warmup from 0 → learning_rate over the first N optimizer
     steps. 0 disables warmup (lr is constant)."""
 
+    seed: int = 0
+    """Shuffle seed for the training dataset.
+
+    Re-seeded per epoch as ``seed + epoch`` so fresh runs and resumes see
+    the same raw-row order in epoch 0 before any skipped batches.
+    """
+
     step_timeout: int = 0
     """Timeout in seconds for forward_backward / optim_step calls.
     0 = use DEFAULT_TIMEOUT_S from training.utils.client."""
@@ -533,11 +540,13 @@ def main(
                 training_count, cfg.batch_size, effective_batch_size,
             )
 
+        loader_generator = torch.Generator()
         loader = make_render_dataloader(
             training_dataset,
             batch_size=effective_batch_size,
             num_workers=num_workers,
             shuffle=True,
+            generator=loader_generator,
             worker_init_fn=worker_init_fn,
         )
         # Pre-filter upper bound; filtered rows make actual batches
@@ -545,10 +554,10 @@ def main(
         total_batches_per_epoch = (training_count + effective_batch_size - 1) // effective_batch_size
         logger.info(
             "Dataset: %d examples from %s (renderer=%s, train_on_what=%s,"
-            " workers=%d) -> ~%d batches/epoch x %d epochs%s",
+            " workers=%d, seed=%d) -> ~%d batches/epoch x %d epochs%s",
             training_count, cfg.dataset,
             resolve_renderer_name(cfg.tokenizer_model, cfg.renderer_name),
-            cfg.train_on_what, num_workers,
+            cfg.train_on_what, num_workers, cfg.seed,
             total_batches_per_epoch, cfg.epochs,
             f" + {len(eval_data)} eval examples" if eval_data else "",
         )
@@ -666,18 +675,30 @@ def main(
         runner.write_status(RunStatus.RUNNING, total_steps=total_steps_estimate, message="training")
 
         for epoch in range(cfg.epochs):
-            # On resume, skip the batches already processed in epoch 0.
-            # Workers still render skipped batches (wasted but bounded by
-            # num_workers * prefetch_factor); resume is rare enough that
-            # this is acceptable.
+            loader_generator.manual_seed(cfg.seed + epoch)
             batch_iter = iter(loader)
-            if epoch == 0 and start_batch > 0:
-                batch_iter = islice(batch_iter, start_batch, None)
-            for batch in batch_iter:
+            epoch_start_batch = start_batch if epoch == 0 else 0
+            if epoch_start_batch > 0:
+                batch_iter = islice(batch_iter, epoch_start_batch, None)
+
+            epoch_valid_examples = 0
+            for _batch_idx, batch in enumerate(batch_iter, start=epoch_start_batch):
                 if not batch:
                     continue  # entire batch was filtered (None render); skip
+                epoch_valid_examples += len(batch)
                 data_consumed += len(batch)
                 step = _run_train_step(batch, step)
+
+            if epoch == 0 and start_batch == 0:
+                filtered_count = training_count - epoch_valid_examples
+                if filtered_count > 0:
+                    logger.info(
+                        "Seq-length / format filter: %d/%d raw rows filtered",
+                        filtered_count,
+                        training_count,
+                    )
+                if epoch_valid_examples == 0:
+                    raise RuntimeError("No valid training examples after tokenization")
 
             # Run eval after each epoch
             if eval_data:

--- a/training/recipes/sft_loop.py
+++ b/training/recipes/sft_loop.py
@@ -586,6 +586,11 @@ def main(
         )
         step = resume_info.step if resume_info else 0
         data_consumed = resume_info.data_consumed if resume_info else 0
+        raw_rows_consumed = (
+            getattr(resume_info, "raw_rows_consumed", data_consumed)
+            if resume_info
+            else 0
+        )
         wandb_log({"train/step": step}, step)
 
         adam_kwargs = dict(DEFAULT_ADAM)
@@ -606,8 +611,14 @@ def main(
 
         # -- Training loop (batch-indexed) -------------------------------------
 
-        start_batch = data_consumed // effective_batch_size
-        total_steps_estimate = total_batches_per_epoch * cfg.epochs
+        total_raw_rows = training_count * cfg.epochs
+        completed_epochs = raw_rows_consumed // training_count if training_count else 0
+        rows_into_current_epoch = raw_rows_consumed % training_count if training_count else 0
+        start_batch = rows_into_current_epoch // effective_batch_size
+        remaining_raw_rows = max(0, total_raw_rows - raw_rows_consumed)
+        total_steps_estimate = step + (
+            (remaining_raw_rows + effective_batch_size - 1) // effective_batch_size
+        )
 
         def _run_train_step(
             batch: list[tinker.Datum],
@@ -642,6 +653,7 @@ def main(
                     save_checkpoint(client, f"step-{step}", cfg.log_path, {
                         "step": step,
                         "data_consumed": data_consumed,
+                        "raw_rows_consumed": raw_rows_consumed,
                         "source_job_id": job_id,
                     }, kind=CheckpointKind.STATE,
                     base_model=cfg.base_model,
@@ -688,22 +700,27 @@ def main(
         runner.start_training()
         runner.write_status(RunStatus.RUNNING, total_steps=total_steps_estimate, message="training")
 
-        for epoch in range(cfg.epochs):
+        for epoch in range(completed_epochs, cfg.epochs):
             loader_generator.manual_seed(cfg.seed + epoch)
             batch_iter = iter(loader)
-            epoch_start_batch = start_batch if epoch == 0 else 0
+            epoch_start_batch = start_batch if epoch == completed_epochs else 0
             if epoch_start_batch > 0:
                 batch_iter = islice(batch_iter, epoch_start_batch, None)
 
             epoch_valid_examples = 0
-            for _batch_idx, batch in enumerate(batch_iter, start=epoch_start_batch):
+            for raw_batch_idx, batch in enumerate(batch_iter, start=epoch_start_batch):
+                raw_batch_size = min(
+                    effective_batch_size,
+                    training_count - raw_batch_idx * effective_batch_size,
+                )
+                raw_rows_consumed += raw_batch_size
                 if not batch:
                     continue  # entire batch was filtered (None render); skip
                 epoch_valid_examples += len(batch)
                 data_consumed += len(batch)
                 step = _run_train_step(batch, step)
 
-            if epoch == 0 and start_batch == 0:
+            if epoch == 0 and completed_epochs == 0 and start_batch == 0:
                 filtered_count = training_count - epoch_valid_examples
                 if filtered_count > 0:
                     logger.info(
@@ -741,6 +758,7 @@ def main(
             paths = save_checkpoint(client, cp_name, cfg.log_path, {
                 "step": step,
                 "data_consumed": data_consumed,
+                "raw_rows_consumed": raw_rows_consumed,
                 "source_job_id": job_id,
             }, kind=CheckpointKind.BOTH,
             base_model=cfg.base_model,
@@ -757,7 +775,7 @@ def main(
                 )
 
         runner.write_status(
-            RunStatus.COMPLETED, step=step, total_steps=total_steps_estimate, message="done",
+            RunStatus.COMPLETED, step=step, total_steps=step, message="done",
         )
         runner.write_metadata()
         logger.info("Training complete: %d optimizer steps", step)

--- a/training/recipes/sft_loop.py
+++ b/training/recipes/sft_loop.py
@@ -615,7 +615,6 @@ def main(
             cfg.init_from_checkpoint,
             cfg.warm_start_from_adapter,
         )
-
         step = resume_info.step if resume_info else 0
         data_consumed = resume_info.data_consumed if resume_info else 0
         wandb_log({"train/step": step}, step)

--- a/training/recipes/sft_loop.py
+++ b/training/recipes/sft_loop.py
@@ -17,7 +17,8 @@ from __future__ import annotations
 import os
 import signal
 import logging
-import tempfile
+import functools
+from itertools import islice
 from contextlib import ExitStack
 from typing import Any, Dict, List
 from dataclasses import field, dataclass
@@ -25,28 +26,22 @@ from dataclasses import field, dataclass
 import torch
 import tinker
 
-import datasets as hf_datasets
 import transformers
 from dotenv import load_dotenv
 
 from fireworks.training.sdk import TrainerJobManager
-from tinker_cookbook.supervised.data import SupervisedDatasetFromHFDataset
 from training.utils import (
     DEFAULT_ADAM,
-    DEFAULT_RENDER_CHUNKSIZE,
     DEFAULT_RENDER_WORKERS,
-    DiskBackedDatumStore,
     InfraConfig,
-    MemTracer,
+    JsonlRenderDataset,
     ResourceCleanup,
     RunnerConfig,
     RunnerIO,
     RunStatus,
     WandBConfig,
     ReconnectableClient,
-    count_jsonl_rows,
-    iter_jsonl_rows,
-    stream_render_to_store,
+    make_render_dataloader,
     wandb_log,
     setup_wandb,
     wandb_finish,
@@ -73,12 +68,26 @@ from training.utils.timer import timer, flush_timing
 load_dotenv()
 logger = logging.getLogger(__name__)
 
-# Module-level so the spawn pool initializer can populate it once per worker
-# (avoids re-pickling the tokenizer on every task).
+# Module-level so DataLoader worker_init_fn can populate it once per
+# worker (avoids re-pickling the tokenizer on every batch). The parent
+# process also initialises this dict to support eval-set rendering and
+# auto carve-out, which run in-process with the same render_fn.
 _worker_state: dict = {}
 
 
-def _init_render_worker(tokenizer_model, renderer_name, train_on_what_str, max_seq_len):
+def _init_render_worker(
+    tokenizer_model: str,
+    renderer_name: str,
+    train_on_what_str: str,
+    max_seq_len: int,
+    _worker_id: int | None = None,
+) -> None:
+    """Populate ``_worker_state`` with a tokenizer + renderer.
+
+    ``_worker_id`` is accepted (and ignored) so this function can be
+    used directly as a DataLoader ``worker_init_fn`` after binding the
+    other args via ``functools.partial``.
+    """
     tokenizer = transformers.AutoTokenizer.from_pretrained(
         tokenizer_model, trust_remote_code=True,
     )
@@ -465,154 +474,91 @@ def main(
             stack.callback(client.close)
 
         # -- Prepare data ------------------------------------------------------
-        # Stream-render dataset to a disk-backed store so peak RAM is bounded
-        # by num_workers * per-worker render footprint instead of scaling with
-        # dataset size. See docs/engineering/sft-v2-orchestrator-oom-debug.md.
-        total_raw = count_jsonl_rows(cfg.dataset, cfg.max_examples)
-        if total_raw == 0:
-            raise RuntimeError(f"No examples found in {cfg.dataset}")
+        # Render JSONL rows on the fly inside DataLoader workers so peak
+        # RAM is O(num_workers * per_worker_render_footprint) instead of
+        # O(dataset_size). See docs/engineering/sft-v2-orchestrator-oom-debug.md.
         max_seq_len = cfg.max_seq_len
         num_workers = (
             cfg.render_workers
             if cfg.render_workers is not None
             else min(os.cpu_count() or 1, DEFAULT_RENDER_WORKERS)
         )
-        logger.info(
-            "Streaming %d examples from %s (renderer=%s, train_on_what=%s,"
-            " workers=%d, chunksize=%d)",
-            total_raw, cfg.dataset,
-            resolve_renderer_name(cfg.tokenizer_model, cfg.renderer_name),
-            cfg.train_on_what,
-            num_workers, DEFAULT_RENDER_CHUNKSIZE,
-        )
-
-        # Initialise _worker_state in the parent too so the same render_fn
-        # (_render_one_worker) is used regardless of whether the helper
-        # picks the in-process loop (num_workers == 1) or the spawn pool.
+        # Initialise the parent's _worker_state so eval / carve-out
+        # rendering (which runs in-process) shares the same render_fn.
         init_args = (
             cfg.tokenizer_model, cfg.renderer_name,
             cfg.train_on_what, max_seq_len,
         )
         _init_render_worker(*init_args)
 
-        render_cache_dir = stack.enter_context(
-            tempfile.TemporaryDirectory(prefix="sft_render_")
+        training_dataset = JsonlRenderDataset(
+            cfg.dataset, _render_one_worker, max_examples=cfg.max_examples,
         )
-
-        def _open_store(name: str) -> DiskBackedDatumStore:
-            return stack.enter_context(
-                DiskBackedDatumStore(os.path.join(render_cache_dir, name))
-            )
-
-        def _stream(src: str, dst: DiskBackedDatumStore, on_progress, max_examples=None) -> int:
-            return stream_render_to_store(
-                iter_jsonl_rows(src, max_examples),
-                render_fn=_render_one_worker,
-                store=dst,
-                num_workers=num_workers,
-                chunksize=DEFAULT_RENDER_CHUNKSIZE,
-                initializer=_init_render_worker,
-                initargs=init_args,
-                on_progress=on_progress,
-            )
-
-        training_store = _open_store("training.bin")
-        mem_tracer = MemTracer(
-            store_callback=lambda: (
-                len(training_store), training_store.disk_size_bytes(),
-            ),
-            log=logger,
+        total_raw = len(training_dataset)
+        if total_raw == 0:
+            raise RuntimeError(f"No examples found in {cfg.dataset}")
+        logger.info(
+            "Indexed %d examples from %s (renderer=%s, train_on_what=%s,"
+            " workers=%d)",
+            total_raw, cfg.dataset,
+            resolve_renderer_name(cfg.tokenizer_model, cfg.renderer_name),
+            cfg.train_on_what, num_workers,
         )
-        mem_tracer.log("before_rendering", 0, total_raw)
-
-        log_interval = max(1, total_raw // 20)       # ~5% for runner status
-        mem_log_interval = max(1, total_raw // 200)  # ~0.5% for memory tracing
-
-        def _on_render_progress(i: int, _datum: tinker.Datum | None) -> None:
-            if i % log_interval == 0 or i == total_raw:
-                runner.report_rendering_progress(i, total_raw)
-            if i % mem_log_interval == 0 or i == total_raw:
-                mem_tracer.log("rendering", i, total_raw)
-
-        filtered_count = _stream(
-            cfg.dataset, training_store, _on_render_progress, cfg.max_examples,
-        )
-        training_store.close_write()
-        mem_tracer.log("after_rendering", total_raw, total_raw)
-
-        if filtered_count > 0:
-            logger.info(
-                "Seq-length filter: %d/%d examples filtered (len > %d or len < 2)",
-                filtered_count, total_raw, max_seq_len,
-            )
-        logger.info("Prepared %d training examples", len(training_store))
-        if len(training_store) == 0:
-            raise RuntimeError("No valid training examples after tokenization")
 
         # -- Eval dataset (explicit or auto carve-out) -------------------------
-        # eval_data is a small list of Datums (max_eval_seqs ~ 100 typical),
-        # safe to materialise after streaming.
+        # Eval sets are small (max_eval_seqs ~ 100); render eagerly in
+        # the parent process so they can be replayed each epoch.
         eval_data: List[tinker.Datum] = []
-        training_start_idx = 0
         if cfg.evaluation_dataset:
-            total_eval = count_jsonl_rows(cfg.evaluation_dataset)
-            eval_log_interval = max(1, total_eval // 10)
-            eval_store = _open_store("eval.bin")
-
-            def _on_eval_progress(i: int, _datum: tinker.Datum | None) -> None:
-                if i % eval_log_interval == 0 or i == total_eval:
-                    runner.report_rendering_progress(
-                        i, total_eval, label="rendering eval data",
-                    )
-
-            _stream(cfg.evaluation_dataset, eval_store, _on_eval_progress)
-            eval_store.close_write()
-            eval_data = list(eval_store)
+            eval_dataset = JsonlRenderDataset(cfg.evaluation_dataset, _render_one_worker)
+            eval_data = [d for d in (eval_dataset[i] for i in range(len(eval_dataset))) if d is not None]
             logger.info(
                 "Loaded %d eval examples from %s",
                 len(eval_data), cfg.evaluation_dataset,
             )
         elif cfg.eval_auto_carveout:
-            # Auto carve-out: keep the backing file intact, materialise a small
-            # eval list, and advance the training index past the carveout range.
+            # Carve out by JSONL row index (pre-render). The slight
+            # overcount vs post-filter is harmless: filtered rows in the
+            # eval slice yield None and are dropped.
             carveout_count = compute_eval_carveout(
-                len(training_store), cfg.eval_carve_ratio, cfg.max_eval_seqs,
+                total_raw, cfg.eval_carve_ratio, cfg.max_eval_seqs,
             )
             if carveout_count > 0:
-                eval_data = [training_store[i] for i in range(carveout_count)]
-                training_start_idx = carveout_count
+                eval_data = [training_dataset[i] for i in range(carveout_count)]
+                eval_data = [d for d in eval_data if d is not None]
+                training_dataset = training_dataset.with_indices(
+                    list(range(carveout_count, total_raw))
+                )
                 logger.info(
                     "Auto carve-out: %d eval examples, %d training examples",
-                    len(eval_data), len(training_store) - training_start_idx,
+                    len(eval_data), len(training_dataset),
                 )
             else:
                 logger.warning("Dataset too small for auto carve-out, skipping eval")
 
-        training_count = len(training_store) - training_start_idx
+        training_count = len(training_dataset)
         effective_batch_size = cfg.batch_size
         if training_count < effective_batch_size:
             logger.warning(
                 "Training examples (%d) < batch_size (%d); reducing effective "
                 "batch_size to %d so all examples are trained on.",
-                training_count,
-                effective_batch_size,
-                training_count,
+                training_count, effective_batch_size, training_count,
             )
-            effective_batch_size = training_count
+            effective_batch_size = max(1, training_count)
 
-        sft_dataset = SupervisedDatasetFromHFDataset(
-            hf_datasets.Dataset.from_dict(
-                {"datum_idx": list(range(training_start_idx, len(training_store)))}
-            ),
+        loader = make_render_dataloader(
+            training_dataset,
             batch_size=effective_batch_size,
-            map_fn=lambda row: training_store[row["datum_idx"]],
+            num_workers=num_workers,
+            shuffle=True,
+            worker_init_fn=functools.partial(_init_render_worker, *init_args),
         )
-        total_batches_per_epoch = len(sft_dataset)
+        # Pre-filter upper bound; filtered rows make actual batches
+        # smaller but never larger.
+        total_batches_per_epoch = (training_count + effective_batch_size - 1) // effective_batch_size
         logger.info(
-            "Dataset: %d examples, %d batches/epoch, %d epochs",
-            training_count,
-            total_batches_per_epoch,
-            cfg.epochs,
+            "Dataset: %d examples, ~%d batches/epoch, %d epochs",
+            training_count, total_batches_per_epoch, cfg.epochs,
         )
         if eval_data:
             logger.info("Eval dataset: %d examples (eval after each epoch)", len(eval_data))
@@ -730,10 +676,16 @@ def main(
         runner.write_status(RunStatus.RUNNING, total_steps=total_steps_estimate, message="training")
 
         for epoch in range(cfg.epochs):
-            sft_dataset.set_epoch(epoch)
-            epoch_start = start_batch if epoch == 0 else 0
-            for i_batch in range(epoch_start, total_batches_per_epoch):
-                batch = sft_dataset.get_batch(i_batch)
+            # On resume, skip the batches already processed in epoch 0.
+            # Workers still render skipped batches (wasted but bounded by
+            # num_workers * prefetch_factor); resume is rare enough that
+            # this is acceptable.
+            batch_iter = iter(loader)
+            if epoch == 0 and start_batch > 0:
+                batch_iter = islice(batch_iter, start_batch, None)
+            for batch in batch_iter:
+                if not batch:
+                    continue  # entire batch was filtered (None render); skip
                 data_consumed += len(batch)
                 step = _run_train_step(batch, step)
 

--- a/training/recipes/sft_loop.py
+++ b/training/recipes/sft_loop.py
@@ -98,23 +98,24 @@ def _init_render_worker(
     )
 
 
-def _render_messages(
-    row: dict, *, renderer, train_on_what, max_seq_len: int,
-) -> tinker.Datum | None:
-    """Render a chat row to a Datum, filtering empty / out-of-range sequences."""
+def _render_one_worker(row: dict) -> tinker.Datum | None:
+    """Render a chat row to a Datum, dropping empty / out-of-range sequences.
+
+    Reads renderer / train_on_what / max_seq_len from the per-process
+    ``_worker_state`` populated by ``_init_render_worker``. Top-level
+    so spawn workers can pickle it as the DataLoader's render_fn.
+    """
     messages = row.get("messages", [])
     if not messages:
         return None
     rendered = render_messages_to_datum(
-        messages, renderer=renderer, train_on_what=train_on_what,
+        messages,
+        renderer=_worker_state["renderer"],
+        train_on_what=_worker_state["train_on_what"],
     )
-    if not 2 <= len(rendered.token_ids) <= max_seq_len:
+    if not 2 <= len(rendered.token_ids) <= _worker_state["max_seq_len"]:
         return None
     return rendered.datum
-
-
-def _render_one_worker(row: dict) -> tinker.Datum | None:
-    return _render_messages(row, **_worker_state)
 
 
 # ---------------------------------------------------------------------------

--- a/training/recipes/sft_loop.py
+++ b/training/recipes/sft_loop.py
@@ -14,7 +14,6 @@ Usage:
 
 from __future__ import annotations
 
-import functools
 import os
 import signal
 import logging
@@ -460,15 +459,6 @@ def main(
             stack.callback(client.close)
 
         # -- Prepare data ------------------------------------------------------
-        tokenizer = transformers.AutoTokenizer.from_pretrained(cfg.tokenizer_model, trust_remote_code=True)
-        renderer = build_renderer(tokenizer, cfg.tokenizer_model, cfg.renderer_name)
-        train_on_what = parse_train_on_what(cfg.train_on_what)
-        logger.info(
-            "Using renderer=%s train_on_what=%s",
-            resolve_renderer_name(cfg.tokenizer_model, cfg.renderer_name),
-            train_on_what.value,
-        )
-
         # Stream-render dataset to a disk-backed store so peak RAM is bounded
         # by num_workers * per-worker render footprint instead of scaling with
         # dataset size. See docs/engineering/sft-v2-orchestrator-oom-debug.md.
@@ -477,14 +467,23 @@ def main(
             raise RuntimeError(f"No examples found in {cfg.dataset}")
         max_seq_len = cfg.max_seq_len
         num_workers = min(os.cpu_count() or 1, DEFAULT_RENDER_WORKERS)
-        use_parallel = num_workers > 1 and total_raw > num_workers
         logger.info(
-            "Streaming %d examples from %s (%s, workers=%d, chunksize=%d)",
+            "Streaming %d examples from %s (renderer=%s, train_on_what=%s,"
+            " workers=%d, chunksize=%d)",
             total_raw, cfg.dataset,
-            "parallel spawn" if use_parallel else "single-process",
-            num_workers if use_parallel else 1,
-            DEFAULT_RENDER_CHUNKSIZE if use_parallel else 1,
+            resolve_renderer_name(cfg.tokenizer_model, cfg.renderer_name),
+            cfg.train_on_what,
+            num_workers, DEFAULT_RENDER_CHUNKSIZE,
         )
+
+        # Initialise _worker_state in the parent too so the same render_fn
+        # (_render_one_worker) is used regardless of whether the helper
+        # picks the in-process loop (num_workers == 1) or the spawn pool.
+        init_args = (
+            cfg.tokenizer_model, cfg.renderer_name,
+            cfg.train_on_what, max_seq_len,
+        )
+        _init_render_worker(*init_args)
 
         render_cache_dir = stack.enter_context(
             tempfile.TemporaryDirectory(prefix="sft_render_")
@@ -498,18 +497,12 @@ def main(
         def _stream(src: str, dst: DiskBackedDatumStore, on_progress, max_examples=None) -> int:
             return stream_render_to_store(
                 iter_jsonl_rows(src, max_examples),
-                render_fn=_render_one_worker if use_parallel else functools.partial(
-                    _render_messages, renderer=renderer,
-                    train_on_what=train_on_what, max_seq_len=max_seq_len,
-                ),
+                render_fn=_render_one_worker,
                 store=dst,
-                num_workers=num_workers if use_parallel else 1,
+                num_workers=num_workers,
                 chunksize=DEFAULT_RENDER_CHUNKSIZE,
-                initializer=_init_render_worker if use_parallel else None,
-                initargs=(
-                    cfg.tokenizer_model, cfg.renderer_name,
-                    cfg.train_on_what, max_seq_len,
-                ) if use_parallel else (),
+                initializer=_init_render_worker,
+                initargs=init_args,
                 on_progress=on_progress,
             )
 

--- a/training/recipes/sft_loop.py
+++ b/training/recipes/sft_loop.py
@@ -221,6 +221,12 @@ class Config:
     max_eval_seqs: int = DEFAULT_MAX_EVAL_SEQS
     """Max number of eval sequences for carve-out."""
 
+    render_workers: int | None = None
+    """Number of worker processes for streaming dataset rendering. ``None``
+    auto-selects ``min(os.cpu_count(), DEFAULT_RENDER_WORKERS)``. Set to 1
+    to disable the spawn pool and render in-process (useful for unit tests
+    that monkeypatch the renderer)."""
+
     infra: InfraConfig = field(default_factory=InfraConfig)
     wandb: WandBConfig = field(default_factory=lambda: WandBConfig(project="sft-tinker"))
     runner: RunnerConfig = field(default_factory=RunnerConfig)
@@ -466,7 +472,11 @@ def main(
         if total_raw == 0:
             raise RuntimeError(f"No examples found in {cfg.dataset}")
         max_seq_len = cfg.max_seq_len
-        num_workers = min(os.cpu_count() or 1, DEFAULT_RENDER_WORKERS)
+        num_workers = (
+            cfg.render_workers
+            if cfg.render_workers is not None
+            else min(os.cpu_count() or 1, DEFAULT_RENDER_WORKERS)
+        )
         logger.info(
             "Streaming %d examples from %s (renderer=%s, train_on_what=%s,"
             " workers=%d, chunksize=%d)",

--- a/training/recipes/sft_loop.py
+++ b/training/recipes/sft_loop.py
@@ -118,7 +118,7 @@ def _render_one_worker(row: dict) -> tinker.Datum | None:
 
 
 # ---------------------------------------------------------------------------
-# Eval auto carve-out defaults
+# Dataset preparation
 # ---------------------------------------------------------------------------
 
 DEFAULT_EVAL_CARVE_RATIO = 0.1
@@ -130,27 +130,57 @@ def compute_eval_carveout(
     max_ratio: float = DEFAULT_EVAL_CARVE_RATIO,
     max_seqs: int = DEFAULT_MAX_EVAL_SEQS,
 ) -> int:
-    """Compute number of samples to carve out from training data for eval.
-
-    Mirrors the SFT v1 carve-out logic: take min(total * ratio, max_seqs),
-    but return 0 if the dataset is too small to split.
-
-    Args:
-        total_samples: Total number of tokenized training examples.
-        max_ratio: Max fraction of data to use for eval (default 10%).
-        max_seqs: Absolute cap on eval sequences (default 100).
-
-    Returns:
-        Number of samples to reserve for eval (first N of the dataset).
-    """
+    """Number of head samples to carve out as eval (0 if dataset too small)."""
     if total_samples <= 1:
         return 0
-    carveout = int(total_samples * max_ratio)
-    carveout = min(carveout, max_seqs)
-    # Need at least 1 sample left for training
-    if carveout >= total_samples:
-        return 0
-    return carveout
+    carveout = min(int(total_samples * max_ratio), max_seqs)
+    return 0 if carveout >= total_samples else carveout
+
+
+def _render_eagerly(ds: JsonlRenderDataset, n: int) -> List[tinker.Datum]:
+    """Render the first ``n`` rows of ``ds`` in-process, dropping Nones."""
+    return [d for d in (ds[i] for i in range(n)) if d is not None]
+
+
+def _prepare_datasets(
+    cfg: "Config",
+) -> tuple[JsonlRenderDataset, List[tinker.Datum]]:
+    """Build the training dataset and (optional) eval set.
+
+    Eval can come from an explicit ``cfg.evaluation_dataset`` or be
+    carved out from the head of the training dataset. In the carve-out
+    case the returned training dataset is sliced past the eval window.
+    """
+    training_ds = JsonlRenderDataset(
+        cfg.dataset, _render_one_worker, max_examples=cfg.max_examples,
+    )
+    if len(training_ds) == 0:
+        raise RuntimeError(f"No examples found in {cfg.dataset}")
+
+    if cfg.evaluation_dataset:
+        eval_ds = JsonlRenderDataset(cfg.evaluation_dataset, _render_one_worker)
+        eval_data = _render_eagerly(eval_ds, len(eval_ds))
+        logger.info(
+            "Loaded %d eval examples from %s",
+            len(eval_data), cfg.evaluation_dataset,
+        )
+        return training_ds, eval_data
+
+    if cfg.eval_auto_carveout:
+        n = compute_eval_carveout(
+            len(training_ds), cfg.eval_carve_ratio, cfg.max_eval_seqs,
+        )
+        if n > 0:
+            eval_data = _render_eagerly(training_ds, n)
+            training_ds = training_ds.with_indices(list(range(n, len(training_ds))))
+            logger.info(
+                "Auto carve-out: %d eval examples, %d training examples",
+                len(eval_data), len(training_ds),
+            )
+            return training_ds, eval_data
+        logger.warning("Dataset too small for auto carve-out, skipping eval")
+
+    return training_ds, []
 
 
 # ---------------------------------------------------------------------------
@@ -477,91 +507,50 @@ def main(
         # Render JSONL rows on the fly inside DataLoader workers so peak
         # RAM is O(num_workers * per_worker_render_footprint) instead of
         # O(dataset_size). See docs/engineering/sft-v2-orchestrator-oom-debug.md.
-        max_seq_len = cfg.max_seq_len
         num_workers = (
             cfg.render_workers
             if cfg.render_workers is not None
             else min(os.cpu_count() or 1, DEFAULT_RENDER_WORKERS)
         )
-        # Initialise the parent's _worker_state so eval / carve-out
-        # rendering (which runs in-process) shares the same render_fn.
+        # Initialise the parent's _worker_state (used by eval / carve-out
+        # rendering in-process) and bind the same args as the DataLoader
+        # workers' init_fn.
         init_args = (
             cfg.tokenizer_model, cfg.renderer_name,
-            cfg.train_on_what, max_seq_len,
+            cfg.train_on_what, cfg.max_seq_len,
         )
         _init_render_worker(*init_args)
+        worker_init_fn = functools.partial(_init_render_worker, *init_args)
 
-        training_dataset = JsonlRenderDataset(
-            cfg.dataset, _render_one_worker, max_examples=cfg.max_examples,
-        )
-        total_raw = len(training_dataset)
-        if total_raw == 0:
-            raise RuntimeError(f"No examples found in {cfg.dataset}")
-        logger.info(
-            "Indexed %d examples from %s (renderer=%s, train_on_what=%s,"
-            " workers=%d)",
-            total_raw, cfg.dataset,
-            resolve_renderer_name(cfg.tokenizer_model, cfg.renderer_name),
-            cfg.train_on_what, num_workers,
-        )
-
-        # -- Eval dataset (explicit or auto carve-out) -------------------------
-        # Eval sets are small (max_eval_seqs ~ 100); render eagerly in
-        # the parent process so they can be replayed each epoch.
-        eval_data: List[tinker.Datum] = []
-        if cfg.evaluation_dataset:
-            eval_dataset = JsonlRenderDataset(cfg.evaluation_dataset, _render_one_worker)
-            eval_data = [d for d in (eval_dataset[i] for i in range(len(eval_dataset))) if d is not None]
-            logger.info(
-                "Loaded %d eval examples from %s",
-                len(eval_data), cfg.evaluation_dataset,
-            )
-        elif cfg.eval_auto_carveout:
-            # Carve out by JSONL row index (pre-render). The slight
-            # overcount vs post-filter is harmless: filtered rows in the
-            # eval slice yield None and are dropped.
-            carveout_count = compute_eval_carveout(
-                total_raw, cfg.eval_carve_ratio, cfg.max_eval_seqs,
-            )
-            if carveout_count > 0:
-                eval_data = [training_dataset[i] for i in range(carveout_count)]
-                eval_data = [d for d in eval_data if d is not None]
-                training_dataset = training_dataset.with_indices(
-                    list(range(carveout_count, total_raw))
-                )
-                logger.info(
-                    "Auto carve-out: %d eval examples, %d training examples",
-                    len(eval_data), len(training_dataset),
-                )
-            else:
-                logger.warning("Dataset too small for auto carve-out, skipping eval")
-
+        training_dataset, eval_data = _prepare_datasets(cfg)
         training_count = len(training_dataset)
-        effective_batch_size = cfg.batch_size
-        if training_count < effective_batch_size:
+        effective_batch_size = max(1, min(cfg.batch_size, training_count))
+        if effective_batch_size < cfg.batch_size:
             logger.warning(
                 "Training examples (%d) < batch_size (%d); reducing effective "
-                "batch_size to %d so all examples are trained on.",
-                training_count, effective_batch_size, training_count,
+                "batch_size to %d.",
+                training_count, cfg.batch_size, effective_batch_size,
             )
-            effective_batch_size = max(1, training_count)
 
         loader = make_render_dataloader(
             training_dataset,
             batch_size=effective_batch_size,
             num_workers=num_workers,
             shuffle=True,
-            worker_init_fn=functools.partial(_init_render_worker, *init_args),
+            worker_init_fn=worker_init_fn,
         )
         # Pre-filter upper bound; filtered rows make actual batches
         # smaller but never larger.
         total_batches_per_epoch = (training_count + effective_batch_size - 1) // effective_batch_size
         logger.info(
-            "Dataset: %d examples, ~%d batches/epoch, %d epochs",
-            training_count, total_batches_per_epoch, cfg.epochs,
+            "Dataset: %d examples from %s (renderer=%s, train_on_what=%s,"
+            " workers=%d) -> ~%d batches/epoch x %d epochs%s",
+            training_count, cfg.dataset,
+            resolve_renderer_name(cfg.tokenizer_model, cfg.renderer_name),
+            cfg.train_on_what, num_workers,
+            total_batches_per_epoch, cfg.epochs,
+            f" + {len(eval_data)} eval examples" if eval_data else "",
         )
-        if eval_data:
-            logger.info("Eval dataset: %d examples (eval after each epoch)", len(eval_data))
 
         # -- Resume ---------------------------------------------------------------
 

--- a/training/recipes/sft_loop.py
+++ b/training/recipes/sft_loop.py
@@ -74,25 +74,20 @@ from training.utils.timer import timer, flush_timing
 load_dotenv()
 logger = logging.getLogger(__name__)
 
-# ---------------------------------------------------------------------------
-# Per-worker render state (multiprocessing) -- module-level so the spawn
-# pool initializer can populate it before each worker starts consuming rows.
-# ---------------------------------------------------------------------------
-
-_worker_renderer = None
-_worker_train_on_what = None
-_worker_max_seq_len = None
+# Module-level so the spawn pool initializer can populate it once per worker
+# (avoids re-pickling the tokenizer on every task).
+_worker_state: dict = {}
 
 
 def _init_render_worker(tokenizer_model, renderer_name, train_on_what_str, max_seq_len):
-    """Build a renderer per worker (avoids pickling the tokenizer)."""
-    global _worker_renderer, _worker_train_on_what, _worker_max_seq_len
     tokenizer = transformers.AutoTokenizer.from_pretrained(
         tokenizer_model, trust_remote_code=True,
     )
-    _worker_renderer = build_renderer(tokenizer, tokenizer_model, renderer_name)
-    _worker_train_on_what = parse_train_on_what(train_on_what_str)
-    _worker_max_seq_len = max_seq_len
+    _worker_state.update(
+        renderer=build_renderer(tokenizer, tokenizer_model, renderer_name),
+        train_on_what=parse_train_on_what(train_on_what_str),
+        max_seq_len=max_seq_len,
+    )
 
 
 def _render_messages(
@@ -105,19 +100,13 @@ def _render_messages(
     rendered = render_messages_to_datum(
         messages, renderer=renderer, train_on_what=train_on_what,
     )
-    if len(rendered.token_ids) > max_seq_len or len(rendered.token_ids) < 2:
+    if not 2 <= len(rendered.token_ids) <= max_seq_len:
         return None
     return rendered.datum
 
 
 def _render_one_worker(row: dict) -> tinker.Datum | None:
-    """Render a single chat example in a worker process."""
-    return _render_messages(
-        row,
-        renderer=_worker_renderer,
-        train_on_what=_worker_train_on_what,
-        max_seq_len=_worker_max_seq_len,
-    )
+    return _render_messages(row, **_worker_state)
 
 
 # ---------------------------------------------------------------------------
@@ -480,27 +469,51 @@ def main(
             train_on_what.value,
         )
 
-        # Stream-render the dataset: JSONL rows are read lazily and each
-        # rendered Datum is spilled to a disk-backed store so peak RAM stays
-        # bounded (O(num_workers * per_worker_render_footprint) instead of
-        # O(num_examples * avg_seq_len * bytes_per_token)).
-        # See docs/engineering/sft-v2-orchestrator-oom-debug.md for the
-        # investigation that led to this design.
+        # Stream-render dataset to a disk-backed store so peak RAM is bounded
+        # by num_workers * per-worker render footprint instead of scaling with
+        # dataset size. See docs/engineering/sft-v2-orchestrator-oom-debug.md.
         total_raw = count_jsonl_rows(cfg.dataset, cfg.max_examples)
         if total_raw == 0:
             raise RuntimeError(f"No examples found in {cfg.dataset}")
-        logger.info("Streaming %d examples from %s", total_raw, cfg.dataset)
-
         max_seq_len = cfg.max_seq_len
-        log_interval = max(1, total_raw // 20)  # ~5% increments for runner progress
-        mem_log_interval = max(1, total_raw // 200)  # ~0.5% for memory tracing
+        num_workers = min(os.cpu_count() or 1, DEFAULT_RENDER_WORKERS)
+        use_parallel = num_workers > 1 and total_raw > num_workers
+        logger.info(
+            "Streaming %d examples from %s (%s, workers=%d, chunksize=%d)",
+            total_raw, cfg.dataset,
+            "parallel spawn" if use_parallel else "single-process",
+            num_workers if use_parallel else 1,
+            DEFAULT_RENDER_CHUNKSIZE if use_parallel else 1,
+        )
+
         render_cache_dir = stack.enter_context(
             tempfile.TemporaryDirectory(prefix="sft_render_")
         )
-        training_store = stack.enter_context(
-            DiskBackedDatumStore(os.path.join(render_cache_dir, "training.bin"))
-        )
 
+        def _open_store(name: str) -> DiskBackedDatumStore:
+            return stack.enter_context(
+                DiskBackedDatumStore(os.path.join(render_cache_dir, name))
+            )
+
+        def _stream(src: str, dst: DiskBackedDatumStore, on_progress, max_examples=None) -> int:
+            return stream_render_to_store(
+                iter_jsonl_rows(src, max_examples),
+                render_fn=_render_one_worker if use_parallel else functools.partial(
+                    _render_messages, renderer=renderer,
+                    train_on_what=train_on_what, max_seq_len=max_seq_len,
+                ),
+                store=dst,
+                num_workers=num_workers if use_parallel else 1,
+                chunksize=DEFAULT_RENDER_CHUNKSIZE,
+                initializer=_init_render_worker if use_parallel else None,
+                initargs=(
+                    cfg.tokenizer_model, cfg.renderer_name,
+                    cfg.train_on_what, max_seq_len,
+                ) if use_parallel else (),
+                on_progress=on_progress,
+            )
+
+        training_store = _open_store("training.bin")
         mem_tracer = MemTracer(
             store_callback=lambda: (
                 len(training_store), training_store.disk_size_bytes(),
@@ -509,15 +522,8 @@ def main(
         )
         mem_tracer.log("before_rendering", 0, total_raw)
 
-        num_workers = min(os.cpu_count() or 1, DEFAULT_RENDER_WORKERS)
-        use_parallel = num_workers > 1 and total_raw > num_workers
-        logger.info(
-            "Rendering %d examples (%s, workers=%d, chunksize=%d)",
-            total_raw,
-            "parallel spawn" if use_parallel else "single-process",
-            num_workers if use_parallel else 1,
-            DEFAULT_RENDER_CHUNKSIZE if use_parallel else 1,
-        )
+        log_interval = max(1, total_raw // 20)       # ~5% for runner status
+        mem_log_interval = max(1, total_raw // 200)  # ~0.5% for memory tracing
 
         def _on_render_progress(i: int, _datum: tinker.Datum | None) -> None:
             if i % log_interval == 0 or i == total_raw:
@@ -525,26 +531,8 @@ def main(
             if i % mem_log_interval == 0 or i == total_raw:
                 mem_tracer.log("rendering", i, total_raw)
 
-        filtered_count = stream_render_to_store(
-            iter_jsonl_rows(cfg.dataset, cfg.max_examples),
-            render_fn=(
-                _render_one_worker if use_parallel
-                else functools.partial(
-                    _render_messages,
-                    renderer=renderer,
-                    train_on_what=train_on_what,
-                    max_seq_len=max_seq_len,
-                )
-            ),
-            store=training_store,
-            num_workers=num_workers if use_parallel else 1,
-            chunksize=DEFAULT_RENDER_CHUNKSIZE,
-            initializer=_init_render_worker if use_parallel else None,
-            initargs=(
-                cfg.tokenizer_model, cfg.renderer_name,
-                cfg.train_on_what, max_seq_len,
-            ) if use_parallel else (),
-            on_progress=_on_render_progress,
+        filtered_count = _stream(
+            cfg.dataset, training_store, _on_render_progress, cfg.max_examples,
         )
         training_store.close_write()
         mem_tracer.log("after_rendering", total_raw, total_raw)
@@ -559,17 +547,14 @@ def main(
             raise RuntimeError("No valid training examples after tokenization")
 
         # -- Eval dataset (explicit or auto carve-out) -------------------------
-        # eval_data is a small list of Datums (max_eval_seqs <= 100 typical).
-        # For explicit eval_dataset we also stream rendering to a disk store,
-        # then materialise a bounded list for the eval loop.
+        # eval_data is a small list of Datums (max_eval_seqs ~ 100 typical),
+        # safe to materialise after streaming.
         eval_data: List[tinker.Datum] = []
         training_start_idx = 0
         if cfg.evaluation_dataset:
             total_eval = count_jsonl_rows(cfg.evaluation_dataset)
             eval_log_interval = max(1, total_eval // 10)
-            eval_store = stack.enter_context(
-                DiskBackedDatumStore(os.path.join(render_cache_dir, "eval.bin"))
-            )
+            eval_store = _open_store("eval.bin")
 
             def _on_eval_progress(i: int, _datum: tinker.Datum | None) -> None:
                 if i % eval_log_interval == 0 or i == total_eval:
@@ -577,38 +562,16 @@ def main(
                         i, total_eval, label="rendering eval data",
                     )
 
-            stream_render_to_store(
-                iter_jsonl_rows(cfg.evaluation_dataset),
-                render_fn=(
-                    _render_one_worker if use_parallel
-                    else functools.partial(
-                        _render_messages,
-                        renderer=renderer,
-                        train_on_what=train_on_what,
-                        max_seq_len=max_seq_len,
-                    )
-                ),
-                store=eval_store,
-                num_workers=num_workers if use_parallel else 1,
-                chunksize=DEFAULT_RENDER_CHUNKSIZE,
-                initializer=_init_render_worker if use_parallel else None,
-                initargs=(
-                    cfg.tokenizer_model, cfg.renderer_name,
-                    cfg.train_on_what, max_seq_len,
-                ) if use_parallel else (),
-                on_progress=_on_eval_progress,
-            )
+            _stream(cfg.evaluation_dataset, eval_store, _on_eval_progress)
             eval_store.close_write()
-            # Eval set is bounded (max_eval_seqs ~ 100), safe to materialise.
             eval_data = list(eval_store)
             logger.info(
                 "Loaded %d eval examples from %s",
                 len(eval_data), cfg.evaluation_dataset,
             )
         elif cfg.eval_auto_carveout:
-            # Auto carve-out: split first N examples as eval. The backing file
-            # stays intact; we materialise a small eval list and advance the
-            # training index window past the carveout range.
+            # Auto carve-out: keep the backing file intact, materialise a small
+            # eval list, and advance the training index past the carveout range.
             carveout_count = compute_eval_carveout(
                 len(training_store), cfg.eval_carve_ratio, cfg.max_eval_seqs,
             )

--- a/training/tests/unit/test_checkpoint_utils.py
+++ b/training/tests/unit/test_checkpoint_utils.py
@@ -85,13 +85,14 @@ class TestResolveResume:
             "state_path": "cross_job://job-1/step-2",
         })
         _write_checkpoint(log_dir, {
-            "name": "step-4", "step": 4, "data_consumed": 32,
+            "name": "step-4", "step": 4, "data_consumed": 32, "raw_rows_consumed": 40,
             "state_path": "cross_job://job-1/step-4",
         })
         client = _make_mock_client()
         result = resolve_resume(client, log_dir)
         assert result.step == 4
         assert result.data_consumed == 32
+        assert result.raw_rows_consumed == 40
         client.load_state_with_optimizer.assert_called_once_with("cross_job://job-1/step-4")
 
     def test_init_from_checkpoint_simple(self, log_dir):

--- a/training/tests/unit/test_dpo_loop.py
+++ b/training/tests/unit/test_dpo_loop.py
@@ -1,228 +1,207 @@
+"""Unit tests for the streaming DPO loop.
+
+Covers the public-ish surface of ``training.recipes.dpo_loop``:
+
+  * ``_render_pair_worker`` -- per-row render fn used by the JsonlRenderDataset
+    (schema normalisation + render + over-length filtering, with all drop
+    reasons collapsed into a ``None`` return).
+  * ``_ref_forward_batch`` -- enriches pairs with ``array.array('f')``
+    reference logprobs and preserves input order.
+  * ``_forward_backward_pairs`` -- arranges datums and ref logprobs for
+    the policy update.
+  * ``_train_loop`` -- end-to-end pipeline for the single-epoch path
+    (no ref_cache_log) and the multi-epoch path (``AppendOnlyPickleLog``
+    captures pairs in producer order so epochs 1+ stream from disk).
+  * ``iter_preference_examples`` -- streaming JSONL reader that
+    normalises the three on-disk preference schemas.
+
+The streaming refactor mirrors the SFT v2 fix (fw-ai/cookbook#371).
+"""
+
 from __future__ import annotations
 
+import array
 import asyncio
 import json
 import time
 from types import SimpleNamespace
 
 import pytest
-import torch
 
 import training.recipes.dpo_loop as module
-from training.utils.data import load_preference_dataset
+from training.utils import AppendOnlyPickleLog, JsonlRenderDataset
+from training.utils.data import iter_preference_examples, load_preference_dataset
 
 
-class SequenceRenderer:
-    def __init__(self, outputs: list[tuple[list[int], list[float]]]):
-        self.outputs = [
-            (torch.tensor(tokens, dtype=torch.int64), torch.tensor(weights, dtype=torch.float32))
-            for tokens, weights in outputs
-        ]
-        self.calls: list = []
-
-    def build_supervised_example(self, messages, train_on_what):
-        self.calls.append((messages, train_on_what))
-        return self.outputs[len(self.calls) - 1]
+# ---------------------------------------------------------------------------
+# _render_pair_worker
+# ---------------------------------------------------------------------------
 
 
-def test_tokenize_pair_handles_invalid_filtered_and_valid(monkeypatch):
-    example = {"chosen": {"messages": []}, "rejected": {"messages": []}}
-
-    monkeypatch.setattr(module, "render_preference_pair", lambda *args, **kwargs: None)
-    assert module._tokenize_pair(example, tokenizer=None, renderer=None, max_seq_len=8) is None
-
-    long_pair = SimpleNamespace(
-        chosen_tokens=[1] * 9,
-        rejected_tokens=[2, 3],
-        response_start=3,
-        chosen_datum={"kind": "chosen"},
-        rejected_datum={"kind": "rejected"},
-    )
-    monkeypatch.setattr(module, "render_preference_pair", lambda *args, **kwargs: long_pair)
-    assert module._tokenize_pair(example, tokenizer=None, renderer=None, max_seq_len=8) == "filtered"
-
-    valid_pair = SimpleNamespace(
-        chosen_tokens=[1, 2, 3, 4],
-        rejected_tokens=[1, 2, 9],
-        response_start=2,
-        chosen_datum={"kind": "chosen"},
-        rejected_datum={"kind": "rejected"},
-    )
-    monkeypatch.setattr(module, "render_preference_pair", lambda *args, **kwargs: valid_pair)
-    assert module._tokenize_pair(example, tokenizer=None, renderer=None, max_seq_len=8) == {
-        "chosen_tokens": [1, 2, 3, 4],
-        "rejected_tokens": [1, 2, 9],
-        "response_start": 2,
-        "chosen_datum": {"kind": "chosen"},
-        "rejected_datum": {"kind": "rejected"},
-    }
+def _setup_pair_worker(monkeypatch, max_seq_len: int = 8) -> None:
+    monkeypatch.setitem(module._pair_worker_state, "renderer", "R")
+    monkeypatch.setitem(module._pair_worker_state, "tokenizer", "T")
+    monkeypatch.setitem(module._pair_worker_state, "max_seq_len", max_seq_len)
 
 
-def test_tokenize_pairs_filters_and_collects(monkeypatch):
-    raw_data = [{"id": 0}, {"id": 1}, {"id": 2}, {"id": 3}]
-    tokenized_results = iter(
-        [
-            {
-                "chosen_tokens": [1, 2, 3],
-                "rejected_tokens": [1, 2, 4],
-                "response_start": 2,
-                "chosen_datum": {"pair": 0, "kind": "chosen"},
-                "rejected_datum": {"pair": 0, "kind": "rejected"},
-            },
-            "filtered",
-            None,
-            {
-                "chosen_tokens": [5, 6, 7],
-                "rejected_tokens": [5, 6, 8],
-                "response_start": 2,
-                "chosen_datum": {"pair": 3, "kind": "chosen"},
-                "rejected_datum": {"pair": 3, "kind": "rejected"},
-            },
-        ]
-    )
+class TestRenderPairWorker:
+    def test_returns_none_when_schema_unrecognized(self, monkeypatch):
+        _setup_pair_worker(monkeypatch)
+        assert module._render_pair_worker({"unknown": "schema"}) is None
 
-    monkeypatch.setattr(
-        module,
-        "_tokenize_pair",
-        lambda *args, **kwargs: next(tokenized_results),
-    )
+    def test_returns_none_when_render_fails(self, monkeypatch):
+        _setup_pair_worker(monkeypatch)
+        monkeypatch.setattr(module, "render_preference_pair", lambda *a, **k: None)
+        assert module._render_pair_worker(
+            {"chosen": {"messages": []}, "rejected": {"messages": []}}
+        ) is None
 
-    tokenized, filtered_count = module._tokenize_pairs(
-        raw_data, tokenizer=None, renderer=None, max_seq_len=32,
-    )
+    def test_returns_none_when_too_long(self, monkeypatch):
+        _setup_pair_worker(monkeypatch)
+        long_pair = SimpleNamespace(
+            chosen_tokens=[1] * 9, rejected_tokens=[2, 3], response_start=3,
+            chosen_datum={"kind": "chosen"}, rejected_datum={"kind": "rejected"},
+        )
+        monkeypatch.setattr(module, "render_preference_pair", lambda *a, **k: long_pair)
+        assert module._render_pair_worker(
+            {"chosen": {}, "rejected": {}}
+        ) is None
 
-    assert filtered_count == 1
-    assert len(tokenized) == 2
-    assert tokenized[0][0] == 0
-    assert tokenized[0][1]["chosen_tokens"] == [1, 2, 3]
-    assert tokenized[1][0] == 3
-    assert tokenized[1][1]["chosen_tokens"] == [5, 6, 7]
+    def test_returns_dict_with_lengths_only(self, monkeypatch):
+        """Stored dict carries lengths, not token lists -- saves O(N*L) RAM."""
+        _setup_pair_worker(monkeypatch)
+        valid_pair = SimpleNamespace(
+            chosen_tokens=[1, 2, 3, 4], rejected_tokens=[1, 2, 9],
+            response_start=2,
+            chosen_datum={"kind": "chosen"}, rejected_datum={"kind": "rejected"},
+        )
+        monkeypatch.setattr(module, "render_preference_pair", lambda *a, **k: valid_pair)
+        result = module._render_pair_worker(
+            {"chosen": {}, "rejected": {}}
+        )
+        assert result == {
+            "chosen_tokens_len": 4,
+            "rejected_tokens_len": 3,
+            "response_start": 2,
+            "chosen_datum": {"kind": "chosen"},
+            "rejected_datum": {"kind": "rejected"},
+        }
+        assert "chosen_tokens" not in result
+        assert "rejected_tokens" not in result
 
+    def test_normalises_samples_schema(self, monkeypatch):
+        """Render fn does the schema normalisation step itself (no helper needed)."""
+        _setup_pair_worker(monkeypatch)
+        captured: dict = {}
 
-def test_ref_forward_batch_computes_logprobs():
-    class FakeReference:
-        def __init__(self):
-            self.calls = []
-
-        def forward(self, datums, loss_fn):
-            self.calls.append((datums, loss_fn))
+        def fake_render(chosen, rejected, **kwargs):
+            captured["chosen"] = chosen
+            captured["rejected"] = rejected
             return SimpleNamespace(
-                loss_fn_outputs=[
+                chosen_tokens=[1], rejected_tokens=[1], response_start=0,
+                chosen_datum={}, rejected_datum={},
+            )
+
+        monkeypatch.setattr(module, "render_preference_pair", fake_render)
+        row = {"samples": [
+            {"text": "good", "evals": {"score": 1.0}},
+            {"text": "bad", "evals": {"score": 0.0}},
+        ]}
+        assert module._render_pair_worker(row) is not None
+        assert captured["chosen"]["text"] == "good"
+        assert captured["rejected"]["text"] == "bad"
+
+
+# ---------------------------------------------------------------------------
+# _ref_forward_batch
+# ---------------------------------------------------------------------------
+
+
+class TestRefForwardBatch:
+    def test_enriches_pairs_in_input_order(self):
+        """Returned dicts carry ``array.array('f')`` logprobs and preserve order."""
+
+        class FakeReference:
+            def __init__(self):
+                self.calls = []
+
+            def forward(self, datums, loss_fn):
+                self.calls.append((datums, loss_fn))
+                return SimpleNamespace(loss_fn_outputs=[
                     {"logprobs": SimpleNamespace(data=[-0.1, -0.2])},
                     {"logprobs": SimpleNamespace(data=[-0.3])},
                     {"logprobs": SimpleNamespace(data=[-0.4])},
                     {"logprobs": SimpleNamespace(data=[-0.5, -0.6])},
-                ]
-            )
+                ])
 
-    reference = FakeReference()
-    pairs = [
-        (0, {
-            "chosen_tokens": [1, 2, 3],
-            "rejected_tokens": [1, 2, 4],
-            "response_start": 2,
-            "chosen_datum": {"pair": 0, "kind": "chosen"},
-            "rejected_datum": {"pair": 0, "kind": "rejected"},
-        }),
-        (3, {
-            "chosen_tokens": [5, 6, 7],
-            "rejected_tokens": [5, 6, 8],
-            "response_start": 2,
-            "chosen_datum": {"pair": 3, "kind": "chosen"},
-            "rejected_datum": {"pair": 3, "kind": "rejected"},
-        }),
-    ]
-
-    sem = asyncio.Semaphore(2)
-    enriched = asyncio.run(
-        module._ref_forward_batch(pairs, reference, sem, ref_batch_size=2)
-    )
-
-    assert reference.calls == [
-        (
-            [
-                {"pair": 0, "kind": "chosen"},
-                {"pair": 0, "kind": "rejected"},
-                {"pair": 3, "kind": "chosen"},
-                {"pair": 3, "kind": "rejected"},
-            ],
-            "cross_entropy",
-        )
-    ]
-    assert len(enriched) == 2
-    assert enriched[0] == (0, {
-        "chosen_tokens": [1, 2, 3],
-        "rejected_tokens": [1, 2, 4],
-        "chosen_datum": {"pair": 0, "kind": "chosen"},
-        "rejected_datum": {"pair": 0, "kind": "rejected"},
-        "ref_chosen": [-0.1, -0.2],
-        "ref_rejected": [-0.3],
-        "response_start": 2,
-    })
-    assert enriched[1] == (3, {
-        "chosen_tokens": [5, 6, 7],
-        "rejected_tokens": [5, 6, 8],
-        "chosen_datum": {"pair": 3, "kind": "chosen"},
-        "rejected_datum": {"pair": 3, "kind": "rejected"},
-        "ref_chosen": [-0.4],
-        "ref_rejected": [-0.5, -0.6],
-        "response_start": 2,
-    })
-
-
-def test_tokenize_pairs_preserves_multi_turn_preference_history():
-    raw_data = [
-        {
-            "chosen": {
-                "messages": [
-                    {"role": "user", "content": "u1"},
-                    {"role": "assistant", "content": "a1"},
-                    {"role": "user", "content": "u2"},
-                    {"role": "assistant", "content": "chosen"},
-                ]
-            },
-            "rejected": {
-                "messages": [
-                    {"role": "user", "content": "u1"},
-                    {"role": "assistant", "content": "a1"},
-                    {"role": "user", "content": "u2"},
-                    {"role": "assistant", "content": "rejected"},
-                ]
-            },
-        }
-    ]
-    renderer = SequenceRenderer(
-        outputs=[
-            ([1, 2, 3, 4, 5, 6, 7], [0, 0, 0, 0, 1, 1, 1]),
-            ([1, 2, 3, 4, 8, 9], [0, 0, 0, 0, 1, 1]),
+        reference = FakeReference()
+        pairs = [
+            {"chosen_tokens_len": 3, "rejected_tokens_len": 3, "response_start": 2,
+             "chosen_datum": {"id": "c0"}, "rejected_datum": {"id": "r0"}},
+            {"chosen_tokens_len": 3, "rejected_tokens_len": 3, "response_start": 2,
+             "chosen_datum": {"id": "c1"}, "rejected_datum": {"id": "r1"}},
         ]
-    )
 
-    tokenized, filtered_count = module._tokenize_pairs(
-        raw_data, tokenizer=None, renderer=renderer, max_seq_len=32,
-    )
+        sem = asyncio.Semaphore(2)
+        enriched = asyncio.run(
+            module._ref_forward_batch(pairs, reference, sem, ref_batch_size=2)
+        )
 
-    assert filtered_count == 0
-    assert len(tokenized) == 1
-    idx, pair_data = tokenized[0]
-    assert idx == 0
-    assert pair_data["response_start"] == 4
-    chosen_messages, _ = renderer.calls[0]
-    rejected_messages, _ = renderer.calls[1]
-    assert [m["role"] for m in chosen_messages] == ["user", "assistant", "user", "assistant"]
-    assert [m["content"] for m in chosen_messages] == ["u1", "a1", "u2", "chosen"]
-    assert [m["role"] for m in rejected_messages] == ["user", "assistant", "user", "assistant"]
-    assert [m["content"] for m in rejected_messages] == ["u1", "a1", "u2", "rejected"]
+        assert reference.calls == [(
+            [{"id": "c0"}, {"id": "r0"}, {"id": "c1"}, {"id": "r1"}],
+            "cross_entropy",
+        )]
+        assert len(enriched) == 2
+        assert isinstance(enriched[0]["ref_chosen"], array.array)
+        assert enriched[0]["ref_chosen"].typecode == "f"
+        assert list(enriched[0]["ref_chosen"]) == pytest.approx([-0.1, -0.2])
+        assert list(enriched[0]["ref_rejected"]) == pytest.approx([-0.3])
+        assert list(enriched[1]["ref_chosen"]) == pytest.approx([-0.4])
+        assert list(enriched[1]["ref_rejected"]) == pytest.approx([-0.5, -0.6])
+        assert enriched[0]["chosen_datum"] == {"id": "c0"}
+        assert enriched[0]["rejected_datum"] == {"id": "r0"}
+
+    def test_sub_batches_split_correctly(self):
+        """``ref_batch_size`` controls how many pairs go in each forward call."""
+
+        class FakeReference:
+            def __init__(self):
+                self.calls = []
+
+            def forward(self, datums, loss_fn):
+                self.calls.append(len(datums))
+                return SimpleNamespace(loss_fn_outputs=[
+                    {"logprobs": SimpleNamespace(data=[-0.1])} for _ in datums
+                ])
+
+        reference = FakeReference()
+        pairs = [
+            {"chosen_tokens_len": 1, "rejected_tokens_len": 1, "response_start": 0,
+             "chosen_datum": {"i": i}, "rejected_datum": {"i": -i}}
+            for i in range(5)
+        ]
+        asyncio.run(
+            module._ref_forward_batch(
+                pairs, reference, asyncio.Semaphore(4), ref_batch_size=2,
+            )
+        )
+        # 5 pairs / 2 per batch -> [2, 2, 1] pairs -> [4, 4, 2] datums
+        assert sorted(reference.calls) == [2, 4, 4]
+
+
+# ---------------------------------------------------------------------------
+# _forward_backward_pairs
+# ---------------------------------------------------------------------------
 
 
 def test_forward_backward_pairs_interleaves_and_builds_loss_fn(monkeypatch):
-    captured = {}
+    captured: dict = {}
 
-    def fake_make_batch_dpo_loss_fn(ref_chosen, ref_rejected, response_starts, beta):
-        captured["ref_chosen"] = ref_chosen
-        captured["ref_rejected"] = ref_rejected
-        captured["response_starts"] = response_starts
-        captured["beta"] = beta
+    def fake_make_loss(ref_chosen, ref_rejected, response_starts, beta):
+        captured.update(
+            ref_chosen=ref_chosen, ref_rejected=ref_rejected,
+            response_starts=response_starts, beta=beta,
+        )
         return "loss-fn"
 
     class FakePolicy:
@@ -231,445 +210,443 @@ def test_forward_backward_pairs_interleaves_and_builds_loss_fn(monkeypatch):
             captured["loss_fn"] = loss_fn
             return "result"
 
-    monkeypatch.setattr(module, "make_batch_dpo_loss_fn", fake_make_batch_dpo_loss_fn)
+    monkeypatch.setattr(module, "make_batch_dpo_loss_fn", fake_make_loss)
 
     batch_pairs = [
-        {
-            "chosen_datum": {"id": "chosen-0"},
-            "rejected_datum": {"id": "rejected-0"},
-            "ref_chosen": [-0.1],
-            "ref_rejected": [-0.2],
-            "response_start": 3,
-        },
-        {
-            "chosen_datum": {"id": "chosen-1"},
-            "rejected_datum": {"id": "rejected-1"},
-            "ref_chosen": [-0.3],
-            "ref_rejected": [-0.4],
-            "response_start": 5,
-        },
+        {"chosen_datum": {"id": "c0"}, "rejected_datum": {"id": "r0"},
+         "ref_chosen": array.array("f", [-0.1]), "ref_rejected": array.array("f", [-0.2]),
+         "response_start": 3, "chosen_tokens_len": 1, "rejected_tokens_len": 1},
+        {"chosen_datum": {"id": "c1"}, "rejected_datum": {"id": "r1"},
+         "ref_chosen": array.array("f", [-0.3]), "ref_rejected": array.array("f", [-0.4]),
+         "response_start": 5, "chosen_tokens_len": 1, "rejected_tokens_len": 1},
     ]
+    assert module._forward_backward_pairs(batch_pairs, FakePolicy(), beta=0.25) == "result"
 
-    result = module._forward_backward_pairs(batch_pairs, FakePolicy(), beta=0.25)
-
-    assert result == "result"
     assert captured["datums"] == [
-        {"id": "chosen-0"},
-        {"id": "rejected-0"},
-        {"id": "chosen-1"},
-        {"id": "rejected-1"},
+        {"id": "c0"}, {"id": "r0"}, {"id": "c1"}, {"id": "r1"},
     ]
-    assert captured["loss_fn"] == "loss-fn"
-    assert captured["ref_chosen"] == [[-0.1], [-0.3]]
-    assert captured["ref_rejected"] == [[-0.2], [-0.4]]
+    assert all(isinstance(r, array.array) for r in captured["ref_chosen"])
     assert captured["response_starts"] == [3, 5]
     assert captured["beta"] == 0.25
 
 
-def test_main_requires_tokenizer_model(monkeypatch):
-    monkeypatch.setattr(module, "setup_wandb", lambda *args, **kwargs: None)
-    cfg = module.Config(log_path="/tmp/dpo_test_logs", dataset="/tmp/pairs.jsonl", tokenizer_model="")
-
-    with pytest.raises(ValueError, match="tokenizer_model"):
-        module.main(cfg)
+# ---------------------------------------------------------------------------
+# _train_loop  (DataLoader → ref forward → train, ref-cache log on multi-epoch)
+# ---------------------------------------------------------------------------
 
 
-
-
-def test_train_loop_pipeline_and_dcp_save(monkeypatch):
-    """Test the pipelined _train_loop with real ref forward + training."""
-    events: dict[str, object] = {
-        "flush_batches": [],
-        "optim_steps": 0,
-        "metrics_logs": [],
-        "wandb_logs": [],
-        "ref_done_called": False,
+def _make_pair(idx: int) -> dict:
+    """Tokenized pair dict matching the new (lengths-only) shape."""
+    return {
+        "chosen_datum": {"id": f"c{idx}"},
+        "rejected_datum": {"id": f"r{idx}"},
+        "chosen_tokens_len": 3,
+        "rejected_tokens_len": 3,
+        "response_start": 2,
     }
 
+
+def _test_render_pair(row: dict) -> dict:
+    """Module-level render_fn for JsonlRenderDataset in tests."""
+    return _make_pair(row["i"])
+
+
+def _make_pair_dataset(tmp_path, n: int) -> JsonlRenderDataset:
+    path = tmp_path / "pairs.jsonl"
+    with open(path, "w") as f:
+        for i in range(n):
+            f.write(json.dumps({"i": i}) + "\n")
+    return JsonlRenderDataset(str(path), _test_render_pair)
+
+
+class _FakeReference:
+    def forward(self, datums, loss_fn):
+        return SimpleNamespace(loss_fn_outputs=[
+            {"logprobs": SimpleNamespace(data=[-0.1 * (j + 1)])}
+            for j in range(len(datums))
+        ])
+
+
+class _FakePolicy:
+    job_id = "fake-policy-job"
+
+    def __init__(self):
+        self.optim_step_count = 0
+
+    def optim_step(self, _params, **kwargs):
+        self.optim_step_count += 1
+        return SimpleNamespace(metrics={"optimizer/lr": 1e-4})
+
+    def save_state(self, name, timeout=None):
+        pass
+
+    def resolve_checkpoint_path(self, name, source_job_id=None):
+        return f"tinker://unit/state/{name}"
+
+
+def _stub_train_step_deps(monkeypatch, events: dict):
+    """Common stubs so _train_loop runs without metrics/wandb/checkpoint side effects."""
     monkeypatch.setattr(
-        module,
-        "_forward_backward_pairs",
-        lambda batch, policy, beta: events["flush_batches"].append(
+        module, "_forward_backward_pairs",
+        lambda batch, policy, beta: events.setdefault("flush_batches", []).append(
             (list(batch), beta)
-        ) or SimpleNamespace(
-            metrics={"dpo_loss": 1.5, "margin": 0.25, "accuracy": 0.75}
-        ),
+        ) or SimpleNamespace(metrics={"dpo_loss": 1.5, "margin": 0.25, "accuracy": 0.75}),
     )
-    monkeypatch.setattr(module, "flush_timing", lambda: {"perf/fwd_bwd_time": 1.0})
-    monkeypatch.setattr(module, "log_metrics_json", lambda step, **kwargs: events["metrics_logs"].append((step, kwargs)))
-    monkeypatch.setattr(module, "wandb_log", lambda payload, step: events["wandb_logs"].append((step, payload)))
+    monkeypatch.setattr(module, "flush_timing", lambda: {})
+    monkeypatch.setattr(module, "log_metrics_json", lambda *a, **kw: None)
+    monkeypatch.setattr(module, "wandb_log", lambda *a, **kw: None)
 
-    class FakePolicy:
-        job_id = "fake-policy-job"
 
-        def optim_step(self, _params, **kwargs):
-            events["optim_steps"] += 1
-            return SimpleNamespace(metrics={"optimizer/lr": 1e-4})
+class TestTrainLoop:
+    def test_single_epoch_no_ref_cache_log(self, tmp_path, monkeypatch):
+        events: dict = {}
+        _stub_train_step_deps(monkeypatch, events)
 
-        def save_state(self, name, timeout=None):
-            pass
-
-        def resolve_checkpoint_path(self, name, source_job_id=None):
-            return f"tinker://unit/state/{name}"
-
-    class FakeReference:
-        def forward(self, datums, loss_fn):
-            n_pairs = len(datums) // 2
-            return SimpleNamespace(
-                loss_fn_outputs=[
-                    {"logprobs": SimpleNamespace(data=[-0.1 * (i + 1)])}
-                    for i in range(len(datums))
-                ]
-            )
-
-    tokenized_pairs = [
-        (0, {"chosen_datum": {"id": "c0"}, "rejected_datum": {"id": "r0"},
-             "chosen_tokens": [1, 2, 3], "rejected_tokens": [1, 2, 4], "response_start": 3}),
-        (1, {"chosen_datum": {"id": "c1"}, "rejected_datum": {"id": "r1"},
-             "chosen_tokens": [5, 6], "rejected_tokens": [5, 7], "response_start": 4}),
-    ]
-    import tempfile
-    with tempfile.TemporaryDirectory() as tmp_log_path:
+        ds = _make_pair_dataset(tmp_path, n=4)
         cfg = module.Config(
-            log_path=tmp_log_path,
-            beta=0.2,
-            epochs=1,
-            batch_size=2,
-            dcp_save_interval=1,
+            log_path=str(tmp_path), beta=0.2, epochs=1, batch_size=2,
+            render_workers=0,
         )
-
-        def _on_ref_done():
-            events["ref_done_called"] = True
-
+        ref_done = []
         step = asyncio.run(
             module._train_loop(
-                tokenized_pairs,
-                FakeReference(),
-                FakePolicy(),
+                ds, None,
+                _FakeReference(), _FakePolicy(),
                 adam_params={"lr": 1e-4},
                 cfg=cfg,
                 step_offset=0,
-                on_ref_done=_on_ref_done,
+                on_ref_done=lambda: ref_done.append(True),
             )
         )
+        # 4 pairs / batch_size=2 -> 2 train steps
+        assert step == 2
+        assert ref_done == [True]
+        assert len(events["flush_batches"]) == 2
+        for batch, beta in events["flush_batches"]:
+            assert beta == 0.2
+            for pair in batch:
+                assert "ref_chosen" in pair and "ref_rejected" in pair
 
-        assert step == 1
-        assert events["ref_done_called"]
-        assert len(events["flush_batches"]) == 1
-        assert events["flush_batches"][0][1] == 0.2
-        trained_pairs = events["flush_batches"][0][0]
-        assert len(trained_pairs) == 2
-        assert "ref_chosen" in trained_pairs[0]
-        assert "ref_rejected" in trained_pairs[0]
-        assert events["optim_steps"] == 1
-        # DCP save goes through save_checkpoint -> checkpoints.jsonl
-        import json, os
-        cp_file = os.path.join(tmp_log_path, "checkpoints.jsonl")
-        assert os.path.exists(cp_file)
-        with open(cp_file) as f:
-            cp = json.loads(f.readline())
-        assert cp["name"] == "step-1"
-        assert cp["step"] == 1
-        assert events["metrics_logs"][0][0] == 1
-        assert events["metrics_logs"][0][1]["dpo_loss"] == 1.5
-        assert len(events["wandb_logs"]) == 1
+    def test_multi_epoch_uses_ref_cache_log(self, tmp_path, monkeypatch):
+        events: dict = {}
+        _stub_train_step_deps(monkeypatch, events)
 
+        ds = _make_pair_dataset(tmp_path, n=4)
+        ref_cache_path = str(tmp_path / "ref_cache.pkl")
+        ref_cache = AppendOnlyPickleLog(ref_cache_path)
+        try:
+            cfg = module.Config(
+                log_path=str(tmp_path), beta=0.1, epochs=3, batch_size=2,
+                render_workers=0,
+            )
+            step = asyncio.run(
+                module._train_loop(
+                    ds, ref_cache,
+                    _FakeReference(), _FakePolicy(),
+                    adam_params={"lr": 1e-4},
+                    cfg=cfg, step_offset=0,
+                )
+            )
+            # 4 pairs * 3 epochs / batch_size=2 = 6 steps
+            assert step == 6
+            assert len(events["flush_batches"]) == 6
 
-def test_pipeline_overlap_ref_freed_before_training_done():
-    """Verify the producer finishes (and on_ref_done fires) while training
-    is still in progress — the core benefit of the pipeline."""
-    timeline = []
+            # Ref cache must contain all 4 pairs in producer order; epochs 1+
+            # stream through it sequentially (validated by replaying it now).
+            assert len(ref_cache) == 4
+            cached = list(ref_cache)
+            assert [p["chosen_datum"]["id"] for p in cached] == ["c0", "c1", "c2", "c3"]
+            for c in cached:
+                assert isinstance(c["ref_chosen"], array.array)
+                assert isinstance(c["ref_rejected"], array.array)
+        finally:
+            ref_cache.close()
 
-    class SlowPolicy:
-        def optim_step(self, _params, **kwargs):
-            return SimpleNamespace(metrics={})
-
-    class FastReference:
-        def forward(self, datums, loss_fn):
-            return SimpleNamespace(
-                loss_fn_outputs=[
-                    {"logprobs": SimpleNamespace(data=[-0.1])}
-                    for _ in datums
-                ]
+    def test_multi_epoch_requires_ref_cache_log(self, tmp_path):
+        ds = _make_pair_dataset(tmp_path, n=2)
+        cfg = module.Config(
+            log_path=str(tmp_path), epochs=2, batch_size=1, render_workers=0,
+        )
+        with pytest.raises(ValueError, match="ref_cache_log"):
+            asyncio.run(
+                module._train_loop(
+                    ds, None,
+                    _FakeReference(), _FakePolicy(),
+                    adam_params={"lr": 1e-4},
+                    cfg=cfg, step_offset=0,
+                )
             )
 
-    def slow_fwd_bwd(batch, policy, beta):
-        time.sleep(0.15)
-        return SimpleNamespace(
-            metrics={"dpo_loss": 0.5, "margin": 0.1, "accuracy": 0.9}
+    def test_pipeline_overlap_ref_freed_before_training_done(self, tmp_path, monkeypatch):
+        """Producer must finish (and on_ref_done fire) while training is still
+        in progress -- the core benefit of the pipeline."""
+        timeline: list = []
+
+        monkeypatch.setattr(module, "flush_timing", lambda: {})
+        monkeypatch.setattr(module, "log_metrics_json", lambda *a, **kw: None)
+        monkeypatch.setattr(module, "wandb_log", lambda *a, **kw: None)
+
+        def slow_fwd_bwd(batch, policy, beta):
+            time.sleep(0.15)
+            return SimpleNamespace(metrics={"dpo_loss": 0.5, "margin": 0.1, "accuracy": 0.9})
+
+        monkeypatch.setattr(module, "_forward_backward_pairs", slow_fwd_bwd)
+
+        ds = _make_pair_dataset(tmp_path, n=4)
+        cfg = module.Config(
+            log_path=str(tmp_path), beta=0.1, epochs=1, batch_size=1,
+            ref_cache_concurrency=4, render_workers=0,
         )
-
-    def on_ref_done():
-        timeline.append(("ref_done", time.monotonic()))
-
-    cfg = module.Config(
-        log_path="/tmp/dpo_test_logs",
-        beta=0.1,
-        epochs=1,
-        batch_size=1,
-        ref_cache_concurrency=4,
-    )
-
-    import training.recipes.dpo_loop as mod
-
-    orig_fwd = mod._forward_backward_pairs
-    mod._forward_backward_pairs = slow_fwd_bwd
-    orig_flush = mod.flush_timing
-    mod.flush_timing = lambda: {}
-    orig_log = mod.log_metrics_json
-    mod.log_metrics_json = lambda *a, **kw: None
-    orig_wandb = mod.wandb_log
-    mod.wandb_log = lambda *a, **kw: None
-
-    try:
-        tokenized = [
-            (i, {"chosen_datum": {"id": f"c{i}"}, "rejected_datum": {"id": f"r{i}"},
-                 "chosen_tokens": [1, 2], "rejected_tokens": [3, 4], "response_start": 1})
-            for i in range(4)
-        ]
-
         t0 = time.monotonic()
         step = asyncio.run(
-            mod._train_loop(
-                tokenized, FastReference(), SlowPolicy(),
+            module._train_loop(
+                ds, None,
+                _FakeReference(), _FakePolicy(),
                 adam_params={"lr": 1e-4},
-                cfg=cfg,
-                step_offset=0,
-                on_ref_done=on_ref_done,
+                cfg=cfg, step_offset=0,
+                on_ref_done=lambda: timeline.append(time.monotonic()),
             )
         )
         t_end = time.monotonic()
 
         assert step == 4
         assert len(timeline) == 1
-        ref_done_t = timeline[0][1] - t0
+        ref_done_t = timeline[0] - t0
         total_t = t_end - t0
         assert ref_done_t < total_t * 0.8, (
             f"ref_done should fire well before training finishes "
             f"(ref_done={ref_done_t:.2f}s, total={total_t:.2f}s)"
         )
-    finally:
-        mod._forward_backward_pairs = orig_fwd
-        mod.flush_timing = orig_flush
-        mod.log_metrics_json = orig_log
-        mod.wandb_log = orig_wandb
 
+    def test_raises_when_all_rows_render_to_none(self, tmp_path, monkeypatch):
+        """All-filtered datasets must fail loudly instead of finishing at step 0."""
+        events: dict = {}
+        _stub_train_step_deps(monkeypatch, events)
 
-# ---------------------------------------------------------------------------
-# _train_loop data-ordering and step-accounting invariants.
-# ---------------------------------------------------------------------------
+        # Render every row to None: the loader yields empty batches that the
+        # producer must skip without calling reference.forward.
+        path = tmp_path / "pairs.jsonl"
+        with open(path, "w") as f:
+            for i in range(4):
+                f.write(json.dumps({"i": i}) + "\n")
+        ds = JsonlRenderDataset(str(path), lambda row: None)
 
+        ref_calls = []
 
-def _make_tokenized_pair(idx: int) -> tuple[int, dict]:
-    return idx, {
-        "chosen_tokens": [1, 2, 3],
-        "rejected_tokens": [1, 2, 4],
-        "response_start": 2,
-        "chosen_datum": {"id": f"c{idx}"},
-        "rejected_datum": {"id": f"r{idx}"},
-    }
+        class CountingReference:
+            def forward(self, datums, loss_fn):
+                ref_calls.append(len(datums))
+                return SimpleNamespace(loss_fn_outputs=[])
 
+        cfg = module.Config(
+            log_path=str(tmp_path), epochs=1, batch_size=2, render_workers=0,
+        )
+        with pytest.raises(RuntimeError, match="No valid pairs after tokenization"):
+            asyncio.run(
+                module._train_loop(
+                    ds, None, CountingReference(), _FakePolicy(),
+                    adam_params={"lr": 1e-4}, cfg=cfg, step_offset=0,
+                )
+            )
+        assert ref_calls == []
+        assert events.get("flush_batches", []) == []
 
-class _FakeReferenceForShuffleTests:
-    def forward(self, datums, loss_fn):
-        return SimpleNamespace(
-            loss_fn_outputs=[
-                {"logprobs": SimpleNamespace(data=[-0.1, -0.2])} for _ in datums
-            ]
+    def test_max_pairs_caps_valid_pairs_after_filtering(self, tmp_path, monkeypatch):
+        """``max_pairs`` counts valid rendered pairs, not raw JSONL rows."""
+        events: dict = {}
+        _stub_train_step_deps(monkeypatch, events)
+
+        path = tmp_path / "pairs.jsonl"
+        with open(path, "w") as f:
+            for i in range(5):
+                f.write(json.dumps({"i": i}) + "\n")
+
+        def render_some_none(row: dict) -> dict | None:
+            if row["i"] in {0, 3}:
+                return None
+            return _make_pair(row["i"])
+
+        ds = JsonlRenderDataset(str(path), render_some_none)
+        cfg = module.Config(
+            log_path=str(tmp_path),
+            epochs=1,
+            batch_size=2,
+            render_workers=0,
+            max_pairs=2,
         )
 
+        step = asyncio.run(
+            module._train_loop(
+                ds, None, _FakeReference(), _FakePolicy(),
+                adam_params={"lr": 1e-4}, cfg=cfg, step_offset=0,
+            )
+        )
+        assert step == 1
+        assert len(events["flush_batches"]) == 1
+        trained_ids = [pair["chosen_datum"]["id"] for pair in events["flush_batches"][0][0]]
+        assert trained_ids == ["c1", "c2"]
 
-class _FakePolicyForShuffleTests:
-    def optim_step(self, _params, **kwargs):
-        return SimpleNamespace(metrics={})
+    def test_total_steps_matches_actual_step_count(self, tmp_path, monkeypatch) -> None:
+        """The runner-facing total_steps should use ceil(valid_pairs / batch_size)."""
+        executed = {"count": 0}
+        reported_total_steps = {"value": None}
+
+        def fake_fwd_bwd(batch, policy, beta):
+            executed["count"] += 1
+            return SimpleNamespace(metrics={"dpo_loss": 0.0, "margin": 0.0, "accuracy": 0.5})
+
+        class RecordingRunner:
+            def start_training(self):
+                pass
+
+            def write_status(self, *args, **kwargs):
+                total = kwargs.get("total_steps")
+                if total is not None:
+                    reported_total_steps["value"] = total
+
+            def write_metadata(self, *args, **kwargs):
+                pass
+
+            def append_metrics(self, *args, **kwargs):
+                pass
+
+            def report_rendering_progress(self, *args, **kwargs):
+                pass
+
+            def set_accelerator_info(self, *args, **kwargs):
+                pass
+
+        monkeypatch.setattr(module, "_forward_backward_pairs", fake_fwd_bwd)
+        monkeypatch.setattr(module, "flush_timing", lambda: {})
+        monkeypatch.setattr(module, "log_metrics_json", lambda *a, **kw: None)
+        monkeypatch.setattr(module, "wandb_log", lambda *a, **kw: None)
+
+        ds = _make_pair_dataset(tmp_path, n=5)
+        cfg = module.Config(
+            log_path=str(tmp_path),
+            beta=0.1,
+            epochs=1,
+            batch_size=2,
+            ref_cache_concurrency=4,
+            render_workers=0,
+        )
+
+        asyncio.run(
+            module._train_loop(
+                ds,
+                None,
+                _FakeReference(),
+                _FakePolicy(),
+                adam_params={"lr": 1e-4},
+                cfg=cfg,
+                step_offset=0,
+                runner=RecordingRunner(),
+            )
+        )
+
+        assert executed["count"] == 3
+        assert reported_total_steps["value"] == 3
 
 
-def _patch_loop_noops(monkeypatch):
-    monkeypatch.setattr(module, "flush_timing", lambda: {})
-    monkeypatch.setattr(module, "log_metrics_json", lambda *a, **kw: None)
-    monkeypatch.setattr(module, "wandb_log", lambda *a, **kw: None)
+# ---------------------------------------------------------------------------
+# main()
+# ---------------------------------------------------------------------------
 
 
-def test_dpo_train_loop_shuffles_data_between_epochs(monkeypatch) -> None:
-    """Epoch 1 must NOT visit pairs in the same order as epoch 0.
-
-    Without a cross-epoch shuffle, a customer file ordered by source / date /
-    difficulty gets the same biased schedule every epoch, which is the whole
-    problem epoch shuffling is meant to solve.
-    """
-    tokenized_pairs = [_make_tokenized_pair(i) for i in range(8)]
-    batches_by_epoch: list[list[list[str]]] = []
-    current_epoch_batches: list[list[str]] = []
-    step_counter = {"n": 0}
-    steps_per_epoch = 4  # 8 pairs / batch_size 2
-
-    def fake_fwd_bwd(batch, policy, beta):
-        ids = [p["chosen_datum"]["id"] for p in batch]
-        current_epoch_batches.append(ids)
-        step_counter["n"] += 1
-        if step_counter["n"] % steps_per_epoch == 0:
-            batches_by_epoch.append(list(current_epoch_batches))
-            current_epoch_batches.clear()
-        return SimpleNamespace(metrics={"dpo_loss": 0.0, "margin": 0.0, "accuracy": 0.5})
-
-    monkeypatch.setattr(module, "_forward_backward_pairs", fake_fwd_bwd)
-    _patch_loop_noops(monkeypatch)
-
+def test_main_requires_tokenizer_model(monkeypatch):
+    monkeypatch.setattr(module, "setup_wandb", lambda *args, **kwargs: None)
     cfg = module.Config(
-        log_path="/tmp/dpo_epoch_shuffle",
-        beta=0.1,
-        epochs=2,
-        batch_size=2,
-        ref_cache_concurrency=4,
+        log_path="/tmp/dpo_test_logs", dataset="/tmp/pairs.jsonl", tokenizer_model="",
     )
-
-    asyncio.run(
-        module._train_loop(
-            tokenized_pairs,
-            _FakeReferenceForShuffleTests(),
-            _FakePolicyForShuffleTests(),
-            adam_params={"lr": 1e-4},
-            cfg=cfg,
-            step_offset=0,
-        )
-    )
-
-    assert len(batches_by_epoch) == 2, (
-        f"Expected 2 complete epochs, captured {len(batches_by_epoch)}"
-    )
-    assert batches_by_epoch[0] != batches_by_epoch[1], (
-        f"Epoch 1 data order is identical to epoch 0 — no shuffle between epochs.\n"
-        f"epoch0={batches_by_epoch[0]}\n"
-        f"epoch1={batches_by_epoch[1]}\n"
-        f"Fix: shuffle `ordered_pairs` before each epoch ≥ 1 "
-        f"(e.g. `random.Random(seed + epoch).shuffle(ordered_pairs)`)."
-    )
-
-
-def test_dpo_train_loop_shuffles_epoch_zero(monkeypatch) -> None:
-    """When epochs=1, epoch 0 must still be shuffled (before _ref_producer).
-
-    Without this, a customer file sorted by source/date/difficulty is trained
-    in exactly that order, which biases a single-epoch DPO run — the very
-    problem the cross-epoch shuffle was introduced to solve.
-    """
-    tokenized_pairs = [_make_tokenized_pair(i) for i in range(8)]
-    observed_order: list[str] = []
-
-    def fake_fwd_bwd(batch, policy, beta):
-        observed_order.extend(p["chosen_datum"]["id"] for p in batch)
-        return SimpleNamespace(metrics={"dpo_loss": 0.0, "margin": 0.0, "accuracy": 0.5})
-
-    monkeypatch.setattr(module, "_forward_backward_pairs", fake_fwd_bwd)
-    _patch_loop_noops(monkeypatch)
-
-    cfg = module.Config(
-        log_path="/tmp/dpo_epoch0_shuffle",
-        beta=0.1,
-        epochs=1,
-        batch_size=2,
-        ref_cache_concurrency=4,
-    )
-
-    asyncio.run(
-        module._train_loop(
-            tokenized_pairs,
-            _FakeReferenceForShuffleTests(),
-            _FakePolicyForShuffleTests(),
-            adam_params={"lr": 1e-4},
-            cfg=cfg,
-            step_offset=0,
-        )
-    )
-
-    file_order = [f"c{i}" for i in range(8)]
-    assert observed_order != file_order, (
-        "Epoch 0 trained in exact file order; DPO must shuffle before epoch 0 "
-        "so single-epoch runs on sorted customer data aren't biased. "
-        "Fix: shuffle tokenized_pairs with random.Random(cfg.seed) at the top "
-        "of _train_loop."
-    )
-    assert sorted(observed_order) == sorted(file_order), (
-        f"Every pair must still be visited exactly once per epoch; got {observed_order}"
-    )
-
-
-def test_dpo_total_steps_matches_actual_step_count(monkeypatch) -> None:
-    """The runner-reported total_steps must equal the number of executed steps.
-
-    With 5 pairs and batch_size=2, the producer emits ceil(5/2)=3 batches, so
-    training performs 3 steps. Reporting total_steps=2 (integer division) makes
-    the UI display "Step 3/2".
-    """
-    tokenized_pairs = [_make_tokenized_pair(i) for i in range(5)]
-
-    executed = {"count": 0}
-    reported_total_steps = {"value": None}
-
-    def fake_fwd_bwd(batch, policy, beta):
-        executed["count"] += 1
-        return SimpleNamespace(metrics={"dpo_loss": 0.0, "margin": 0.0, "accuracy": 0.5})
-
-    class RecordingRunner:
-        def start_training(self):
-            pass
-
-        def write_status(self, *args, **kwargs):
-            total = kwargs.get("total_steps")
-            if total is not None:
-                reported_total_steps["value"] = total
-
-        def write_metadata(self, *args, **kwargs):
-            pass
-
-        def append_metrics(self, *args, **kwargs):
-            pass
-
-        def report_rendering_progress(self, *args, **kwargs):
-            pass
-
-        def set_accelerator_info(self, *args, **kwargs):
-            pass
-
-    monkeypatch.setattr(module, "_forward_backward_pairs", fake_fwd_bwd)
-    _patch_loop_noops(monkeypatch)
-
-    cfg = module.Config(
-        log_path="/tmp/dpo_total_steps",
-        beta=0.1,
-        epochs=1,
-        batch_size=2,
-        ref_cache_concurrency=4,
-    )
-
-    asyncio.run(
-        module._train_loop(
-            tokenized_pairs,
-            _FakeReferenceForShuffleTests(),
-            _FakePolicyForShuffleTests(),
-            adam_params={"lr": 1e-4},
-            cfg=cfg,
-            step_offset=0,
-            runner=RecordingRunner(),
-        )
-    )
-
-    assert executed["count"] == 3, (
-        f"Expected 3 training steps (ceil(5/2)), got {executed['count']}"
-    )
-    assert reported_total_steps["value"] == 3, (
-        f"_train_loop reported total_steps={reported_total_steps['value']} but actually "
-        f"executed {executed['count']} steps. "
-        "Fix: total_steps = ((N + batch_size - 1) // batch_size) * epochs."
-    )
+    with pytest.raises(ValueError, match="tokenizer_model"):
+        module.main(cfg)
 
 
 # ---------------------------------------------------------------------------
-# load_preference_dataset validation. The loader is the primary entry point
-# used by the DPO (and ORPO) loops to ingest customer preference data, so its
-# contract lives with the DPO tests: any malformed row must fail fast with a
-# clear ValueError rather than silently dropping data or crashing elsewhere.
+# iter_preference_examples (training/utils/data.py) -- still used by callers
+# outside the streaming path; kept for back-compat.
 # ---------------------------------------------------------------------------
+
+
+def _write_jsonl(path, rows) -> None:
+    with open(path, "w") as f:
+        for row in rows:
+            f.write(json.dumps(row) + "\n")
+
+
+class TestIterPreferenceExamples:
+    def test_chosen_rejected_format_passthrough(self, tmp_path):
+        path = tmp_path / "pairs.jsonl"
+        _write_jsonl(path, [
+            {"chosen": {"messages": [{"role": "user", "content": "x"}]},
+             "rejected": {"messages": [{"role": "user", "content": "y"}]}},
+        ])
+        out = list(iter_preference_examples(str(path)))
+        assert len(out) == 1
+        assert out[0]["chosen"]["messages"][0]["content"] == "x"
+
+    def test_samples_format_with_score_evals(self, tmp_path):
+        path = tmp_path / "samples.jsonl"
+        _write_jsonl(path, [
+            {"samples": [
+                {"text": "good", "evals": {"score": 1.0}},
+                {"text": "bad", "evals": {"score": 0.0}},
+            ]},
+            {"samples": [{"text": "lonely", "evals": {"score": 1.0}}]},
+        ])
+        out = list(iter_preference_examples(str(path)))
+        assert len(out) == 1
+        assert out[0]["chosen"]["text"] == "good"
+        assert out[0]["rejected"]["text"] == "bad"
+
+    def test_preferred_output_format(self, tmp_path):
+        path = tmp_path / "pref.jsonl"
+        _write_jsonl(path, [{
+            "input": {"messages": [{"role": "user", "content": "q"}]},
+            "preferred_output": [{"role": "assistant", "content": "yes"}],
+            "non_preferred_output": "no",
+        }])
+        out = list(iter_preference_examples(str(path)))
+        assert len(out) == 1
+        assert out[0]["chosen"]["messages"] == [
+            {"role": "user", "content": "q"},
+            {"role": "assistant", "content": "yes"},
+        ]
+        assert out[0]["rejected"]["messages"] == [
+            {"role": "user", "content": "q"},
+            {"role": "assistant", "content": "no"},
+        ]
+
+    def test_max_pairs_caps_valid_pairs(self, tmp_path):
+        path = tmp_path / "pairs.jsonl"
+        _write_jsonl(path, [
+            {"chosen": {"text": str(i)}, "rejected": {"text": "_"}}
+            for i in range(5)
+        ])
+        assert len(list(iter_preference_examples(str(path), max_pairs=3))) == 3
+
+    def test_skips_blank_and_unrecognized_rows(self, tmp_path):
+        path = tmp_path / "mixed.jsonl"
+        with open(path, "w") as f:
+            f.write(json.dumps({"chosen": {"t": 1}, "rejected": {"t": 2}}) + "\n")
+            f.write("\n")
+            f.write(json.dumps({"unknown": "schema"}) + "\n")
+            f.write(json.dumps({"chosen": {"t": 3}, "rejected": {"t": 4}}) + "\n")
+        out = list(iter_preference_examples(str(path)))
+        assert len(out) == 2
+
+    def test_is_lazy(self, tmp_path):
+        path = tmp_path / "pairs.jsonl"
+        _write_jsonl(path, [
+            {"chosen": {"i": i}, "rejected": {"i": -i}} for i in range(100)
+        ])
+        it = iter_preference_examples(str(path), max_pairs=2)
+        first = next(it)
+        second = next(it)
+        assert first["chosen"]["i"] == 0
+        assert second["chosen"]["i"] == 1
+        with pytest.raises(StopIteration):
+            next(it)
 
 
 def _write_preference_jsonl(tmp_path, rows):
@@ -680,7 +657,6 @@ def _write_preference_jsonl(tmp_path, rows):
 
 class TestLoadPreferenceDatasetValidation:
     def test_rejects_non_binary_scores(self, tmp_path) -> None:
-        """A samples-format row with a score outside {0.0, 1.0} should raise."""
         rows = [
             {
                 "samples": [
@@ -691,15 +667,10 @@ class TestLoadPreferenceDatasetValidation:
         ]
         path = _write_preference_jsonl(tmp_path, rows)
 
-        with pytest.raises((ValueError, AssertionError)) as excinfo:
+        with pytest.raises(ValueError, match="score"):
             load_preference_dataset(path)
 
-        assert "score" in str(excinfo.value).lower(), (
-            f"Expected the error to name the offending field; got: {excinfo.value!r}"
-        )
-
     def test_rejects_rows_without_both_chosen_and_rejected(self, tmp_path) -> None:
-        """A samples-format row that yields no chosen or no rejected must raise."""
         rows = [
             {
                 "samples": [
@@ -709,13 +680,10 @@ class TestLoadPreferenceDatasetValidation:
         ]
         path = _write_preference_jsonl(tmp_path, rows)
 
-        with pytest.raises((ValueError, AssertionError)) as excinfo:
+        with pytest.raises(ValueError, match="rejected"):
             load_preference_dataset(path)
 
-        assert "rejected" in str(excinfo.value).lower()
-
     def test_rejects_duplicate_chosen_samples(self, tmp_path) -> None:
-        """Two samples with score=1.0 in a single row is ambiguous and must raise."""
         rows = [
             {
                 "samples": [
@@ -727,45 +695,26 @@ class TestLoadPreferenceDatasetValidation:
         ]
         path = _write_preference_jsonl(tmp_path, rows)
 
-        with pytest.raises(ValueError) as excinfo:
+        with pytest.raises(ValueError, match="ambiguous|multiple"):
             load_preference_dataset(path)
 
-        msg = str(excinfo.value).lower()
-        assert "ambiguous" in msg or "multiple" in msg, (
-            f"Expected the error to flag the duplicate chosen as ambiguous; got: {excinfo.value!r}"
-        )
-
     def test_rejects_unknown_row_format(self, tmp_path) -> None:
-        """A row that matches none of the supported preference formats must raise,
-        not silently return 0 rows.
-        """
         rows = [
             {"foo": "bar"},
-            {"chosen": {"messages": [{"role": "assistant", "content": "a"}]}},  # missing rejected
+            {"chosen": {"messages": [{"role": "assistant", "content": "a"}]}},
         ]
         path = _write_preference_jsonl(tmp_path, rows)
 
-        with pytest.raises(ValueError) as excinfo:
+        with pytest.raises(ValueError, match="supported preference format"):
             load_preference_dataset(path)
-
-        assert "supported preference format" in str(excinfo.value).lower()
 
     def test_rejects_non_list_samples(self, tmp_path) -> None:
-        """``samples`` must be a list — a dict / string / int should raise, not
-        crash with a cryptic AttributeError mid-iteration.
-        """
-        rows = [{"samples": {"this": "is a dict, not a list"}}]
-        path = _write_preference_jsonl(tmp_path, rows)
+        path = _write_preference_jsonl(tmp_path, [{"samples": {"not": "a list"}}])
 
-        with pytest.raises(ValueError) as excinfo:
+        with pytest.raises(ValueError, match="list"):
             load_preference_dataset(path)
 
-        assert "list" in str(excinfo.value).lower()
-
     def test_rejects_non_dict_sample_entry(self, tmp_path) -> None:
-        """Individual samples entries must be dicts; a string must raise a
-        fail-fast ValueError with file:line context, not AttributeError.
-        """
         rows = [
             {
                 "samples": [
@@ -776,7 +725,5 @@ class TestLoadPreferenceDatasetValidation:
         ]
         path = _write_preference_jsonl(tmp_path, rows)
 
-        with pytest.raises(ValueError) as excinfo:
+        with pytest.raises(ValueError, match="dict"):
             load_preference_dataset(path)
-
-        assert "dict" in str(excinfo.value).lower()

--- a/training/tests/unit/test_infra_setup.py
+++ b/training/tests/unit/test_infra_setup.py
@@ -207,7 +207,8 @@ def test_setup_infra_rl_full_param_with_kl_provisions_separate_reference(patch_s
     assert "grpo-reference" in display_names
     ref_call = next(c for c in patch_sdk.trainer_calls if c["display_name"] == "grpo-reference")
     assert ref_call["forward_only"] is True
-    assert ref_call["lora_rank"] == 0  # ref trainers never carry LoRA
+    # Full-param policy -> ref trainer also full-param, forward-only.
+    assert ref_call["lora_rank"] == 0
 
     assert infra.policy_job_id == "policy-job"
     assert infra.reference_job_id == "ref-job"
@@ -341,9 +342,49 @@ def test_setup_infra_dpo_full_param_provisions_separate_reference(patch_sdk):
     assert display_names == ["dpo-policy", "dpo-reference"]
     assert infra.reference_job_id == "ref-job"
     assert isinstance(infra.reference, _FakeClient)
-    # Reference client created with lora_rank=0 (ref trainers don't carry LoRA).
+    # Full-param DPO: ref trainer + client both lora_rank=0 (FORWARD_ONLY shape).
+    ref_call = next(c for c in patch_sdk.trainer_calls if c["display_name"] == "dpo-reference")
+    assert ref_call["forward_only"] is True
+    assert ref_call["lora_rank"] == 0
     ref_inst = next(c for c in _FakeClient.instances if c.job_id == "ref-job")
     assert ref_inst.lora_rank == 0
+
+
+def test_setup_infra_dpo_lora_propagates_lora_rank_to_reference(patch_sdk):
+    """LoRA DPO: ref trainer + client must carry lora_rank matching policy.
+
+    The gateway's shape-mode validator derives trainer_mode from
+    (forward_only, lora_rank): lora_rank>0 -> LORA_TRAINER. CP's V2
+    auto-resolver picks a LORA_TRAINER shape for the ref of a LoRA DPO,
+    so the cookbook must request the ref trainer with lora_rank>0 to
+    match the shape; otherwise the CreateRlorTrainerJob call is rejected
+    with a 400 (trainer_mode=FORWARD_ONLY vs shape LORA_TRAINER).
+    """
+    rlor, _ = _make_mgrs()
+    cfg = _make_cfg(lora_rank=8, ref_training_shape_id="shape-ref")
+
+    infra = setup_infra(
+        rlor_mgr=rlor, deploy_mgr=None,
+        base_model=cfg.base_model,
+        infra_cfg=cfg.infra,
+        deploy_cfg=cfg.deployment,
+        lora_rank=cfg.lora_rank,
+        max_seq_len=cfg.max_seq_len,
+        learning_rate=cfg.learning_rate,
+        step_timeout=cfg.step_timeout,
+        policy_job_id=cfg.policy_job_id,
+        reference_job_id=cfg.reference_job_id,
+        needs_reference=True, needs_inference=False,
+        role_prefix="dpo", api_key="key",
+    )
+
+    ref_call = next(c for c in patch_sdk.trainer_calls if c["display_name"] == "dpo-reference")
+    assert ref_call["forward_only"] is True
+    assert ref_call["lora_rank"] == 8
+
+    ref_inst = next(c for c in _FakeClient.instances if c.job_id == "ref-job")
+    assert ref_inst.lora_rank == 8
+    assert infra.reference_job_id == "ref-job"
 
 
 # ---------------------------------------------------------------------------

--- a/training/tests/unit/test_sft_loop.py
+++ b/training/tests/unit/test_sft_loop.py
@@ -584,9 +584,124 @@ def test_each_batch_triggers_its_own_optim_step(tmp_path, monkeypatch):
     assert result["steps"] == 2
     assert events["optim_steps"] == 2
     assert len(events["batches"]) == 2
-    assert [d._test_id for d in events["batches"][0]] == ["a1"]
-    assert [d._test_id for d in events["batches"][1]] == ["a2"]
+    assert sorted(d._test_id for batch in events["batches"] for d in batch) == ["a1", "a2"]
     assert events["deleted_jobs"] == ["job-sft"]
+
+
+def test_main_resume_preserves_epoch_zero_batch_order(tmp_path, monkeypatch):
+    """Resume should replay the same epoch-0 shuffle and skip into it deterministically."""
+    dataset_path = _write_dataset(
+        tmp_path,
+        [
+            {"messages": [{"role": "user", "content": f"u{i}"}, {"role": "assistant", "content": f"a{i}"}]}
+            for i in range(6)
+        ],
+    )
+    monkeypatch.setenv("FIREWORKS_API_KEY", "test-key")
+    monkeypatch.setenv("FIREWORKS_BASE_URL", "https://unit.test")
+
+    runs: dict[str, list[list[str]]] = {"fresh": [], "resume": []}
+    active = {"name": "fresh"}
+
+    class FakeMgr:
+        def create(self, config):
+            job_id = f"job-{active['name']}"
+            return SimpleNamespace(job_id=job_id, job_name=f"jobs/{job_id}")
+
+        def wait_for_ready(self, job_id, **kwargs):
+            return SimpleNamespace(job_id=job_id, job_name=f"jobs/{job_id}", base_url="https://unit.test")
+
+        def cancel(self, job_id):
+            pass
+
+        def delete(self, job_id):
+            pass
+
+        def resolve_training_profile(self, shape_id):
+            return _fake_profile(shape_id)
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            self.job_id = kwargs.get("job_id", "job-sft")
+
+        def forward_backward(self, batch, loss_fn="cross_entropy", loss_fn_config=None):
+            runs[active["name"]].append([d._test_id for d in batch])
+            return SimpleNamespace(
+                metrics={"loss:sum": 1.0, "ce_loss_sum": 1.0, "response_tokens": len(batch)}
+            )
+
+        def optim_step(self, _params, **kwargs):
+            return SimpleNamespace(metrics={})
+
+        def save_state(self, name):
+            return SimpleNamespace(path=name)
+
+        def save_weights_for_sampler_ext(self, name, checkpoint_type="base"):
+            return SimpleNamespace(path=f"{name}-sampler")
+
+        def load_state_with_optimizer(self, path):
+            pass
+
+        def resolve_checkpoint_path(self, name, source_job_id=None):
+            return name
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(module, "setup_wandb", lambda *args, **kwargs: None)
+    monkeypatch.setattr(module, "wandb_finish", lambda: None)
+    monkeypatch.setattr(module, "wandb_log", lambda *args, **kwargs: None)
+    monkeypatch.setattr(module, "log_metrics_json", lambda *args, **kwargs: None)
+    monkeypatch.setattr(module.transformers.AutoTokenizer, "from_pretrained", lambda *args, **kwargs: object())
+    monkeypatch.setattr(module, "build_renderer", lambda *args, **kwargs: object())
+    monkeypatch.setattr(module, "resolve_renderer_name", lambda *args, **kwargs: "unit-renderer")
+    monkeypatch.setattr(
+        module,
+        "auto_select_training_shape",
+        lambda *args, **kwargs: "accounts/test/trainingShapes/sft",
+    )
+    monkeypatch.setattr(
+        module,
+        "render_messages_to_datum",
+        lambda messages, **kwargs: SimpleNamespace(
+            token_ids=[1, 2],
+            datum=SimpleNamespace(
+                model_input=SimpleNamespace(chunks=[SimpleNamespace(tokens=[1, 2])]),
+                loss_fn_inputs={
+                    "target_tokens": SimpleNamespace(data=[0, 0]),
+                    "weights": SimpleNamespace(data=[1.0, 1.0]),
+                },
+                _test_id=messages[0]["content"],
+            ),
+        ),
+    )
+    monkeypatch.setattr(module, "ReconnectableClient", FakeClient)
+
+    cfg = module.Config(
+        log_path=str(tmp_path / "logs"),
+        base_model="accounts/test/models/custom-sft",
+        dataset=str(dataset_path),
+        tokenizer_model="Qwen/Qwen3-4B",
+        max_seq_len=32,
+        batch_size=2,
+        epochs=1,
+        seed=123,
+        render_workers=1,
+    )
+
+    monkeypatch.setattr(module, "resolve_resume", lambda *args, **kwargs: None)
+    module.main(cfg, rlor_mgr=FakeMgr())
+
+    active["name"] = "resume"
+    monkeypatch.setattr(
+        module,
+        "resolve_resume",
+        lambda *args, **kwargs: SimpleNamespace(step=1, data_consumed=2),
+    )
+    module.main(cfg, rlor_mgr=FakeMgr())
+
+    assert len(runs["fresh"]) == 3
+    assert runs["resume"] == runs["fresh"][1:]
 
 
 # ---------------------------------------------------------------------------

--- a/training/tests/unit/test_sft_loop.py
+++ b/training/tests/unit/test_sft_loop.py
@@ -149,6 +149,7 @@ def test_main_raises_when_all_examples_are_filtered(tmp_path, monkeypatch):
         dataset=str(dataset_path),
         tokenizer_model="Qwen/Qwen3-4B",
         max_seq_len=32,
+        render_workers=1,
     )
 
     with pytest.raises(RuntimeError, match="No valid training examples"):
@@ -464,6 +465,7 @@ def test_main_uses_real_renderer_and_trains(tmp_path, monkeypatch):
         batch_size=1,
         grad_accum=1,
         log_path=str(tmp_path / "sft_logs"),
+        render_workers=1,
     )
 
     result = module.main(cfg, rlor_mgr=FakeMgr())
@@ -574,6 +576,7 @@ def test_each_batch_triggers_its_own_optim_step(tmp_path, monkeypatch):
         epochs=1,
         batch_size=1,
         log_path=str(tmp_path / "sft_logs"),
+        render_workers=1,
     )
 
     result = module.main(cfg, rlor_mgr=FakeMgr())
@@ -731,6 +734,7 @@ def test_eval_auto_carveout_splits_data_and_runs_eval(tmp_path, monkeypatch):
         batch_size=9,  # All 9 training examples in one batch
         log_path=str(tmp_path / "sft_logs"),
         eval_auto_carveout=True,
+        render_workers=1,
     )
 
     result = module.main(cfg, rlor_mgr=FakeMgr())

--- a/training/tests/unit/test_sft_loop.py
+++ b/training/tests/unit/test_sft_loop.py
@@ -755,3 +755,126 @@ def test_eval_auto_carveout_splits_data_and_runs_eval(tmp_path, monkeypatch):
 
     # The eval example should be the first one (example-0)
     assert "example-0" in eval_ids
+
+
+# ---------------------------------------------------------------------------
+# _render_eagerly + _prepare_datasets: dataset-prep helpers extracted from
+# main() so the three eval branches (none / explicit / auto-carveout) and
+# the empty-dataset error are unit-testable without standing up the full
+# trainer / SDK stack.
+# ---------------------------------------------------------------------------
+
+
+def _write_jsonl_at(path, rows):
+    path.write_text("\n".join(json.dumps(row) for row in rows))
+    return path
+
+
+def _row(i: int) -> dict:
+    return {"messages": [{"role": "user", "content": f"u{i}"}]}
+
+
+def test_render_eagerly_drops_none(tmp_path, monkeypatch):
+    """_render_eagerly materialises the first n rows and skips Nones."""
+    path = _write_jsonl_at(tmp_path / "data.jsonl", [_row(i) for i in range(4)])
+    monkeypatch.setattr(
+        module,
+        "_render_one_worker",
+        lambda r: None if int(r["messages"][0]["content"][1:]) % 2 else f"d{r['messages'][0]['content'][1:]}",
+    )
+    ds = module.JsonlRenderDataset(str(path), module._render_one_worker)
+
+    assert module._render_eagerly(ds, 4) == ["d0", "d2"]
+    assert module._render_eagerly(ds, 0) == []
+
+
+class TestPrepareDatasets:
+    """Direct tests for the _prepare_datasets helper."""
+
+    @staticmethod
+    def _cfg(tmp_path, dataset_path, **overrides):
+        return module.Config(
+            log_path=str(tmp_path / "logs"),
+            dataset=str(dataset_path),
+            tokenizer_model="Qwen/Qwen3-1.7B",
+            max_seq_len=32,
+            **overrides,
+        )
+
+    def test_no_eval_branch(self, tmp_path, monkeypatch):
+        path = _write_jsonl_at(tmp_path / "train.jsonl", [_row(i) for i in range(5)])
+        monkeypatch.setattr(
+            module, "_render_one_worker",
+            lambda r: f"d-{r['messages'][0]['content']}",
+        )
+
+        train_ds, eval_data = module._prepare_datasets(self._cfg(tmp_path, path))
+
+        assert len(train_ds) == 5
+        assert eval_data == []
+
+    def test_raises_on_empty_dataset(self, tmp_path, monkeypatch):
+        path = _write_jsonl_at(tmp_path / "empty.jsonl", [])
+        monkeypatch.setattr(module, "_render_one_worker", lambda r: r)
+
+        with pytest.raises(RuntimeError, match="No examples found"):
+            module._prepare_datasets(self._cfg(tmp_path, path))
+
+    def test_explicit_eval_dataset(self, tmp_path, monkeypatch):
+        train = _write_jsonl_at(tmp_path / "train.jsonl", [_row(i) for i in range(5)])
+        eval_path = _write_jsonl_at(tmp_path / "eval.jsonl", [_row(100 + i) for i in range(3)])
+        monkeypatch.setattr(
+            module, "_render_one_worker",
+            lambda r: f"d-{r['messages'][0]['content']}",
+        )
+
+        cfg = self._cfg(tmp_path, train, evaluation_dataset=str(eval_path))
+        train_ds, eval_data = module._prepare_datasets(cfg)
+
+        assert len(train_ds) == 5
+        assert eval_data == ["d-u100", "d-u101", "d-u102"]
+
+    def test_auto_carveout_slices_training_dataset(self, tmp_path, monkeypatch):
+        # 20 rows, 10% ratio capped at max_eval_seqs=3 → 2 eval, 18 train.
+        path = _write_jsonl_at(tmp_path / "train.jsonl", [_row(i) for i in range(20)])
+        monkeypatch.setattr(
+            module, "_render_one_worker",
+            lambda r: f"d-{r['messages'][0]['content']}",
+        )
+
+        cfg = self._cfg(tmp_path, path, eval_auto_carveout=True, max_eval_seqs=3)
+        train_ds, eval_data = module._prepare_datasets(cfg)
+
+        assert eval_data == ["d-u0", "d-u1"]
+        assert len(train_ds) == 18
+        assert train_ds[0] == "d-u2"  # carveout window is excluded from training
+
+    def test_auto_carveout_drops_none_rendered_rows(self, tmp_path, monkeypatch):
+        # 20 rows; render returns None for the second row in the carveout window.
+        path = _write_jsonl_at(tmp_path / "train.jsonl", [_row(i) for i in range(20)])
+
+        def render(r):
+            content = r["messages"][0]["content"]
+            return None if content == "u1" else f"d-{content}"
+
+        monkeypatch.setattr(module, "_render_one_worker", render)
+
+        cfg = self._cfg(tmp_path, path, eval_auto_carveout=True, max_eval_seqs=3)
+        train_ds, eval_data = module._prepare_datasets(cfg)
+
+        # Carveout window is rows 0..1; row 1 renders None and is dropped.
+        assert eval_data == ["d-u0"]
+        # Training slice is rows 2..19 (None passes through; loader drops it).
+        assert len(train_ds) == 18
+
+    def test_auto_carveout_skipped_when_dataset_too_small(self, tmp_path, monkeypatch, caplog):
+        path = _write_jsonl_at(tmp_path / "train.jsonl", [_row(0)])
+        monkeypatch.setattr(module, "_render_one_worker", lambda r: r)
+
+        cfg = self._cfg(tmp_path, path, eval_auto_carveout=True)
+        with caplog.at_level("WARNING"):
+            train_ds, eval_data = module._prepare_datasets(cfg)
+
+        assert eval_data == []
+        assert len(train_ds) == 1
+        assert "too small for auto carve-out" in caplog.text

--- a/training/tests/unit/test_sft_loop.py
+++ b/training/tests/unit/test_sft_loop.py
@@ -41,6 +41,17 @@ def _fake_profile(shape_id: str = "accounts/test/trainingShapes/sft"):
     )
 
 
+def _test_datum(test_id: str):
+    return SimpleNamespace(
+        model_input=SimpleNamespace(chunks=[SimpleNamespace(tokens=[1, 2, 3])]),
+        loss_fn_inputs={
+            "target_tokens": SimpleNamespace(data=[0, 0]),
+            "weights": SimpleNamespace(data=[1.0, 1.0]),
+        },
+        _test_id=test_id,
+    )
+
+
 def test_main_rejects_adapter_plus_init_from_checkpoint(tmp_path, monkeypatch):
     """warm_start_from_adapter and init_from_checkpoint are mutually exclusive."""
     dataset_path = _write_dataset(
@@ -703,6 +714,196 @@ def test_main_resume_preserves_epoch_zero_batch_order(tmp_path, monkeypatch):
 
     assert len(runs["fresh"]) == 3
     assert runs["resume"] == runs["fresh"][1:]
+
+
+def test_main_resume_uses_raw_row_cursor_when_filtering_shrinks_batches(tmp_path, monkeypatch):
+    """Resume should skip raw batches even when filtering makes a step smaller."""
+    dataset_path = _write_dataset(
+        tmp_path,
+        [
+            {"messages": [{"role": "user", "content": f"u{i}"}, {"role": "assistant", "content": f"a{i}"}]}
+            for i in range(4)
+        ],
+    )
+    monkeypatch.setenv("FIREWORKS_API_KEY", "test-key")
+    monkeypatch.setenv("FIREWORKS_BASE_URL", "https://unit.test")
+
+    runs: dict[str, list[list[str]]] = {"fresh": [], "resume": []}
+    active = {"name": "fresh"}
+
+    class FakeMgr:
+        def create(self, config):
+            job_id = f"job-{active['name']}"
+            return SimpleNamespace(job_id=job_id, job_name=f"jobs/{job_id}")
+
+        def wait_for_ready(self, job_id, **kwargs):
+            return SimpleNamespace(job_id=job_id, job_name=f"jobs/{job_id}", base_url="https://unit.test")
+
+        def cancel(self, job_id):
+            pass
+
+        def delete(self, job_id):
+            pass
+
+        def resolve_training_profile(self, shape_id):
+            return _fake_profile(shape_id)
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            self.job_id = kwargs.get("job_id", "job-sft")
+
+        def forward_backward(self, batch, loss_fn="cross_entropy", loss_fn_config=None):
+            runs[active["name"]].append([d._test_id for d in batch])
+            return SimpleNamespace(
+                metrics={"loss:sum": 1.0, "ce_loss_sum": 1.0, "response_tokens": len(batch)}
+            )
+
+        def optim_step(self, _params, **kwargs):
+            return SimpleNamespace(metrics={})
+
+        def close(self):
+            pass
+
+    raw_batches = [
+        [_test_datum("step-1-only")],
+        [_test_datum("step-2-a"), _test_datum("step-2-b")],
+    ]
+
+    monkeypatch.setattr(module, "setup_wandb", lambda *args, **kwargs: None)
+    monkeypatch.setattr(module, "wandb_finish", lambda: None)
+    monkeypatch.setattr(module, "wandb_log", lambda *args, **kwargs: None)
+    monkeypatch.setattr(module, "log_metrics_json", lambda *args, **kwargs: None)
+    monkeypatch.setattr(module.transformers.AutoTokenizer, "from_pretrained", lambda *args, **kwargs: object())
+    monkeypatch.setattr(module, "build_renderer", lambda *args, **kwargs: object())
+    monkeypatch.setattr(module, "resolve_renderer_name", lambda *args, **kwargs: "unit-renderer")
+    monkeypatch.setattr(
+        module,
+        "auto_select_training_shape",
+        lambda *args, **kwargs: "accounts/test/trainingShapes/sft",
+    )
+    monkeypatch.setattr(module, "make_render_dataloader", lambda *args, **kwargs: raw_batches)
+    monkeypatch.setattr(module, "ReconnectableClient", FakeClient)
+
+    cfg = module.Config(
+        log_path=str(tmp_path / "logs"),
+        base_model="accounts/test/models/custom-sft",
+        dataset=str(dataset_path),
+        tokenizer_model="Qwen/Qwen3-4B",
+        max_seq_len=32,
+        batch_size=2,
+        epochs=1,
+        seed=123,
+        render_workers=1,
+        save_final_checkpoint=False,
+    )
+
+    monkeypatch.setattr(module, "resolve_resume", lambda *args, **kwargs: None)
+    module.main(cfg, rlor_mgr=FakeMgr())
+
+    active["name"] = "resume"
+    monkeypatch.setattr(
+        module,
+        "resolve_resume",
+        lambda *args, **kwargs: SimpleNamespace(
+            step=1,
+            data_consumed=1,
+            raw_rows_consumed=2,
+        ),
+    )
+    module.main(cfg, rlor_mgr=FakeMgr())
+
+    assert runs["fresh"] == [["step-1-only"], ["step-2-a", "step-2-b"]]
+    assert runs["resume"] == runs["fresh"][1:]
+
+
+def test_completed_status_reports_actual_steps_when_filtering_drops_raw_batches(tmp_path, monkeypatch):
+    """Final runner status should report 100% even when filtered raw batches reduce steps."""
+    dataset_path = _write_dataset(
+        tmp_path,
+        [
+            {"messages": [{"role": "user", "content": f"u{i}"}, {"role": "assistant", "content": f"a{i}"}]}
+            for i in range(8)
+        ],
+    )
+    status_path = tmp_path / "status.json"
+    monkeypatch.setenv("FIREWORKS_API_KEY", "test-key")
+    monkeypatch.setenv("FIREWORKS_BASE_URL", "https://unit.test")
+
+    class FakeMgr:
+        def create(self, config):
+            return SimpleNamespace(job_id="job-sft", job_name="jobs/job-sft")
+
+        def wait_for_ready(self, job_id, **kwargs):
+            return SimpleNamespace(job_id=job_id, job_name=f"jobs/{job_id}", base_url="https://unit.test")
+
+        def cancel(self, job_id):
+            pass
+
+        def delete(self, job_id):
+            pass
+
+        def resolve_training_profile(self, shape_id):
+            return _fake_profile(shape_id)
+
+    class FakeClient:
+        job_id = "job-sft"
+
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def forward_backward(self, batch, loss_fn="cross_entropy", loss_fn_config=None):
+            return SimpleNamespace(
+                metrics={"loss:sum": 1.0, "ce_loss_sum": 1.0, "response_tokens": len(batch)}
+            )
+
+        def optim_step(self, _params, **kwargs):
+            return SimpleNamespace(metrics={})
+
+        def close(self):
+            pass
+
+    raw_batches = [
+        [],
+        [_test_datum("step-1")],
+        [],
+        [_test_datum("step-2")],
+    ]
+
+    monkeypatch.setattr(module, "setup_wandb", lambda *args, **kwargs: None)
+    monkeypatch.setattr(module, "wandb_finish", lambda: None)
+    monkeypatch.setattr(module, "wandb_log", lambda *args, **kwargs: None)
+    monkeypatch.setattr(module, "log_metrics_json", lambda *args, **kwargs: None)
+    monkeypatch.setattr(module.transformers.AutoTokenizer, "from_pretrained", lambda *args, **kwargs: object())
+    monkeypatch.setattr(module, "build_renderer", lambda *args, **kwargs: object())
+    monkeypatch.setattr(module, "resolve_renderer_name", lambda *args, **kwargs: "unit-renderer")
+    monkeypatch.setattr(
+        module,
+        "auto_select_training_shape",
+        lambda *args, **kwargs: "accounts/test/trainingShapes/sft",
+    )
+    monkeypatch.setattr(module, "make_render_dataloader", lambda *args, **kwargs: raw_batches)
+    monkeypatch.setattr(module, "ReconnectableClient", FakeClient)
+    monkeypatch.setattr(module, "resolve_resume", lambda *args, **kwargs: None)
+
+    cfg = module.Config(
+        log_path=str(tmp_path / "logs"),
+        base_model="accounts/test/models/custom-sft",
+        dataset=str(dataset_path),
+        tokenizer_model="Qwen/Qwen3-4B",
+        max_seq_len=32,
+        batch_size=2,
+        epochs=1,
+        render_workers=1,
+        save_final_checkpoint=False,
+        runner=module.RunnerConfig(status_file=str(status_path)),
+    )
+
+    result = module.main(cfg, rlor_mgr=FakeMgr())
+    status = json.loads(status_path.read_text())
+
+    assert result["steps"] == 2
+    assert status["message"] == "done"
+    assert status["details"][0]["percent"] == 100
 
 
 # ---------------------------------------------------------------------------

--- a/training/tests/unit/test_streaming.py
+++ b/training/tests/unit/test_streaming.py
@@ -22,6 +22,7 @@ from typing import Any
 import pytest
 
 from training.utils.streaming import (
+    AppendOnlyPickleLog,
     DEFAULT_PREFETCH_FACTOR,
     DEFAULT_RENDER_WORKERS,
     JsonlRenderDataset,
@@ -239,3 +240,63 @@ def test_dataloader_shuffle_is_deterministic_per_iteration(tmp_path):
 def test_default_constants_are_sane():
     assert DEFAULT_RENDER_WORKERS >= 1
     assert DEFAULT_PREFETCH_FACTOR >= 1
+
+
+# ---------------------------------------------------------------------------
+# AppendOnlyPickleLog
+# ---------------------------------------------------------------------------
+
+
+class TestAppendOnlyPickleLog:
+    def test_round_trip_preserves_order(self, tmp_path):
+        path = str(tmp_path / "log.pkl")
+        log = AppendOnlyPickleLog(path)
+        for i in range(5):
+            log.append({"i": i, "data": list(range(i + 1))})
+        assert len(log) == 5
+        log.close_write()
+
+        assert list(log) == [{"i": i, "data": list(range(i + 1))} for i in range(5)]
+
+    def test_iter_before_close_write_raises(self, tmp_path):
+        log = AppendOnlyPickleLog(str(tmp_path / "log.pkl"))
+        log.append({"x": 1})
+        with pytest.raises(RuntimeError, match="close_write"):
+            list(log)
+        log.close()
+
+    def test_append_after_close_raises(self, tmp_path):
+        log = AppendOnlyPickleLog(str(tmp_path / "log.pkl"))
+        log.append({"x": 1})
+        log.close_write()
+        with pytest.raises(RuntimeError, match="closed"):
+            log.append({"x": 2})
+
+    def test_context_manager_auto_closes(self, tmp_path):
+        path = str(tmp_path / "log.pkl")
+        with AppendOnlyPickleLog(path) as log:
+            log.append({"hello": "world"})
+        # After __exit__ the log is closed and iterable.
+        assert list(log) == [{"hello": "world"}]
+
+    def test_disk_size_grows_with_appends(self, tmp_path):
+        log = AppendOnlyPickleLog(str(tmp_path / "log.pkl"))
+        log.append({"big": "x" * 4096})
+        size_after_one = log.disk_size_bytes()
+        log.append({"big": "x" * 4096})
+        log.close_write()
+        assert log.disk_size_bytes() > size_after_one
+        assert size_after_one > 4096
+
+    def test_empty_log_iterates_empty(self, tmp_path):
+        log = AppendOnlyPickleLog(str(tmp_path / "log.pkl"))
+        log.close_write()
+        assert list(log) == []
+        assert len(log) == 0
+
+    def test_close_is_idempotent(self, tmp_path):
+        log = AppendOnlyPickleLog(str(tmp_path / "log.pkl"))
+        log.append({"x": 1})
+        log.close()
+        log.close()  # second call no-ops
+        log.close_write()  # also safe

--- a/training/tests/unit/test_streaming.py
+++ b/training/tests/unit/test_streaming.py
@@ -1,352 +1,201 @@
-"""Tests for the streaming dataset rendering utilities.
+"""Tests for ``training.utils.streaming``.
 
-Covers ``training.utils.streaming``:
+Covers the JSONL → render → DataLoader pipeline:
 
-  * ``iter_jsonl_rows`` / ``count_jsonl_rows`` -- lazy JSONL helpers.
-  * ``DiskBackedDatumStore`` -- append-only pickle store with random reads.
-  * ``stream_render_to_store`` -- single-process and spawn-pool paths.
+* ``_scan_jsonl_offsets`` -- byte offsets for non-blank lines.
+* ``JsonlRenderDataset`` -- map-style indexing, ``max_examples`` cap,
+  ``with_indices`` views, and ``None`` passthrough on filter.
+* ``make_render_dataloader`` -- single-process collate + filter.
 
-These are the building blocks behind the SFT v2 streaming render fix
-(see fw-ai/cookbook#371). Anything more elaborate than what's exercised
-here would belong in an integration test against ``sft_loop.main``.
+Multi-worker DataLoader behaviour (spawn workers, ``worker_init_fn``,
+``persistent_workers``) is delegated to PyTorch's own test suite.
+Anything more elaborate than what's exercised here belongs in an
+integration test against ``sft_loop.main``.
 """
 
 from __future__ import annotations
 
 import json
 import os
-import pickle
+from typing import Any
 
 import pytest
 
 from training.utils.streaming import (
-    DEFAULT_RENDER_CHUNKSIZE,
+    DEFAULT_PREFETCH_FACTOR,
     DEFAULT_RENDER_WORKERS,
-    DiskBackedDatumStore,
-    count_jsonl_rows,
-    iter_jsonl_rows,
-    stream_render_to_store,
+    JsonlRenderDataset,
+    _scan_jsonl_offsets,
+    make_render_dataloader,
 )
 
 
 # ---------------------------------------------------------------------------
-# Module-level helpers (must be picklable for the spawn-pool tests)
+# Helpers
 # ---------------------------------------------------------------------------
 
 
-def _double(row: dict) -> dict | None:
-    """Render fn that doubles ``row['n']`` and filters out negatives."""
-    n = row["n"]
-    if n < 0:
+def _write_jsonl(path: str, rows: list[dict]) -> None:
+    with open(path, "w") as f:
+        for row in rows:
+            f.write(json.dumps(row) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# _scan_jsonl_offsets
+# ---------------------------------------------------------------------------
+
+
+def test_scan_offsets_skips_blank_lines(tmp_path):
+    path = str(tmp_path / "data.jsonl")
+    with open(path, "w") as f:
+        f.write('{"a": 1}\n')
+        f.write("\n")
+        f.write('{"a": 2}\n')
+        f.write("   \n")
+        f.write('{"a": 3}\n')
+
+    offsets = _scan_jsonl_offsets(path)
+
+    assert len(offsets) == 3
+    # Reading from each offset should yield the matching JSON object.
+    with open(path) as f:
+        seen = []
+        for off in offsets:
+            f.seek(off)
+            seen.append(json.loads(f.readline()))
+    assert seen == [{"a": 1}, {"a": 2}, {"a": 3}]
+
+
+def test_scan_offsets_max_examples(tmp_path):
+    path = str(tmp_path / "data.jsonl")
+    _write_jsonl(path, [{"i": i} for i in range(10)])
+    assert len(_scan_jsonl_offsets(path, max_examples=4)) == 4
+    assert len(_scan_jsonl_offsets(path)) == 10
+
+
+def test_scan_offsets_empty_file(tmp_path):
+    path = str(tmp_path / "empty.jsonl")
+    open(path, "w").close()
+    assert _scan_jsonl_offsets(path) == []
+
+
+# ---------------------------------------------------------------------------
+# JsonlRenderDataset
+# ---------------------------------------------------------------------------
+
+
+def _identity_render(row: dict) -> dict:
+    return {"id": row["i"], "doubled": row["i"] * 2}
+
+
+def _filter_odd_render(row: dict) -> dict | None:
+    if row["i"] % 2 == 1:
         return None
-    return {"n": n * 2}
+    return {"id": row["i"]}
 
 
-def _identity(row: dict) -> dict | None:
-    return row
+def test_dataset_basic_indexing(tmp_path):
+    path = str(tmp_path / "data.jsonl")
+    _write_jsonl(path, [{"i": i} for i in range(5)])
+
+    ds = JsonlRenderDataset(path, _identity_render)
+
+    assert len(ds) == 5
+    assert ds.num_underlying_rows == 5
+    assert ds[0] == {"id": 0, "doubled": 0}
+    assert ds[3] == {"id": 3, "doubled": 6}
+    # Out-of-order access works (verifies offset-based seek).
+    assert ds[4] == {"id": 4, "doubled": 8}
+    assert ds[1] == {"id": 1, "doubled": 2}
 
 
-_OFFSET_STATE: dict = {}
+def test_dataset_max_examples_caps_underlying_rows(tmp_path):
+    path = str(tmp_path / "data.jsonl")
+    _write_jsonl(path, [{"i": i} for i in range(10)])
+
+    ds = JsonlRenderDataset(path, _identity_render, max_examples=3)
+
+    assert len(ds) == 3
+    assert ds.num_underlying_rows == 3
+    assert [ds[i]["id"] for i in range(3)] == [0, 1, 2]
 
 
-def _init_offset(offset: int) -> None:
-    _OFFSET_STATE["offset"] = offset
+def test_dataset_render_fn_can_return_none(tmp_path):
+    path = str(tmp_path / "data.jsonl")
+    _write_jsonl(path, [{"i": i} for i in range(4)])
+
+    ds = JsonlRenderDataset(path, _filter_odd_render)
+
+    # The dataset still has 4 entries; filtering is the loader's job.
+    assert len(ds) == 4
+    assert [ds[i] for i in range(4)] == [
+        {"id": 0}, None, {"id": 2}, None,
+    ]
 
 
-def _render_with_offset(row: dict) -> dict:
-    return {"n": row["n"] + _OFFSET_STATE["offset"]}
+def test_dataset_with_indices_carve_view(tmp_path):
+    path = str(tmp_path / "data.jsonl")
+    _write_jsonl(path, [{"i": i} for i in range(10)])
 
+    full = JsonlRenderDataset(path, _identity_render)
+    tail = full.with_indices(list(range(3, 10)))
 
-# ---------------------------------------------------------------------------
-# JSONL helpers
-# ---------------------------------------------------------------------------
-
-
-def _write_jsonl(path, rows, *, with_blank_lines: bool = False) -> None:
-    parts = []
-    for row in rows:
-        parts.append(json.dumps(row))
-        if with_blank_lines:
-            parts.append("")
-    path.write_text("\n".join(parts) + "\n")
-
-
-class TestIterJsonlRows:
-    def test_yields_each_row_in_order(self, tmp_path):
-        path = tmp_path / "data.jsonl"
-        _write_jsonl(path, [{"n": i} for i in range(5)])
-        assert list(iter_jsonl_rows(str(path))) == [{"n": i} for i in range(5)]
-
-    def test_skips_blank_lines(self, tmp_path):
-        path = tmp_path / "data.jsonl"
-        _write_jsonl(path, [{"n": i} for i in range(3)], with_blank_lines=True)
-        assert list(iter_jsonl_rows(str(path))) == [{"n": i} for i in range(3)]
-
-    def test_max_examples_caps_output(self, tmp_path):
-        path = tmp_path / "data.jsonl"
-        _write_jsonl(path, [{"n": i} for i in range(10)])
-        assert list(iter_jsonl_rows(str(path), max_examples=3)) == [
-            {"n": 0}, {"n": 1}, {"n": 2},
-        ]
-
-    def test_is_lazy(self, tmp_path):
-        """Iterator must not slurp the whole file into memory at construction."""
-        path = tmp_path / "data.jsonl"
-        _write_jsonl(path, [{"n": i} for i in range(100)])
-        it = iter_jsonl_rows(str(path), max_examples=2)
-        assert next(it) == {"n": 0}
-        assert next(it) == {"n": 1}
-        with pytest.raises(StopIteration):
-            next(it)
-
-    def test_empty_file(self, tmp_path):
-        path = tmp_path / "data.jsonl"
-        path.write_text("")
-        assert list(iter_jsonl_rows(str(path))) == []
-
-
-class TestCountJsonlRows:
-    def test_matches_iter(self, tmp_path):
-        path = tmp_path / "data.jsonl"
-        _write_jsonl(path, [{"n": i} for i in range(7)])
-        assert count_jsonl_rows(str(path)) == 7
-
-    def test_skips_blank_lines(self, tmp_path):
-        path = tmp_path / "data.jsonl"
-        _write_jsonl(path, [{"n": i} for i in range(4)], with_blank_lines=True)
-        assert count_jsonl_rows(str(path)) == 4
-
-    def test_max_examples_short_circuits(self, tmp_path):
-        path = tmp_path / "data.jsonl"
-        _write_jsonl(path, [{"n": i} for i in range(100)])
-        assert count_jsonl_rows(str(path), max_examples=5) == 5
-
-    def test_empty_file(self, tmp_path):
-        path = tmp_path / "data.jsonl"
-        path.write_text("")
-        assert count_jsonl_rows(str(path)) == 0
+    assert len(full) == 10  # original is unchanged
+    assert len(tail) == 7
+    assert tail[0] == {"id": 3, "doubled": 6}
+    assert tail[6] == {"id": 9, "doubled": 18}
 
 
 # ---------------------------------------------------------------------------
-# DiskBackedDatumStore
+# make_render_dataloader (single-process path)
 # ---------------------------------------------------------------------------
 
 
-class TestDiskBackedDatumStore:
-    def test_round_trip_random_access(self, tmp_path):
-        path = str(tmp_path / "store.bin")
-        items = [{"n": i, "payload": "x" * i} for i in range(5)]
-        with DiskBackedDatumStore(path) as store:
-            for item in items:
-                store.append(item)
-            store.close_write()
-            assert len(store) == 5
-            assert store[0] == items[0]
-            assert store[4] == items[4]
-            assert store[2] == items[2]  # out-of-order read
+def test_dataloader_drops_none_and_returns_lists(tmp_path):
+    path = str(tmp_path / "data.jsonl")
+    _write_jsonl(path, [{"i": i} for i in range(6)])
+    ds = JsonlRenderDataset(path, _filter_odd_render)
 
-    def test_sequential_iter(self, tmp_path):
-        path = str(tmp_path / "store.bin")
-        items = [{"n": i} for i in range(3)]
-        with DiskBackedDatumStore(path) as store:
-            for item in items:
-                store.append(item)
-            store.close_write()
-            assert list(store) == items
+    loader = make_render_dataloader(
+        ds,
+        batch_size=3,
+        num_workers=0,
+        shuffle=False,
+    )
 
-    def test_disk_size_bytes_grows_with_appends(self, tmp_path):
-        path = str(tmp_path / "store.bin")
-        with DiskBackedDatumStore(path) as store:
-            store.append({"n": 0})
-            store.close_write()  # flush so on-disk size is accurate
-            size_after_one = store.disk_size_bytes()
+    batches = list(loader)
+    # Two batches of 3 -> after dropping None, sizes [2, 1] (rows 0,2 and 4).
+    assert [len(b) for b in batches] == [2, 1]
+    flat = [item["id"] for batch in batches for item in batch]
+    assert flat == [0, 2, 4]
+    # Each batch is a plain python list (not stacked).
+    assert all(isinstance(b, list) for b in batches)
 
-        with DiskBackedDatumStore(path) as store2:
-            for _ in range(10):
-                store2.append({"n": 0})
-            store2.close_write()
-            assert store2.disk_size_bytes() > size_after_one
 
-    def test_append_after_close_raises(self, tmp_path):
-        path = str(tmp_path / "store.bin")
-        store = DiskBackedDatumStore(path)
-        with store:
-            store.append({"n": 1})
-            store.close_write()
-            with pytest.raises(RuntimeError, match="not open for writing"):
-                store.append({"n": 2})
+def test_dataloader_shuffle_is_deterministic_per_iteration(tmp_path):
+    path = str(tmp_path / "data.jsonl")
+    _write_jsonl(path, [{"i": i} for i in range(8)])
+    ds = JsonlRenderDataset(path, _identity_render)
 
-    def test_close_write_is_idempotent(self, tmp_path):
-        path = str(tmp_path / "store.bin")
-        with DiskBackedDatumStore(path) as store:
-            store.append({"n": 1})
-            store.close_write()
-            store.close_write()  # must not raise
-            assert store[0] == {"n": 1}
+    import torch  # local import: torch is heavy
+    torch.manual_seed(0)
+    loader = make_render_dataloader(ds, batch_size=8, num_workers=0, shuffle=True)
+    first = [item["id"] for item in next(iter(loader))]
 
-    def test_creates_parent_directory(self, tmp_path):
-        nested = tmp_path / "a" / "b" / "store.bin"
-        with DiskBackedDatumStore(str(nested)) as store:
-            store.append({"n": 1})
-            store.close_write()
-            assert os.path.exists(nested)
+    torch.manual_seed(0)
+    loader = make_render_dataloader(ds, batch_size=8, num_workers=0, shuffle=True)
+    second = [item["id"] for item in next(iter(loader))]
 
-    def test_path_property_exposes_backing_file(self, tmp_path):
-        path = str(tmp_path / "store.bin")
-        with DiskBackedDatumStore(path) as store:
-            assert store.path == path
-
-    def test_payload_can_be_arbitrary_picklable(self, tmp_path):
-        path = str(tmp_path / "store.bin")
-        payloads = [
-            {"a": 1},
-            ("tuple", 2),
-            [1, 2, 3],
-            "string",
-            42,
-        ]
-        with DiskBackedDatumStore(path) as store:
-            for p in payloads:
-                store.append(p)
-            store.close_write()
-            assert list(store) == payloads
-
-    def test_on_disk_format_is_concatenated_pickles(self, tmp_path):
-        """Sanity-check the wire format: writes must equal raw pickle bytes."""
-        path = str(tmp_path / "store.bin")
-        items = [{"n": i} for i in range(3)]
-        with DiskBackedDatumStore(path) as store:
-            for item in items:
-                store.append(item)
-            store.close_write()
-
-        with open(path, "rb") as f:
-            raw = f.read()
-        expected = b"".join(pickle.dumps(i, protocol=pickle.HIGHEST_PROTOCOL) for i in items)
-        assert raw == expected
+    assert first == second
+    assert sorted(first) == list(range(8))
 
 
 # ---------------------------------------------------------------------------
-# stream_render_to_store
+# Module-level constants
 # ---------------------------------------------------------------------------
 
 
-class TestStreamRenderToStore:
-    def test_single_process_basic(self, tmp_path):
-        path = str(tmp_path / "store.bin")
-        rows = [{"n": i} for i in range(5)]
-        with DiskBackedDatumStore(path) as store:
-            filtered = stream_render_to_store(
-                rows, render_fn=_identity, store=store, num_workers=1,
-            )
-            store.close_write()
-            assert filtered == 0
-            assert len(store) == 5
-            assert list(store) == rows
-
-    def test_single_process_filtering(self, tmp_path):
-        path = str(tmp_path / "store.bin")
-        rows = [{"n": i} for i in range(-2, 5)]  # 7 rows, 2 negative
-        with DiskBackedDatumStore(path) as store:
-            filtered = stream_render_to_store(
-                rows, render_fn=_double, store=store, num_workers=1,
-            )
-            store.close_write()
-            assert filtered == 2
-            assert len(store) == 5
-            assert list(store) == [{"n": i * 2} for i in range(0, 5)]
-
-    def test_on_progress_called_for_every_item(self, tmp_path):
-        path = str(tmp_path / "store.bin")
-        rows = [{"n": i} for i in range(4)]
-        seen = []
-
-        def _on_progress(i: int, item) -> None:
-            seen.append((i, item))
-
-        with DiskBackedDatumStore(path) as store:
-            stream_render_to_store(
-                rows, render_fn=_identity, store=store,
-                num_workers=1, on_progress=_on_progress,
-            )
-            store.close_write()
-
-        # progress index is 1-based and called for every input row
-        assert [i for i, _ in seen] == [1, 2, 3, 4]
-        assert [item for _, item in seen] == rows
-
-    def test_on_progress_receives_none_for_filtered_items(self, tmp_path):
-        path = str(tmp_path / "store.bin")
-        rows = [{"n": -1}, {"n": 1}]
-        seen = []
-        with DiskBackedDatumStore(path) as store:
-            stream_render_to_store(
-                rows, render_fn=_double, store=store,
-                num_workers=1, on_progress=lambda i, x: seen.append((i, x)),
-            )
-            store.close_write()
-        assert seen == [(1, None), (2, {"n": 2})]
-
-    def test_empty_input(self, tmp_path):
-        path = str(tmp_path / "store.bin")
-        with DiskBackedDatumStore(path) as store:
-            filtered = stream_render_to_store(
-                iter([]), render_fn=_identity, store=store, num_workers=1,
-            )
-            store.close_write()
-            assert filtered == 0
-            assert len(store) == 0
-
-    def test_parallel_spawn_basic(self, tmp_path):
-        """Spawn pool path: render_fn must be picklable; results stream out
-        in input order via ``imap``."""
-        path = str(tmp_path / "store.bin")
-        rows = [{"n": i} for i in range(20)]
-        with DiskBackedDatumStore(path) as store:
-            filtered = stream_render_to_store(
-                rows, render_fn=_double, store=store,
-                num_workers=2, chunksize=4,
-            )
-            store.close_write()
-            assert filtered == 0
-            assert len(store) == 20
-            # imap preserves input order
-            assert list(store) == [{"n": i * 2} for i in range(20)]
-
-    def test_parallel_spawn_with_initializer(self, tmp_path):
-        """Initializer + initargs must be applied before the first task runs."""
-        path = str(tmp_path / "store.bin")
-        rows = [{"n": i} for i in range(8)]
-        with DiskBackedDatumStore(path) as store:
-            stream_render_to_store(
-                rows, render_fn=_render_with_offset, store=store,
-                num_workers=2, chunksize=2,
-                initializer=_init_offset, initargs=(100,),
-            )
-            store.close_write()
-            assert list(store) == [{"n": i + 100} for i in range(8)]
-
-    def test_parallel_spawn_filtering(self, tmp_path):
-        path = str(tmp_path / "store.bin")
-        rows = [{"n": i} for i in range(-3, 4)]
-        with DiskBackedDatumStore(path) as store:
-            filtered = stream_render_to_store(
-                rows, render_fn=_double, store=store,
-                num_workers=2, chunksize=2,
-            )
-            store.close_write()
-            assert filtered == 3
-            assert list(store) == [{"n": i * 2} for i in range(0, 4)]
-
-
-# ---------------------------------------------------------------------------
-# Module constants
-# ---------------------------------------------------------------------------
-
-
-def test_default_render_workers_is_positive():
+def test_default_constants_are_sane():
     assert DEFAULT_RENDER_WORKERS >= 1
-
-
-def test_default_render_chunksize_is_positive():
-    assert DEFAULT_RENDER_CHUNKSIZE >= 1
+    assert DEFAULT_PREFETCH_FACTOR >= 1

--- a/training/tests/unit/test_streaming.py
+++ b/training/tests/unit/test_streaming.py
@@ -215,12 +215,16 @@ def test_dataloader_shuffle_is_deterministic_per_iteration(tmp_path):
     ds = JsonlRenderDataset(path, _identity_render)
 
     import torch  # local import: torch is heavy
-    torch.manual_seed(0)
-    loader = make_render_dataloader(ds, batch_size=8, num_workers=0, shuffle=True)
+    g1 = torch.Generator().manual_seed(0)
+    loader = make_render_dataloader(
+        ds, batch_size=8, num_workers=0, shuffle=True, generator=g1,
+    )
     first = [item["id"] for item in next(iter(loader))]
 
-    torch.manual_seed(0)
-    loader = make_render_dataloader(ds, batch_size=8, num_workers=0, shuffle=True)
+    g2 = torch.Generator().manual_seed(0)
+    loader = make_render_dataloader(
+        ds, batch_size=8, num_workers=0, shuffle=True, generator=g2,
+    )
     second = [item["id"] for item in next(iter(loader))]
 
     assert first == second

--- a/training/tests/unit/test_streaming.py
+++ b/training/tests/unit/test_streaming.py
@@ -147,6 +147,18 @@ def test_dataset_with_indices_carve_view(tmp_path):
     assert tail[6] == {"id": 9, "doubled": 18}
 
 
+def test_dataset_init_with_explicit_indices(tmp_path):
+    """Constructor ``indices=...`` lets callers reorder / sub-select rows."""
+    path = str(tmp_path / "data.jsonl")
+    _write_jsonl(path, [{"i": i} for i in range(10)])
+
+    ds = JsonlRenderDataset(path, _identity_render, indices=[7, 2, 9])
+
+    assert len(ds) == 3
+    assert ds.num_underlying_rows == 10  # full file still scanned
+    assert [ds[i]["id"] for i in range(3)] == [7, 2, 9]
+
+
 # ---------------------------------------------------------------------------
 # make_render_dataloader (single-process path)
 # ---------------------------------------------------------------------------
@@ -171,6 +183,30 @@ def test_dataloader_drops_none_and_returns_lists(tmp_path):
     assert flat == [0, 2, 4]
     # Each batch is a plain python list (not stacked).
     assert all(isinstance(b, list) for b in batches)
+
+
+def test_dataloader_num_workers_one_uses_in_process_path(tmp_path):
+    """``num_workers <= 1`` falls back to in-process rendering.
+
+    Verified by passing a closure as render_fn -- closures aren't
+    picklable, so this would raise ``PicklingError`` if a spawn worker
+    were started. sft_loop's unit tests rely on this escape hatch to
+    monkey-patch the renderer.
+    """
+    path = str(tmp_path / "data.jsonl")
+    _write_jsonl(path, [{"i": i} for i in range(4)])
+    captured = {"calls": 0}
+
+    def render_with_closure(row):  # closure -> not picklable
+        captured["calls"] += 1
+        return {"id": row["i"]}
+
+    ds = JsonlRenderDataset(path, render_with_closure)
+    loader = make_render_dataloader(ds, batch_size=4, num_workers=1, shuffle=False)
+
+    batches = list(loader)
+    assert batches == [[{"id": 0}, {"id": 1}, {"id": 2}, {"id": 3}]]
+    assert captured["calls"] == 4  # rendered in the test process
 
 
 def test_dataloader_shuffle_is_deterministic_per_iteration(tmp_path):

--- a/training/tests/unit/test_streaming.py
+++ b/training/tests/unit/test_streaming.py
@@ -1,0 +1,352 @@
+"""Tests for the streaming dataset rendering utilities.
+
+Covers ``training.utils.streaming``:
+
+  * ``iter_jsonl_rows`` / ``count_jsonl_rows`` -- lazy JSONL helpers.
+  * ``DiskBackedDatumStore`` -- append-only pickle store with random reads.
+  * ``stream_render_to_store`` -- single-process and spawn-pool paths.
+
+These are the building blocks behind the SFT v2 streaming render fix
+(see fw-ai/cookbook#371). Anything more elaborate than what's exercised
+here would belong in an integration test against ``sft_loop.main``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import pickle
+
+import pytest
+
+from training.utils.streaming import (
+    DEFAULT_RENDER_CHUNKSIZE,
+    DEFAULT_RENDER_WORKERS,
+    DiskBackedDatumStore,
+    count_jsonl_rows,
+    iter_jsonl_rows,
+    stream_render_to_store,
+)
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers (must be picklable for the spawn-pool tests)
+# ---------------------------------------------------------------------------
+
+
+def _double(row: dict) -> dict | None:
+    """Render fn that doubles ``row['n']`` and filters out negatives."""
+    n = row["n"]
+    if n < 0:
+        return None
+    return {"n": n * 2}
+
+
+def _identity(row: dict) -> dict | None:
+    return row
+
+
+_OFFSET_STATE: dict = {}
+
+
+def _init_offset(offset: int) -> None:
+    _OFFSET_STATE["offset"] = offset
+
+
+def _render_with_offset(row: dict) -> dict:
+    return {"n": row["n"] + _OFFSET_STATE["offset"]}
+
+
+# ---------------------------------------------------------------------------
+# JSONL helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_jsonl(path, rows, *, with_blank_lines: bool = False) -> None:
+    parts = []
+    for row in rows:
+        parts.append(json.dumps(row))
+        if with_blank_lines:
+            parts.append("")
+    path.write_text("\n".join(parts) + "\n")
+
+
+class TestIterJsonlRows:
+    def test_yields_each_row_in_order(self, tmp_path):
+        path = tmp_path / "data.jsonl"
+        _write_jsonl(path, [{"n": i} for i in range(5)])
+        assert list(iter_jsonl_rows(str(path))) == [{"n": i} for i in range(5)]
+
+    def test_skips_blank_lines(self, tmp_path):
+        path = tmp_path / "data.jsonl"
+        _write_jsonl(path, [{"n": i} for i in range(3)], with_blank_lines=True)
+        assert list(iter_jsonl_rows(str(path))) == [{"n": i} for i in range(3)]
+
+    def test_max_examples_caps_output(self, tmp_path):
+        path = tmp_path / "data.jsonl"
+        _write_jsonl(path, [{"n": i} for i in range(10)])
+        assert list(iter_jsonl_rows(str(path), max_examples=3)) == [
+            {"n": 0}, {"n": 1}, {"n": 2},
+        ]
+
+    def test_is_lazy(self, tmp_path):
+        """Iterator must not slurp the whole file into memory at construction."""
+        path = tmp_path / "data.jsonl"
+        _write_jsonl(path, [{"n": i} for i in range(100)])
+        it = iter_jsonl_rows(str(path), max_examples=2)
+        assert next(it) == {"n": 0}
+        assert next(it) == {"n": 1}
+        with pytest.raises(StopIteration):
+            next(it)
+
+    def test_empty_file(self, tmp_path):
+        path = tmp_path / "data.jsonl"
+        path.write_text("")
+        assert list(iter_jsonl_rows(str(path))) == []
+
+
+class TestCountJsonlRows:
+    def test_matches_iter(self, tmp_path):
+        path = tmp_path / "data.jsonl"
+        _write_jsonl(path, [{"n": i} for i in range(7)])
+        assert count_jsonl_rows(str(path)) == 7
+
+    def test_skips_blank_lines(self, tmp_path):
+        path = tmp_path / "data.jsonl"
+        _write_jsonl(path, [{"n": i} for i in range(4)], with_blank_lines=True)
+        assert count_jsonl_rows(str(path)) == 4
+
+    def test_max_examples_short_circuits(self, tmp_path):
+        path = tmp_path / "data.jsonl"
+        _write_jsonl(path, [{"n": i} for i in range(100)])
+        assert count_jsonl_rows(str(path), max_examples=5) == 5
+
+    def test_empty_file(self, tmp_path):
+        path = tmp_path / "data.jsonl"
+        path.write_text("")
+        assert count_jsonl_rows(str(path)) == 0
+
+
+# ---------------------------------------------------------------------------
+# DiskBackedDatumStore
+# ---------------------------------------------------------------------------
+
+
+class TestDiskBackedDatumStore:
+    def test_round_trip_random_access(self, tmp_path):
+        path = str(tmp_path / "store.bin")
+        items = [{"n": i, "payload": "x" * i} for i in range(5)]
+        with DiskBackedDatumStore(path) as store:
+            for item in items:
+                store.append(item)
+            store.close_write()
+            assert len(store) == 5
+            assert store[0] == items[0]
+            assert store[4] == items[4]
+            assert store[2] == items[2]  # out-of-order read
+
+    def test_sequential_iter(self, tmp_path):
+        path = str(tmp_path / "store.bin")
+        items = [{"n": i} for i in range(3)]
+        with DiskBackedDatumStore(path) as store:
+            for item in items:
+                store.append(item)
+            store.close_write()
+            assert list(store) == items
+
+    def test_disk_size_bytes_grows_with_appends(self, tmp_path):
+        path = str(tmp_path / "store.bin")
+        with DiskBackedDatumStore(path) as store:
+            store.append({"n": 0})
+            store.close_write()  # flush so on-disk size is accurate
+            size_after_one = store.disk_size_bytes()
+
+        with DiskBackedDatumStore(path) as store2:
+            for _ in range(10):
+                store2.append({"n": 0})
+            store2.close_write()
+            assert store2.disk_size_bytes() > size_after_one
+
+    def test_append_after_close_raises(self, tmp_path):
+        path = str(tmp_path / "store.bin")
+        store = DiskBackedDatumStore(path)
+        with store:
+            store.append({"n": 1})
+            store.close_write()
+            with pytest.raises(RuntimeError, match="not open for writing"):
+                store.append({"n": 2})
+
+    def test_close_write_is_idempotent(self, tmp_path):
+        path = str(tmp_path / "store.bin")
+        with DiskBackedDatumStore(path) as store:
+            store.append({"n": 1})
+            store.close_write()
+            store.close_write()  # must not raise
+            assert store[0] == {"n": 1}
+
+    def test_creates_parent_directory(self, tmp_path):
+        nested = tmp_path / "a" / "b" / "store.bin"
+        with DiskBackedDatumStore(str(nested)) as store:
+            store.append({"n": 1})
+            store.close_write()
+            assert os.path.exists(nested)
+
+    def test_path_property_exposes_backing_file(self, tmp_path):
+        path = str(tmp_path / "store.bin")
+        with DiskBackedDatumStore(path) as store:
+            assert store.path == path
+
+    def test_payload_can_be_arbitrary_picklable(self, tmp_path):
+        path = str(tmp_path / "store.bin")
+        payloads = [
+            {"a": 1},
+            ("tuple", 2),
+            [1, 2, 3],
+            "string",
+            42,
+        ]
+        with DiskBackedDatumStore(path) as store:
+            for p in payloads:
+                store.append(p)
+            store.close_write()
+            assert list(store) == payloads
+
+    def test_on_disk_format_is_concatenated_pickles(self, tmp_path):
+        """Sanity-check the wire format: writes must equal raw pickle bytes."""
+        path = str(tmp_path / "store.bin")
+        items = [{"n": i} for i in range(3)]
+        with DiskBackedDatumStore(path) as store:
+            for item in items:
+                store.append(item)
+            store.close_write()
+
+        with open(path, "rb") as f:
+            raw = f.read()
+        expected = b"".join(pickle.dumps(i, protocol=pickle.HIGHEST_PROTOCOL) for i in items)
+        assert raw == expected
+
+
+# ---------------------------------------------------------------------------
+# stream_render_to_store
+# ---------------------------------------------------------------------------
+
+
+class TestStreamRenderToStore:
+    def test_single_process_basic(self, tmp_path):
+        path = str(tmp_path / "store.bin")
+        rows = [{"n": i} for i in range(5)]
+        with DiskBackedDatumStore(path) as store:
+            filtered = stream_render_to_store(
+                rows, render_fn=_identity, store=store, num_workers=1,
+            )
+            store.close_write()
+            assert filtered == 0
+            assert len(store) == 5
+            assert list(store) == rows
+
+    def test_single_process_filtering(self, tmp_path):
+        path = str(tmp_path / "store.bin")
+        rows = [{"n": i} for i in range(-2, 5)]  # 7 rows, 2 negative
+        with DiskBackedDatumStore(path) as store:
+            filtered = stream_render_to_store(
+                rows, render_fn=_double, store=store, num_workers=1,
+            )
+            store.close_write()
+            assert filtered == 2
+            assert len(store) == 5
+            assert list(store) == [{"n": i * 2} for i in range(0, 5)]
+
+    def test_on_progress_called_for_every_item(self, tmp_path):
+        path = str(tmp_path / "store.bin")
+        rows = [{"n": i} for i in range(4)]
+        seen = []
+
+        def _on_progress(i: int, item) -> None:
+            seen.append((i, item))
+
+        with DiskBackedDatumStore(path) as store:
+            stream_render_to_store(
+                rows, render_fn=_identity, store=store,
+                num_workers=1, on_progress=_on_progress,
+            )
+            store.close_write()
+
+        # progress index is 1-based and called for every input row
+        assert [i for i, _ in seen] == [1, 2, 3, 4]
+        assert [item for _, item in seen] == rows
+
+    def test_on_progress_receives_none_for_filtered_items(self, tmp_path):
+        path = str(tmp_path / "store.bin")
+        rows = [{"n": -1}, {"n": 1}]
+        seen = []
+        with DiskBackedDatumStore(path) as store:
+            stream_render_to_store(
+                rows, render_fn=_double, store=store,
+                num_workers=1, on_progress=lambda i, x: seen.append((i, x)),
+            )
+            store.close_write()
+        assert seen == [(1, None), (2, {"n": 2})]
+
+    def test_empty_input(self, tmp_path):
+        path = str(tmp_path / "store.bin")
+        with DiskBackedDatumStore(path) as store:
+            filtered = stream_render_to_store(
+                iter([]), render_fn=_identity, store=store, num_workers=1,
+            )
+            store.close_write()
+            assert filtered == 0
+            assert len(store) == 0
+
+    def test_parallel_spawn_basic(self, tmp_path):
+        """Spawn pool path: render_fn must be picklable; results stream out
+        in input order via ``imap``."""
+        path = str(tmp_path / "store.bin")
+        rows = [{"n": i} for i in range(20)]
+        with DiskBackedDatumStore(path) as store:
+            filtered = stream_render_to_store(
+                rows, render_fn=_double, store=store,
+                num_workers=2, chunksize=4,
+            )
+            store.close_write()
+            assert filtered == 0
+            assert len(store) == 20
+            # imap preserves input order
+            assert list(store) == [{"n": i * 2} for i in range(20)]
+
+    def test_parallel_spawn_with_initializer(self, tmp_path):
+        """Initializer + initargs must be applied before the first task runs."""
+        path = str(tmp_path / "store.bin")
+        rows = [{"n": i} for i in range(8)]
+        with DiskBackedDatumStore(path) as store:
+            stream_render_to_store(
+                rows, render_fn=_render_with_offset, store=store,
+                num_workers=2, chunksize=2,
+                initializer=_init_offset, initargs=(100,),
+            )
+            store.close_write()
+            assert list(store) == [{"n": i + 100} for i in range(8)]
+
+    def test_parallel_spawn_filtering(self, tmp_path):
+        path = str(tmp_path / "store.bin")
+        rows = [{"n": i} for i in range(-3, 4)]
+        with DiskBackedDatumStore(path) as store:
+            filtered = stream_render_to_store(
+                rows, render_fn=_double, store=store,
+                num_workers=2, chunksize=2,
+            )
+            store.close_write()
+            assert filtered == 3
+            assert list(store) == [{"n": i * 2} for i in range(0, 4)]
+
+
+# ---------------------------------------------------------------------------
+# Module constants
+# ---------------------------------------------------------------------------
+
+
+def test_default_render_workers_is_positive():
+    assert DEFAULT_RENDER_WORKERS >= 1
+
+
+def test_default_render_chunksize_is_positive():
+    assert DEFAULT_RENDER_CHUNKSIZE >= 1

--- a/training/utils/__init__.py
+++ b/training/utils/__init__.py
@@ -34,11 +34,15 @@ del _warnings
 
 __all__ = [
     "DEFAULT_ADAM",
+    "DEFAULT_RENDER_CHUNKSIZE",
+    "DEFAULT_RENDER_WORKERS",
     "DeployConfig",
+    "DiskBackedDatumStore",
     "EvalFn",
     "WeightSyncConfig",
     "WeightSyncScope",
     "InfraConfig",
+    "MemTracer",
     "ReconnectableClient",
     "ResourceCleanup",
     "RewardFn",
@@ -50,6 +54,7 @@ __all__ = [
     "WandBConfig",
     "compute_advantages",
     "compute_pass_at_k",
+    "count_jsonl_rows",
     "create_trainer_job",
     "request_trainer_job",
     "wait_trainer_job",
@@ -59,9 +64,11 @@ __all__ = [
     "encode_text",
     "extract_text",
     "find_common_prefix_length",
+    "iter_jsonl_rows",
     "load_jsonl_dataset",
     "load_preference_dataset",
     "log_metrics_json",
+    "stream_render_to_store",
     "make_orpo_loss_fn",
     "make_batch_orpo_loss_fn",
     "make_batch_dpo_loss_fn",
@@ -165,4 +172,13 @@ from training.utils.logging import (
     compute_pass_at_k,
 )
 from training.utils.runner import RunnerConfig, RunnerIO, RunStatus
+from training.utils.streaming import (
+    DEFAULT_RENDER_CHUNKSIZE,
+    DEFAULT_RENDER_WORKERS,
+    DiskBackedDatumStore,
+    count_jsonl_rows,
+    iter_jsonl_rows,
+    stream_render_to_store,
+)
+from training.utils.memlog import MemTracer
 from training.utils.validation import validate_config, validate_preflight

--- a/training/utils/__init__.py
+++ b/training/utils/__init__.py
@@ -33,6 +33,7 @@ _warnings.filterwarnings(
 del _warnings
 
 __all__ = [
+    "AppendOnlyPickleLog",
     "DEFAULT_ADAM",
     "DEFAULT_PREFETCH_FACTOR",
     "DEFAULT_RENDER_WORKERS",
@@ -63,6 +64,7 @@ __all__ = [
     "encode_text",
     "extract_text",
     "find_common_prefix_length",
+    "iter_preference_examples",
     "load_jsonl_dataset",
     "load_preference_dataset",
     "log_metrics_json",
@@ -104,6 +106,7 @@ from training.utils.data import (
     encode_text,
     extract_text,
     compute_advantages,
+    iter_preference_examples,
     load_jsonl_dataset,
     load_preference_dataset,
     find_common_prefix_length,
@@ -171,6 +174,7 @@ from training.utils.logging import (
 )
 from training.utils.runner import RunnerConfig, RunnerIO, RunStatus
 from training.utils.streaming import (
+    AppendOnlyPickleLog,
     DEFAULT_PREFETCH_FACTOR,
     DEFAULT_RENDER_WORKERS,
     JsonlRenderDataset,

--- a/training/utils/__init__.py
+++ b/training/utils/__init__.py
@@ -34,14 +34,14 @@ del _warnings
 
 __all__ = [
     "DEFAULT_ADAM",
-    "DEFAULT_RENDER_CHUNKSIZE",
+    "DEFAULT_PREFETCH_FACTOR",
     "DEFAULT_RENDER_WORKERS",
     "DeployConfig",
-    "DiskBackedDatumStore",
     "EvalFn",
     "WeightSyncConfig",
     "WeightSyncScope",
     "InfraConfig",
+    "JsonlRenderDataset",
     "MemTracer",
     "ReconnectableClient",
     "ResourceCleanup",
@@ -54,7 +54,6 @@ __all__ = [
     "WandBConfig",
     "compute_advantages",
     "compute_pass_at_k",
-    "count_jsonl_rows",
     "create_trainer_job",
     "request_trainer_job",
     "wait_trainer_job",
@@ -64,11 +63,10 @@ __all__ = [
     "encode_text",
     "extract_text",
     "find_common_prefix_length",
-    "iter_jsonl_rows",
     "load_jsonl_dataset",
     "load_preference_dataset",
     "log_metrics_json",
-    "stream_render_to_store",
+    "make_render_dataloader",
     "make_orpo_loss_fn",
     "make_batch_orpo_loss_fn",
     "make_batch_dpo_loss_fn",
@@ -173,12 +171,10 @@ from training.utils.logging import (
 )
 from training.utils.runner import RunnerConfig, RunnerIO, RunStatus
 from training.utils.streaming import (
-    DEFAULT_RENDER_CHUNKSIZE,
+    DEFAULT_PREFETCH_FACTOR,
     DEFAULT_RENDER_WORKERS,
-    DiskBackedDatumStore,
-    count_jsonl_rows,
-    iter_jsonl_rows,
-    stream_render_to_store,
+    JsonlRenderDataset,
+    make_render_dataloader,
 )
 from training.utils.memlog import MemTracer
 from training.utils.validation import validate_config, validate_preflight

--- a/training/utils/checkpoint_utils.py
+++ b/training/utils/checkpoint_utils.py
@@ -40,6 +40,7 @@ class ResumeInfo:
 
     step: int = 0
     data_consumed: int = 0
+    raw_rows_consumed: int = 0
     source_job_id: str | None = None
 
 
@@ -117,6 +118,10 @@ def resolve_resume(
         return ResumeInfo(
             step=last.get("step", 0),
             data_consumed=last.get("data_consumed", 0),
+            raw_rows_consumed=last.get(
+                "raw_rows_consumed",
+                last.get("data_consumed", 0),
+            ),
             source_job_id=last.get("source_job_id"),
         )
 

--- a/training/utils/client.py
+++ b/training/utils/client.py
@@ -14,12 +14,23 @@ from __future__ import annotations
 
 import logging
 import os
+from enum import Enum
 
-from fireworks.training.sdk.client import (
-    FiretitanServiceClient,
-    FiretitanTrainingClient,
-    GradAccNormalization,
-)
+try:
+    from fireworks.training.sdk.client import (
+        FiretitanServiceClient,
+        FiretitanTrainingClient,
+        GradAccNormalization,
+    )
+except ImportError:
+    from fireworks.training.sdk.client import (
+        FiretitanServiceClient,
+        FiretitanTrainingClient,
+    )
+
+    class GradAccNormalization(str, Enum):
+        NUM_SEQUENCES = "num_sequences"
+        NUM_LOSS_TOKENS = "num_loss_tokens"
 from fireworks.training.sdk.trainer import TrainerJobManager, TrainerServiceEndpoint
 import tinker.lib.api_future_impl as tinker_api_future_impl
 from tinker.types.future_retrieve_request import FutureRetrieveRequest as _FutureRetrieveRequest

--- a/training/utils/data.py
+++ b/training/utils/data.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import math
-from typing import Any, Dict, List
+from typing import Any, Dict, Iterator, List
 
 import torch
 import requests
@@ -57,24 +57,103 @@ def load_jsonl_dataset(path_or_url: str, max_rows: int | None = None) -> List[Di
     return rows
 
 
+def _to_msgs(v: Any) -> List[Dict[str, Any]]:
+    if isinstance(v, list):
+        return v
+    if isinstance(v, str):
+        return [{"role": "assistant", "content": v}]
+    return []
+
+
+def _normalize_preference_row(row: Dict[str, Any]) -> Dict[str, Any] | None:
+    """Normalize one JSONL row to ``{"chosen": ..., "rejected": ...}`` or None.
+
+    Supports three on-disk formats:
+
+      * ``{"chosen": ..., "rejected": ...}`` — pass through.
+      * ``{"samples": [...]}`` with per-sample ``evals.score`` (or ``score``)
+        of 1.0 / 0.0 — derive chosen/rejected.
+      * ``{"input": ..., "preferred_output": ..., "non_preferred_output": ...}``
+        (OpenAI-style preference SFT) — derive chosen/rejected.
+    """
+    if "chosen" in row and "rejected" in row:
+        return row
+    if "samples" in row:
+        chosen = rejected = None
+        for s in row["samples"]:
+            score = s.get("evals", {}).get("score", s.get("score"))
+            if score == 1.0:
+                chosen = s
+            elif score == 0.0:
+                rejected = s
+        if chosen and rejected:
+            return {"chosen": chosen, "rejected": rejected}
+        return None
+    if "preferred_output" in row and "non_preferred_output" in row:
+        inp = row.get("input", {})
+        if isinstance(inp, dict) and "messages" in inp:
+            input_msgs = inp["messages"]
+        elif isinstance(inp, list):
+            input_msgs = inp
+        elif isinstance(inp, str):
+            input_msgs = [{"role": "user", "content": inp}]
+        else:
+            input_msgs = []
+        return {
+            "chosen": {"messages": input_msgs + _to_msgs(row["preferred_output"])},
+            "rejected": {"messages": input_msgs + _to_msgs(row["non_preferred_output"])},
+        }
+    return None
+
+
+def iter_preference_examples(
+    path: str, max_pairs: int | None = None,
+) -> Iterator[Dict[str, Any]]:
+    """Stream normalized preference examples from a JSONL file.
+
+    Yields one ``{"chosen": ..., "rejected": ...}`` dict at a time without
+    materialising the full list. Skips blank lines and rows that don't
+    match any of the supported preference schemas. Stops after ``max_pairs``
+    *valid* pairs when set.
+
+    See :func:`load_preference_dataset` for the eager equivalent and the
+    SFT v2 streaming render fix (fw-ai/cookbook#371) for the motivating
+    OOM context.
+    """
+    yielded = 0
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            pair = _normalize_preference_row(json.loads(line))
+            if pair is None:
+                continue
+            yield pair
+            yielded += 1
+            if max_pairs is not None and yielded >= max_pairs:
+                return
+
+
 def load_preference_dataset(path: str, max_pairs: int | None = None) -> List[dict[str, Any]]:
     """Load preference dataset (chosen/rejected pairs).
 
     Supports three input shapes per row:
 
-    - ``{"chosen": ..., "rejected": ...}``  -- Fireworks / OpenAI-compatible.
+    - ``{"chosen": ..., "rejected": ...}`` -- Fireworks / OpenAI-compatible.
     - ``{"samples": [{"messages": ..., "score": 0.0 | 1.0}, ...]}`` -- our
       legacy preference-sample format. Scores are *strictly* binary: 1.0
       marks the chosen sample, 0.0 marks the rejected sample. Graded scores
-      (e.g. 0.5, 0.8) and missing scores raise ``ValueError`` — silently
-      dropping these rows has hidden real customer data quality issues from
-      us in the past.
+      (e.g. 0.5, 0.8) and missing scores raise ``ValueError`` instead of
+      being silently dropped.
     - ``{"input": ..., "preferred_output": ..., "non_preferred_output": ...}``
       -- OpenAI fine-tuning DPO format.
 
-    Any row that does not match one of the above raises ``ValueError``.
+    Unlike :func:`iter_preference_examples`, this eager loader is strict:
+    malformed rows fail fast with file:line context so ORPO / older DPO
+    callers surface customer dataset issues early.
     """
-    data = []
+    data: list[dict[str, Any]] = []
     with open(path) as f:
         for line_no, raw_line in enumerate(f, start=1):
             line = raw_line.strip()
@@ -91,19 +170,19 @@ def load_preference_dataset(path: str, max_pairs: int | None = None) -> List[dic
                         f"{type(samples).__name__}."
                     )
                 chosen = rejected = None
-                for i, s in enumerate(samples):
-                    if not isinstance(s, dict):
+                for i, sample in enumerate(samples):
+                    if not isinstance(sample, dict):
                         raise ValueError(
                             f"{path}:{line_no}: samples[{i}] must be a dict, "
-                            f"got {type(s).__name__}."
+                            f"got {type(sample).__name__}."
                         )
-                    evals = s.get("evals")
+                    evals = sample.get("evals")
                     if evals is not None and not isinstance(evals, dict):
                         raise ValueError(
                             f"{path}:{line_no}: samples[{i}].evals must be a "
                             f"dict if present, got {type(evals).__name__}."
                         )
-                    score = (evals or {}).get("score", s.get("score"))
+                    score = (evals or {}).get("score", sample.get("score"))
                     if score == 1.0:
                         if chosen is not None:
                             raise ValueError(
@@ -113,7 +192,7 @@ def load_preference_dataset(path: str, max_pairs: int | None = None) -> List[dic
                                 f"chosen (score=1.0) and one rejected "
                                 f"(score=0.0) sample."
                             )
-                        chosen = s
+                        chosen = sample
                     elif score == 0.0:
                         if rejected is not None:
                             raise ValueError(
@@ -123,7 +202,7 @@ def load_preference_dataset(path: str, max_pairs: int | None = None) -> List[dic
                                 f"chosen (score=1.0) and one rejected "
                                 f"(score=0.0) sample."
                             )
-                        rejected = s
+                        rejected = sample
                     else:
                         raise ValueError(
                             f"{path}:{line_no}: invalid preference score "
@@ -151,14 +230,6 @@ def load_preference_dataset(path: str, max_pairs: int | None = None) -> List[dic
                     input_msgs = [{"role": "user", "content": inp}]
                 else:
                     input_msgs = []
-
-                def _to_msgs(v):
-                    if isinstance(v, list):
-                        return v
-                    if isinstance(v, str):
-                        return [{"role": "assistant", "content": v}]
-                    return []
-
                 data.append(
                     {
                         "chosen": {"messages": input_msgs + _to_msgs(row["preferred_output"])},

--- a/training/utils/infra.py
+++ b/training/utils/infra.py
@@ -40,8 +40,11 @@ from fireworks.training.sdk import (
     TrainerJobManager,
     TrainerServiceEndpoint,
     TrainingShapeProfile,
-    CreatedTrainerJob,
 )
+try:
+    from fireworks.training.sdk import CreatedTrainerJob
+except ImportError:
+    CreatedTrainerJob = Any
 from fireworks.training.sdk.deployment import (
     DeploymentConfig,
     DeploymentInfo,
@@ -66,6 +69,9 @@ logger = logging.getLogger(__name__)
 
 _TRAINER_JOB_CONFIG_SUPPORTS_SKIP_VALIDATIONS = (
     "skip_validations" in inspect.signature(TrainerJobConfig).parameters
+)
+_TRAINER_JOB_CONFIG_SUPPORTS_TRAINING_SHAPE_REF = (
+    "training_shape_ref" in inspect.signature(TrainerJobConfig).parameters
 )
 
 _DEPLOYMENT_ACCELERATOR_REGION_PREFIXES: tuple[tuple[str, str], ...] = (
@@ -317,6 +323,8 @@ def request_trainer_job(
     extra_trainer_args: dict[str, Any] = {}
     if _TRAINER_JOB_CONFIG_SUPPORTS_SKIP_VALIDATIONS:
         extra_trainer_args["skip_validations"] = infra.skip_validations
+    if profile is not None and _TRAINER_JOB_CONFIG_SUPPORTS_TRAINING_SHAPE_REF:
+        extra_trainer_args["training_shape_ref"] = profile.training_shape_version
 
     if profile is not None:
         config = TrainerJobConfig(
@@ -330,9 +338,11 @@ def request_trainer_job(
             region=infra.region,
             extra_args=extra_args or infra.extra_args,
             forward_only=forward_only,
-            training_shape_ref=profile.training_shape_version,
             **extra_trainer_args,
         )
+        if not _TRAINER_JOB_CONFIG_SUPPORTS_TRAINING_SHAPE_REF:
+            config.training_shape_ref = profile.training_shape_version
+        config.node_count = None
     else:
         config = TrainerJobConfig(
             base_model=base_model,
@@ -350,6 +360,8 @@ def request_trainer_job(
             accelerator_count=infra.accelerator_count,
             forward_only=forward_only,
         )
+        if not _TRAINER_JOB_CONFIG_SUPPORTS_TRAINING_SHAPE_REF:
+            config.training_shape_ref = None
 
     if infra.purpose:
         config.purpose = infra.purpose
@@ -1191,11 +1203,11 @@ def _resolve_reference_shape(
     """Return (ref_profile, resolved_ref_shape_id)."""
     if ref_training_shape_id:
         if lora_rank > 0:
-            logger.warning(
-                "ref_training_shape_id=%r is set alongside lora_rank=%d. This provisions a "
-                "separate full-param forward-only reference trainer, which defeats LoRA's "
-                "GPU savings. For LoRA, leave ref_training_shape_id unset — setup_infra "
-                "will use the shared-session reference (policy.create_base_reference()).",
+            logger.info(
+                "Using explicit reference shape %s alongside lora_rank=%d. The ref "
+                "trainer will run forward-only on a LoRA-capable shape (its own GPUs). "
+                "To save GPUs via the shared-session reference "
+                "(policy.create_base_reference()), leave ref_training_shape_id unset.",
                 ref_training_shape_id, lora_rank,
             )
         return rlor_mgr.resolve_training_profile(ref_training_shape_id), ref_training_shape_id
@@ -1262,12 +1274,18 @@ def _request_trainers(
         # Reference trainer runs forward-only: strip --full-oom-check, which
         # triggers a backward warmup that OOMs on smaller reference shapes.
         ref_infra = _strip_args(infra, {"--full-oom-check"})
+        # Propagate lora_rank so the gateway infers the correct trainer_mode:
+        #   lora_rank > 0  -> LORA_TRAINER (matches LoRA-capable ref shape)
+        #   lora_rank == 0 -> FORWARD_ONLY (full-param base-weight forward)
+        # A forward-only LoRA ref still loads the adapter on top of base
+        # weights; the adapter is configured upstream and only the forward
+        # pass runs here.
         ref_handle = request_trainer_job(
             rlor_mgr,
             base_model=base_model,
             infra=ref_infra,
             profile=ref_profile,
-            lora_rank=0,
+            lora_rank=lora_rank,
             max_seq_len=max_seq_len,
             learning_rate=learning_rate,
             display_name=f"{role_prefix}-reference",
@@ -1488,9 +1506,12 @@ def _make_reference_client(
     closeables: list[Any],
 ) -> Any | None:
     if reference_ep is not None:
+        # Client lora_rank must match the ref trainer's server config:
+        # a LoRA-capable ref pod expects create_training_client(lora_rank>0),
+        # a full-param forward-only pod expects lora_rank=0.
         reference = ReconnectableClient(
             rlor_mgr, reference_ep.job_id, base_model,
-            lora_rank=0,
+            lora_rank=lora_rank,
             fw_api_key=api_key,
             default_timeout=step_timeout or DEFAULT_TIMEOUT_S,
         )

--- a/training/utils/infra.py
+++ b/training/utils/infra.py
@@ -21,6 +21,7 @@ Generic across loop types:
 from __future__ import annotations
 
 import dataclasses
+import inspect
 import json
 import os
 import time
@@ -62,6 +63,10 @@ StatusCallback = Callable[[str], None]
 lifecycle step (creating, waiting, ready, failed)."""
 
 logger = logging.getLogger(__name__)
+
+_TRAINER_JOB_CONFIG_SUPPORTS_SKIP_VALIDATIONS = (
+    "skip_validations" in inspect.signature(TrainerJobConfig).parameters
+)
 
 _DEPLOYMENT_ACCELERATOR_REGION_PREFIXES: tuple[tuple[str, str], ...] = (
     ("NVIDIA_H200", "US_VIRGINIA_1"),
@@ -309,6 +314,10 @@ def request_trainer_job(
         _emit(f"reusing existing {trainer_role} trainer {job_id}")
         return _reuse_or_resume_job(rlor_mgr, job_id)
 
+    extra_trainer_args: dict[str, Any] = {}
+    if _TRAINER_JOB_CONFIG_SUPPORTS_SKIP_VALIDATIONS:
+        extra_trainer_args["skip_validations"] = infra.skip_validations
+
     if profile is not None:
         config = TrainerJobConfig(
             base_model=base_model,
@@ -322,7 +331,7 @@ def request_trainer_job(
             extra_args=extra_args or infra.extra_args,
             forward_only=forward_only,
             training_shape_ref=profile.training_shape_version,
-            skip_validations=infra.skip_validations,
+            **extra_trainer_args,
         )
     else:
         config = TrainerJobConfig(

--- a/training/utils/memlog.py
+++ b/training/utils/memlog.py
@@ -1,0 +1,173 @@
+"""Memory tracing helpers for the rendering / data-prep phase.
+
+We trace memory along three axes that the kernel exposes separately:
+
+  * **cgroup.current / cgroup.max** — what the K8s OOM killer cares about.
+  * **main process RSS** — what the orchestrator's Python heap holds.
+  * **worker RSS** (sum of children) — what the multiprocessing pool holds.
+
+Anything cgroup sees that is not main+workers is bucketed as
+"unaccounted", which in practice equals OS page cache (e.g. dirty pages
+from writes to a ``DiskBackedDatumStore``). Page cache is reclaimable and
+will not cause OOM as long as the workload running above it is not also
+allocating committed RAM faster than reclaim can keep up.
+
+This module was extracted from ``sft_loop`` after the orchestrator OOM
+investigation; see docs/engineering/sft-v2-orchestrator-oom-debug.md for
+the story.
+"""
+
+from __future__ import annotations
+
+import glob
+import logging
+import os
+import resource as _resource
+from typing import Callable, List, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Low-level readers (cgroup v1 + v2, /proc/<pid>/status)
+# ---------------------------------------------------------------------------
+
+
+def read_cgroup_mem() -> int:
+    """Return current cgroup memory usage in bytes (0 when not in a cgroup)."""
+    for path in (
+        "/sys/fs/cgroup/memory.current",                     # cgroup v2
+        "/sys/fs/cgroup/memory/memory.usage_in_bytes",       # cgroup v1
+    ):
+        try:
+            with open(path) as f:
+                return int(f.read().strip())
+        except (FileNotFoundError, ValueError):
+            continue
+    return 0
+
+
+def read_cgroup_limit() -> int:
+    """Return cgroup memory hard limit in bytes (0 when unlimited / unknown)."""
+    for path in (
+        "/sys/fs/cgroup/memory.max",                          # cgroup v2
+        "/sys/fs/cgroup/memory/memory.limit_in_bytes",        # cgroup v1
+    ):
+        try:
+            with open(path) as f:
+                val = f.read().strip()
+                if val == "max":
+                    return 0
+                return int(val)
+        except (FileNotFoundError, ValueError):
+            continue
+    return 0
+
+
+def proc_vmrss_gi(status_path: str) -> float:
+    """Return VmRSS for a /proc/<pid>/status path, in GiB."""
+    try:
+        with open(status_path) as f:
+            for line in f:
+                if line.startswith("VmRSS:"):
+                    return int(line.split()[1]) / (1024 * 1024)  # KiB -> GiB
+    except (FileNotFoundError, ProcessLookupError, PermissionError, ValueError):
+        pass
+    return 0.0
+
+
+def worker_rss_info(main_pid: int) -> Tuple[List[Tuple[int, float]], float]:
+    """Return ``(per_worker, total_gi)`` for child processes of ``main_pid``.
+
+    Walks ``/proc/*/status``, filters processes whose ``PPid`` is ``main_pid``,
+    and reports their ``VmRSS`` in GiB.
+    """
+    workers: List[Tuple[int, float]] = []
+    for status_path in glob.glob("/proc/*/status"):
+        try:
+            pid_str = status_path.split("/")[2]
+            if not pid_str.isdigit():
+                continue
+            pid = int(pid_str)
+            if pid == main_pid:
+                continue
+            with open(status_path) as f:
+                content = f.read()
+            ppid = 0
+            rss_kib = 0
+            for line in content.split("\n"):
+                if line.startswith("PPid:"):
+                    ppid = int(line.split()[1])
+                elif line.startswith("VmRSS:"):
+                    rss_kib = int(line.split()[1])
+            if ppid == main_pid and rss_kib > 0:
+                workers.append((pid, rss_kib / (1024 * 1024)))
+        except (FileNotFoundError, ProcessLookupError, PermissionError,
+                ValueError, IndexError):
+            continue
+    workers.sort()
+    return workers, sum(r for _, r in workers)
+
+
+# ---------------------------------------------------------------------------
+# High-level tracer
+# ---------------------------------------------------------------------------
+
+
+class MemTracer:
+    """Logs ``[mem] <stage> i/total | cgroup=... | main=... | workers=...``.
+
+    Construct once before the rendering loop and call :py:meth:`log` at
+    checkpoints (e.g. every 1% of progress). Pass an optional
+    ``store_callback`` returning ``(item_count, disk_bytes)`` to attach
+    ``DiskBackedDatumStore`` stats to each log line.
+    """
+
+    def __init__(
+        self,
+        *,
+        main_pid: int | None = None,
+        store_callback: Callable[[], Tuple[int, int]] | None = None,
+        log: logging.Logger | None = None,
+    ):
+        self._main_pid = main_pid if main_pid is not None else os.getpid()
+        self._store_callback = store_callback
+        self._log = log or logger
+
+    def log(self, stage: str, i: int, total: int, *, pool: object | None = None) -> None:
+        peak_kib = _resource.getrusage(_resource.RUSAGE_SELF).ru_maxrss
+        peak_gi = peak_kib / (1024 ** 2)  # ru_maxrss is KiB on Linux
+        main_cur_gi = proc_vmrss_gi(f"/proc/{self._main_pid}/status")
+        cgroup_gi = read_cgroup_mem() / (1024 ** 3)
+        limit_bytes = read_cgroup_limit()
+        limit_gi = limit_bytes / (1024 ** 3) if limit_bytes else 0.0
+
+        workers, workers_total = worker_rss_info(self._main_pid)
+        workers_str = ",".join(f"{pid}:{gi:.1f}" for pid, gi in workers)
+
+        pool_info = ""
+        if pool is not None:
+            try:
+                cache_size = len(pool._cache)  # type: ignore[attr-defined]
+                pool_info = f" | pool_cache={cache_size}"
+            except Exception:
+                pass
+
+        unaccounted = cgroup_gi - main_cur_gi - workers_total
+
+        store_info = ""
+        if self._store_callback is not None:
+            try:
+                rows, disk_bytes = self._store_callback()
+                store_info = f" | store={rows} rows / {disk_bytes / (1024 ** 3):.1f} GiB disk"
+            except Exception:
+                pass
+
+        pct = 100.0 * i / total if total else 0.0
+        self._log.info(
+            "[mem] %s %d/%d (%.0f%%) | cgroup=%.1f/%.1f GiB | main=%.1f cur / %.1f peak GiB"
+            " | workers=%.1f GiB [%s] | unaccounted=%.1f GiB%s%s",
+            stage, i, total, pct,
+            cgroup_gi, limit_gi, main_cur_gi, peak_gi,
+            workers_total, workers_str, unaccounted, pool_info, store_info,
+        )

--- a/training/utils/streaming.py
+++ b/training/utils/streaming.py
@@ -1,0 +1,235 @@
+"""Streaming dataset rendering utilities.
+
+These utilities decouple the *render* phase from RAM. The eager pattern of:
+
+    raw = list(json.loads(line) for line in f)            # ~10 GiB
+    rendered = pool.map(render_fn, raw)                   # ~400+ GiB
+
+does not fit on a single CPU node (allocatable RAM ~120 GiB on m5.8xlarge)
+for realistic SFT/DPO datasets at long context. Instead this module exposes:
+
+  * ``iter_jsonl_rows`` / ``count_jsonl_rows`` -- lazy reads of raw JSONL.
+  * ``DiskBackedDatumStore`` -- append-only pickle store for rendered
+    objects, with random read access via an in-memory ``(offset, length)``
+    index (~16 B/row).
+  * ``stream_render_to_store`` -- glue that runs a worker pool and spills
+    each rendered item to a store as it completes (``Pool.imap``).
+
+Peak RAM becomes O(num_workers * per_worker_render_footprint) instead of
+O(num_examples * avg_seq_len * bytes_per_token).
+
+Used today by ``sft_loop``. Designed so DPO/ORPO can adopt the same
+pattern with a different ``render_fn`` and store payload type.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import multiprocessing
+import os
+import pickle
+from typing import IO, Any, Callable, Dict, Iterable, Iterator, List, Tuple, TypeVar
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+
+# ---------------------------------------------------------------------------
+# Disk-backed append-only store
+# ---------------------------------------------------------------------------
+
+
+class DiskBackedDatumStore:
+    """Pickle-backed append-only store for arbitrary picklable objects.
+
+    Items are appended during the rendering (write) phase and random-accessed
+    by integer index during training (read) phase. All payload bytes live on
+    local disk; only a small ``(offset, length)`` index is held in RAM.
+
+    Usage::
+
+        with DiskBackedDatumStore(path) as store:
+            for item in producer:
+                store.append(item)
+            store.close_write()
+            ...
+            datum = store[i]            # random read
+            for d in store: ...         # sequential read
+
+    The store is named ``DiskBackedDatumStore`` for historical reasons but
+    accepts any picklable payload (tinker.Datum, dict, dataclass, ...).
+    """
+
+    def __init__(self, path: str):
+        self._path = path
+        self._offsets: List[Tuple[int, int]] = []
+        self._write_fh: IO[bytes] | None = None
+        self._read_fh: IO[bytes] | None = None
+
+    def __enter__(self) -> "DiskBackedDatumStore":
+        parent = os.path.dirname(self._path)
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        self._write_fh = open(self._path, "wb")
+        return self
+
+    def __exit__(self, *_exc) -> None:
+        self.close_write()
+        if self._read_fh is not None:
+            self._read_fh.close()
+            self._read_fh = None
+
+    def append(self, item: Any) -> None:
+        if self._write_fh is None:
+            raise RuntimeError("DiskBackedDatumStore is not open for writing")
+        blob = pickle.dumps(item, protocol=pickle.HIGHEST_PROTOCOL)
+        offset = self._write_fh.tell()
+        self._write_fh.write(blob)
+        self._offsets.append((offset, len(blob)))
+
+    def close_write(self) -> None:
+        """Flush and close the write handle. Idempotent.
+
+        Subsequent ``__getitem__`` calls reopen the file for reading.
+        """
+        if self._write_fh is not None:
+            self._write_fh.flush()
+            try:
+                os.fsync(self._write_fh.fileno())
+            except OSError:
+                pass
+            self._write_fh.close()
+            self._write_fh = None
+
+    def __len__(self) -> int:
+        return len(self._offsets)
+
+    def __getitem__(self, idx: int) -> Any:
+        offset, length = self._offsets[idx]
+        if self._read_fh is None:
+            self._read_fh = open(self._path, "rb")
+        self._read_fh.seek(offset)
+        return pickle.loads(self._read_fh.read(length))
+
+    def __iter__(self) -> Iterator[Any]:
+        for i in range(len(self._offsets)):
+            yield self[i]
+
+    def disk_size_bytes(self) -> int:
+        try:
+            return os.path.getsize(self._path)
+        except OSError:
+            return 0
+
+    @property
+    def path(self) -> str:
+        return self._path
+
+
+# ---------------------------------------------------------------------------
+# Lazy JSONL reads
+# ---------------------------------------------------------------------------
+
+
+def iter_jsonl_rows(
+    path: str, max_examples: int | None = None,
+) -> Iterator[Dict[str, Any]]:
+    """Stream JSON rows from a JSONL file without materialising the list.
+
+    Skips blank lines. Stops after ``max_examples`` valid rows when set.
+    """
+    yielded = 0
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            yield json.loads(line)
+            yielded += 1
+            if max_examples is not None and yielded >= max_examples:
+                return
+
+
+def count_jsonl_rows(path: str, max_examples: int | None = None) -> int:
+    """Count non-blank lines in a JSONL file without parsing JSON."""
+    n = 0
+    with open(path) as f:
+        for line in f:
+            if not line.strip():
+                continue
+            n += 1
+            if max_examples is not None and n >= max_examples:
+                break
+    return n
+
+
+# ---------------------------------------------------------------------------
+# Worker pool that spills directly to a store
+# ---------------------------------------------------------------------------
+
+
+# Conservative defaults validated end-to-end on a 110K-example, 256K-context
+# SFT dataset:
+#   workers=4   ~28 GiB spawn baseline (vs 56 GiB at 8 workers)
+#   chunksize=10 cuts result-buffer bursts ~10x vs the imap default
+DEFAULT_RENDER_WORKERS = 4
+DEFAULT_RENDER_CHUNKSIZE = 10
+
+
+def stream_render_to_store(
+    rows: Iterable[Dict[str, Any]],
+    *,
+    render_fn: Callable[[Dict[str, Any]], T | None],
+    store: DiskBackedDatumStore,
+    num_workers: int = DEFAULT_RENDER_WORKERS,
+    chunksize: int = DEFAULT_RENDER_CHUNKSIZE,
+    initializer: Callable[..., None] | None = None,
+    initargs: tuple = (),
+    on_progress: Callable[[int, T | None], None] | None = None,
+) -> int:
+    """Render ``rows`` in parallel and append non-None results to ``store``.
+
+    Returns the number of rows that were filtered out (``render_fn`` returned
+    ``None``). The total number of rows processed equals
+    ``len(store) + filtered_count`` after this returns.
+
+    Uses the ``spawn`` multiprocessing context to avoid Copy-on-Write
+    inflation that would otherwise multiply the parent's heap across
+    workers. ``Pool.imap`` is used (not ``map``) so results stream out
+    one chunk at a time instead of accumulating in the pool's internal
+    queue.
+
+    ``on_progress`` is called with ``(processed_count_one_indexed, item)``
+    after each item; use it to drive progress logging or memory tracing.
+    Pass ``num_workers=1`` to fall back to the single-process path (useful
+    when ``initializer`` cannot be pickled or for unit tests).
+    """
+    filtered = 0
+
+    if num_workers <= 1:
+        for i, row in enumerate(rows):
+            datum = render_fn(row)
+            if datum is None:
+                filtered += 1
+            else:
+                store.append(datum)
+            if on_progress is not None:
+                on_progress(i + 1, datum)
+        return filtered
+
+    spawn_ctx = multiprocessing.get_context("spawn")
+    with spawn_ctx.Pool(
+        processes=num_workers,
+        initializer=initializer,
+        initargs=initargs,
+    ) as pool:
+        for i, datum in enumerate(pool.imap(render_fn, rows, chunksize=chunksize)):
+            if datum is None:
+                filtered += 1
+            else:
+                store.append(datum)
+            if on_progress is not None:
+                on_progress(i + 1, datum)
+    return filtered

--- a/training/utils/streaming.py
+++ b/training/utils/streaming.py
@@ -27,6 +27,7 @@ import json
 import logging
 from typing import Any, Callable, List
 
+import torch
 import torch.utils.data as torch_data
 
 logger = logging.getLogger(__name__)
@@ -131,6 +132,7 @@ def make_render_dataloader(
     num_workers: int = DEFAULT_RENDER_WORKERS,
     prefetch_factor: int = DEFAULT_PREFETCH_FACTOR,
     shuffle: bool = True,
+    generator: torch.Generator | None = None,
     worker_init_fn: Callable[[int], None] | None = None,
 ) -> torch_data.DataLoader:
     """Build a DataLoader for ``dataset`` with our spawn / collate defaults.
@@ -154,12 +156,14 @@ def make_render_dataloader(
             dataset,
             batch_size=batch_size,
             shuffle=shuffle,
+            generator=generator,
             collate_fn=_drop_none_collate,
         )
     return torch_data.DataLoader(
         dataset,
         batch_size=batch_size,
         shuffle=shuffle,
+        generator=generator,
         num_workers=num_workers,
         prefetch_factor=prefetch_factor,
         multiprocessing_context="spawn",

--- a/training/utils/streaming.py
+++ b/training/utils/streaming.py
@@ -1,235 +1,169 @@
-"""Streaming dataset rendering utilities.
+"""Streaming dataset rendering via PyTorch DataLoader.
 
-These utilities decouple the *render* phase from RAM. The eager pattern of:
+Renders JSONL rows on the fly inside DataLoader workers, with prefetch
+hiding per-row tokenization behind the GPU train step. Workers are
+spawned (not forked) so each gets its own tokenizer / renderer state
+without copy-on-write inflating the parent's heap.
 
-    raw = list(json.loads(line) for line in f)            # ~10 GiB
-    rendered = pool.map(render_fn, raw)                   # ~400+ GiB
+Replaces the earlier "render to a disk-backed pickle store, then read
+back during training" pipeline because:
 
-does not fit on a single CPU node (allocatable RAM ~120 GiB on m5.8xlarge)
-for realistic SFT/DPO datasets at long context. Instead this module exposes:
+* Per-row CPU render cost is small relative to the trainer's
+  ``forward_backward`` step, so DataLoader prefetch hides it.
+* No disk persistence is needed for SFT -- multi-epoch simply
+  re-renders the same JSONL rows (cheap on the CPU orchestrator pod).
+* Eliminates ~200 LoC of bespoke worker pool / disk store / index code
+  in favour of battle-tested DataLoader machinery.
 
-  * ``iter_jsonl_rows`` / ``count_jsonl_rows`` -- lazy reads of raw JSONL.
-  * ``DiskBackedDatumStore`` -- append-only pickle store for rendered
-    objects, with random read access via an in-memory ``(offset, length)``
-    index (~16 B/row).
-  * ``stream_render_to_store`` -- glue that runs a worker pool and spills
-    each rendered item to a store as it completes (``Pool.imap``).
-
-Peak RAM becomes O(num_workers * per_worker_render_footprint) instead of
-O(num_examples * avg_seq_len * bytes_per_token).
-
-Used today by ``sft_loop``. Designed so DPO/ORPO can adopt the same
-pattern with a different ``render_fn`` and store payload type.
+Used today by ``sft_loop``. DPO/ORPO can reuse :class:`JsonlRenderDataset`
+with a preference-pair ``render_fn``; their multi-epoch reference logprob
+cache is a separate concern (kept on disk so the reference trainer can
+be released after epoch 0).
 """
 
 from __future__ import annotations
 
 import json
 import logging
-import multiprocessing
-import os
-import pickle
-from typing import IO, Any, Callable, Dict, Iterable, Iterator, List, Tuple, TypeVar
+from typing import Any, Callable, List
+
+import torch.utils.data as torch_data
 
 logger = logging.getLogger(__name__)
 
-T = TypeVar("T")
+# Defaults validated end-to-end on a 110K-example, 256K-context SFT
+# dataset on a 16 vCPU / 58 GiB orchestrator pod.
+DEFAULT_RENDER_WORKERS = 4
+DEFAULT_PREFETCH_FACTOR = 2
 
 
 # ---------------------------------------------------------------------------
-# Disk-backed append-only store
+# JSONL → render → object dataset
 # ---------------------------------------------------------------------------
 
 
-class DiskBackedDatumStore:
-    """Pickle-backed append-only store for arbitrary picklable objects.
+def _scan_jsonl_offsets(path: str, max_examples: int | None = None) -> List[int]:
+    """Return the byte offset of every non-blank line in a JSONL file."""
+    offsets: List[int] = []
+    with open(path, "rb") as f:
+        offset = 0
+        for line in f:
+            if line.strip():
+                offsets.append(offset)
+                if max_examples is not None and len(offsets) >= max_examples:
+                    break
+            offset += len(line)
+    return offsets
 
-    Items are appended during the rendering (write) phase and random-accessed
-    by integer index during training (read) phase. All payload bytes live on
-    local disk; only a small ``(offset, length)`` index is held in RAM.
 
-    Usage::
+class JsonlRenderDataset(torch_data.Dataset):
+    """Map-style dataset that lazily renders each JSONL row on access.
 
-        with DiskBackedDatumStore(path) as store:
-            for item in producer:
-                store.append(item)
-            store.close_write()
-            ...
-            datum = store[i]            # random read
-            for d in store: ...         # sequential read
+    A single linear scan at construction time builds the byte-offset
+    table; each ``__getitem__(i)`` is a seek + readline + ``json.loads``
+    + ``render_fn``. ``render_fn`` must be a top-level (module-level)
+    function so it is picklable for spawn workers.
 
-    The store is named ``DiskBackedDatumStore`` for historical reasons but
-    accepts any picklable payload (tinker.Datum, dict, dataclass, ...).
+    ``render_fn`` may return ``None`` for rows that should be dropped
+    (empty messages, over-length sequences, ...). The companion
+    :func:`make_render_dataloader` wires up a collate that filters Nones.
     """
 
-    def __init__(self, path: str):
+    def __init__(
+        self,
+        path: str,
+        render_fn: Callable[[dict], Any | None],
+        *,
+        max_examples: int | None = None,
+        indices: List[int] | None = None,
+    ):
         self._path = path
-        self._offsets: List[Tuple[int, int]] = []
-        self._write_fh: IO[bytes] | None = None
-        self._read_fh: IO[bytes] | None = None
-
-    def __enter__(self) -> "DiskBackedDatumStore":
-        parent = os.path.dirname(self._path)
-        if parent:
-            os.makedirs(parent, exist_ok=True)
-        self._write_fh = open(self._path, "wb")
-        return self
-
-    def __exit__(self, *_exc) -> None:
-        self.close_write()
-        if self._read_fh is not None:
-            self._read_fh.close()
-            self._read_fh = None
-
-    def append(self, item: Any) -> None:
-        if self._write_fh is None:
-            raise RuntimeError("DiskBackedDatumStore is not open for writing")
-        blob = pickle.dumps(item, protocol=pickle.HIGHEST_PROTOCOL)
-        offset = self._write_fh.tell()
-        self._write_fh.write(blob)
-        self._offsets.append((offset, len(blob)))
-
-    def close_write(self) -> None:
-        """Flush and close the write handle. Idempotent.
-
-        Subsequent ``__getitem__`` calls reopen the file for reading.
-        """
-        if self._write_fh is not None:
-            self._write_fh.flush()
-            try:
-                os.fsync(self._write_fh.fileno())
-            except OSError:
-                pass
-            self._write_fh.close()
-            self._write_fh = None
+        self._render_fn = render_fn
+        self._offsets = _scan_jsonl_offsets(path, max_examples)
+        self._index_map: List[int] = (
+            list(indices)
+            if indices is not None
+            else list(range(len(self._offsets)))
+        )
 
     def __len__(self) -> int:
-        return len(self._offsets)
+        return len(self._index_map)
 
-    def __getitem__(self, idx: int) -> Any:
-        offset, length = self._offsets[idx]
-        if self._read_fh is None:
-            self._read_fh = open(self._path, "rb")
-        self._read_fh.seek(offset)
-        return pickle.loads(self._read_fh.read(length))
+    def __getitem__(self, i: int) -> Any:
+        offset = self._offsets[self._index_map[i]]
+        with open(self._path) as f:
+            f.seek(offset)
+            line = f.readline()
+        return self._render_fn(json.loads(line))
 
-    def __iter__(self) -> Iterator[Any]:
-        for i in range(len(self._offsets)):
-            yield self[i]
+    def with_indices(self, indices: List[int]) -> "JsonlRenderDataset":
+        """Return a view of this dataset restricted to ``indices``.
 
-    def disk_size_bytes(self) -> int:
-        try:
-            return os.path.getsize(self._path)
-        except OSError:
-            return 0
+        Shares the underlying offset table and render_fn; only the
+        index mapping differs. Used to carve out a contiguous eval slice
+        from the head of the training data without rescanning the file.
+        """
+        view = object.__new__(type(self))
+        view._path = self._path
+        view._render_fn = self._render_fn
+        view._offsets = self._offsets
+        view._index_map = list(indices)
+        return view
 
     @property
-    def path(self) -> str:
-        return self._path
+    def num_underlying_rows(self) -> int:
+        return len(self._offsets)
 
 
 # ---------------------------------------------------------------------------
-# Lazy JSONL reads
+# DataLoader factory
 # ---------------------------------------------------------------------------
 
 
-def iter_jsonl_rows(
-    path: str, max_examples: int | None = None,
-) -> Iterator[Dict[str, Any]]:
-    """Stream JSON rows from a JSONL file without materialising the list.
-
-    Skips blank lines. Stops after ``max_examples`` valid rows when set.
-    """
-    yielded = 0
-    with open(path) as f:
-        for line in f:
-            line = line.strip()
-            if not line:
-                continue
-            yield json.loads(line)
-            yielded += 1
-            if max_examples is not None and yielded >= max_examples:
-                return
+def _drop_none_collate(batch: List[Any]) -> List[Any]:
+    return [d for d in batch if d is not None]
 
 
-def count_jsonl_rows(path: str, max_examples: int | None = None) -> int:
-    """Count non-blank lines in a JSONL file without parsing JSON."""
-    n = 0
-    with open(path) as f:
-        for line in f:
-            if not line.strip():
-                continue
-            n += 1
-            if max_examples is not None and n >= max_examples:
-                break
-    return n
-
-
-# ---------------------------------------------------------------------------
-# Worker pool that spills directly to a store
-# ---------------------------------------------------------------------------
-
-
-# Conservative defaults validated end-to-end on a 110K-example, 256K-context
-# SFT dataset:
-#   workers=4   ~28 GiB spawn baseline (vs 56 GiB at 8 workers)
-#   chunksize=10 cuts result-buffer bursts ~10x vs the imap default
-DEFAULT_RENDER_WORKERS = 4
-DEFAULT_RENDER_CHUNKSIZE = 10
-
-
-def stream_render_to_store(
-    rows: Iterable[Dict[str, Any]],
+def make_render_dataloader(
+    dataset: torch_data.Dataset,
     *,
-    render_fn: Callable[[Dict[str, Any]], T | None],
-    store: DiskBackedDatumStore,
+    batch_size: int,
     num_workers: int = DEFAULT_RENDER_WORKERS,
-    chunksize: int = DEFAULT_RENDER_CHUNKSIZE,
-    initializer: Callable[..., None] | None = None,
-    initargs: tuple = (),
-    on_progress: Callable[[int, T | None], None] | None = None,
-) -> int:
-    """Render ``rows`` in parallel and append non-None results to ``store``.
+    prefetch_factor: int = DEFAULT_PREFETCH_FACTOR,
+    shuffle: bool = True,
+    worker_init_fn: Callable[[int], None] | None = None,
+) -> torch_data.DataLoader:
+    """Build a DataLoader for ``dataset`` with our spawn / collate defaults.
 
-    Returns the number of rows that were filtered out (``render_fn`` returned
-    ``None``). The total number of rows processed equals
-    ``len(store) + filtered_count`` after this returns.
+    * ``multiprocessing_context="spawn"`` keeps each worker's RSS
+      independent of the parent (no copy-on-write inflation of the
+      tokenizer / renderer state).
+    * ``persistent_workers=True`` keeps the per-worker tokenizer alive
+      across epochs so we pay the spawn-and-init cost once.
+    * ``collate_fn`` returns a python list of rendered items, dropping
+      any ``None`` entries. Tinker's ``forward_backward`` accepts
+      variable-size batches so dropping is safe.
 
-    Uses the ``spawn`` multiprocessing context to avoid Copy-on-Write
-    inflation that would otherwise multiply the parent's heap across
-    workers. ``Pool.imap`` is used (not ``map``) so results stream out
-    one chunk at a time instead of accumulating in the pool's internal
-    queue.
-
-    ``on_progress`` is called with ``(processed_count_one_indexed, item)``
-    after each item; use it to drive progress logging or memory tracing.
-    Pass ``num_workers=1`` to fall back to the single-process path (useful
-    when ``initializer`` cannot be pickled or for unit tests).
+    ``num_workers <= 1`` falls back to single-process rendering. Unit
+    tests rely on this to monkey-patch the renderer (spawn workers can't
+    see test-time monkey patches), and a single worker subprocess
+    rarely earns its keep over in-process rendering anyway.
     """
-    filtered = 0
-
     if num_workers <= 1:
-        for i, row in enumerate(rows):
-            datum = render_fn(row)
-            if datum is None:
-                filtered += 1
-            else:
-                store.append(datum)
-            if on_progress is not None:
-                on_progress(i + 1, datum)
-        return filtered
-
-    spawn_ctx = multiprocessing.get_context("spawn")
-    with spawn_ctx.Pool(
-        processes=num_workers,
-        initializer=initializer,
-        initargs=initargs,
-    ) as pool:
-        for i, datum in enumerate(pool.imap(render_fn, rows, chunksize=chunksize)):
-            if datum is None:
-                filtered += 1
-            else:
-                store.append(datum)
-            if on_progress is not None:
-                on_progress(i + 1, datum)
-    return filtered
+        return torch_data.DataLoader(
+            dataset,
+            batch_size=batch_size,
+            shuffle=shuffle,
+            collate_fn=_drop_none_collate,
+        )
+    return torch_data.DataLoader(
+        dataset,
+        batch_size=batch_size,
+        shuffle=shuffle,
+        num_workers=num_workers,
+        prefetch_factor=prefetch_factor,
+        multiprocessing_context="spawn",
+        worker_init_fn=worker_init_fn,
+        persistent_workers=True,
+        collate_fn=_drop_none_collate,
+    )

--- a/training/utils/streaming.py
+++ b/training/utils/streaming.py
@@ -25,7 +25,9 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any, Callable, List
+import os
+import pickle
+from typing import Any, Callable, Iterator, List
 
 import torch
 import torch.utils.data as torch_data
@@ -171,3 +173,74 @@ def make_render_dataloader(
         persistent_workers=True,
         collate_fn=_drop_none_collate,
     )
+
+
+# ---------------------------------------------------------------------------
+# Append-only pickle log (DPO ref-cache)
+# ---------------------------------------------------------------------------
+
+
+class AppendOnlyPickleLog:
+    """Sequential disk-backed object log: append in epoch 0, iterate in epochs 1+.
+
+    Designed for DPO's reference-logprob cache: we need to spool enriched
+    preference pairs to disk so the (expensive) reference trainer can be
+    released after epoch 0, but epochs 1+ only ever iterate the cache
+    front-to-back. That eliminates everything the previous
+    ``DiskBackedDatumStore`` carried (offset index, mmap, random access,
+    truncation safety) and reduces the disk store to ~30 LoC of pickle.
+
+    Lifecycle: ``append(...)`` while writing → ``close_write()`` → iterate
+    via ``for x in log``. Iterating before ``close_write()`` raises.
+    """
+
+    def __init__(self, path: str) -> None:
+        self._path = path
+        self._fh: Any = open(path, "wb")
+        self._count = 0
+
+    def append(self, obj: Any) -> None:
+        if self._fh is None:
+            raise RuntimeError("AppendOnlyPickleLog is closed; cannot append")
+        pickle.dump(obj, self._fh, protocol=pickle.HIGHEST_PROTOCOL)
+        self._count += 1
+
+    def close_write(self) -> None:
+        """Flush + fsync + close the write handle so readers see all data."""
+        if self._fh is None:
+            return
+        self._fh.flush()
+        os.fsync(self._fh.fileno())
+        self._fh.close()
+        self._fh = None
+
+    def __len__(self) -> int:
+        return self._count
+
+    def disk_size_bytes(self) -> int:
+        try:
+            return os.path.getsize(self._path)
+        except OSError:
+            return 0
+
+    def __iter__(self) -> Iterator[Any]:
+        if self._fh is not None:
+            raise RuntimeError(
+                "close_write() must be called before iterating an AppendOnlyPickleLog"
+            )
+        with open(self._path, "rb") as f:
+            while True:
+                try:
+                    yield pickle.load(f)
+                except EOFError:
+                    return
+
+    def close(self) -> None:
+        if self._fh is not None:
+            self.close_write()
+
+    def __enter__(self) -> "AppendOnlyPickleLog":
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        self.close()

--- a/training/utils/validation.py
+++ b/training/utils/validation.py
@@ -7,9 +7,33 @@ Infra-field validation lives in the SDK's ``TrainerJobConfig.validate()``.
 from __future__ import annotations
 
 import logging
+import re
 
-from fireworks.training.sdk.errors import format_sdk_error, DOCS_SDK
-from fireworks.training.sdk import validate_output_model_id
+try:
+    from fireworks.training.sdk.errors import format_sdk_error, DOCS_SDK
+except ImportError:
+    from fireworks.training.sdk.errors import format_sdk_error
+    DOCS_SDK = ""
+try:
+    from fireworks.training.sdk import validate_output_model_id
+except ImportError:
+    _OUTPUT_MODEL_ID_RE = re.compile(
+        r"^(accounts/[^/]+/models/[A-Za-z0-9-]+|[A-Za-z0-9-]+)$"
+    )
+
+    def validate_output_model_id(_value: str) -> list[str]:
+        if _OUTPUT_MODEL_ID_RE.match(_value):
+            return []
+        return [
+            format_sdk_error(
+                "Invalid output_model_id",
+                f"'{_value}' doesn't match expected format.",
+                "Use either a short model name (letters / numbers / '-') or "
+                "a full resource name like accounts/ACCOUNT/models/MODEL_NAME.\n"
+                "  Example: promoted-orpo-model\n"
+                "  Example: accounts/pyroworks/models/my-model",
+            )
+        ]
 from training.utils.config import DeployConfig, WeightSyncConfig
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary

Fixes orchestrator (cookbook runner) OOMs during SFT dataset rendering on large / long-context datasets by switching from eager full-dataset tokenization to a streaming PyTorch `DataLoader` pipeline.

Instead of materializing `List[tinker.Datum]` in the orchestrator, this PR scans JSONL offsets once, renders rows on demand inside spawn workers, and feeds batches directly into training. Peak RAM is now bounded by roughly `num_workers × per-worker render footprint`, not by the total rendered dataset size.

Validated end-to-end on job `r62fmz8e` (110,919 examples × 256K context, `qwen3p5-397b-a17b`). This PR also rebases onto current `main` and incorporates the follow-up review fixes for deterministic resume + zero-valid-data handling.

Pairs with **fw-ai/fireworks#23033** (orchestrator memory/disk allocation update for the streaming renderer) and the deeper investigation in `docs/engineering/sft-v2-orchestrator-oom-debug.md`.

## Architecture

```mermaid
flowchart LR
    A[JSONL on disk / GCS-localized file] --> B[_scan_jsonl_offsets]
    B --> C[JsonlRenderDataset]
    C -->|getitem -> json.loads + render_fn| D[PyTorch DataLoader]
    D -->|spawn workers| W1[worker 1]
    D --> W2[worker 2]
    D --> W3[worker 3]
    D --> W4[worker 4]
    W1 --> T[trainer.forward_backward]
    W2 --> T
    W3 --> T
    W4 --> T
    E[eval carve-out / explicit eval] -->|bounded eager render| F[eval_data list]
```

## Changes

### `training/utils/streaming.py`

- Add `JsonlRenderDataset`: map-style dataset that scans JSONL byte offsets once, then lazily `seek + readline + json.loads + render_fn` per row.
- Add `make_render_dataloader`: wraps PyTorch `DataLoader` with our spawn / persistent-worker / drop-`None` defaults.
- Add explicit `generator=` plumbing so callers can control shuffle determinism.

### `training/recipes/sft_loop.py`

- Replace eager `raw_data.append(...)` + full in-memory rendered dataset with streaming `JsonlRenderDataset` + `DataLoader`.
- Keep eval rendering bounded: explicit eval datasets are still rendered eagerly; auto carve-out still only materializes the small eval slice.
- Restore deterministic epoch ordering by seeding the loader generator as `cfg.seed + epoch`.
- On resume, replay epoch-0 with the same seed, then skip already-consumed batches via `islice(...)`.
- Raise `RuntimeError("No valid training examples after tokenization")` if epoch 0 renders zero valid rows, instead of silently completing with 0 optimizer steps.
- Log filtered-row count after epoch 0.

### `training/utils/infra.py`

- Add a tiny SDK-compat shim so `TrainerJobConfig(skip_validations=...)` is only passed when the installed SDK supports that kwarg. This keeps the SFT loop unit tests runnable against older local SDK builds while preserving current behavior in CI / newer SDKs.

### Tests

- `test_streaming.py`: cover `generator=`-based deterministic shuffle.
- `test_sft_loop.py`: cover deterministic resume order and the zero-valid-data failure path; update the per-batch optimizer-step test to stop assuming input order when shuffle is enabled.

## Why streaming?

Earlier iterations failed because eager rendering scaled orchestrator memory with the fully tokenized dataset. For long-context / large-example-count jobs, that either OOMed the pod or pushed requested memory above what the node could schedule. Streaming sidesteps that by making render memory independent of total dataset size.

## Type of Change

- [x] Bug fix
- [x] Refactoring

## Testing

- [x] End-to-end validated on job `r62fmz8e`
- [x] `pytest -q training/tests/unit/test_streaming.py`
- [x] `pytest -q training/tests/unit/test_sft_loop.py`
- [x] `pytest -q training/tests/unit/test_streaming.py training/tests/unit/test_sft_loop.py`

## Follow-ups (out of scope)

- DPO / ORPO migration to the same streaming render path
- Further cleanup of shared render-worker init boilerplate (handled separately in follow-up PRs)