### PR TITLE
feat(rl): MessageEnv abstraction + helpers for pluggable rollouts

### DIFF
--- a/training/tests/unit/test_rl_env.py
+++ b/training/tests/unit/test_rl_env.py
@@ -1,0 +1,116 @@
+"""Unit tests for training.utils.rl.env types."""
+
+from __future__ import annotations
+
+import pytest
+
+from training.utils.rl.env import (
+    MessageEnv,
+    MessageStepResult,
+    Trajectory,
+    Transition,
+)
+
+
+def _make_transition(
+    *, reward: float = 1.0, done: bool = True, finish: str = "stop", valid: bool = True
+) -> Transition:
+    return Transition(
+        prompt_tokens=[1, 2, 3],
+        completion_tokens=[4, 5],
+        completion_text="hi",
+        inference_logprobs=[-0.1, -0.2],
+        assistant_message={"role": "assistant", "content": "hi"},
+        reward=reward,
+        episode_done=done,
+        finish_reason=finish,
+        is_reward_valid=valid,
+    )
+
+
+class TestMessageStepResult:
+    def test_defaults_are_empty(self):
+        result = MessageStepResult(reward=1.0, episode_done=True)
+        assert result.next_messages == []
+        assert result.metrics == {}
+        assert result.is_reward_valid is True
+
+
+class TestTrajectory:
+    def test_empty_trajectory_is_not_complete(self):
+        traj = Trajectory()
+        assert traj.transitions == []
+        assert traj.is_complete is False
+        assert traj.total_reward == 0.0
+
+    def test_single_turn_trajectory(self):
+        traj = Trajectory(transitions=[_make_transition(reward=0.7)])
+        assert traj.is_complete is True
+        assert traj.total_reward == pytest.approx(0.7)
+        assert traj.any_truncated is False
+        assert traj.all_rewards_valid is True
+
+    def test_multi_turn_reward_sum(self):
+        traj = Trajectory(
+            transitions=[
+                _make_transition(reward=0.5, done=False),
+                _make_transition(reward=0.25, done=True),
+            ]
+        )
+        assert traj.total_reward == pytest.approx(0.75)
+        assert traj.is_complete is True
+
+    def test_is_complete_false_when_last_turn_not_done(self):
+        traj = Trajectory(transitions=[_make_transition(done=False)])
+        assert traj.is_complete is False
+
+    def test_any_truncated_picks_up_length_finish(self):
+        traj = Trajectory(
+            transitions=[
+                _make_transition(done=False, finish="stop"),
+                _make_transition(done=True, finish="length"),
+            ]
+        )
+        assert traj.any_truncated is True
+
+    def test_all_rewards_valid_false_on_invalid_turn(self):
+        traj = Trajectory(transitions=[_make_transition(valid=False)])
+        assert traj.all_rewards_valid is False
+
+    def test_add_turn_reward_default_targets_last_turn(self):
+        traj = Trajectory(
+            transitions=[
+                _make_transition(reward=0.1),
+                _make_transition(reward=0.2),
+            ]
+        )
+        traj.add_turn_reward(0.5)
+        assert traj.transitions[-1].reward == pytest.approx(0.7)
+        assert traj.transitions[0].reward == pytest.approx(0.1)
+
+    def test_add_turn_reward_specific_index(self):
+        traj = Trajectory(transitions=[_make_transition(reward=0.1), _make_transition(reward=0.2)])
+        traj.add_turn_reward(0.3, turn_index=0)
+        assert traj.transitions[0].reward == pytest.approx(0.4)
+        assert traj.transitions[1].reward == pytest.approx(0.2)
+
+    def test_add_turn_reward_on_empty_trajectory_raises(self):
+        with pytest.raises(ValueError, match="empty trajectory"):
+            Trajectory().add_turn_reward(1.0)
+
+
+class TestMessageEnv:
+    def test_abstract_methods_must_be_implemented(self):
+        with pytest.raises(TypeError):
+            MessageEnv()  # type: ignore[abstract]
+
+    def test_concrete_subclass_is_instantiable(self):
+        class _Impl(MessageEnv):
+            async def initial_messages(self):
+                return []
+
+            async def step(self, assistant_message):
+                return MessageStepResult(reward=0.0, episode_done=True)
+
+        env = _Impl()
+        assert isinstance(env, MessageEnv)

--- a/training/tests/unit/test_rl_env_adapters.py
+++ b/training/tests/unit/test_rl_env_adapters.py
@@ -1,0 +1,129 @@
+"""Unit tests for training.utils.rl.env_adapters."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from training.utils.rl.env import MessageEnv, MessageStepResult
+from training.utils.rl.env_adapters import SingleTurnEnv, _extract_text, wrap_reward_fn
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+class TestExtractText:
+    def test_none_returns_empty_string(self):
+        assert _extract_text(None) == ""
+
+    def test_str_passthrough(self):
+        assert _extract_text("hello") == "hello"
+
+    def test_list_of_parts_concatenated(self):
+        content = [{"type": "text", "text": "foo "}, {"type": "text", "text": "bar"}]
+        assert _extract_text(content) == "foo bar"
+
+    def test_list_with_non_dict_parts(self):
+        assert _extract_text(["a", "b", "c"]) == "abc"
+
+    def test_other_types_stringified(self):
+        assert _extract_text(42) == "42"
+
+
+class TestSingleTurnEnv:
+    def test_is_a_message_env(self):
+        env = SingleTurnEnv(row={}, reward_fn=lambda c, r: 0.0)
+        assert isinstance(env, MessageEnv)
+
+    def test_initial_messages_returns_row_messages(self):
+        msgs = [{"role": "user", "content": "hi"}]
+        env = SingleTurnEnv(row={"messages": msgs}, reward_fn=lambda c, r: 0.0)
+        result = _run(env.initial_messages())
+        assert result == msgs
+        # Defensive copy so mutating row doesn't mutate env output.
+        assert result is not msgs
+
+    def test_initial_messages_defaults_to_empty(self):
+        env = SingleTurnEnv(row={}, reward_fn=lambda c, r: 0.0)
+        assert _run(env.initial_messages()) == []
+
+    def test_custom_messages_field(self):
+        msgs = [{"role": "user", "content": "x"}]
+        env = SingleTurnEnv(row={"convo": msgs}, reward_fn=lambda c, r: 0.0, messages_field="convo")
+        assert _run(env.initial_messages()) == msgs
+
+    def test_step_calls_sync_reward_fn_with_text_and_row(self):
+        captured: dict = {}
+
+        def reward(completion, row):
+            captured["completion"] = completion
+            captured["row"] = row
+            return 0.75
+
+        env = SingleTurnEnv(row={"answer": 42, "messages": []}, reward_fn=reward)
+        result = _run(env.step({"role": "assistant", "content": "the answer"}))
+
+        assert isinstance(result, MessageStepResult)
+        assert result.reward == pytest.approx(0.75)
+        assert result.episode_done is True
+        assert result.next_messages == []
+        assert captured["completion"] == "the answer"
+        assert captured["row"] == {"answer": 42, "messages": []}
+
+    def test_step_awaits_async_reward_fn(self):
+        async def reward(completion, row):
+            return 1.0 if "yes" in completion else 0.0
+
+        env = SingleTurnEnv(row={}, reward_fn=reward)
+
+        assert _run(env.step({"role": "assistant", "content": "yes sir"})).reward == 1.0
+        assert _run(env.step({"role": "assistant", "content": "nope"})).reward == 0.0
+
+    def test_step_extracts_text_from_list_content(self):
+        seen: dict = {}
+
+        def reward(completion, row):
+            seen["text"] = completion
+            return 0.0
+
+        env = SingleTurnEnv(row={}, reward_fn=reward)
+        _run(
+            env.step(
+                {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "A"}, {"type": "text", "text": "B"}],
+                }
+            )
+        )
+        assert seen["text"] == "AB"
+
+    def test_step_coerces_reward_to_float(self):
+        env = SingleTurnEnv(row={}, reward_fn=lambda c, r: True)
+        assert _run(env.step({"role": "assistant", "content": ""})).reward == 1.0
+
+
+class TestWrapRewardFn:
+    def test_returns_env_builder_producing_single_turn_envs(self):
+        builder = wrap_reward_fn(lambda c, r: 0.5)
+        env = builder({"messages": [{"role": "user", "content": "q"}]})
+        assert isinstance(env, SingleTurnEnv)
+        result = _run(env.step({"role": "assistant", "content": "a"}))
+        assert result.reward == pytest.approx(0.5)
+
+    def test_builder_produces_fresh_env_each_call(self):
+        builder = wrap_reward_fn(lambda c, r: 0.0)
+        e1 = builder({})
+        e2 = builder({})
+        assert e1 is not e2
+
+    def test_rejects_non_callable(self):
+        with pytest.raises(TypeError, match="callable"):
+            wrap_reward_fn("not a function")  # type: ignore[arg-type]
+
+    def test_forwards_messages_field_kwarg(self):
+        builder = wrap_reward_fn(lambda c, r: 0.0, messages_field="convo")
+        msgs = [{"role": "user", "content": "x"}]
+        env = builder({"convo": msgs})
+        assert _run(env.initial_messages()) == msgs

--- a/training/tests/unit/test_rl_tokenize.py
+++ b/training/tests/unit/test_rl_tokenize.py
@@ -1,0 +1,249 @@
+"""Unit tests for training.utils.rl.tokenize helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from training.utils.rl import tokenize as tokenize_mod
+from training.utils.rl.tokenize import (
+    _normalize_inference_base_url,
+    get_prefill_logprobs,
+    tokenize_chat_turn,
+)
+
+
+class _FakeTokenizer:
+    """Minimal chat-template tokenizer.
+
+    Each message contributes a deterministic list of token IDs:
+    role=user -> [1, <content_len>], role=assistant -> [2, <content_len>,
+    3 (eot)], system -> [0, <content_len>]. ``add_generation_prompt`` adds
+    a trailing ``[99]`` marker.  Crucially, rendering the same message list
+    always yields the same prefix when more messages are appended, so the
+    prefix-diff in tokenize_chat_turn works.
+    """
+
+    _ROLE_TOKEN = {"system": 0, "user": 1, "assistant": 2}
+    _EOT = 3
+    _GEN_PROMPT = 99
+
+    def apply_chat_template(self, messages, *, tokenize=True, add_generation_prompt=False, **_):
+        out: list[int] = []
+        for m in messages:
+            role = m.get("role", "user")
+            content_len = len(str(m.get("content", "")))
+            out.append(self._ROLE_TOKEN.get(role, 1))
+            out.append(content_len)
+            if role == "assistant":
+                out.append(self._EOT)
+        if add_generation_prompt:
+            out.append(self._GEN_PROMPT)
+        if not tokenize:
+            raise NotImplementedError("fake only supports tokenize=True")
+        return out
+
+
+class TestTokenizeChatTurn:
+    def test_raises_when_prefix_invariant_violated(self):
+        """If the assistant turn isn't a strict extension of the rendered
+        prompt, the helper must fail loudly rather than silently derive
+        garbage completion_ids.  The default fake tokenizer violates the
+        invariant (the generation-prompt marker is outside the assistant
+        turn), so it's the natural negative-test fixture."""
+        tokenizer = _FakeTokenizer()
+        messages = [{"role": "user", "content": "hi"}]
+        assistant = {"role": "assistant", "content": "yo"}
+
+        with pytest.raises(RuntimeError, match="prefix extension"):
+            tokenize_chat_turn(messages, assistant, tokenizer)
+
+    def test_prefix_preserving_tokenizer_produces_expected_split(self):
+        """A chat template where the generation-prompt marker is *inside*
+        the assistant turn satisfies the strict-prefix invariant; the
+        helper then returns the assistant-added suffix as completion_ids."""
+
+        class _PrefixTokenizer:
+            _ROLE_TOKEN = {"system": 0, "user": 1, "assistant": 2}
+            _EOT = 3
+            _GEN_PROMPT = 99
+
+            def apply_chat_template(
+                self, messages, *, tokenize=True, add_generation_prompt=False, **_
+            ):
+                out: list[int] = []
+                for m in messages:
+                    role = m.get("role", "user")
+                    content_len = len(str(m.get("content", "")))
+                    if role == "assistant":
+                        out.append(self._GEN_PROMPT)  # part of assistant turn
+                        out.append(self._ROLE_TOKEN[role])
+                        out.append(content_len)
+                        out.append(self._EOT)
+                    else:
+                        out.append(self._ROLE_TOKEN.get(role, 1))
+                        out.append(content_len)
+                if add_generation_prompt:
+                    out.append(self._GEN_PROMPT)
+                return out
+
+        tokenizer = _PrefixTokenizer()
+        messages = [{"role": "user", "content": "hi"}]  # 2 chars
+        assistant = {"role": "assistant", "content": "yo"}  # 2 chars
+
+        prompt_ids, completion_ids = tokenize_chat_turn(messages, assistant, tokenizer)
+
+        # user: [1, 2], gen prompt: [99] -> prompt_ids = [1, 2, 99]
+        assert prompt_ids == [1, 2, 99]
+        # Full: user [1, 2] + assistant [99, 2, 2, 3] -> [1, 2, 99, 2, 2, 3].
+        # completion_ids is the suffix past the rendered prompt.
+        assert completion_ids == [2, 2, 3]
+
+    def test_multi_turn_prompt_includes_earlier_messages(self):
+        class _PrefixTokenizer:
+            _ROLE_TOKEN = {"system": 0, "user": 1, "assistant": 2}
+            _EOT = 3
+            _GEN_PROMPT = 99
+
+            def apply_chat_template(
+                self, messages, *, tokenize=True, add_generation_prompt=False, **_
+            ):
+                out: list[int] = []
+                for m in messages:
+                    role = m.get("role", "user")
+                    content_len = len(str(m.get("content", "")))
+                    if role == "assistant":
+                        out.extend([self._GEN_PROMPT, self._ROLE_TOKEN[role], content_len, self._EOT])
+                    else:
+                        out.extend([self._ROLE_TOKEN.get(role, 1), content_len])
+                if add_generation_prompt:
+                    out.append(self._GEN_PROMPT)
+                return out
+
+        tokenizer = _PrefixTokenizer()
+        messages = [
+            {"role": "system", "content": "s"},
+            {"role": "user", "content": "q1"},
+            {"role": "assistant", "content": "a1"},
+            {"role": "user", "content": "q2"},
+        ]
+        assistant = {"role": "assistant", "content": "a2"}
+
+        prompt_ids, completion_ids = tokenize_chat_turn(messages, assistant, tokenizer)
+
+        assert prompt_ids[-1] == 99, "generation prompt marker must end the prompt"
+        assert len(completion_ids) > 0
+        # The first assistant turn must appear before the generation prompt.
+        assert 3 in prompt_ids, "earlier assistant EOT should be preserved in prompt"
+
+
+class TestNormalizeInferenceBaseUrl:
+    def test_strips_inference_suffix(self):
+        assert _normalize_inference_base_url("https://host.example/inference") == "https://host.example"
+
+    def test_strips_inference_v1_suffix(self):
+        assert (
+            _normalize_inference_base_url("https://host.example/inference/v1")
+            == "https://host.example"
+        )
+
+    def test_strips_trailing_slash(self):
+        assert _normalize_inference_base_url("https://host.example/") == "https://host.example"
+
+    def test_leaves_other_urls_alone(self):
+        assert _normalize_inference_base_url("https://host.example/v1") == "https://host.example/v1"
+
+
+class TestGetPrefillLogprobs:
+    def test_returns_empty_for_no_tokens(self):
+        assert get_prefill_logprobs(url="x", tokens=[], api_key="k", model="m") == []
+
+    def test_returns_zero_padding_for_single_token(self):
+        assert get_prefill_logprobs(url="x", tokens=[5], api_key="k", model="m") == []
+
+    def test_aligns_and_drops_leading_none(self, monkeypatch):
+        captured: dict = {}
+
+        class _Resp:
+            status_code = 200
+
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {
+                    "choices": [
+                        {"logprobs": {"token_logprobs": [None, -0.1, -0.2, -0.3]}}
+                    ]
+                }
+
+        def fake_post(url, json=None, headers=None, timeout=None):
+            captured["url"] = url
+            captured["payload"] = json
+            captured["headers"] = headers
+            return _Resp()
+
+        monkeypatch.setattr(tokenize_mod.requests, "post", fake_post)
+
+        out = get_prefill_logprobs(
+            url="https://host/inference/v1",
+            tokens=[10, 20, 30, 40],
+            api_key="secret",
+            model="model-x",
+        )
+
+        assert out == [-0.1, -0.2, -0.3]
+        assert captured["url"].endswith("/inference/v1/completions")
+        assert captured["url"].startswith("https://host/")
+        assert captured["payload"]["prompt"] == [10, 20, 30, 40]
+        assert captured["payload"]["echo"] is True
+        assert captured["payload"]["max_tokens"] == 1
+        assert captured["payload"]["model"] == "model-x"
+        assert captured["headers"]["Authorization"] == "Bearer secret"
+
+    def test_pads_when_server_returns_fewer_logprobs(self, monkeypatch):
+        class _Resp:
+            status_code = 200
+
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"choices": [{"logprobs": {"token_logprobs": [None, -0.5]}}]}
+
+        monkeypatch.setattr(tokenize_mod.requests, "post", lambda *a, **kw: _Resp())
+
+        out = get_prefill_logprobs(
+            url="https://host", tokens=[1, 2, 3, 4], api_key="k", model="m"
+        )
+        # Expected length = len(tokens) - 1 = 3; server returned 1 aligned value.
+        assert out == [-0.5, 0.0, 0.0]
+
+    def test_replaces_none_logprobs_with_zero(self, monkeypatch):
+        class _Resp:
+            status_code = 200
+
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"choices": [{"logprobs": {"token_logprobs": [None, -0.1, None, -0.3]}}]}
+
+        monkeypatch.setattr(tokenize_mod.requests, "post", lambda *a, **kw: _Resp())
+
+        out = get_prefill_logprobs(url="https://host", tokens=[1, 2, 3, 4], api_key="k", model="m")
+        assert out == [-0.1, 0.0, -0.3]
+
+    def test_handles_empty_choices(self, monkeypatch):
+        class _Resp:
+            status_code = 200
+
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"choices": []}
+
+        monkeypatch.setattr(tokenize_mod.requests, "post", lambda *a, **kw: _Resp())
+
+        out = get_prefill_logprobs(url="https://host", tokens=[1, 2, 3], api_key="k", model="m")
+        assert out == [0.0, 0.0]

--- a/training/utils/rl/__init__.py
+++ b/training/utils/rl/__init__.py
@@ -33,6 +33,16 @@ __all__ = [
     "expand_turn_advantages_from_spans",
     "make_igpo_loss_fn",
     "score_prefix",
+    # Env-based rollout abstraction
+    "Message",
+    "MessageEnv",
+    "MessageStepResult",
+    "Transition",
+    "Trajectory",
+    "SingleTurnEnv",
+    "wrap_reward_fn",
+    "tokenize_chat_turn",
+    "get_prefill_logprobs",
 ]
 
 from training.utils.rl.pp import PPBatchRecommendation, compute_pp_recommendation
@@ -63,3 +73,12 @@ from training.utils.rl.igpo import (
     make_igpo_loss_fn,
     score_prefix,
 )
+from training.utils.rl.env import (
+    Message,
+    MessageEnv,
+    MessageStepResult,
+    Trajectory,
+    Transition,
+)
+from training.utils.rl.env_adapters import SingleTurnEnv, wrap_reward_fn
+from training.utils.rl.tokenize import get_prefill_logprobs, tokenize_chat_turn

--- a/training/utils/rl/env.py
+++ b/training/utils/rl/env.py
@@ -1,0 +1,166 @@
+"""Message-level RL environment abstraction.
+
+This module defines the extension point that user recipes implement to plug
+a custom task into ``rl_loop.py``.  The training loop never knows how a
+reward was computed or whether a rollout was single- or multi-turn — it only
+consumes :class:`Trajectory` objects produced by running a :class:`MessageEnv`.
+
+Concepts
+--------
+- :class:`MessageEnv` — stateful, single-use environment operating at the
+  chat-message level.  Subclass this for any custom task.
+- :class:`MessageStepResult` — what :meth:`MessageEnv.step` returns: the
+  reward for the assistant turn plus whether the episode is done and any
+  messages to append before the next sample.
+- :class:`Transition` — one completed turn: the assistant tokens, their
+  per-token inference logprobs, the reward, and metrics.
+- :class:`Trajectory` — ordered list of :class:`Transition`.  A single-turn
+  task produces a trajectory with exactly one transition.
+
+Extension points in :class:`Trajectory` are deliberately minimal.  Users do
+not construct Transitions themselves; the rollout runner does that from the
+sampler output and the :class:`MessageStepResult` the env returned.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any
+
+Message = dict[str, Any]
+"""Chat message, OpenAI-compatible: ``{"role": ..., "content": ..., ...}``."""
+
+
+@dataclass
+class MessageStepResult:
+    """Result of a single assistant turn.
+
+    Attributes:
+        reward: Immediate reward for the assistant turn.
+        episode_done: Whether the episode has ended.  Single-turn envs always
+            set this to ``True``.
+        next_messages: Messages (e.g. tool results, simulator feedback) to
+            append to the conversation *before* the next sample.  Empty when
+            the episode is done.
+        metrics: Per-turn scalar metrics merged into training logs.
+        is_reward_valid: Set to ``False`` when the grader could not score the
+            turn (e.g. remote grader returned ``transient=true``).  The
+            rollout runner may drop rollouts whose final turn is invalid.
+    """
+
+    reward: float
+    episode_done: bool
+    next_messages: list[Message] = field(default_factory=list)
+    metrics: dict[str, float] = field(default_factory=dict)
+    is_reward_valid: bool = True
+
+
+class MessageEnv(ABC):
+    """Stateful, single-use environment operating at the chat-message level.
+
+    Subclasses implement :meth:`initial_messages` (the starting conversation)
+    and :meth:`step` (score one assistant turn and decide what happens next).
+    The training loop creates a fresh env per rollout — do not assume any
+    env is reused.
+
+    Minimal single-turn example::
+
+        class MathEnv(MessageEnv):
+            def __init__(self, row):
+                self.row = row
+
+            async def initial_messages(self):
+                return self.row["messages"]
+
+            async def step(self, assistant_message):
+                completion = assistant_message.get("content", "")
+                reward = 1.0 if self.row["answer"] in completion else 0.0
+                return MessageStepResult(reward=reward, episode_done=True)
+
+    Multi-turn envs should keep episode state on ``self`` and terminate by
+    returning ``episode_done=True``.
+    """
+
+    @abstractmethod
+    async def initial_messages(self) -> list[Message]:
+        """Return the conversation the agent sees before its first turn."""
+
+    @abstractmethod
+    async def step(self, assistant_message: Message) -> MessageStepResult:
+        """Score one assistant turn and advance the environment."""
+
+
+@dataclass
+class Transition:
+    """One completed turn within a :class:`Trajectory`.
+
+    Attributes:
+        prompt_tokens: Rendered prompt tokens the sampler saw at this turn.
+        completion_tokens: Assistant tokens produced by the sampler.
+        completion_text: Decoded assistant text, convenient for graders and
+            trajectory logging.
+        inference_logprobs: Per-token logprobs from the sampler (aligned with
+            ``completion_tokens``).  ``None`` when the rollout source does
+            not return them; the rollout builder will recover them via an
+            ``echo=True`` prefill call.
+        assistant_message: The structured assistant message (role/content/
+            tool_calls) passed to :meth:`MessageEnv.step`.
+        reward: Reward returned by :meth:`MessageEnv.step`.
+        episode_done: Whether this transition ended the episode.
+        finish_reason: Sampler-reported finish reason (``"stop"``, ``"length"``,
+            ...).  Used to flag truncation.
+        is_reward_valid: Propagated from :class:`MessageStepResult`.
+        metrics: Per-turn scalars.
+        routing_matrices: Optional MoE routing matrices for router replay.
+    """
+
+    prompt_tokens: list[int]
+    completion_tokens: list[int]
+    completion_text: str
+    inference_logprobs: list[float] | None
+    assistant_message: Message
+    reward: float
+    episode_done: bool
+    finish_reason: str = "stop"
+    is_reward_valid: bool = True
+    metrics: dict[str, float] = field(default_factory=dict)
+    routing_matrices: Any | None = None
+
+
+@dataclass
+class Trajectory:
+    """Ordered list of :class:`Transition` making up one episode."""
+
+    transitions: list[Transition] = field(default_factory=list)
+
+    @property
+    def total_reward(self) -> float:
+        """Sum of per-turn rewards across the trajectory."""
+        return float(sum(t.reward for t in self.transitions))
+
+    @property
+    def is_complete(self) -> bool:
+        """Whether the trajectory ended with an ``episode_done=True`` turn."""
+        return bool(self.transitions) and self.transitions[-1].episode_done
+
+    @property
+    def any_truncated(self) -> bool:
+        """Whether any turn hit the token budget (``finish_reason == "length"``)."""
+        return any(t.finish_reason == "length" for t in self.transitions)
+
+    @property
+    def all_rewards_valid(self) -> bool:
+        """Whether every turn had ``is_reward_valid=True``."""
+        return all(t.is_reward_valid for t in self.transitions)
+
+    def add_turn_reward(self, delta: float, *, turn_index: int = -1) -> None:
+        """Add ``delta`` to the reward of one turn.
+
+        Used by ``group_reward_fn`` to fold group-level rewards (pairwise
+        reward models, etc.) back into the trajectory.  Default target is
+        the final turn.
+        """
+        if not self.transitions:
+            raise ValueError("Cannot add reward to an empty trajectory")
+        self.transitions[turn_index].reward += float(delta)

--- a/training/utils/rl/env_adapters.py
+++ b/training/utils/rl/env_adapters.py
@@ -1,0 +1,94 @@
+"""Adapters that lower simpler user-supplied inputs to a :class:`MessageEnv`.
+
+These keep the ergonomic entry points cheap for the common cases:
+
+- :class:`SingleTurnEnv` wraps a plain ``reward_fn(completion, row) -> float``
+  into a one-step :class:`MessageEnv`.  The 80% of recipes that just want a
+  custom reward never subclass :class:`MessageEnv` directly.
+- :func:`wrap_reward_fn` takes a sync or async reward callable and returns
+  an ``env_builder`` suitable for :data:`rl_loop.Config.env_builder`.
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any, Awaitable, Callable, Union
+
+from training.utils.rl.env import Message, MessageEnv, MessageStepResult
+
+RewardFn = Callable[[str, dict], Union[float, Awaitable[float]]]
+"""Reward callable: ``(completion_text, row) -> float | Awaitable[float]``."""
+
+EnvBuilder = Callable[[dict], MessageEnv]
+"""Row → env factory used by the RL loop to construct one env per rollout."""
+
+
+def _extract_text(content: Any) -> str:
+    """Coerce OpenAI-style ``content`` (str or list-of-parts) to a string."""
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for part in content:
+            if isinstance(part, dict):
+                parts.append(str(part.get("text", "")))
+            else:
+                parts.append(str(part))
+        return "".join(parts)
+    return str(content)
+
+
+class SingleTurnEnv(MessageEnv):
+    """One-step :class:`MessageEnv` driven by a user-supplied ``reward_fn``.
+
+    Takes a dataset row and a reward callable; runs one turn, extracts the
+    assistant completion text, awaits the reward (if async), and terminates.
+
+    The row is expected to carry a ``messages`` field (OpenAI-compatible
+    chat list).  If absent, ``initial_messages`` returns an empty list so
+    downstream rendering raises a clear error.
+    """
+
+    def __init__(
+        self,
+        row: dict,
+        reward_fn: RewardFn,
+        *,
+        messages_field: str = "messages",
+    ) -> None:
+        self._row = row
+        self._reward_fn = reward_fn
+        self._messages_field = messages_field
+
+    async def initial_messages(self) -> list[Message]:
+        return list(self._row.get(self._messages_field, []))
+
+    async def step(self, assistant_message: Message) -> MessageStepResult:
+        completion = _extract_text(assistant_message.get("content"))
+        result = self._reward_fn(completion, self._row)
+        if inspect.isawaitable(result):
+            result = await result
+        reward = float(result)
+        return MessageStepResult(reward=reward, episode_done=True)
+
+
+def wrap_reward_fn(reward_fn: RewardFn, **single_turn_kwargs: Any) -> EnvBuilder:
+    """Return an env-builder that wraps ``reward_fn`` into a :class:`SingleTurnEnv`.
+
+    Usage::
+
+        train(Config(..., env_builder=wrap_reward_fn(my_reward)))
+
+    Equivalent to, but more explicit than, setting ``Config.reward_fn`` —
+    the RL loop auto-wraps ``reward_fn`` internally on behalf of users who
+    just want the default single-turn path.
+    """
+    if not callable(reward_fn):
+        raise TypeError(f"reward_fn must be callable, got {type(reward_fn).__name__}")
+
+    def _build(row: dict) -> MessageEnv:
+        return SingleTurnEnv(row=row, reward_fn=reward_fn, **single_turn_kwargs)
+
+    return _build

--- a/training/utils/rl/tokenize.py
+++ b/training/utils/rl/tokenize.py
@@ -1,0 +1,146 @@
+"""Client-side tokenization helpers used by RL rollout plumbing.
+
+The training loop needs two things no external rollout source reliably
+provides:
+
+1. **Chat-template tokenization** — turning a message list + assistant reply
+   into the exact prompt/completion token IDs the trainer expects.
+2. **Inference-logprob recovery** — for importance-sampling-family losses
+   (GRPO/DAPO/CISPO/GSPO) we need per-token logprobs aligned with the
+   tokenized completion.  Samplers that produce text-only responses
+   (remote agents, EP rollouts, judge pipelines) do not return these, so
+   we recover them via an ``echo=True`` prefill call.
+
+Both helpers are dependency-light and framework-neutral: they expect an
+HF-compatible tokenizer and an HTTP endpoint speaking the OpenAI
+``/v1/completions`` schema.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import requests
+
+
+def tokenize_chat_turn(
+    messages: list[dict[str, Any]],
+    assistant_message: dict[str, Any],
+    tokenizer: Any,
+    *,
+    add_generation_prompt: bool = True,
+) -> tuple[list[int], list[int]]:
+    """Return ``(prompt_ids, completion_ids)`` for one assistant turn.
+
+    ``prompt_ids`` are what the sampler would have seen (rendered via the
+    tokenizer's chat template with ``add_generation_prompt=True``).
+    ``completion_ids`` are the delta introduced by appending the assistant
+    turn — computed as ``apply_chat_template([*messages, assistant_message])``
+    minus the prompt prefix, so it includes any template-added assistant
+    role markers / end-of-turn tokens.
+
+    Args:
+        messages: Conversation before this turn (system/user/tool messages).
+        assistant_message: The assistant turn to encode.
+        tokenizer: HuggingFace-compatible tokenizer with
+            ``apply_chat_template``.
+        add_generation_prompt: Passed through when rendering the prompt.
+    """
+    prompt_ids = list(
+        tokenizer.apply_chat_template(
+            list(messages),
+            add_generation_prompt=add_generation_prompt,
+            tokenize=True,
+        )
+    )
+    full_ids = list(
+        tokenizer.apply_chat_template(
+            [*messages, assistant_message],
+            add_generation_prompt=False,
+            tokenize=True,
+        )
+    )
+    if len(full_ids) < len(prompt_ids) or full_ids[: len(prompt_ids)] != prompt_ids:
+        raise RuntimeError(
+            "Chat-template rendering is not a strict prefix extension. "
+            "Tokenizer likely rewrote earlier tokens when the assistant "
+            "turn was appended; cannot derive completion_ids by diff."
+        )
+    completion_ids = full_ids[len(prompt_ids) :]
+    return prompt_ids, completion_ids
+
+
+def _normalize_inference_base_url(url: str) -> str:
+    """Strip trailing ``/inference`` or ``/inference/v1`` from ``url``."""
+    normalized = url.rstrip("/")
+    for suffix in ("/inference/v1", "/inference"):
+        if normalized.endswith(suffix):
+            return normalized[: -len(suffix)]
+    return normalized
+
+
+def get_prefill_logprobs(
+    *,
+    url: str,
+    tokens: list[int],
+    api_key: str,
+    model: str,
+    timeout: float = 180.0,
+) -> list[float]:
+    """Recover per-token inference logprobs for a known token sequence.
+
+    Issues an ``echo=True`` + ``max_tokens=1`` completion so the server
+    scores ``tokens`` under the current (possibly hotloaded) policy without
+    generating anything new.  Returns ``len(tokens) - 1`` logprobs aligned
+    so that index ``i`` is the logprob of ``tokens[i + 1]`` conditioned on
+    ``tokens[:i + 1]``.
+
+    Used when the rollout source returned text only (no token-aligned
+    logprobs) and the configured loss needs ``inf_logprobs`` for
+    importance-sampling correction.
+    """
+    if not tokens:
+        return []
+    if len(tokens) < 2:
+        return [0.0] * (len(tokens) - 1)
+
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {api_key}",
+        "X-Api-Key": api_key,
+    }
+    payload: dict[str, Any] = {
+        "prompt": tokens,
+        "max_tokens": 1,
+        "echo": True,
+        "logprobs": True,
+        "prompt_cache_max_len": 0,
+    }
+    if model:
+        payload["model"] = model
+
+    base_url = _normalize_inference_base_url(url)
+    response = requests.post(
+        f"{base_url}/inference/v1/completions",
+        json=payload,
+        headers=headers,
+        timeout=timeout,
+    )
+    response.raise_for_status()
+    result = response.json()
+
+    choices = result.get("choices") or []
+    if not choices:
+        return [0.0] * (len(tokens) - 1)
+
+    logprobs_data = choices[0].get("logprobs") or {}
+    token_logprobs = logprobs_data.get("token_logprobs") or []
+
+    # Echo returns one logprob per token; the first is always ``None`` (no
+    # conditioning).  Drop it and pad to the expected length so the caller
+    # can assume ``len(out) == len(tokens) - 1``.
+    aligned = [float(lp) if lp is not None else 0.0 for lp in token_logprobs[1 : len(tokens)]]
+    expected = len(tokens) - 1
+    if len(aligned) < expected:
+        aligned.extend([0.0] * (expected - len(aligned)))
+    return aligned


### PR DESCRIPTION
## Summary

First of 3 PRs that refactor the RL training loop so users can plug in a custom rollout/eval (multi-turn agents, remote graders, tool-using envs, etc.) without forking `rl_loop.py`. This PR lands the foundational, **additive-only** types and helpers. No behavior change.

## What's in this PR

Three new modules under `training/utils/rl/`:

| Module | Purpose |
|---|---|
| `env.py` | `MessageEnv` (ABC), `MessageStepResult`, `Transition`, `Trajectory`. Zero external deps. |
| `env_adapters.py` | `SingleTurnEnv(row, reward_fn)` wraps a plain `reward_fn(completion, row) -> float` into a one-step env; `wrap_reward_fn` produces an env-builder. Lets the 80% case stay a one-liner. |
| `tokenize.py` | `tokenize_chat_turn` (strict-prefix chat-template split) + `get_prefill_logprobs` (echo=True logprob recovery for rollout sources that return text only, e.g. remote agents / judge pipelines). |

`training/utils/rl/__init__.py` re-exports the new names. `rl_loop.py`, the default sampler path, and existing recipes are untouched.

## Follow-ups (separate PRs)

1. `rollout_runner.py` — group-level runner with first-turn batching so single-turn groups keep today's one-call-per-group efficiency.
2. `rollout_builder.py` — `Trajectory → PromptGroup`; lifts the ~200 core lines out of `sample_one_prompt`.
3. Rewire `rl_loop.Config` with `reward_fn` / `env_builder` / `rollout_source` / `group_reward_fn`; delete the module-level `rl_loop.reward_fn` monkey-patch path; port DeepMath recipe.

## Design context

Motivated by a customer fork (`rollr_cispo`) that had to copy ~1000 lines of `rl_loop.main` to replace a single-turn sampler with their remote-agent rollout source. Earlier design-plan discussion drew on `tinker-cookbook`'s env/trajectory abstraction, with three deliberate deviations to keep our surface smaller:

- Only a **message-level** `MessageEnv` (no token-level `Env` in the public API).
- `group_size` stays a loop parameter; no user-facing `EnvGroupBuilder`.
- `dataset` stays `str | Iterable[dict]`; no `RLDatasetBuilder`.

## Test plan

- [x] 42 new unit tests in `test_rl_env.py`, `test_rl_env_adapters.py`, `test_rl_tokenize.py`. All pass.
- [x] 86 pre-existing tests (`test_rl_loop.py`, `test_rl_train.py`, `test_rl_metrics_aliases.py`, `test_smoke_imports.py`) still pass — no behavior change expected since this PR is additive.
- [x] `get_prefill_logprobs` tests monkey-patch `requests.post`; no network required.
- [x] `tokenize_chat_turn` tests use fake tokenizers; no HF model download required.

## Notes

- No changes to `rl_loop.py`. This PR is safe to land on its own.
- No dependency additions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)