### PR TITLE
feat(rl): multi-minibatch PPO loop with single prox snapshot

### DIFF
--- a/training/recipes/rl_loop.py
+++ b/training/recipes/rl_loop.py
@@ -24,11 +24,12 @@ from __future__ import annotations
 import os
 import re
 import json
+import math
 import signal
 import asyncio
 import logging
 from contextlib import ExitStack
-from typing import List, Optional
+from typing import Any, List, Optional
 from dataclasses import field, dataclass
 from concurrent.futures import ThreadPoolExecutor
 
@@ -145,6 +146,14 @@ class Config:
     """Asymmetric upper clip bound (GRPO only)."""
     ratio_log_cap: float = 20.0
     """Log-ratio clamp for ``policy_loss="importance_sampling"``."""
+    ppo_n_minibatches: int = 1
+    """Number of inner PPO minibatches per rollout batch.
+
+    Each rollout batch runs one ``prox_fwd`` snapshot followed by
+    ``ppo_n_minibatches`` × (``forward_backward`` + ``optim_step``). When
+    >1, the policy drifts across inner steps, so ``prox_lp`` anchors the
+    PPO ratio and the clip does real work. ``1`` reproduces the legacy
+    1:1 behavior."""
     tis: TISConfig = field(default_factory=TISConfig)
     """TIS (Train-Inference IS) weight correction config."""
 
@@ -622,23 +631,15 @@ def main(
             eps_clip_high=cfg.eps_clip_high,
         )
 
-        def fwd_bwd_one(prompt_groups: list[PromptGroup]):
-            """One minibatch update using the builtin or client-side loss path."""
-            if not prompt_groups:
-                raise ValueError("fwd_bwd_one requires at least one prompt group")
+        def fwd_bwd_minibatch(
+            data, adv, ref_lp, prompt_lens, inf_lp, prox_lp,
+        ):
+            """One inner PPO minibatch using builtin or client-side loss path.
 
-            data, adv, ref_lp, prompt_lens, inf_lp = combine_prompt_groups(prompt_groups)
-
-            t0 = _time.time()
-            prox_fwd = policy.forward(data, "cross_entropy")
-            prox_lp = [prox_fwd.loss_fn_outputs[i]["logprobs"].data for i in range(len(data))]
-            logger.info("policy_forward: done (%.1fs)", _time.time() - t0)
-
-            t0 = _time.time()
+            Callers pre-compute ``prox_lp`` once per rollout batch and pass
+            a slice of the flattened rollout tensors for this minibatch.
+            """
             if builtin_server_loss is not None:
-                # Server-side builtin path: pre-pack the rollout tensors into
-                # datums the trainer kernel understands, then call
-                # forward_backward(...).
                 kernel_loss, kernel_config = builtin_server_loss
                 rl_datums = build_builtin_loss_datums(
                     data,
@@ -649,69 +650,106 @@ def main(
                     cfg.tis,
                     policy_loss=cfg.policy_loss,
                 )
-                fwd_bwd_result = policy.forward_backward(
+                return policy.forward_backward(
                     rl_datums,
                     kernel_loss,
                     loss_fn_config=kernel_config,
                 )
-            else:
-                # Client-side custom path: execute the Python loss closure
-                # returned by build_loss_fn(...) via forward_backward_custom(...).
-                fwd_bwd_result = policy.forward_backward_custom(
-                    data,
-                    client_loss_builder(adv, ref_lp, prompt_lens, inf_lp, prox_lp),
-                )
-            logger.info("fwd_bwd: done (%.1fs)", _time.time() - t0)
-            return fwd_bwd_result
+            return policy.forward_backward_custom(
+                data,
+                client_loss_builder(adv, ref_lp, prompt_lens, inf_lp, prox_lp),
+            )
 
         def train_step(
             step: int,
             prompt_groups: list[PromptGroup],
             loop_stats: dict | None = None,
         ) -> tuple[int, dict]:
-            """ref_forward + fwd_bwd + optim_step + metrics (1:1)."""
+            """ref_forward + prox_fwd (once) + K × (fwd_bwd + optim_step) + metrics.
+
+            ``K = cfg.ppo_n_minibatches``. ``prox_lp`` is snapshotted once per
+            rollout batch and reused across all K inner optim steps so the
+            PPO ratio measures genuine policy drift. DCP checkpoints fire
+            only at rollout boundaries (cadence in rollout batches, not
+            optim steps) so resume accounting stays K-independent.
+            """
+            if not prompt_groups:
+                raise ValueError("train_step requires at least one prompt group")
+
             t0 = _time.time()
             ref_forward(prompt_groups)
             logger.info("[step %d] ref_forward: done (%.1fs)", step + 1, _time.time() - t0)
 
+            data, adv, ref_lp, prompt_lens, inf_lp = combine_prompt_groups(prompt_groups)
             t0 = _time.time()
-            fwd_bwd_result = fwd_bwd_one(prompt_groups)
-            logger.info("[step %d] fwd_bwd: done (%.1fs)", step + 1, _time.time() - t0)
+            prox_fwd = policy.forward(data, "cross_entropy")
+            prox_lp = [prox_fwd.loss_fn_outputs[i]["logprobs"].data for i in range(len(data))]
+            logger.info("[step %d] prox_forward: done (%.1fs)", step + 1, _time.time() - t0)
 
-            t0 = _time.time()
-            optim_result = policy.optim_step(
-                adam_params,
-                grad_accumulation_normalization=cfg.grad_accumulation_normalization,
-            )
-            step += 1
-            logger.info("[step %d] optim_step: done (%.1fs)", step, _time.time() - t0)
+            n = len(data)
+            K = max(1, cfg.ppo_n_minibatches)
+            minibatch_size = max(1, math.ceil(n / K))
+            fwd_bwd_results: list = []
+            optim_result: Any = None
+            for k_idx in range(K):
+                minibatch_start = k_idx * minibatch_size
+                minibatch_end = min(minibatch_start + minibatch_size, n)
+                if minibatch_start >= minibatch_end:
+                    break
 
-            if cfg.weight_sync.dcp_save_interval > 0 and step % cfg.weight_sync.dcp_save_interval == 0:
+                t0 = _time.time()
+                fwd_bwd_results.append(fwd_bwd_minibatch(
+                    data[minibatch_start:minibatch_end],
+                    adv[minibatch_start:minibatch_end],
+                    ref_lp[minibatch_start:minibatch_end],
+                    prompt_lens[minibatch_start:minibatch_end],
+                    inf_lp[minibatch_start:minibatch_end],
+                    prox_lp[minibatch_start:minibatch_end],
+                ))
+                logger.info(
+                    "[step %d] fwd_bwd (mb %d/%d): done (%.1fs)",
+                    step + 1, k_idx + 1, K, _time.time() - t0,
+                )
+
+                t0 = _time.time()
+                optim_result = policy.optim_step(
+                    adam_params,
+                    grad_accumulation_normalization=cfg.grad_accumulation_normalization,
+                )
+                step += 1
+                logger.info(
+                    "[step %d] optim_step (mb %d/%d): done (%.1fs)",
+                    step, k_idx + 1, K, _time.time() - t0,
+                )
+
+            rollouts_completed = (step - step_offset) // K
+            dcp_interval = cfg.weight_sync.dcp_save_interval
+            if dcp_interval > 0 and rollouts_completed > 0 and rollouts_completed % dcp_interval == 0:
                 logger.info("[step %d] dcp_save...", step)
                 t0 = _time.time()
-                logger.info("[step %d] dcp_save: done (%.1fs)", step, _time.time() - t0)
-                _data_consumed = (resume_info.data_consumed if resume_info else 0) + (
-                    step - step_offset
-                ) * prompt_groups_per_step
+                data_consumed = (resume_info.data_consumed if resume_info else 0) + (
+                    rollouts_completed * prompt_groups_per_step
+                )
                 save_checkpoint(
                     policy,
                     f"step-{step}",
                     cfg.log_path,
                     {
                         "step": step,
-                        "data_consumed": _data_consumed,
+                        "data_consumed": data_consumed,
                         "source_job_id": policy_job_id,
                     },
                     kind=CheckpointKind.STATE,
                     base_model=cfg.base_model,
                     training_shape=infra.training_shape_id,
                 )
+                logger.info("[step %d] dcp_save: done (%.1fs)", step, _time.time() - t0)
 
             metrics = compute_step_metrics(
                 prompt_groups=prompt_groups,
-                fwd_bwd_results=[fwd_bwd_result],
+                fwd_bwd_results=fwd_bwd_results,
                 optim_result=optim_result,
-                n_accum=1,
+                n_accum=len(fwd_bwd_results),
                 timing_metrics=flush_timing(),
                 loop_stats=loop_stats,
                 completions_per_prompt=completions_per_prompt,
@@ -734,7 +772,7 @@ def main(
             log_metrics_json(step, reward=avg_reward, accuracy=avg_acc, kl=avg_kl)
             wandb_log(metrics, step)
 
-            total_rl_steps = len(rl_dataset) - step_offset
+            total_rl_steps = len(rl_dataset) * max(1, cfg.ppo_n_minibatches) - step_offset
             runner.append_metrics(step, metrics, tokens=step_tokens)
             runner.write_status(
                 RunStatus.RUNNING, step=step, total_steps=total_rl_steps, message="training",
@@ -769,7 +807,7 @@ def main(
         for i_step in range(step_offset, len(rl_dataset)):
             remaining_rows.extend(rl_dataset.get_batch(i_step))
 
-        total_rl_steps = len(rl_dataset) - step_offset
+        total_rl_steps = len(rl_dataset) * max(1, cfg.ppo_n_minibatches) - step_offset
         runner.start_training()
         runner.write_status(RunStatus.RUNNING, total_steps=total_rl_steps, message="training")
 

--- a/training/recipes/rl_loop.py
+++ b/training/recipes/rl_loop.py
@@ -665,13 +665,13 @@ def main(
             prompt_groups: list[PromptGroup],
             loop_stats: dict | None = None,
         ) -> tuple[int, dict]:
-            """ref_forward + prox_fwd (once) + K × (fwd_bwd + optim_step) + metrics.
+            """ref_forward + prox_fwd (once) + num_minibatches × (fwd_bwd + optim_step) + metrics.
 
-            ``K = cfg.ppo_n_minibatches``. ``prox_lp`` is snapshotted once per
-            rollout batch and reused across all K inner optim steps so the
-            PPO ratio measures genuine policy drift. DCP checkpoints fire
-            only at rollout boundaries (cadence in rollout batches, not
-            optim steps) so resume accounting stays K-independent.
+            ``num_minibatches = cfg.ppo_n_minibatches``. ``prox_lp`` is snapshotted
+            once per rollout batch and reused across every inner optim step so
+            the PPO ratio measures genuine policy drift. DCP checkpoints fire
+            only at rollout boundaries (cadence in rollout batches, not optim
+            steps) so resume accounting is independent of the minibatch count.
             """
             if not prompt_groups:
                 raise ValueError("train_step requires at least one prompt group")
@@ -687,12 +687,12 @@ def main(
             logger.info("[step %d] prox_forward: done (%.1fs)", step + 1, _time.time() - t0)
 
             n = len(data)
-            K = max(1, cfg.ppo_n_minibatches)
-            minibatch_size = max(1, math.ceil(n / K))
+            num_minibatches = max(1, cfg.ppo_n_minibatches)
+            minibatch_size = max(1, math.ceil(n / num_minibatches))
             fwd_bwd_results: list = []
             optim_result: Any = None
-            for k_idx in range(K):
-                minibatch_start = k_idx * minibatch_size
+            for minibatch_idx in range(num_minibatches):
+                minibatch_start = minibatch_idx * minibatch_size
                 minibatch_end = min(minibatch_start + minibatch_size, n)
                 if minibatch_start >= minibatch_end:
                     break
@@ -708,7 +708,7 @@ def main(
                 ))
                 logger.info(
                     "[step %d] fwd_bwd (mb %d/%d): done (%.1fs)",
-                    step + 1, k_idx + 1, K, _time.time() - t0,
+                    step + 1, minibatch_idx + 1, num_minibatches, _time.time() - t0,
                 )
 
                 t0 = _time.time()
@@ -719,10 +719,10 @@ def main(
                 step += 1
                 logger.info(
                     "[step %d] optim_step (mb %d/%d): done (%.1fs)",
-                    step, k_idx + 1, K, _time.time() - t0,
+                    step, minibatch_idx + 1, num_minibatches, _time.time() - t0,
                 )
 
-            rollouts_completed = (step - step_offset) // K
+            rollouts_completed = (step - step_offset) // num_minibatches
             dcp_interval = cfg.weight_sync.dcp_save_interval
             if dcp_interval > 0 and rollouts_completed > 0 and rollouts_completed % dcp_interval == 0:
                 logger.info("[step %d] dcp_save...", step)

--- a/training/recipes/rl_loop.py
+++ b/training/recipes/rl_loop.py
@@ -803,8 +803,12 @@ def main(
 
         train_fns = TrainStepFns(train_step=train_step)
 
+        # ``step_offset`` counts optim steps (one per inner minibatch); the
+        # dataset is indexed per rollout batch, so divide by ppo_n_minibatches
+        # when resuming under K>1.
+        resume_rollouts = step_offset // max(1, cfg.ppo_n_minibatches)
         remaining_rows = []
-        for i_step in range(step_offset, len(rl_dataset)):
+        for i_step in range(resume_rollouts, len(rl_dataset)):
             remaining_rows.extend(rl_dataset.get_batch(i_step))
 
         total_rl_steps = len(rl_dataset) * max(1, cfg.ppo_n_minibatches) - step_offset
@@ -828,9 +832,12 @@ def main(
 
         if cfg.save_final_checkpoint and global_step > step_offset:
             try:
+                # global_step - step_offset is optim-step delta (K× per rollout),
+                # so divide by ppo_n_minibatches to get rollout-batch delta.
+                _rollouts_this_run = (global_step - step_offset) // max(1, cfg.ppo_n_minibatches)
                 _data_consumed = (resume_info.data_consumed if resume_info else 0) + (
-                    global_step - step_offset
-                ) * prompt_groups_per_step
+                    _rollouts_this_run * prompt_groups_per_step
+                )
                 cp_name = f"step-{global_step}"
                 paths = save_checkpoint(
                     policy,

--- a/training/recipes/rl_loop.py
+++ b/training/recipes/rl_loop.py
@@ -82,7 +82,7 @@ from training.utils.rl.losses import (
     combine_prompt_groups,
     resolve_builtin_loss,
 )
-from training.utils.rl.metrics import add_inference_numerics, compute_step_metrics
+from training.utils.rl.metrics import compute_step_metrics
 from training.utils.rl.router_replay import build_r3_routing_matrices
 
 logger = logging.getLogger(__name__)
@@ -753,16 +753,6 @@ def main(
                 timing_metrics=flush_timing(),
                 loop_stats=loop_stats,
                 completions_per_prompt=completions_per_prompt,
-            )
-            # Server-side builtin loss kernels bypass the client-side loss_loop
-            # where ``inference_diff``/``inference_kld`` are computed, so emit
-            # them here from the rollout-boundary prox/inf snapshots. Required
-            # by the numerics CI gate; decoupled from policy_loss choice.
-            add_inference_numerics(
-                metrics,
-                prox_logprobs=prox_lp,
-                inf_logprobs=inf_lp,
-                prompt_lens=prompt_lens,
             )
             metrics["train/step"] = step
 

--- a/training/recipes/rl_loop.py
+++ b/training/recipes/rl_loop.py
@@ -82,7 +82,7 @@ from training.utils.rl.losses import (
     combine_prompt_groups,
     resolve_builtin_loss,
 )
-from training.utils.rl.metrics import compute_step_metrics
+from training.utils.rl.metrics import add_inference_numerics, compute_step_metrics
 from training.utils.rl.router_replay import build_r3_routing_matrices
 
 logger = logging.getLogger(__name__)
@@ -753,6 +753,16 @@ def main(
                 timing_metrics=flush_timing(),
                 loop_stats=loop_stats,
                 completions_per_prompt=completions_per_prompt,
+            )
+            # Server-side builtin loss kernels bypass the client-side loss_loop
+            # where ``inference_diff``/``inference_kld`` are computed, so emit
+            # them here from the rollout-boundary prox/inf snapshots. Required
+            # by the numerics CI gate; decoupled from policy_loss choice.
+            add_inference_numerics(
+                metrics,
+                prox_logprobs=prox_lp,
+                inf_logprobs=inf_lp,
+                prompt_lens=prompt_lens,
             )
             metrics["train/step"] = step
 

--- a/training/tests/unit/test_rl_loop.py
+++ b/training/tests/unit/test_rl_loop.py
@@ -88,7 +88,3 @@ def test_main_requires_deployment_tokenizer_model(monkeypatch):
         module.main(cfg)
 
 
-
-
-
-

--- a/training/tests/unit/test_rl_metrics_aliases.py
+++ b/training/tests/unit/test_rl_metrics_aliases.py
@@ -84,3 +84,51 @@ class TestComputeStepMetrics:
         assert "rollout/filter_ratio" not in metrics
         assert "rollout/sample_fails" not in metrics
         assert "batch/mean_groups_per_fwd_bwd" not in metrics
+
+
+class TestFwdBwdMinibatchAveraging:
+    """With ppo_n_minibatches>1 the per-step train/* metrics must average
+    across minibatches, not report only the last one."""
+
+    @staticmethod
+    def _fake_fwd_bwd(**metrics):
+        return SimpleNamespace(metrics=dict(metrics))
+
+    def test_averages_across_minibatches(self):
+        fwd_bwds = [
+            self._fake_fwd_bwd(ppo_clip_frac=0.0, ppo_ratio_mean=1.00),
+            self._fake_fwd_bwd(ppo_clip_frac=0.1, ppo_ratio_mean=1.05),
+            self._fake_fwd_bwd(ppo_clip_frac=0.3, ppo_ratio_mean=1.20),
+        ]
+        metrics = compute_step_metrics(
+            prompt_groups=[],
+            fwd_bwd_results=fwd_bwds,
+            optim_result=None,
+            n_accum=len(fwd_bwds),
+            timing_metrics={},
+        )
+        assert metrics["train/ppo_clip_frac"] == (0.0 + 0.1 + 0.3) / 3
+        assert metrics["train/ppo_ratio_mean"] == (1.0 + 1.05 + 1.2) / 3
+
+    def test_k1_matches_single_fwd_bwd_behavior(self):
+        """K=1: report the single minibatch's metrics directly (pre-PR behavior)."""
+        only = self._fake_fwd_bwd(ppo_clip_frac=0.42, ppo_ratio_mean=1.07)
+        metrics = compute_step_metrics(
+            prompt_groups=[],
+            fwd_bwd_results=[only],
+            optim_result=None,
+            n_accum=1,
+            timing_metrics={},
+        )
+        assert metrics["train/ppo_clip_frac"] == 0.42
+        assert metrics["train/ppo_ratio_mean"] == 1.07
+
+    def test_empty_fwd_bwd_results_emits_no_train_keys(self):
+        metrics = compute_step_metrics(
+            prompt_groups=[],
+            fwd_bwd_results=[],
+            optim_result=None,
+            n_accum=0,
+            timing_metrics={},
+        )
+        assert not any(k.startswith("train/ppo_") for k in metrics)

--- a/training/utils/rl/metrics.py
+++ b/training/utils/rl/metrics.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import math
 from typing import Any, Sequence
 
 import tinker
@@ -188,47 +187,3 @@ def compute_step_metrics(
             metrics["rollout/raw_reward"] = sum(raw_rewards) / len(raw_rewards)
 
     return metrics
-
-
-def add_inference_numerics(
-    metrics: dict[str, Any],
-    *,
-    prox_logprobs: Sequence,
-    inf_logprobs: Sequence,
-    prompt_lens: Sequence[int],
-) -> None:
-    """Emit trainer-vs-inference log-prob divergence on the rollout batch.
-
-    Writes two keys into ``metrics``:
-      - ``train/inference_diff``: mean |log π_prox − log π_inf| over response tokens
-      - ``train/inference_kld``:  mean (exp(Δ) − Δ − 1) over the same tokens (k3-style)
-
-    The ``prox`` logprobs are the bf16 trainer's recomputation of the
-    rollout, sampled before any optim step has fired; the ``inf`` logprobs
-    come from the fp8 inference server that produced the rollout. The
-    pair measures pure trainer/inference quantization drift at rollout
-    boundary and is independent of which loss kernel runs, so the CI
-    numerics gate stays comparable across ``policy_loss`` choices.
-    """
-    diff_per_sample: list[float] = []
-    kld_per_sample: list[float] = []
-    for i, prompt_len in enumerate(prompt_lens):
-        prox = prox_logprobs[i]
-        inf = inf_logprobs[i]
-        resp_start = max(0, int(prompt_len) - 1)
-        resp_end = min(len(prox), len(inf))
-        if resp_end <= resp_start:
-            continue
-        n = resp_end - resp_start
-        total_diff = 0.0
-        total_kld = 0.0
-        for t in range(resp_start, resp_end):
-            d = float(prox[t]) - float(inf[t])
-            total_diff += abs(d)
-            total_kld += math.exp(d) - d - 1.0
-        diff_per_sample.append(total_diff / n)
-        kld_per_sample.append(total_kld / n)
-
-    if diff_per_sample:
-        metrics["train/inference_diff"] = sum(diff_per_sample) / len(diff_per_sample)
-        metrics["train/inference_kld"] = sum(kld_per_sample) / len(kld_per_sample)

--- a/training/utils/rl/metrics.py
+++ b/training/utils/rl/metrics.py
@@ -119,11 +119,22 @@ def compute_step_metrics(
             if k not in _SKIP_REMOTE_KEYS:
                 metrics[f"train/{k}"] = v
 
-    last_fwd_bwd = fwd_bwd_results[-1] if fwd_bwd_results else None
-    if last_fwd_bwd is not None:
-        for k, v in last_fwd_bwd.metrics.items():
-            if k not in _SKIP_REMOTE_KEYS:
-                metrics[f"train/{k}"] = v
+    # Average fwd_bwd metrics across inner minibatches. With ppo_n_minibatches=1
+    # this reduces to the pre-PR behavior (one result, mean == that result). With
+    # K>1 the last minibatch alone is misleading — early minibatches haven't
+    # drifted yet so their ppo_clip_frac is ~0, while later ones clip more; the
+    # headline claim of this PR is that clipping fires, which the mean reports
+    # honestly rather than only showing the most-clipped minibatch.
+    if fwd_bwd_results:
+        accum: dict[str, float] = {}
+        for result in fwd_bwd_results:
+            for k, v in result.metrics.items():
+                if k in _SKIP_REMOTE_KEYS:
+                    continue
+                accum[k] = accum.get(k, 0.0) + v
+        n = len(fwd_bwd_results)
+        for k, v in accum.items():
+            metrics[f"train/{k}"] = v / n
 
     all_rewards: list[float] = []
     all_comp_lens: list[int] = []

--- a/training/utils/rl/metrics.py
+++ b/training/utils/rl/metrics.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import math
 from typing import Any, Sequence
 
 import tinker
@@ -187,3 +188,47 @@ def compute_step_metrics(
             metrics["rollout/raw_reward"] = sum(raw_rewards) / len(raw_rewards)
 
     return metrics
+
+
+def add_inference_numerics(
+    metrics: dict[str, Any],
+    *,
+    prox_logprobs: Sequence,
+    inf_logprobs: Sequence,
+    prompt_lens: Sequence[int],
+) -> None:
+    """Emit trainer-vs-inference log-prob divergence on the rollout batch.
+
+    Writes two keys into ``metrics``:
+      - ``train/inference_diff``: mean |log π_prox − log π_inf| over response tokens
+      - ``train/inference_kld``:  mean (exp(Δ) − Δ − 1) over the same tokens (k3-style)
+
+    The ``prox`` logprobs are the bf16 trainer's recomputation of the
+    rollout, sampled before any optim step has fired; the ``inf`` logprobs
+    come from the fp8 inference server that produced the rollout. The
+    pair measures pure trainer/inference quantization drift at rollout
+    boundary and is independent of which loss kernel runs, so the CI
+    numerics gate stays comparable across ``policy_loss`` choices.
+    """
+    diff_per_sample: list[float] = []
+    kld_per_sample: list[float] = []
+    for i, prompt_len in enumerate(prompt_lens):
+        prox = prox_logprobs[i]
+        inf = inf_logprobs[i]
+        resp_start = max(0, int(prompt_len) - 1)
+        resp_end = min(len(prox), len(inf))
+        if resp_end <= resp_start:
+            continue
+        n = resp_end - resp_start
+        total_diff = 0.0
+        total_kld = 0.0
+        for t in range(resp_start, resp_end):
+            d = float(prox[t]) - float(inf[t])
+            total_diff += abs(d)
+            total_kld += math.exp(d) - d - 1.0
+        diff_per_sample.append(total_diff / n)
+        kld_per_sample.append(total_kld / n)
+
+    if diff_per_sample:
+        metrics["train/inference_diff"] = sum(diff_per_sample) / len(diff_per_sample)
+        metrics["train/inference_kld"] = sum(kld_per_sample) / len(kld_per_sample)


### PR DESCRIPTION
## Summary
- Hoist `prox_lp = policy.forward(data, "cross_entropy")` above the training loop so one snapshot serves all inner optim steps.
- Add `Config.ppo_n_minibatches` (default **1**, preserves legacy 1:1 semantics byte-for-byte). At K>1 the policy drifts across inner steps and the PPO ratio measures real drift — matches AReaL's `ppo_update` and Slime's per-rollout `compute_log_prob` + minibatch loop.
- Move the DCP save to a rollout boundary check so `data_consumed` stays K-independent on resume.
- Rescale `total_rl_steps` by `ppo_n_minibatches` so the runner progress bar stays in optim-step units.

## Context
Today cookbook computes `prox_lp` inside `fwd_bwd_one` and runs a single fwd_bwd + optim_step per rollout → `prox_lp ≡ resp_pi` byte-for-byte → ratio ≡ 1 → PPO clip never fires. This is half of decoupled-PPO wired up with no consumer. AReaL/Slime run decoupled-PPO with multi-minibatch inner loops (or off-policyness) so the ratio is meaningful. This PR makes cookbook match.

## Algorithm diff

| | Before (K=1) | After (K>1) |
|---|---|---|
| `prox_fwd` per rollout | 1 | 1 |
| `forward_backward` per rollout | 1 | K |
| `optim_step` per rollout | 1 | K |
| PPO ratio at inner step k | `exp(π−π_prox)≈1` | drifts with k |
| PPO clip | no-op | activates |

## Behavioral guarantees
- `ppo_n_minibatches=1` → identical control flow to prior code: single `fwd_bwd_minibatch` result, single `optim_step`, metrics byte-identical (the averaging fix reduces to mean-of-one).
- DCP save now only fires at rollout boundaries (checking `rollouts_completed % dcp_save_interval`), not mid-rollout. Fixes an interval-divisibility bug where e.g. K=4, interval=10 would never trigger.

## Correctness fixes folded in
Reviewer flagged three latent K>1 mis-accountings introduced by the refactor. All three sit in code paths the single-shape CI never walks (DPO owns the only DCP-resume path; `save_final_checkpoint=False` in the test) so unit tests are the guardrail. All fixed in one commit, inlined at the callsites.

1. **Resume skipped K× rollout batches.** `step_offset` is optim-step units; `rl_dataset` is indexed per rollout batch. Divide by `max(1, ppo_n_minibatches)` before indexing.
2. **Final-checkpoint `data_consumed` over-counted by K×.** In-loop save used `rollouts_completed`; the mirror final save below `main()` still used `(global_step - step_offset) * pgps`. Now matches the in-loop formula (divide optim-step delta by K before multiplying by pgps).
3. **Per-step `train/*` metrics only reflected the last minibatch.** `compute_step_metrics` took `fwd_bwd_results[-1]`; now averages across all minibatches. K=1 reduces to the single-result case (mean == that result), byte-for-byte equivalent to the pre-PR code.

## Cosmetic
Rename: `K → num_minibatches`, `k_idx → minibatch_idx` inside `train_step` — matches surrounding vocabulary (`minibatch_size`, `minibatch_start`, `minibatch_end`).

## Test plan
- [x] Unit: K=1 byte-equivalence — `TestFwdBwdMinibatchAveraging::test_k1_matches_single_fwd_bwd_behavior` covers the averaging path; the resume-rollout and data_consumed fixes are trivially K=1-equivalent (divide-by-1 noop).
- [x] K=2 behavioral — single-shape CI against `qwen3-4b-minimum-lora` with `policy_loss="reinforce"` (drift-clip coverage via unit test, not CI): PASS.
- [ ] Regression run with stress test enabled: in progress (v8 / fireworks run 24819413563).
