### PR TITLE
feat(rl): async RL loop with pluggable rollout + reward (supersedes #375)

### DIFF
--- a/training/examples/custom_env/message_env/train.py
+++ b/training/examples/custom_env/message_env/train.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Multi-turn async RL example: custom ``MessageEnv``.
+
+Implements a toy "guessing" task where the env replies with "higher" or
+"lower" feedback until the model guesses the target number or runs out of
+turns.  Real multi-turn tasks (tool use, code agents, simulators) follow
+the same shape: subclass :class:`MessageEnv` and keep state on ``self``.
+
+Usage::
+
+    export FIREWORKS_API_KEY=...
+    python -m training.examples.custom_env.message_env.train
+"""
+
+from __future__ import annotations
+
+import re
+
+from training.recipes.rl_loop_async import AsyncConfig, Config, main
+from training.utils.rl import MessageEnv, MessageStepResult
+
+
+def _extract_guess(text: str) -> int | None:
+    match = re.search(r"<guess>\s*(-?\d+)\s*</guess>", text)
+    return int(match.group(1)) if match else None
+
+
+class GuessingEnv(MessageEnv):
+    """Env replies with higher/lower feedback until the model nails the target."""
+
+    SYSTEM_PROMPT = (
+        "You are playing a number-guessing game. Reply with your guess in "
+        "<guess>...</guess> tags. The user will tell you whether the target is "
+        "higher or lower than your guess."
+    )
+
+    def __init__(self, row: dict):
+        self.target = int(row["target"])
+        self.turns_left = int(row.get("max_turns", 6))
+
+    async def initial_messages(self):
+        return [
+            {"role": "system", "content": self.SYSTEM_PROMPT},
+            {"role": "user", "content": "Guess a number between 1 and 100."},
+        ]
+
+    async def step(self, assistant_message):
+        self.turns_left -= 1
+        guess = _extract_guess(assistant_message.get("content", "") or "")
+        if guess is None:
+            # Unparseable -- penalise and bail.
+            return MessageStepResult(reward=-0.1, episode_done=True)
+
+        if guess == self.target:
+            return MessageStepResult(reward=1.0, episode_done=True)
+
+        if self.turns_left <= 0:
+            return MessageStepResult(reward=0.0, episode_done=True)
+
+        hint = "higher" if guess < self.target else "lower"
+        return MessageStepResult(
+            reward=0.0,
+            episode_done=False,
+            next_messages=[{"role": "user", "content": f"The target is {hint}."}],
+        )
+
+
+def env_builder(row: dict) -> GuessingEnv:
+    return GuessingEnv(row)
+
+
+if __name__ == "__main__":
+    import random
+
+    random.seed(0)
+    rows = [{"target": random.randint(1, 100), "max_turns": 6} for _ in range(64)]
+
+    cfg = Config(
+        log_path="/tmp/rl-async-message-env",
+        base_model="accounts/fireworks/models/qwen3-8b",
+        async_config=AsyncConfig(max_steps_off_policy=1, groups_per_batch=4),
+        completions_per_prompt=4,
+        max_turns=6,
+        max_rows=len(rows),
+    )
+    main(cfg, env_builder=env_builder, rows=rows)

--- a/training/examples/custom_env/reward_fn/train.py
+++ b/training/examples/custom_env/reward_fn/train.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Single-turn async RL example: bring your own ``reward_fn``.
+
+Matches the sync-loop ergonomics -- one function, no envs to wire up.
+The async loop internally wraps the reward into a one-step env via
+``SingleTurnEnv``.
+
+Usage::
+
+    export FIREWORKS_API_KEY=...
+    python -m training.examples.custom_env.reward_fn.train
+"""
+
+from __future__ import annotations
+
+import re
+
+from training.recipes.rl_loop_async import AsyncConfig, Config, main
+
+
+def _extract_number(text: str) -> str | None:
+    match = re.search(r"<answer>\s*(-?\d+)", text, re.IGNORECASE | re.DOTALL)
+    return match.group(1) if match else None
+
+
+def reward_fn(completion: str, row: dict) -> float:
+    """Return 1.0 iff the model's extracted number matches ``row['answer']``."""
+    predicted = _extract_number(completion)
+    if predicted is None:
+        return 0.0
+    truth = str(row.get("answer", "")).strip()
+    return 1.0 if predicted == truth else 0.0
+
+
+if __name__ == "__main__":
+    cfg = Config(
+        log_path="/tmp/rl-async-reward-fn",
+        base_model="accounts/fireworks/models/qwen3-8b",
+        dataset="https://raw.githubusercontent.com/eval-protocol/python-sdk/main/development/gsm8k_sample.jsonl",
+        async_config=AsyncConfig(max_steps_off_policy=1, groups_per_batch=4),
+        completions_per_prompt=4,
+        max_rows=32,
+    )
+    main(cfg, reward_fn=reward_fn)

--- a/training/examples/custom_env/rollout_source/train.py
+++ b/training/examples/custom_env/rollout_source/train.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Async RL example: bring your own ``rollout_source``.
+
+Use this path when the cookbook's sampler is not the one producing the
+completions -- typical cases are remote agent frameworks, pre-recorded
+trajectories, or LLM-as-judge flows.  The rollout source hands back a
+list of :class:`Trajectory` objects; the cookbook packs them into a
+:class:`PromptGroup` and (if ``inference_logprobs`` was not provided)
+recovers per-token logprobs via an ``echo=True`` prefill call.
+
+For the example below the "remote agent" is just a stub -- replace
+``_call_remote_agent`` with your real integration.
+
+Usage::
+
+    export FIREWORKS_API_KEY=...
+    python -m training.examples.custom_env.rollout_source.train
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import transformers
+
+from training.recipes.rl_loop_async import AsyncConfig, Config, main
+from training.utils.rl import Trajectory, Transition, tokenize_chat_turn
+
+
+def _call_remote_agent(prompt_messages: list[dict]) -> list[dict[str, Any]]:
+    """Stub remote agent: returns a fixed completion + placeholder reward.
+
+    Replace with HTTP call to your agent framework.  Return one dict per
+    completion with keys ``text`` and ``reward``.
+    """
+    return [
+        {"text": "<answer>42</answer>", "reward": 1.0},
+        {"text": "<answer>7</answer>", "reward": 0.0},
+        {"text": "<answer>100</answer>", "reward": 0.0},
+        {"text": "<answer>42</answer>", "reward": 1.0},
+    ]
+
+
+def _build_rollout_source(tokenizer: Any):
+    """Bind the tokenizer so we can build :class:`Transition` objects."""
+
+    async def rollout_source(row: dict, *, n: int) -> list[Trajectory]:
+        prompt_messages = row.get("messages") or [
+            {"role": "user", "content": row.get("prompt", "")},
+        ]
+        completions = _call_remote_agent(prompt_messages)[:n]
+
+        trajectories: list[Trajectory] = []
+        for comp in completions:
+            assistant_message = {"role": "assistant", "content": comp["text"]}
+            prompt_tokens, completion_tokens = tokenize_chat_turn(
+                prompt_messages, assistant_message, tokenizer,
+            )
+            transition = Transition(
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+                completion_text=comp["text"],
+                inference_logprobs=None,  # cookbook will prefill-recover.
+                assistant_message=assistant_message,
+                reward=float(comp["reward"]),
+                episode_done=True,
+            )
+            trajectories.append(Trajectory(transitions=[transition]))
+        return trajectories
+
+    return rollout_source
+
+
+if __name__ == "__main__":
+    rows = [
+        {"messages": [{"role": "user", "content": "What's the answer?"}]}
+        for _ in range(32)
+    ]
+
+    cfg = Config(
+        log_path="/tmp/rl-async-rollout-source",
+        base_model="accounts/fireworks/models/qwen3-8b",
+        async_config=AsyncConfig(max_steps_off_policy=1, groups_per_batch=4),
+        completions_per_prompt=4,
+        max_rows=len(rows),
+    )
+
+    tokenizer_model = cfg.deployment.tokenizer_model or os.environ.get(
+        "COOKBOOK_TOKENIZER_MODEL", "Qwen/Qwen3-1.7B",
+    )
+    cfg.deployment.tokenizer_model = tokenizer_model
+    tokenizer = transformers.AutoTokenizer.from_pretrained(
+        tokenizer_model, trust_remote_code=True,
+    )
+
+    main(cfg, rollout_source=_build_rollout_source(tokenizer), rows=rows)

--- a/training/recipes/rl_loop_async.py
+++ b/training/recipes/rl_loop_async.py
@@ -1,0 +1,523 @@
+#!/usr/bin/env python3
+"""Async off-policy RL training loop (eval-framework-neutral).
+
+A parallel entry point to :mod:`training.recipes.rl_loop` that overlaps
+generation and training using :func:`run_rl_loop_async`.  The loop is
+fully decoupled from rollout scheduling and reward/evaluation --
+users plug in exactly one of:
+
+* ``reward_fn(completion: str, row: dict) -> float`` -- single-turn
+  shortcut.  Matches the sync loop's ``reward_fn`` signature.
+* ``env_builder(row: dict) -> MessageEnv`` -- custom single- or
+  multi-turn environment.
+* ``rollout_source(row, *, n) -> list[Trajectory]`` -- user owns
+  generation (remote agent, pre-recorded trajectories, LLM judge).
+
+An optional ``group_reward_fn(trajectories, row) -> list[float]`` adds
+a group-level delta (pairwise reward model, etc.) to the final reward
+before advantage centering.
+
+The cookbook is eval-framework-neutral: it does not import any
+evaluator, grader, or Eval Protocol types.  Users wire their own
+graders through the three hooks above.
+
+Example::
+
+    from training.recipes.rl_loop_async import Config, main
+
+    def my_reward(completion, row):
+        return 1.0 if row["answer"] in completion else 0.0
+
+    cfg = Config(log_path="/tmp/run", base_model="accounts/fireworks/models/qwen3-8b")
+    main(cfg, reward_fn=my_reward)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import signal
+from contextlib import ExitStack
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+import tinker
+import transformers
+
+from fireworks.training.sdk import DeploymentManager, TrainerJobManager
+from fireworks.training.sdk.client import GradAccNormalization
+from fireworks.training.sdk.deployment import (
+    AdaptiveConcurrencyController,
+    DeploymentSampler,
+)
+from fireworks.training.sdk.weight_syncer import WeightSyncer
+from training.utils import (
+    DEFAULT_ADAM,
+    ConcurrencyConfig,
+    DeployConfig,
+    InfraConfig,
+    ResourceCleanup,
+    RLPromptDataset,
+    RunnerConfig,
+    RunnerIO,
+    RunStatus,
+    WandBConfig,
+    WeightSyncConfig,
+    load_jsonl_dataset,
+    log_metrics_json,
+    read_api_extra_headers_env,
+    setup_wandb,
+    validate_config,
+    wandb_log,
+)
+from training.utils.checkpoint_utils import (
+    CheckpointKind,
+    resolve_resume,
+    save_checkpoint,
+)
+from training.utils.rl import (
+    PromptGroup,
+    setup_infra,
+)
+from training.utils.rl.cispo import CISPOConfig
+from training.utils.rl.dapo import DAPOConfig
+from training.utils.rl.gspo import GSPOConfig
+from training.utils.rl.losses import (
+    build_builtin_loss_datums,
+    build_loss_fn,
+    combine_prompt_groups,
+    resolve_builtin_loss,
+)
+from training.utils.rl.metrics import compute_step_metrics
+from training.utils.rl.sample_fn_factory import (
+    EnvBuilder,
+    RewardFn,
+    RolloutSource,
+    build_sample_fn,
+)
+from training.utils.rl.tis import TISConfig
+from training.utils.rl.train import DynamicFilterFn, TrainStepFns
+from training.utils.rl.train_async import AsyncConfig, run_rl_loop_async
+from training.utils.timer import flush_timing, timer
+import time as _time
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Config:
+    log_path: str
+    """Directory for checkpoints and logs. Required, no default."""
+
+    base_model: str = "accounts/fireworks/models/qwen3-8b"
+    rollout_base_model: str | None = None
+    dataset: str | None = None
+    """Path or URL to a JSONL dataset.  Each row is passed to reward_fn /
+    env_builder / rollout_source.  Required unless ``rows`` is passed to
+    :func:`main` directly."""
+
+    learning_rate: float = 1e-5
+    kl_beta: float = 0.001
+    completions_per_prompt: int = 4
+    max_completion_tokens: int = 1024
+    temperature: float = 1.0
+    epochs: int = 1
+    max_rows: int = 100
+    max_seq_len: int | None = None
+    lora_rank: int = 0
+
+    max_turns: int = 1
+    """Max assistant turns per rollout (env path only).  1 = single-turn."""
+
+    router_replay: bool = False
+    router_replay_completion_only: bool = True
+
+    grad_accumulation_normalization: GradAccNormalization | str | None = (
+        GradAccNormalization.NUM_LOSS_TOKENS
+    )
+
+    policy_loss: str = "grpo"
+    dapo: DAPOConfig = field(default_factory=DAPOConfig)
+    gspo: GSPOConfig = field(default_factory=GSPOConfig)
+    cispo: CISPOConfig = field(default_factory=CISPOConfig)
+    eps_clip: float = 0.2
+    eps_clip_high: float | None = None
+    ratio_log_cap: float = 20.0
+    tis: TISConfig = field(default_factory=TISConfig)
+
+    async_config: AsyncConfig = field(default_factory=AsyncConfig)
+    """Staleness bound and groups-per-batch for the async runner."""
+
+    concurrency: ConcurrencyConfig = field(default_factory=ConcurrencyConfig)
+    trajectory_dir: str | None = None
+
+    policy_job_id: str | None = None
+    reference_job_id: str | None = None
+    init_from_checkpoint: str | None = None
+    output_model_id: str | None = None
+    save_final_checkpoint: bool = True
+    step_timeout: int = 0
+
+    infra: InfraConfig = field(default_factory=InfraConfig)
+    deployment: DeployConfig = field(default_factory=DeployConfig)
+    weight_sync: WeightSyncConfig = field(default_factory=WeightSyncConfig)
+    wandb: WandBConfig = field(default_factory=lambda: WandBConfig(project="rl-async"))
+    runner: RunnerConfig = field(default_factory=RunnerConfig)
+
+
+def should_accept(pg: PromptGroup) -> bool:
+    """Reject groups where all rewards are identical (zero-variance)."""
+    return len(set(pg.rewards)) > 1
+
+
+def main(
+    config: Config,
+    *,
+    reward_fn: RewardFn | None = None,
+    env_builder: EnvBuilder | None = None,
+    rollout_source: RolloutSource | None = None,
+    group_reward_fn: Callable[..., Any] | None = None,
+    dynamic_filter_fn: DynamicFilterFn | None = should_accept,
+    rows: list[dict] | None = None,
+    rlor_mgr: TrainerJobManager | None = None,
+    deploy_mgr: DeploymentManager | None = None,
+    cancel_on_exit: bool = False,
+) -> None:
+    """Run the async RL loop.
+
+    Exactly one of ``reward_fn`` / ``env_builder`` / ``rollout_source`` must
+    be provided.  See module docstring for the full contract.
+    """
+    cfg = config
+    runner = RunnerIO(cfg.runner)
+
+    def _signal_handler(signum, _frame):
+        name = signal.Signals(signum).name
+        logger.warning("Received %s -- raising SystemExit for cleanup", name)
+        raise SystemExit(f"Terminated by {name}")
+
+    signal.signal(signal.SIGTERM, _signal_handler)
+    signal.signal(signal.SIGINT, _signal_handler)
+
+    validate_config(
+        cfg.base_model,
+        cfg.dataset or "",
+        cfg.weight_sync,
+        cfg.deployment,
+        output_model_id=cfg.output_model_id,
+    )
+    if not cfg.deployment.tokenizer_model:
+        raise ValueError(
+            "deployment.tokenizer_model is required for client-side tokenization."
+        )
+
+    completions_per_prompt = cfg.completions_per_prompt
+    groups_per_batch = cfg.async_config.groups_per_batch
+    setup_wandb(
+        cfg.wandb,
+        {
+            "completions_per_prompt": completions_per_prompt,
+            "groups_per_batch": groups_per_batch,
+            "kl_beta": cfg.kl_beta,
+            "lr": cfg.learning_rate,
+            "max_steps_off_policy": cfg.async_config.max_steps_off_policy,
+        },
+    )
+
+    api_key = os.environ["FIREWORKS_API_KEY"]
+    base_url = os.environ.get("FIREWORKS_BASE_URL", "https://api.fireworks.ai")
+    additional_headers = read_api_extra_headers_env()
+
+    if rlor_mgr is None:
+        rlor_mgr = TrainerJobManager(
+            api_key=api_key, base_url=base_url, additional_headers=additional_headers,
+        )
+    if deploy_mgr is None:
+        deploy_mgr = DeploymentManager(
+            api_key=api_key, base_url=base_url, additional_headers=additional_headers,
+        )
+
+    runner.write_status(RunStatus.PENDING, message="provisioning")
+
+    def _on_trainer_status(msg: str) -> None:
+        runner.write_status(RunStatus.PENDING, message=msg)
+
+    with runner, ResourceCleanup(rlor_mgr, deploy_mgr) as cleanup, ExitStack() as stack:
+        infra = setup_infra(
+            rlor_mgr=rlor_mgr,
+            deploy_mgr=deploy_mgr,
+            base_model=cfg.base_model,
+            infra_cfg=cfg.infra,
+            deploy_cfg=cfg.deployment,
+            lora_rank=cfg.lora_rank,
+            max_seq_len=cfg.max_seq_len,
+            learning_rate=cfg.learning_rate,
+            step_timeout=cfg.step_timeout,
+            policy_job_id=cfg.policy_job_id,
+            reference_job_id=cfg.reference_job_id,
+            needs_reference=(cfg.kl_beta > 0),
+            needs_inference=True,
+            role_prefix="rl-async",
+            api_key=api_key,
+            cleanup=cleanup if cancel_on_exit else None,
+            on_status=_on_trainer_status,
+        )
+        for closeable in infra.closeables:
+            stack.callback(closeable.close)
+
+        runner.set_accelerator_info(profile=infra.policy_profile)
+        wandb_log(infra.boot_metrics, step=0)
+
+        policy = infra.policy
+        reference = infra.reference
+        policy_profile = infra.policy_profile
+        policy_job_id = infra.policy_job_id
+
+        tokenizer = transformers.AutoTokenizer.from_pretrained(
+            cfg.deployment.tokenizer_model, trust_remote_code=True,
+        )
+
+        initial_window = cfg.concurrency.initial_window or (8 * infra.deployment_gpu_count)
+        concurrency_controller = AdaptiveConcurrencyController(
+            initial_window=initial_window,
+            min_window=cfg.concurrency.min_window,
+            max_window=cfg.concurrency.max_window,
+            prefill_queue_target=cfg.concurrency.prefill_queue_target,
+        )
+        sampler = DeploymentSampler(
+            inference_url=deploy_mgr.inference_url,
+            model=infra.inference_model,
+            api_key=api_key,
+            tokenizer=tokenizer,
+            concurrency_controller=concurrency_controller,
+        )
+        weight_syncer = WeightSyncer(
+            policy_client=policy.inner,
+            deploy_mgr=deploy_mgr,
+            deployment_id=infra.deployment_id,
+            base_model=cfg.rollout_base_model or cfg.base_model,
+            hotload_timeout=cfg.weight_sync.weight_sync_timeout,
+            first_checkpoint_type=cfg.weight_sync.first_checkpoint_type,
+            lora_rank=cfg.lora_rank,
+        )
+
+        resume_info = resolve_resume(policy, cfg.log_path, cfg.init_from_checkpoint)
+        step_offset = resume_info.step if resume_info else 0
+        wandb_log({"train/step": step_offset}, step_offset)
+
+        if cfg.weight_sync.weight_sync_before_training and infra.deployment_id:
+            name = f"resume-{step_offset}-base" if step_offset > 0 else "step-0-base"
+            weight_syncer.save_and_hotload(name, checkpoint_type="base")
+
+        # -- Dataset ---------------------------------------------------------
+        if rows is None:
+            if not cfg.dataset:
+                raise ValueError("Either cfg.dataset or rows= must be provided.")
+            raw = load_jsonl_dataset(cfg.dataset, cfg.max_rows)
+            rows = raw * cfg.epochs
+
+        adam_params = tinker.AdamParams(learning_rate=cfg.learning_rate, **DEFAULT_ADAM)
+        client_loss_builder = build_loss_fn(
+            policy_loss=cfg.policy_loss,
+            kl_beta=cfg.kl_beta,
+            dapo_config=cfg.dapo,
+            gspo_config=cfg.gspo,
+            cispo_config=cfg.cispo,
+            ratio_log_cap=cfg.ratio_log_cap,
+            tis_config=cfg.tis,
+            eps_clip=cfg.eps_clip,
+            eps_clip_high=cfg.eps_clip_high,
+        )
+
+        sample_kwargs: dict = dict(
+            max_tokens=cfg.max_completion_tokens,
+            temperature=cfg.temperature,
+            max_seq_len=infra.max_seq_len,
+            http_timeout=cfg.deployment.sample_timeout,
+            logprobs=True,
+        )
+        if cfg.router_replay:
+            sample_kwargs.update(include_routing_matrix=True, echo=True)
+
+        # -- Build sample_fn -------------------------------------------------
+        sample_fn = build_sample_fn(
+            reward_fn=reward_fn,
+            env_builder=env_builder,
+            rollout_source=rollout_source,
+            group_reward_fn=group_reward_fn,
+            sampler=sampler,
+            completions_per_prompt=completions_per_prompt,
+            sample_kwargs=sample_kwargs,
+            max_turns=cfg.max_turns,
+            tokenizer=tokenizer,
+            inference_url=deploy_mgr.inference_url,
+            api_key=api_key,
+            model=infra.inference_model,
+            router_replay=cfg.router_replay,
+            router_replay_completion_only=cfg.router_replay_completion_only,
+            keep_trajectory_logs=bool(cfg.trajectory_dir),
+        )
+
+        # -- Training callbacks ---------------------------------------------
+        builtin_server_loss = resolve_builtin_loss(
+            cfg.policy_loss,
+            policy_profile,
+            dapo_config=cfg.dapo,
+            gspo_config=cfg.gspo,
+            cispo_config=cfg.cispo,
+            ratio_log_cap=cfg.ratio_log_cap,
+            eps_clip=cfg.eps_clip,
+            eps_clip_high=cfg.eps_clip_high,
+        )
+
+        def ref_forward(groups: list[PromptGroup]) -> None:
+            if reference is None:
+                return
+            all_ref_data = [d for pg in groups for d in pg.ref_data]
+            ref_fwd = reference.forward(all_ref_data, "cross_entropy")
+            idx = 0
+            for pg in groups:
+                n = len(pg.ref_data)
+                pg.ref_logprobs = [
+                    ref_fwd.loss_fn_outputs[idx + i]["logprobs"].data for i in range(n)
+                ]
+                idx += n
+
+        def fwd_bwd_one(prompt_groups: list[PromptGroup]):
+            if not prompt_groups:
+                raise ValueError("fwd_bwd_one requires at least one prompt group")
+            data, adv, ref_lp, prompt_lens, inf_lp = combine_prompt_groups(prompt_groups)
+            prox_fwd = policy.forward(data, "cross_entropy")
+            prox_lp = [prox_fwd.loss_fn_outputs[i]["logprobs"].data for i in range(len(data))]
+            if builtin_server_loss is not None:
+                kernel_loss, kernel_config = builtin_server_loss
+                rl_datums = build_builtin_loss_datums(
+                    data, adv, prox_lp, inf_lp, prompt_lens,
+                    cfg.tis, policy_loss=cfg.policy_loss,
+                )
+                return policy.forward_backward(
+                    rl_datums, kernel_loss, loss_fn_config=kernel_config,
+                )
+            return policy.forward_backward_custom(
+                data, client_loss_builder(adv, ref_lp, prompt_lens, inf_lp, prox_lp),
+            )
+
+        def train_step(
+            step: int, prompt_groups: list[PromptGroup], loop_stats: dict | None = None,
+        ) -> tuple[int, dict]:
+            ref_forward(prompt_groups)
+            fwd_bwd_result = fwd_bwd_one(prompt_groups)
+            optim_result = policy.optim_step(
+                adam_params,
+                grad_accumulation_normalization=cfg.grad_accumulation_normalization,
+            )
+            step += 1
+
+            if cfg.weight_sync.dcp_save_interval > 0 and step % cfg.weight_sync.dcp_save_interval == 0:
+                _data_consumed = (resume_info.data_consumed if resume_info else 0) + (
+                    step - step_offset
+                ) * groups_per_batch
+                save_checkpoint(
+                    policy, f"step-{step}", cfg.log_path,
+                    {
+                        "step": step,
+                        "data_consumed": _data_consumed,
+                        "source_job_id": policy_job_id,
+                    },
+                    kind=CheckpointKind.STATE,
+                    base_model=cfg.base_model,
+                    training_shape=infra.training_shape_id,
+                )
+
+            if cfg.weight_sync.weight_sync_interval > 0 and step % cfg.weight_sync.weight_sync_interval == 0:
+                with timer("weight_sync"):
+                    weight_syncer.save_and_hotload(f"step-{step}")
+
+            metrics = compute_step_metrics(
+                prompt_groups=prompt_groups,
+                fwd_bwd_results=[fwd_bwd_result],
+                optim_result=optim_result,
+                n_accum=1,
+                timing_metrics=flush_timing(),
+                loop_stats=loop_stats,
+                completions_per_prompt=completions_per_prompt,
+            )
+            metrics["train/step"] = step
+
+            step_tokens = sum(
+                len(d.loss_fn_inputs["target_tokens"].data)
+                for pg in prompt_groups for d in pg.data
+            )
+            avg_reward = metrics.get("rollout/reward", 0.0)
+            avg_acc = metrics.get("rollout/accuracy", 0.0)
+            avg_kl = metrics.get("train/mean_kl", 0.0)
+            logger.info(
+                "Step %d | Reward: %.3f | Acc: %.1f%% | KL: %.4f",
+                step, avg_reward, avg_acc * 100, avg_kl,
+            )
+            log_metrics_json(step, reward=avg_reward, accuracy=avg_acc, kl=avg_kl)
+            wandb_log(metrics, step)
+
+            total_rl_steps = max(1, len(rows) // groups_per_batch) - step_offset
+            runner.append_metrics(step, metrics, tokens=step_tokens)
+            runner.write_status(
+                RunStatus.RUNNING, step=step, total_steps=total_rl_steps, message="training",
+            )
+            runner.write_metadata()
+            return step, metrics
+
+        def _loop_metrics_callback(loop_metrics: dict) -> None:
+            if concurrency_controller is not None:
+                cc_summary = concurrency_controller.step_completed()
+                for k, v in cc_summary.items():
+                    loop_metrics[f"concurrency/{k}"] = v
+            wandb_log(loop_metrics, step=loop_metrics.get("train/step", 0))
+
+        train_fns = TrainStepFns(train_step=train_step)
+
+        total_rl_steps = max(1, len(rows) // groups_per_batch) - step_offset
+        runner.start_training()
+        runner.write_status(RunStatus.RUNNING, total_steps=total_rl_steps, message="training")
+
+        global_step = asyncio.run(
+            run_rl_loop_async(
+                sample_fn=sample_fn,
+                rows=rows[step_offset * groups_per_batch:],
+                train_fns=train_fns,
+                async_config=cfg.async_config,
+                dynamic_filter_fn=dynamic_filter_fn,
+                global_step=step_offset,
+                metrics_callback=_loop_metrics_callback,
+            )
+        )
+
+        if cfg.save_final_checkpoint and global_step > step_offset:
+            try:
+                _data_consumed = (resume_info.data_consumed if resume_info else 0) + (
+                    global_step - step_offset
+                ) * groups_per_batch
+                cp_name = f"step-{global_step}"
+                paths = save_checkpoint(
+                    policy, cp_name, cfg.log_path,
+                    {
+                        "step": global_step,
+                        "data_consumed": _data_consumed,
+                        "source_job_id": policy_job_id,
+                    },
+                    kind=CheckpointKind.BOTH,
+                    base_model=cfg.base_model,
+                    training_shape=infra.training_shape_id,
+                )
+                if cfg.output_model_id:
+                    rlor_mgr.promote_checkpoint(
+                        policy_job_id,
+                        paths["sampler_path"],
+                        cfg.output_model_id,
+                        cfg.base_model,
+                    )
+                    runner.write_output_model(
+                        model_id=cfg.output_model_id, checkpoint=cp_name, job_id=policy_job_id,
+                    )
+            except Exception as e:
+                logger.warning("Failed to save final checkpoint: %s", e)

--- a/training/tests/unit/test_async_loop.py
+++ b/training/tests/unit/test_async_loop.py
@@ -1,0 +1,158 @@
+"""Unit tests for training.utils.rl.train_async."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from training.utils.rl.losses import PromptGroup
+from training.utils.rl.train import TrainStepFns
+from training.utils.rl.train_async import AsyncConfig, run_rl_loop_async
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _empty_prompt_group(reward: float = 1.0) -> PromptGroup:
+    return PromptGroup(
+        data=[],
+        advantages=[0.0],
+        ref_logprobs=None,
+        prompt_len=0,
+        rewards=[reward],
+    )
+
+
+class TestAsyncConfig:
+    def test_defaults(self):
+        cfg = AsyncConfig()
+        assert cfg.max_steps_off_policy == 2
+        assert cfg.groups_per_batch == 8
+
+    def test_rejects_staleness_above_two(self):
+        with pytest.raises(ValueError, match="exceeds"):
+            AsyncConfig(max_steps_off_policy=3)
+
+    def test_rejects_negative_staleness(self):
+        with pytest.raises(ValueError, match=">= 0"):
+            AsyncConfig(max_steps_off_policy=-1)
+
+    def test_rejects_zero_groups_per_batch(self):
+        with pytest.raises(ValueError, match=">= 1"):
+            AsyncConfig(groups_per_batch=0)
+
+
+class TestRunRlLoopAsync:
+    def test_returns_early_when_too_few_rows(self):
+        cfg = AsyncConfig(groups_per_batch=8)
+
+        def train_step(step, groups, stats):
+            raise AssertionError("train_step should not fire")
+
+        result = _run(
+            run_rl_loop_async(
+                sample_fn=lambda row: _async_return(_empty_prompt_group()),
+                rows=[{"a": 1}],
+                train_fns=TrainStepFns(train_step=train_step),
+                async_config=cfg,
+            )
+        )
+        assert result == 0
+
+    def test_training_runs_one_step_per_batch(self):
+        cfg = AsyncConfig(max_steps_off_policy=0, groups_per_batch=2)
+        rows = [{"i": i} for i in range(4)]
+        train_calls: list[int] = []
+
+        def train_step(step, groups, stats):
+            train_calls.append(step)
+            assert len(groups) == 2
+            return step + 1, {}
+
+        async def sample_fn(row):
+            return _empty_prompt_group(reward=float(row["i"]))
+
+        result = _run(
+            run_rl_loop_async(
+                sample_fn=sample_fn,
+                rows=rows,
+                train_fns=TrainStepFns(train_step=train_step),
+                async_config=cfg,
+            )
+        )
+        assert result == 2
+        assert train_calls == [0, 1]
+
+    def test_sample_fn_exceptions_counted_as_sample_fails(self):
+        cfg = AsyncConfig(max_steps_off_policy=0, groups_per_batch=1)
+        rows = [{"i": i} for i in range(4)]
+        captured_stats: list[dict] = []
+
+        def train_step(step, groups, stats):
+            captured_stats.append(stats)
+            return step + 1, {}
+
+        async def sample_fn(row):
+            if row["i"] == 1:
+                raise RuntimeError("boom")
+            return _empty_prompt_group()
+
+        _run(
+            run_rl_loop_async(
+                sample_fn=sample_fn, rows=rows,
+                train_fns=TrainStepFns(train_step=train_step),
+                async_config=cfg,
+            )
+        )
+        # One of the four rows explodes -> it shows up as a sample_fail.
+        assert sum(s.get("sample_fails", 0) for s in captured_stats) == 1
+
+    def test_dynamic_filter_drops_groups(self):
+        cfg = AsyncConfig(max_steps_off_policy=0, groups_per_batch=1)
+        rows = [{"i": i} for i in range(4)]
+        call_count = [0]
+
+        def train_step(step, groups, stats):
+            call_count[0] += 1
+            return step + 1, {}
+
+        async def sample_fn(row):
+            return _empty_prompt_group(reward=float(row["i"]))
+
+        _run(
+            run_rl_loop_async(
+                sample_fn=sample_fn, rows=rows,
+                train_fns=TrainStepFns(train_step=train_step),
+                async_config=cfg,
+                dynamic_filter_fn=lambda pg: pg.rewards[0] >= 2.0,
+            )
+        )
+        # i=0,1 get filtered; i=2,3 pass -> exactly 2 train calls.
+        assert call_count[0] == 2
+
+    def test_generation_step_stamped_on_prompt_group(self):
+        cfg = AsyncConfig(max_steps_off_policy=0, groups_per_batch=1)
+        rows = [{"i": i} for i in range(2)]
+        seen: list[int | None] = []
+
+        def train_step(step, groups, stats):
+            seen.append(groups[0].generation_step)
+            return step + 1, {}
+
+        async def sample_fn(row):
+            return _empty_prompt_group()
+
+        _run(
+            run_rl_loop_async(
+                sample_fn=sample_fn, rows=rows,
+                train_fns=TrainStepFns(train_step=train_step),
+                async_config=cfg,
+            )
+        )
+        assert all(s is not None and s >= 0 for s in seen)
+
+
+async def _async_return(value):
+    return value

--- a/training/tests/unit/test_rl_env.py
+++ b/training/tests/unit/test_rl_env.py
@@ -1,0 +1,116 @@
+"""Unit tests for training.utils.rl.env types."""
+
+from __future__ import annotations
+
+import pytest
+
+from training.utils.rl.env import (
+    MessageEnv,
+    MessageStepResult,
+    Trajectory,
+    Transition,
+)
+
+
+def _make_transition(
+    *, reward: float = 1.0, done: bool = True, finish: str = "stop", valid: bool = True
+) -> Transition:
+    return Transition(
+        prompt_tokens=[1, 2, 3],
+        completion_tokens=[4, 5],
+        completion_text="hi",
+        inference_logprobs=[-0.1, -0.2],
+        assistant_message={"role": "assistant", "content": "hi"},
+        reward=reward,
+        episode_done=done,
+        finish_reason=finish,
+        is_reward_valid=valid,
+    )
+
+
+class TestMessageStepResult:
+    def test_defaults_are_empty(self):
+        result = MessageStepResult(reward=1.0, episode_done=True)
+        assert result.next_messages == []
+        assert result.metrics == {}
+        assert result.is_reward_valid is True
+
+
+class TestTrajectory:
+    def test_empty_trajectory_is_not_complete(self):
+        traj = Trajectory()
+        assert traj.transitions == []
+        assert traj.is_complete is False
+        assert traj.total_reward == 0.0
+
+    def test_single_turn_trajectory(self):
+        traj = Trajectory(transitions=[_make_transition(reward=0.7)])
+        assert traj.is_complete is True
+        assert traj.total_reward == pytest.approx(0.7)
+        assert traj.any_truncated is False
+        assert traj.all_rewards_valid is True
+
+    def test_multi_turn_reward_sum(self):
+        traj = Trajectory(
+            transitions=[
+                _make_transition(reward=0.5, done=False),
+                _make_transition(reward=0.25, done=True),
+            ]
+        )
+        assert traj.total_reward == pytest.approx(0.75)
+        assert traj.is_complete is True
+
+    def test_is_complete_false_when_last_turn_not_done(self):
+        traj = Trajectory(transitions=[_make_transition(done=False)])
+        assert traj.is_complete is False
+
+    def test_any_truncated_picks_up_length_finish(self):
+        traj = Trajectory(
+            transitions=[
+                _make_transition(done=False, finish="stop"),
+                _make_transition(done=True, finish="length"),
+            ]
+        )
+        assert traj.any_truncated is True
+
+    def test_all_rewards_valid_false_on_invalid_turn(self):
+        traj = Trajectory(transitions=[_make_transition(valid=False)])
+        assert traj.all_rewards_valid is False
+
+    def test_add_turn_reward_default_targets_last_turn(self):
+        traj = Trajectory(
+            transitions=[
+                _make_transition(reward=0.1),
+                _make_transition(reward=0.2),
+            ]
+        )
+        traj.add_turn_reward(0.5)
+        assert traj.transitions[-1].reward == pytest.approx(0.7)
+        assert traj.transitions[0].reward == pytest.approx(0.1)
+
+    def test_add_turn_reward_specific_index(self):
+        traj = Trajectory(transitions=[_make_transition(reward=0.1), _make_transition(reward=0.2)])
+        traj.add_turn_reward(0.3, turn_index=0)
+        assert traj.transitions[0].reward == pytest.approx(0.4)
+        assert traj.transitions[1].reward == pytest.approx(0.2)
+
+    def test_add_turn_reward_on_empty_trajectory_raises(self):
+        with pytest.raises(ValueError, match="empty trajectory"):
+            Trajectory().add_turn_reward(1.0)
+
+
+class TestMessageEnv:
+    def test_abstract_methods_must_be_implemented(self):
+        with pytest.raises(TypeError):
+            MessageEnv()  # type: ignore[abstract]
+
+    def test_concrete_subclass_is_instantiable(self):
+        class _Impl(MessageEnv):
+            async def initial_messages(self):
+                return []
+
+            async def step(self, assistant_message):
+                return MessageStepResult(reward=0.0, episode_done=True)
+
+        env = _Impl()
+        assert isinstance(env, MessageEnv)

--- a/training/tests/unit/test_rl_env_adapters.py
+++ b/training/tests/unit/test_rl_env_adapters.py
@@ -1,0 +1,129 @@
+"""Unit tests for training.utils.rl.env_adapters."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from training.utils.rl.env import MessageEnv, MessageStepResult
+from training.utils.rl.env_adapters import SingleTurnEnv, _extract_text, wrap_reward_fn
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+class TestExtractText:
+    def test_none_returns_empty_string(self):
+        assert _extract_text(None) == ""
+
+    def test_str_passthrough(self):
+        assert _extract_text("hello") == "hello"
+
+    def test_list_of_parts_concatenated(self):
+        content = [{"type": "text", "text": "foo "}, {"type": "text", "text": "bar"}]
+        assert _extract_text(content) == "foo bar"
+
+    def test_list_with_non_dict_parts(self):
+        assert _extract_text(["a", "b", "c"]) == "abc"
+
+    def test_other_types_stringified(self):
+        assert _extract_text(42) == "42"
+
+
+class TestSingleTurnEnv:
+    def test_is_a_message_env(self):
+        env = SingleTurnEnv(row={}, reward_fn=lambda c, r: 0.0)
+        assert isinstance(env, MessageEnv)
+
+    def test_initial_messages_returns_row_messages(self):
+        msgs = [{"role": "user", "content": "hi"}]
+        env = SingleTurnEnv(row={"messages": msgs}, reward_fn=lambda c, r: 0.0)
+        result = _run(env.initial_messages())
+        assert result == msgs
+        # Defensive copy so mutating row doesn't mutate env output.
+        assert result is not msgs
+
+    def test_initial_messages_defaults_to_empty(self):
+        env = SingleTurnEnv(row={}, reward_fn=lambda c, r: 0.0)
+        assert _run(env.initial_messages()) == []
+
+    def test_custom_messages_field(self):
+        msgs = [{"role": "user", "content": "x"}]
+        env = SingleTurnEnv(row={"convo": msgs}, reward_fn=lambda c, r: 0.0, messages_field="convo")
+        assert _run(env.initial_messages()) == msgs
+
+    def test_step_calls_sync_reward_fn_with_text_and_row(self):
+        captured: dict = {}
+
+        def reward(completion, row):
+            captured["completion"] = completion
+            captured["row"] = row
+            return 0.75
+
+        env = SingleTurnEnv(row={"answer": 42, "messages": []}, reward_fn=reward)
+        result = _run(env.step({"role": "assistant", "content": "the answer"}))
+
+        assert isinstance(result, MessageStepResult)
+        assert result.reward == pytest.approx(0.75)
+        assert result.episode_done is True
+        assert result.next_messages == []
+        assert captured["completion"] == "the answer"
+        assert captured["row"] == {"answer": 42, "messages": []}
+
+    def test_step_awaits_async_reward_fn(self):
+        async def reward(completion, row):
+            return 1.0 if "yes" in completion else 0.0
+
+        env = SingleTurnEnv(row={}, reward_fn=reward)
+
+        assert _run(env.step({"role": "assistant", "content": "yes sir"})).reward == 1.0
+        assert _run(env.step({"role": "assistant", "content": "nope"})).reward == 0.0
+
+    def test_step_extracts_text_from_list_content(self):
+        seen: dict = {}
+
+        def reward(completion, row):
+            seen["text"] = completion
+            return 0.0
+
+        env = SingleTurnEnv(row={}, reward_fn=reward)
+        _run(
+            env.step(
+                {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "A"}, {"type": "text", "text": "B"}],
+                }
+            )
+        )
+        assert seen["text"] == "AB"
+
+    def test_step_coerces_reward_to_float(self):
+        env = SingleTurnEnv(row={}, reward_fn=lambda c, r: True)
+        assert _run(env.step({"role": "assistant", "content": ""})).reward == 1.0
+
+
+class TestWrapRewardFn:
+    def test_returns_env_builder_producing_single_turn_envs(self):
+        builder = wrap_reward_fn(lambda c, r: 0.5)
+        env = builder({"messages": [{"role": "user", "content": "q"}]})
+        assert isinstance(env, SingleTurnEnv)
+        result = _run(env.step({"role": "assistant", "content": "a"}))
+        assert result.reward == pytest.approx(0.5)
+
+    def test_builder_produces_fresh_env_each_call(self):
+        builder = wrap_reward_fn(lambda c, r: 0.0)
+        e1 = builder({})
+        e2 = builder({})
+        assert e1 is not e2
+
+    def test_rejects_non_callable(self):
+        with pytest.raises(TypeError, match="callable"):
+            wrap_reward_fn("not a function")  # type: ignore[arg-type]
+
+    def test_forwards_messages_field_kwarg(self):
+        builder = wrap_reward_fn(lambda c, r: 0.0, messages_field="convo")
+        msgs = [{"role": "user", "content": "x"}]
+        env = builder({"convo": msgs})
+        assert _run(env.initial_messages()) == msgs

--- a/training/tests/unit/test_rl_rollout_builder.py
+++ b/training/tests/unit/test_rl_rollout_builder.py
@@ -1,0 +1,103 @@
+"""Unit tests for training.utils.rl.rollout_builder."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from training.utils.rl.env import Trajectory, Transition
+from training.utils.rl.rollout_builder import trajectories_to_prompt_group
+
+
+def _make_transition(
+    *,
+    prompt_tokens=(1, 2, 3),
+    completion_tokens=(10, 11),
+    reward=1.0,
+    inference_logprobs=(-0.1, -0.2),
+    finish_reason="stop",
+):
+    return Transition(
+        prompt_tokens=list(prompt_tokens),
+        completion_tokens=list(completion_tokens),
+        completion_text="x",
+        inference_logprobs=list(inference_logprobs) if inference_logprobs is not None else None,
+        assistant_message={"role": "assistant", "content": "x"},
+        reward=float(reward),
+        episode_done=True,
+        finish_reason=finish_reason,
+    )
+
+
+def _make_trajectory(*transitions):
+    return Trajectory(transitions=list(transitions))
+
+
+class TestTrajectoriesToPromptGroup:
+    def test_empty_input_returns_none(self):
+        assert trajectories_to_prompt_group([], need_reference=False, tokenizer=None) is None
+
+    def test_single_turn_group_packs_prompt_group(self):
+        trajs = [
+            _make_trajectory(_make_transition(reward=1.0)),
+            _make_trajectory(_make_transition(reward=0.0)),
+        ]
+        pg = trajectories_to_prompt_group(trajs, need_reference=False, tokenizer=None)
+        assert pg is not None
+        assert len(pg.data) == 2
+        assert pg.rewards == [1.0, 0.0]
+        assert pg.ref_data == []
+        # Advantages centered.
+        assert sum(pg.advantages) == pytest.approx(0.0, abs=1e-5)
+        # Completion-length accounting matches the transition.
+        assert pg.completion_lens == [2, 2]
+        assert pg.truncated == [False, False]
+
+    def test_need_reference_builds_reference_datums(self):
+        trajs = [_make_trajectory(_make_transition())]
+        pg = trajectories_to_prompt_group(trajs, need_reference=True, tokenizer=None)
+        assert pg is not None
+        assert len(pg.ref_data) == len(pg.data) == 1
+
+    def test_truncated_flag_propagates(self):
+        trajs = [_make_trajectory(_make_transition(finish_reason="length"))]
+        pg = trajectories_to_prompt_group(trajs, need_reference=False, tokenizer=None)
+        assert pg is not None
+        assert pg.truncated == [True]
+
+    def test_drops_too_short_trajectories(self):
+        """Trajectories with <2 total tokens are unusable (need a shift-pair)."""
+        t = Transition(
+            prompt_tokens=[],
+            completion_tokens=[42],
+            completion_text="",
+            inference_logprobs=[-0.5],
+            assistant_message={"role": "assistant", "content": ""},
+            reward=1.0,
+            episode_done=True,
+        )
+        trajs = [_make_trajectory(t)]
+        assert trajectories_to_prompt_group(
+            trajs, need_reference=False, tokenizer=None,
+        ) is None
+
+    def test_auto_prefill_when_logprobs_missing(self):
+        trajs = [_make_trajectory(_make_transition(inference_logprobs=None))]
+        with patch(
+            "training.utils.rl.rollout_builder.get_prefill_logprobs",
+            return_value=[-0.5, -0.6, -0.7],
+        ) as mock:
+            pg = trajectories_to_prompt_group(
+                trajs, need_reference=False, tokenizer=None,
+                inference_url="https://x", api_key="k", model="m",
+            )
+        assert pg is not None
+        assert mock.call_count == 1
+
+    def test_rejects_missing_logprobs_without_inference_url(self):
+        trajs = [_make_trajectory(_make_transition(inference_logprobs=None))]
+        with pytest.raises(RuntimeError, match="prefill"):
+            trajectories_to_prompt_group(
+                trajs, need_reference=False, tokenizer=None,
+            )

--- a/training/tests/unit/test_rl_rollout_runner.py
+++ b/training/tests/unit/test_rl_rollout_runner.py
@@ -1,0 +1,163 @@
+"""Unit tests for training.utils.rl.rollout_runner."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any
+
+from training.utils.rl.env import MessageEnv, MessageStepResult
+from training.utils.rl.env_adapters import SingleTurnEnv
+from training.utils.rl.rollout_runner import (
+    run_env_group_to_trajectories,
+    run_env_to_trajectory,
+)
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+@dataclass
+class _FakeSampled:
+    text: str
+    full_tokens: list[int]
+    prompt_len: int
+    finish_reason: str = "stop"
+    inference_logprobs: list[float] | None = None
+    routing_matrices: Any | None = None
+
+
+@dataclass
+class _FakeGroupSampler:
+    """Records calls; returns ``n`` fixed completions per sample_with_tokens."""
+
+    completions: list[_FakeSampled] = field(default_factory=list)
+    calls: list[dict] = field(default_factory=list)
+
+    async def sample_with_tokens(self, *, messages, n, **kwargs):
+        self.calls.append({"messages": list(messages), "n": n, "kwargs": kwargs})
+        return self.completions[:n]
+
+
+class TestRunEnvGroupToTrajectories:
+    def test_single_turn_single_api_call_for_n_completions(self):
+        sampler = _FakeGroupSampler(
+            completions=[
+                _FakeSampled(text="a", full_tokens=[1, 2, 10], prompt_len=2),
+                _FakeSampled(text="b", full_tokens=[1, 2, 20], prompt_len=2),
+                _FakeSampled(text="c", full_tokens=[1, 2, 30], prompt_len=2),
+                _FakeSampled(text="d", full_tokens=[1, 2, 40], prompt_len=2),
+            ]
+        )
+
+        def reward(completion, row):
+            return 1.0 if completion == "a" else 0.0
+
+        envs = [
+            SingleTurnEnv(
+                row={"messages": [{"role": "user", "content": "hi"}]}, reward_fn=reward,
+            )
+            for _ in range(4)
+        ]
+
+        trajs = _run(
+            run_env_group_to_trajectories(
+                envs, sampler, completions_per_prompt=4, max_turns=1,
+            )
+        )
+        assert trajs is not None
+        assert len(trajs) == 4
+        # One single api call (n=4) -- matches sync loop's group batching.
+        assert len(sampler.calls) == 1
+        assert sampler.calls[0]["n"] == 4
+        # Rewards reflect the per-completion reward_fn.
+        assert trajs[0].total_reward == 1.0
+        assert sum(t.total_reward for t in trajs) == 1.0
+        for t in trajs:
+            assert t.is_complete
+            assert len(t.transitions) == 1
+
+    def test_returns_none_when_sampler_returns_fewer_than_n(self):
+        sampler = _FakeGroupSampler(
+            completions=[_FakeSampled(text="a", full_tokens=[1, 2, 3], prompt_len=2)]
+        )
+        envs = [
+            SingleTurnEnv(row={"messages": [{"role": "user", "content": "x"}]}, reward_fn=lambda c, r: 0.0)
+            for _ in range(4)
+        ]
+        assert _run(
+            run_env_group_to_trajectories(envs, sampler, completions_per_prompt=4)
+        ) is None
+
+    def test_rejects_mismatched_n_and_env_count(self):
+        sampler = _FakeGroupSampler()
+        envs = [
+            SingleTurnEnv(row={"messages": [{"role": "user", "content": "x"}]}, reward_fn=lambda c, r: 0.0)
+            for _ in range(3)
+        ]
+        import pytest
+
+        with pytest.raises(ValueError, match="must match"):
+            _run(run_env_group_to_trajectories(envs, sampler, completions_per_prompt=4))
+
+    def test_multi_turn_fans_out_after_turn_one(self):
+        """Turn 1 is batched, turn 2 issues per-env calls concurrently."""
+
+        class _TwoTurnEnv(MessageEnv):
+            def __init__(self, finish_on_second: bool):
+                self.finish_on_second = finish_on_second
+                self.turns = 0
+
+            async def initial_messages(self):
+                return [{"role": "user", "content": "go"}]
+
+            async def step(self, msg):
+                self.turns += 1
+                if self.turns == 1 and self.finish_on_second:
+                    return MessageStepResult(
+                        reward=0.5, episode_done=False,
+                        next_messages=[{"role": "user", "content": "again"}],
+                    )
+                return MessageStepResult(reward=1.0, episode_done=True)
+
+        sampler = _FakeGroupSampler(
+            completions=[
+                _FakeSampled(text="x", full_tokens=[1, 2, 3], prompt_len=2),
+                _FakeSampled(text="y", full_tokens=[1, 2, 4], prompt_len=2),
+            ]
+        )
+        envs = [_TwoTurnEnv(finish_on_second=True), _TwoTurnEnv(finish_on_second=False)]
+
+        trajs = _run(
+            run_env_group_to_trajectories(
+                envs, sampler, completions_per_prompt=2, max_turns=3,
+            )
+        )
+        assert trajs is not None
+        # Env 0 runs two turns (0.5 + 1.0), env 1 runs one (1.0).
+        assert len(trajs[0].transitions) == 2
+        assert len(trajs[1].transitions) == 1
+        assert trajs[0].total_reward == 1.5
+        # First call was n=2 (batched); second call was per-env with n=1.
+        assert sampler.calls[0]["n"] == 2
+        assert sampler.calls[1]["n"] == 1
+
+
+class TestRunEnvToTrajectory:
+    def test_runs_single_env_single_turn(self):
+        sampler = _FakeGroupSampler(
+            completions=[_FakeSampled(text="ok", full_tokens=[1, 2, 7], prompt_len=2)]
+        )
+        env = SingleTurnEnv(
+            row={"messages": [{"role": "user", "content": "hi"}]},
+            reward_fn=lambda c, r: 0.42,
+        )
+        traj = _run(run_env_to_trajectory(env, sampler, max_turns=1))
+        assert traj is not None and len(traj.transitions) == 1
+        assert traj.transitions[0].reward == 0.42
+
+    def test_returns_none_on_empty_initial_messages(self):
+        sampler = _FakeGroupSampler()
+        env = SingleTurnEnv(row={}, reward_fn=lambda c, r: 0.0)
+        assert _run(run_env_to_trajectory(env, sampler, max_turns=1)) is None

--- a/training/tests/unit/test_rl_sample_fn_factory.py
+++ b/training/tests/unit/test_rl_sample_fn_factory.py
@@ -1,0 +1,192 @@
+"""Unit tests for training.utils.rl.sample_fn_factory."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from training.utils.rl.env import Trajectory, Transition
+from training.utils.rl.sample_fn_factory import (
+    build_sample_fn,
+    validate_rollout_regime,
+)
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+@dataclass
+class _FakeSampled:
+    text: str
+    full_tokens: list[int]
+    prompt_len: int
+    finish_reason: str = "stop"
+    inference_logprobs: list[float] | None = None
+    routing_matrices: Any | None = None
+
+
+@dataclass
+class _FakeSampler:
+    completions: list[_FakeSampled] = field(default_factory=list)
+    calls: list[dict] = field(default_factory=list)
+
+    async def sample_with_tokens(self, *, messages, n, **kwargs):
+        self.calls.append({"n": n, "messages": list(messages)})
+        return self.completions[:n]
+
+
+class TestValidateRolloutRegime:
+    def test_requires_exactly_one(self):
+        with pytest.raises(ValueError, match="one of"):
+            validate_rollout_regime(reward_fn=None, env_builder=None, rollout_source=None)
+
+    def test_rejects_multiple(self):
+        with pytest.raises(ValueError, match="exactly one"):
+            validate_rollout_regime(
+                reward_fn=lambda c, r: 0.0,
+                env_builder=lambda r: object(),
+                rollout_source=None,
+            )
+
+
+class TestBuildSampleFn:
+    def _make_sampler(self) -> _FakeSampler:
+        return _FakeSampler(
+            completions=[
+                _FakeSampled(
+                    text=f"c{i}",
+                    full_tokens=[1, 2, 10 + i, 11 + i],
+                    prompt_len=2,
+                    inference_logprobs=[-0.1, -0.2],
+                )
+                for i in range(4)
+            ]
+        )
+
+    def test_reward_fn_path_produces_prompt_group(self):
+        sampler = self._make_sampler()
+        sample_fn = build_sample_fn(
+            reward_fn=lambda completion, row: 1.0 if "c0" in completion else 0.0,
+            sampler=sampler,
+            completions_per_prompt=4,
+            sample_kwargs={},
+            tokenizer=object(),
+        )
+        row = {"messages": [{"role": "user", "content": "hi"}]}
+        pg = _run(sample_fn(row))
+        assert pg is not None
+        assert sum(pg.rewards) == pytest.approx(1.0)
+        assert len(pg.advantages) == len(pg.data)
+
+    def test_env_builder_path(self):
+        from training.utils.rl.env_adapters import SingleTurnEnv
+
+        sampler = self._make_sampler()
+
+        def env_builder(row):
+            return SingleTurnEnv(row=row, reward_fn=lambda c, r: 0.5)
+
+        sample_fn = build_sample_fn(
+            env_builder=env_builder,
+            sampler=sampler,
+            completions_per_prompt=4,
+            sample_kwargs={},
+            tokenizer=object(),
+        )
+        pg = _run(sample_fn({"messages": [{"role": "user", "content": "y"}]}))
+        assert pg is not None
+        assert pg.rewards == [0.5, 0.5, 0.5, 0.5]
+
+    def test_rollout_source_path_with_provided_logprobs(self):
+        async def rollout_source(row, *, n):
+            return [
+                Trajectory(
+                    transitions=[
+                        Transition(
+                            prompt_tokens=[1, 2],
+                            completion_tokens=[3, 4],
+                            completion_text="x",
+                            inference_logprobs=[-0.1, -0.2],
+                            assistant_message={"role": "assistant", "content": "x"},
+                            reward=float(i),
+                            episode_done=True,
+                        )
+                    ]
+                )
+                for i in range(n)
+            ]
+
+        sample_fn = build_sample_fn(
+            rollout_source=rollout_source,
+            sampler=object(),  # unused on this path
+            completions_per_prompt=3,
+            sample_kwargs={},
+            tokenizer=object(),
+        )
+        pg = _run(sample_fn({}))
+        assert pg is not None
+        assert pg.rewards == [0.0, 1.0, 2.0]
+
+    def test_rollout_source_auto_prefill_when_logprobs_missing(self):
+        async def rollout_source(row, *, n):
+            return [
+                Trajectory(
+                    transitions=[
+                        Transition(
+                            prompt_tokens=[1, 2],
+                            completion_tokens=[3, 4],
+                            completion_text="x",
+                            inference_logprobs=None,
+                            assistant_message={"role": "assistant", "content": "x"},
+                            reward=1.0,
+                            episode_done=True,
+                        )
+                    ]
+                )
+                for _ in range(n)
+            ]
+
+        with patch(
+            "training.utils.rl.rollout_builder.get_prefill_logprobs",
+            return_value=[-0.1, -0.2, -0.3],
+        ) as mock:
+            sample_fn = build_sample_fn(
+                rollout_source=rollout_source,
+                sampler=object(),
+                completions_per_prompt=2,
+                sample_kwargs={},
+                tokenizer=object(),
+                inference_url="https://x",
+                api_key="k",
+                model="m",
+            )
+            pg = _run(sample_fn({}))
+        assert pg is not None
+        # get_prefill_logprobs should have been called once per trajectory.
+        assert mock.call_count == 2
+
+    def test_group_reward_fn_folds_into_final_reward(self):
+        sampler = self._make_sampler()
+
+        async def group_reward_fn(trajectories, row):
+            return [0.1] * len(trajectories)
+
+        sample_fn = build_sample_fn(
+            reward_fn=lambda c, r: 0.0,
+            sampler=sampler,
+            completions_per_prompt=4,
+            sample_kwargs={},
+            tokenizer=object(),
+            group_reward_fn=group_reward_fn,
+        )
+        row = {"messages": [{"role": "user", "content": "q"}]}
+        pg = _run(sample_fn(row))
+        assert pg is not None
+        # All rewards should reflect the +0.1 delta.
+        for r in pg.rewards:
+            assert r == pytest.approx(0.1)

--- a/training/tests/unit/test_rl_tokenize.py
+++ b/training/tests/unit/test_rl_tokenize.py
@@ -1,0 +1,249 @@
+"""Unit tests for training.utils.rl.tokenize helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from training.utils.rl import tokenize as tokenize_mod
+from training.utils.rl.tokenize import (
+    _normalize_inference_base_url,
+    get_prefill_logprobs,
+    tokenize_chat_turn,
+)
+
+
+class _FakeTokenizer:
+    """Minimal chat-template tokenizer.
+
+    Each message contributes a deterministic list of token IDs:
+    role=user -> [1, <content_len>], role=assistant -> [2, <content_len>,
+    3 (eot)], system -> [0, <content_len>]. ``add_generation_prompt`` adds
+    a trailing ``[99]`` marker.  Crucially, rendering the same message list
+    always yields the same prefix when more messages are appended, so the
+    prefix-diff in tokenize_chat_turn works.
+    """
+
+    _ROLE_TOKEN = {"system": 0, "user": 1, "assistant": 2}
+    _EOT = 3
+    _GEN_PROMPT = 99
+
+    def apply_chat_template(self, messages, *, tokenize=True, add_generation_prompt=False, **_):
+        out: list[int] = []
+        for m in messages:
+            role = m.get("role", "user")
+            content_len = len(str(m.get("content", "")))
+            out.append(self._ROLE_TOKEN.get(role, 1))
+            out.append(content_len)
+            if role == "assistant":
+                out.append(self._EOT)
+        if add_generation_prompt:
+            out.append(self._GEN_PROMPT)
+        if not tokenize:
+            raise NotImplementedError("fake only supports tokenize=True")
+        return out
+
+
+class TestTokenizeChatTurn:
+    def test_raises_when_prefix_invariant_violated(self):
+        """If the assistant turn isn't a strict extension of the rendered
+        prompt, the helper must fail loudly rather than silently derive
+        garbage completion_ids.  The default fake tokenizer violates the
+        invariant (the generation-prompt marker is outside the assistant
+        turn), so it's the natural negative-test fixture."""
+        tokenizer = _FakeTokenizer()
+        messages = [{"role": "user", "content": "hi"}]
+        assistant = {"role": "assistant", "content": "yo"}
+
+        with pytest.raises(RuntimeError, match="prefix extension"):
+            tokenize_chat_turn(messages, assistant, tokenizer)
+
+    def test_prefix_preserving_tokenizer_produces_expected_split(self):
+        """A chat template where the generation-prompt marker is *inside*
+        the assistant turn satisfies the strict-prefix invariant; the
+        helper then returns the assistant-added suffix as completion_ids."""
+
+        class _PrefixTokenizer:
+            _ROLE_TOKEN = {"system": 0, "user": 1, "assistant": 2}
+            _EOT = 3
+            _GEN_PROMPT = 99
+
+            def apply_chat_template(
+                self, messages, *, tokenize=True, add_generation_prompt=False, **_
+            ):
+                out: list[int] = []
+                for m in messages:
+                    role = m.get("role", "user")
+                    content_len = len(str(m.get("content", "")))
+                    if role == "assistant":
+                        out.append(self._GEN_PROMPT)  # part of assistant turn
+                        out.append(self._ROLE_TOKEN[role])
+                        out.append(content_len)
+                        out.append(self._EOT)
+                    else:
+                        out.append(self._ROLE_TOKEN.get(role, 1))
+                        out.append(content_len)
+                if add_generation_prompt:
+                    out.append(self._GEN_PROMPT)
+                return out
+
+        tokenizer = _PrefixTokenizer()
+        messages = [{"role": "user", "content": "hi"}]  # 2 chars
+        assistant = {"role": "assistant", "content": "yo"}  # 2 chars
+
+        prompt_ids, completion_ids = tokenize_chat_turn(messages, assistant, tokenizer)
+
+        # user: [1, 2], gen prompt: [99] -> prompt_ids = [1, 2, 99]
+        assert prompt_ids == [1, 2, 99]
+        # Full: user [1, 2] + assistant [99, 2, 2, 3] -> [1, 2, 99, 2, 2, 3].
+        # completion_ids is the suffix past the rendered prompt.
+        assert completion_ids == [2, 2, 3]
+
+    def test_multi_turn_prompt_includes_earlier_messages(self):
+        class _PrefixTokenizer:
+            _ROLE_TOKEN = {"system": 0, "user": 1, "assistant": 2}
+            _EOT = 3
+            _GEN_PROMPT = 99
+
+            def apply_chat_template(
+                self, messages, *, tokenize=True, add_generation_prompt=False, **_
+            ):
+                out: list[int] = []
+                for m in messages:
+                    role = m.get("role", "user")
+                    content_len = len(str(m.get("content", "")))
+                    if role == "assistant":
+                        out.extend([self._GEN_PROMPT, self._ROLE_TOKEN[role], content_len, self._EOT])
+                    else:
+                        out.extend([self._ROLE_TOKEN.get(role, 1), content_len])
+                if add_generation_prompt:
+                    out.append(self._GEN_PROMPT)
+                return out
+
+        tokenizer = _PrefixTokenizer()
+        messages = [
+            {"role": "system", "content": "s"},
+            {"role": "user", "content": "q1"},
+            {"role": "assistant", "content": "a1"},
+            {"role": "user", "content": "q2"},
+        ]
+        assistant = {"role": "assistant", "content": "a2"}
+
+        prompt_ids, completion_ids = tokenize_chat_turn(messages, assistant, tokenizer)
+
+        assert prompt_ids[-1] == 99, "generation prompt marker must end the prompt"
+        assert len(completion_ids) > 0
+        # The first assistant turn must appear before the generation prompt.
+        assert 3 in prompt_ids, "earlier assistant EOT should be preserved in prompt"
+
+
+class TestNormalizeInferenceBaseUrl:
+    def test_strips_inference_suffix(self):
+        assert _normalize_inference_base_url("https://host.example/inference") == "https://host.example"
+
+    def test_strips_inference_v1_suffix(self):
+        assert (
+            _normalize_inference_base_url("https://host.example/inference/v1")
+            == "https://host.example"
+        )
+
+    def test_strips_trailing_slash(self):
+        assert _normalize_inference_base_url("https://host.example/") == "https://host.example"
+
+    def test_leaves_other_urls_alone(self):
+        assert _normalize_inference_base_url("https://host.example/v1") == "https://host.example/v1"
+
+
+class TestGetPrefillLogprobs:
+    def test_returns_empty_for_no_tokens(self):
+        assert get_prefill_logprobs(url="x", tokens=[], api_key="k", model="m") == []
+
+    def test_returns_zero_padding_for_single_token(self):
+        assert get_prefill_logprobs(url="x", tokens=[5], api_key="k", model="m") == []
+
+    def test_aligns_and_drops_leading_none(self, monkeypatch):
+        captured: dict = {}
+
+        class _Resp:
+            status_code = 200
+
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {
+                    "choices": [
+                        {"logprobs": {"token_logprobs": [None, -0.1, -0.2, -0.3]}}
+                    ]
+                }
+
+        def fake_post(url, json=None, headers=None, timeout=None):
+            captured["url"] = url
+            captured["payload"] = json
+            captured["headers"] = headers
+            return _Resp()
+
+        monkeypatch.setattr(tokenize_mod.requests, "post", fake_post)
+
+        out = get_prefill_logprobs(
+            url="https://host/inference/v1",
+            tokens=[10, 20, 30, 40],
+            api_key="secret",
+            model="model-x",
+        )
+
+        assert out == [-0.1, -0.2, -0.3]
+        assert captured["url"].endswith("/inference/v1/completions")
+        assert captured["url"].startswith("https://host/")
+        assert captured["payload"]["prompt"] == [10, 20, 30, 40]
+        assert captured["payload"]["echo"] is True
+        assert captured["payload"]["max_tokens"] == 1
+        assert captured["payload"]["model"] == "model-x"
+        assert captured["headers"]["Authorization"] == "Bearer secret"
+
+    def test_pads_when_server_returns_fewer_logprobs(self, monkeypatch):
+        class _Resp:
+            status_code = 200
+
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"choices": [{"logprobs": {"token_logprobs": [None, -0.5]}}]}
+
+        monkeypatch.setattr(tokenize_mod.requests, "post", lambda *a, **kw: _Resp())
+
+        out = get_prefill_logprobs(
+            url="https://host", tokens=[1, 2, 3, 4], api_key="k", model="m"
+        )
+        # Expected length = len(tokens) - 1 = 3; server returned 1 aligned value.
+        assert out == [-0.5, 0.0, 0.0]
+
+    def test_replaces_none_logprobs_with_zero(self, monkeypatch):
+        class _Resp:
+            status_code = 200
+
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"choices": [{"logprobs": {"token_logprobs": [None, -0.1, None, -0.3]}}]}
+
+        monkeypatch.setattr(tokenize_mod.requests, "post", lambda *a, **kw: _Resp())
+
+        out = get_prefill_logprobs(url="https://host", tokens=[1, 2, 3, 4], api_key="k", model="m")
+        assert out == [-0.1, 0.0, -0.3]
+
+    def test_handles_empty_choices(self, monkeypatch):
+        class _Resp:
+            status_code = 200
+
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"choices": []}
+
+        monkeypatch.setattr(tokenize_mod.requests, "post", lambda *a, **kw: _Resp())
+
+        out = get_prefill_logprobs(url="https://host", tokens=[1, 2, 3], api_key="k", model="m")
+        assert out == [0.0, 0.0]

--- a/training/utils/rl/__init__.py
+++ b/training/utils/rl/__init__.py
@@ -18,6 +18,16 @@ __all__ = [
     "DynamicFilterFn",
     "TrainStepFns",
     "run_rl_loop",
+    # Async training loop + env-driven sampling
+    "AsyncConfig",
+    "run_rl_loop_async",
+    "run_env_group_to_trajectories",
+    "run_env_to_trajectory",
+    "trajectories_to_prompt_group",
+    "build_sample_fn",
+    "RewardFn",
+    "EnvBuilder",
+    "RolloutSource",
     # Bundled infra setup
     "Infra",
     "setup_infra",
@@ -82,3 +92,15 @@ from training.utils.rl.env import (
 )
 from training.utils.rl.env_adapters import SingleTurnEnv, wrap_reward_fn
 from training.utils.rl.tokenize import get_prefill_logprobs, tokenize_chat_turn
+from training.utils.rl.train_async import AsyncConfig, run_rl_loop_async
+from training.utils.rl.rollout_runner import (
+    run_env_group_to_trajectories,
+    run_env_to_trajectory,
+)
+from training.utils.rl.rollout_builder import trajectories_to_prompt_group
+from training.utils.rl.sample_fn_factory import (
+    EnvBuilder,
+    RewardFn,
+    RolloutSource,
+    build_sample_fn,
+)

--- a/training/utils/rl/__init__.py
+++ b/training/utils/rl/__init__.py
@@ -33,6 +33,16 @@ __all__ = [
     "expand_turn_advantages_from_spans",
     "make_igpo_loss_fn",
     "score_prefix",
+    # Env-based rollout abstraction
+    "Message",
+    "MessageEnv",
+    "MessageStepResult",
+    "Transition",
+    "Trajectory",
+    "SingleTurnEnv",
+    "wrap_reward_fn",
+    "tokenize_chat_turn",
+    "get_prefill_logprobs",
 ]
 
 from training.utils.rl.pp import PPBatchRecommendation, compute_pp_recommendation
@@ -63,3 +73,12 @@ from training.utils.rl.igpo import (
     make_igpo_loss_fn,
     score_prefix,
 )
+from training.utils.rl.env import (
+    Message,
+    MessageEnv,
+    MessageStepResult,
+    Trajectory,
+    Transition,
+)
+from training.utils.rl.env_adapters import SingleTurnEnv, wrap_reward_fn
+from training.utils.rl.tokenize import get_prefill_logprobs, tokenize_chat_turn

--- a/training/utils/rl/env.py
+++ b/training/utils/rl/env.py
@@ -1,0 +1,166 @@
+"""Message-level RL environment abstraction.
+
+This module defines the extension point that user recipes implement to plug
+a custom task into ``rl_loop.py``.  The training loop never knows how a
+reward was computed or whether a rollout was single- or multi-turn — it only
+consumes :class:`Trajectory` objects produced by running a :class:`MessageEnv`.
+
+Concepts
+--------
+- :class:`MessageEnv` — stateful, single-use environment operating at the
+  chat-message level.  Subclass this for any custom task.
+- :class:`MessageStepResult` — what :meth:`MessageEnv.step` returns: the
+  reward for the assistant turn plus whether the episode is done and any
+  messages to append before the next sample.
+- :class:`Transition` — one completed turn: the assistant tokens, their
+  per-token inference logprobs, the reward, and metrics.
+- :class:`Trajectory` — ordered list of :class:`Transition`.  A single-turn
+  task produces a trajectory with exactly one transition.
+
+Extension points in :class:`Trajectory` are deliberately minimal.  Users do
+not construct Transitions themselves; the rollout runner does that from the
+sampler output and the :class:`MessageStepResult` the env returned.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any
+
+Message = dict[str, Any]
+"""Chat message, OpenAI-compatible: ``{"role": ..., "content": ..., ...}``."""
+
+
+@dataclass
+class MessageStepResult:
+    """Result of a single assistant turn.
+
+    Attributes:
+        reward: Immediate reward for the assistant turn.
+        episode_done: Whether the episode has ended.  Single-turn envs always
+            set this to ``True``.
+        next_messages: Messages (e.g. tool results, simulator feedback) to
+            append to the conversation *before* the next sample.  Empty when
+            the episode is done.
+        metrics: Per-turn scalar metrics merged into training logs.
+        is_reward_valid: Set to ``False`` when the grader could not score the
+            turn (e.g. remote grader returned ``transient=true``).  The
+            rollout runner may drop rollouts whose final turn is invalid.
+    """
+
+    reward: float
+    episode_done: bool
+    next_messages: list[Message] = field(default_factory=list)
+    metrics: dict[str, float] = field(default_factory=dict)
+    is_reward_valid: bool = True
+
+
+class MessageEnv(ABC):
+    """Stateful, single-use environment operating at the chat-message level.
+
+    Subclasses implement :meth:`initial_messages` (the starting conversation)
+    and :meth:`step` (score one assistant turn and decide what happens next).
+    The training loop creates a fresh env per rollout — do not assume any
+    env is reused.
+
+    Minimal single-turn example::
+
+        class MathEnv(MessageEnv):
+            def __init__(self, row):
+                self.row = row
+
+            async def initial_messages(self):
+                return self.row["messages"]
+
+            async def step(self, assistant_message):
+                completion = assistant_message.get("content", "")
+                reward = 1.0 if self.row["answer"] in completion else 0.0
+                return MessageStepResult(reward=reward, episode_done=True)
+
+    Multi-turn envs should keep episode state on ``self`` and terminate by
+    returning ``episode_done=True``.
+    """
+
+    @abstractmethod
+    async def initial_messages(self) -> list[Message]:
+        """Return the conversation the agent sees before its first turn."""
+
+    @abstractmethod
+    async def step(self, assistant_message: Message) -> MessageStepResult:
+        """Score one assistant turn and advance the environment."""
+
+
+@dataclass
+class Transition:
+    """One completed turn within a :class:`Trajectory`.
+
+    Attributes:
+        prompt_tokens: Rendered prompt tokens the sampler saw at this turn.
+        completion_tokens: Assistant tokens produced by the sampler.
+        completion_text: Decoded assistant text, convenient for graders and
+            trajectory logging.
+        inference_logprobs: Per-token logprobs from the sampler (aligned with
+            ``completion_tokens``).  ``None`` when the rollout source does
+            not return them; the rollout builder will recover them via an
+            ``echo=True`` prefill call.
+        assistant_message: The structured assistant message (role/content/
+            tool_calls) passed to :meth:`MessageEnv.step`.
+        reward: Reward returned by :meth:`MessageEnv.step`.
+        episode_done: Whether this transition ended the episode.
+        finish_reason: Sampler-reported finish reason (``"stop"``, ``"length"``,
+            ...).  Used to flag truncation.
+        is_reward_valid: Propagated from :class:`MessageStepResult`.
+        metrics: Per-turn scalars.
+        routing_matrices: Optional MoE routing matrices for router replay.
+    """
+
+    prompt_tokens: list[int]
+    completion_tokens: list[int]
+    completion_text: str
+    inference_logprobs: list[float] | None
+    assistant_message: Message
+    reward: float
+    episode_done: bool
+    finish_reason: str = "stop"
+    is_reward_valid: bool = True
+    metrics: dict[str, float] = field(default_factory=dict)
+    routing_matrices: Any | None = None
+
+
+@dataclass
+class Trajectory:
+    """Ordered list of :class:`Transition` making up one episode."""
+
+    transitions: list[Transition] = field(default_factory=list)
+
+    @property
+    def total_reward(self) -> float:
+        """Sum of per-turn rewards across the trajectory."""
+        return float(sum(t.reward for t in self.transitions))
+
+    @property
+    def is_complete(self) -> bool:
+        """Whether the trajectory ended with an ``episode_done=True`` turn."""
+        return bool(self.transitions) and self.transitions[-1].episode_done
+
+    @property
+    def any_truncated(self) -> bool:
+        """Whether any turn hit the token budget (``finish_reason == "length"``)."""
+        return any(t.finish_reason == "length" for t in self.transitions)
+
+    @property
+    def all_rewards_valid(self) -> bool:
+        """Whether every turn had ``is_reward_valid=True``."""
+        return all(t.is_reward_valid for t in self.transitions)
+
+    def add_turn_reward(self, delta: float, *, turn_index: int = -1) -> None:
+        """Add ``delta`` to the reward of one turn.
+
+        Used by ``group_reward_fn`` to fold group-level rewards (pairwise
+        reward models, etc.) back into the trajectory.  Default target is
+        the final turn.
+        """
+        if not self.transitions:
+            raise ValueError("Cannot add reward to an empty trajectory")
+        self.transitions[turn_index].reward += float(delta)

--- a/training/utils/rl/env_adapters.py
+++ b/training/utils/rl/env_adapters.py
@@ -1,0 +1,94 @@
+"""Adapters that lower simpler user-supplied inputs to a :class:`MessageEnv`.
+
+These keep the ergonomic entry points cheap for the common cases:
+
+- :class:`SingleTurnEnv` wraps a plain ``reward_fn(completion, row) -> float``
+  into a one-step :class:`MessageEnv`.  The 80% of recipes that just want a
+  custom reward never subclass :class:`MessageEnv` directly.
+- :func:`wrap_reward_fn` takes a sync or async reward callable and returns
+  an ``env_builder`` suitable for :data:`rl_loop.Config.env_builder`.
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any, Awaitable, Callable, Union
+
+from training.utils.rl.env import Message, MessageEnv, MessageStepResult
+
+RewardFn = Callable[[str, dict], Union[float, Awaitable[float]]]
+"""Reward callable: ``(completion_text, row) -> float | Awaitable[float]``."""
+
+EnvBuilder = Callable[[dict], MessageEnv]
+"""Row → env factory used by the RL loop to construct one env per rollout."""
+
+
+def _extract_text(content: Any) -> str:
+    """Coerce OpenAI-style ``content`` (str or list-of-parts) to a string."""
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for part in content:
+            if isinstance(part, dict):
+                parts.append(str(part.get("text", "")))
+            else:
+                parts.append(str(part))
+        return "".join(parts)
+    return str(content)
+
+
+class SingleTurnEnv(MessageEnv):
+    """One-step :class:`MessageEnv` driven by a user-supplied ``reward_fn``.
+
+    Takes a dataset row and a reward callable; runs one turn, extracts the
+    assistant completion text, awaits the reward (if async), and terminates.
+
+    The row is expected to carry a ``messages`` field (OpenAI-compatible
+    chat list).  If absent, ``initial_messages`` returns an empty list so
+    downstream rendering raises a clear error.
+    """
+
+    def __init__(
+        self,
+        row: dict,
+        reward_fn: RewardFn,
+        *,
+        messages_field: str = "messages",
+    ) -> None:
+        self._row = row
+        self._reward_fn = reward_fn
+        self._messages_field = messages_field
+
+    async def initial_messages(self) -> list[Message]:
+        return list(self._row.get(self._messages_field, []))
+
+    async def step(self, assistant_message: Message) -> MessageStepResult:
+        completion = _extract_text(assistant_message.get("content"))
+        result = self._reward_fn(completion, self._row)
+        if inspect.isawaitable(result):
+            result = await result
+        reward = float(result)
+        return MessageStepResult(reward=reward, episode_done=True)
+
+
+def wrap_reward_fn(reward_fn: RewardFn, **single_turn_kwargs: Any) -> EnvBuilder:
+    """Return an env-builder that wraps ``reward_fn`` into a :class:`SingleTurnEnv`.
+
+    Usage::
+
+        train(Config(..., env_builder=wrap_reward_fn(my_reward)))
+
+    Equivalent to, but more explicit than, setting ``Config.reward_fn`` —
+    the RL loop auto-wraps ``reward_fn`` internally on behalf of users who
+    just want the default single-turn path.
+    """
+    if not callable(reward_fn):
+        raise TypeError(f"reward_fn must be callable, got {type(reward_fn).__name__}")
+
+    def _build(row: dict) -> MessageEnv:
+        return SingleTurnEnv(row=row, reward_fn=reward_fn, **single_turn_kwargs)
+
+    return _build

--- a/training/utils/rl/losses.py
+++ b/training/utils/rl/losses.py
@@ -152,6 +152,8 @@ class PromptGroup:
     """Per-sample completion lengths in tokens."""
     truncated: List[bool] = field(default_factory=list)
     """Per-sample flag: True if completion hit max_completion_tokens."""
+    generation_step: int | None = None
+    """Training step when this group's rollout was submitted (async mode)."""
     prompt: list[dict] | None = None
     """Original prompt messages (for trajectory logging)."""
     completions: list[str] | None = None

--- a/training/utils/rl/rollout_builder.py
+++ b/training/utils/rl/rollout_builder.py
@@ -1,0 +1,223 @@
+"""Build :class:`PromptGroup` objects from trajectories.
+
+The rollout runner produces :class:`Trajectory` objects; this module packages
+them into the ``(data, ref_data, advantages, inf_logprobs, ...)`` shape the
+training step expects.  It also auto-recovers missing inference logprobs via
+an ``echo=True`` prefill call when the rollout source only returned text.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, List
+
+import tinker
+
+from training.utils.data import compute_advantages
+from training.utils.rl.env import Trajectory
+from training.utils.rl.losses import PromptGroup
+from training.utils.rl.router_replay import build_r3_routing_matrices
+from training.utils.rl.tokenize import get_prefill_logprobs
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["trajectories_to_prompt_group"]
+
+
+def _ensure_inference_logprobs(
+    transition,
+    *,
+    inference_url: str | None,
+    api_key: str | None,
+    model: str | None,
+) -> List[float]:
+    """Return per-token logprobs for ``transition.completion_tokens``.
+
+    If the rollout source already provided them use them as-is; otherwise call
+    the deployment with ``echo=True, max_tokens=1`` to score the known token
+    sequence under the current policy.
+    """
+    if transition.inference_logprobs is not None and transition.inference_logprobs:
+        return list(transition.inference_logprobs)
+
+    if not transition.completion_tokens:
+        return []
+
+    if not (inference_url and api_key and model):
+        raise RuntimeError(
+            "rollout_source returned text-only transitions but inference_url / "
+            "api_key / model were not threaded through -- cannot recover "
+            "logprobs via prefill."
+        )
+
+    full_tokens = list(transition.prompt_tokens) + list(transition.completion_tokens)
+    full_lp = get_prefill_logprobs(
+        url=inference_url, tokens=full_tokens, api_key=api_key, model=model,
+    )
+    n_comp = len(transition.completion_tokens)
+    if len(full_lp) < n_comp:
+        full_lp = full_lp + [0.0] * (n_comp - len(full_lp))
+    return full_lp[-n_comp:]
+
+
+def trajectories_to_prompt_group(
+    trajectories: List[Trajectory],
+    *,
+    need_reference: bool,
+    tokenizer: Any,
+    inference_url: str | None = None,
+    api_key: str | None = None,
+    model: str | None = None,
+    router_replay: bool = False,
+    router_replay_completion_only: bool = False,
+    keep_trajectory_logs: bool = False,
+    row_meta: dict | None = None,
+) -> PromptGroup | None:
+    """Pack N trajectories (one row's group) into a :class:`PromptGroup`.
+
+    Computes group-centered advantages over ``trajectory.total_reward``, builds
+    policy and (optional) reference datums per trajectory, and fills inference
+    logprobs -- auto-prefilling via ``echo=True`` when the rollout source did
+    not return them.
+
+    Returns ``None`` if no trajectory survived tokenization (e.g. every
+    rollout was a single-token completion).
+    """
+    if not trajectories:
+        return None
+
+    rewards = [t.total_reward for t in trajectories]
+    advantages = compute_advantages(rewards)
+
+    policy_data: List[tinker.Datum] = []
+    reference_data: List[tinker.Datum] = []
+    adv_filtered: List[float] = []
+    inf_logprobs_aligned: List[List[float]] = []
+    completion_lens: List[int] = []
+    truncated: List[bool] = []
+    prompt_len_ref: int | None = None
+    completion_texts: List[str] = []
+
+    for idx, traj in enumerate(trajectories):
+        if not traj.transitions:
+            continue
+        # Multi-turn envs: concatenate turn-wise prompts/completions onto the
+        # initial prompt.  The initial prompt is the first transition's
+        # prompt; later prompts are supersets that already include all prior
+        # turns, so we only need to keep the tail of each later prompt plus
+        # its completion.
+        first = traj.transitions[0]
+        tokens: List[int] = list(first.prompt_tokens) + list(first.completion_tokens)
+        inf_lp: List[float] = list(
+            _ensure_inference_logprobs(
+                first, inference_url=inference_url, api_key=api_key, model=model,
+            )
+        )
+        prompt_end = len(first.prompt_tokens)
+
+        for transition in traj.transitions[1:]:
+            prev_len = len(tokens)
+            new_prompt = list(transition.prompt_tokens)
+            if not (len(new_prompt) >= prev_len and new_prompt[:prev_len] == tokens):
+                raise RuntimeError(
+                    "Multi-turn transition prompt is not an extension of the "
+                    "prior turn's tokens. This indicates a tokenizer/chat "
+                    "template mismatch between turns."
+                )
+            tail = new_prompt[prev_len:]
+            tokens.extend(tail)
+            tokens.extend(transition.completion_tokens)
+            # Extend inf_lp: prior turns' prompt-extension tokens contribute
+            # zeros (not sampled), new turn's completion contributes its lp.
+            inf_lp.extend([0.0] * len(tail))
+            inf_lp.extend(
+                _ensure_inference_logprobs(
+                    transition,
+                    inference_url=inference_url,
+                    api_key=api_key,
+                    model=model,
+                )
+            )
+
+        if len(tokens) < 2:
+            continue
+
+        model_input_len = len(tokens) - 1
+
+        rm = None
+        if router_replay and first.routing_matrices is not None:
+            rm = build_r3_routing_matrices(
+                first.routing_matrices,
+                prompt_end,
+                model_input_len,
+                completion_only=router_replay_completion_only,
+            )
+
+        policy_datum = tinker.Datum(
+            model_input=tinker.ModelInput.from_ints(tokens[:-1], routing_matrices=rm),
+            loss_fn_inputs={
+                "target_tokens": tinker.TensorData(
+                    data=tokens[1:], dtype="int64", shape=[model_input_len],
+                ),
+            },
+        )
+        policy_data.append(policy_datum)
+
+        if need_reference:
+            reference_datum = tinker.Datum(
+                model_input=tinker.ModelInput.from_ints(tokens[:-1]),
+                loss_fn_inputs={
+                    "target_tokens": tinker.TensorData(
+                        data=tokens[1:], dtype="int64", shape=[model_input_len],
+                    ),
+                },
+            )
+            reference_data.append(reference_datum)
+
+        adv_filtered.append(advantages[idx])
+
+        # Align inf_lp to len(model_input_len) by prepending zeros for the
+        # prompt positions that did not correspond to generated tokens.
+        n_comp = sum(len(t.completion_tokens) for t in traj.transitions)
+        # Our inf_lp currently has zeros for prompt-extensions between turns
+        # plus generated-token logprobs.  For the "first turn only" case
+        # len(inf_lp) == n_comp.
+        response_start = model_input_len - n_comp
+        aligned = [0.0] * max(0, response_start) + inf_lp
+        if len(aligned) > model_input_len:
+            aligned = aligned[-model_input_len:]
+        elif len(aligned) < model_input_len:
+            aligned = aligned + [0.0] * (model_input_len - len(aligned))
+        inf_logprobs_aligned.append(aligned)
+
+        if prompt_len_ref is None:
+            prompt_len_ref = prompt_end
+        completion_lens.append(n_comp)
+        truncated.append(traj.any_truncated)
+        completion_texts.append(" ".join(t.completion_text for t in traj.transitions))
+
+    if not policy_data or prompt_len_ref is None:
+        return None
+
+    prompt_messages = None
+    completions_log = None
+    meta_log = None
+    if keep_trajectory_logs:
+        prompt_messages = []
+        completions_log = completion_texts
+        meta_log = dict(row_meta or {})
+
+    return PromptGroup(
+        data=policy_data,
+        ref_data=reference_data,
+        advantages=adv_filtered,
+        ref_logprobs=None,
+        prompt_len=prompt_len_ref,
+        rewards=rewards[: len(adv_filtered)] if len(adv_filtered) < len(rewards) else rewards,
+        inf_logprobs=inf_logprobs_aligned,
+        completion_lens=completion_lens,
+        truncated=truncated,
+        prompt=prompt_messages,
+        completions=completions_log,
+        row_meta=meta_log,
+    )

--- a/training/utils/rl/rollout_runner.py
+++ b/training/utils/rl/rollout_runner.py
@@ -1,0 +1,210 @@
+"""Run :class:`MessageEnv` groups against a sampler to produce trajectories.
+
+The first turn is issued as a single ``sample_with_tokens(n=N)`` call so the
+group-batched API shape matches the sync loop.  On later turns each env's
+conversation has diverged, so the runner falls back to per-env sampling fired
+concurrently via ``asyncio.gather``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from training.utils.rl.env import (
+    Message,
+    MessageEnv,
+    MessageStepResult,
+    Trajectory,
+    Transition,
+)
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "run_env_group_to_trajectories",
+    "run_env_to_trajectory",
+]
+
+
+def _completion_to_assistant_message(text: str) -> Message:
+    return {"role": "assistant", "content": text}
+
+
+def _transition_from_sample(
+    sampled: Any,
+    step_result: MessageStepResult,
+    *,
+    assistant_message: Message,
+) -> Transition:
+    full_tokens = list(sampled.full_tokens)
+    prompt_len = int(sampled.prompt_len)
+    prompt_tokens = full_tokens[:prompt_len]
+    completion_tokens = full_tokens[prompt_len:]
+
+    inf_lp = getattr(sampled, "inference_logprobs", None)
+    if inf_lp is not None:
+        # DeploymentSampler returns a flat list aligned with the generated
+        # tokens when echo=False; pass through unchanged.
+        inf_lp = list(inf_lp)
+
+    return Transition(
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        completion_text=getattr(sampled, "text", "") or "",
+        inference_logprobs=inf_lp,
+        assistant_message=assistant_message,
+        reward=float(step_result.reward),
+        episode_done=bool(step_result.episode_done),
+        finish_reason=getattr(sampled, "finish_reason", "stop") or "stop",
+        is_reward_valid=bool(step_result.is_reward_valid),
+        metrics=dict(step_result.metrics),
+        routing_matrices=getattr(sampled, "routing_matrices", None),
+    )
+
+
+async def run_env_to_trajectory(
+    env: MessageEnv,
+    sampler: Any,
+    *,
+    max_turns: int = 1,
+    sample_kwargs: dict[str, Any] | None = None,
+) -> Trajectory | None:
+    """Run a single env to completion, one turn at a time.
+
+    Returns ``None`` if the sampler returns no completions at any point.
+    """
+    sample_kwargs = dict(sample_kwargs or {})
+    messages = list(await env.initial_messages())
+    if not messages:
+        return None
+
+    trajectory = Trajectory()
+    for _ in range(max_turns):
+        sampled = await sampler.sample_with_tokens(messages=messages, n=1, **sample_kwargs)
+        if not sampled:
+            return None
+        s = sampled[0]
+        assistant_message = _completion_to_assistant_message(getattr(s, "text", "") or "")
+        step_result = await env.step(assistant_message)
+        trajectory.transitions.append(
+            _transition_from_sample(s, step_result, assistant_message=assistant_message)
+        )
+        if step_result.episode_done:
+            return trajectory
+        messages = messages + [assistant_message, *step_result.next_messages]
+
+    return trajectory
+
+
+async def run_env_group_to_trajectories(
+    envs: list[MessageEnv],
+    sampler: Any,
+    *,
+    completions_per_prompt: int,
+    max_turns: int = 1,
+    sample_kwargs: dict[str, Any] | None = None,
+) -> list[Trajectory] | None:
+    """Run ``len(envs)`` parallel rollouts and return one trajectory each.
+
+    Preserves the sync loop's call shape: turn 1 is a single
+    ``sample_with_tokens(n=N)`` call, so the deployment sees one batched request
+    for N divergent completions.  Turn 2+ uses concurrent per-env calls because
+    each env's conversation has diverged.
+
+    Returns ``None`` if the first-turn sampler call produces fewer than ``N``
+    completions (match sync loop drop-on-short behaviour).
+    """
+    if completions_per_prompt != len(envs):
+        raise ValueError(
+            f"completions_per_prompt ({completions_per_prompt}) must match len(envs) "
+            f"({len(envs)})"
+        )
+    if completions_per_prompt < 1:
+        raise ValueError("completions_per_prompt must be >= 1")
+
+    sample_kwargs = dict(sample_kwargs or {})
+
+    # All envs in a group share the same row and therefore the same
+    # initial_messages -- use the first env's view as the group prompt.
+    initial = list(await envs[0].initial_messages())
+    if not initial:
+        return None
+
+    sampled = await sampler.sample_with_tokens(
+        messages=initial, n=completions_per_prompt, **sample_kwargs,
+    )
+    if not sampled or len(sampled) < completions_per_prompt:
+        return None
+
+    trajectories: list[Trajectory] = [Trajectory() for _ in envs]
+    per_env_messages: list[list[Message]] = [list(initial) for _ in envs]
+    alive: list[bool] = [True] * len(envs)
+
+    # -- Turn 1 (group-batched) ---------------------------------------------
+    step_results = await asyncio.gather(
+        *(
+            env.step(_completion_to_assistant_message(getattr(s, "text", "") or ""))
+            for env, s in zip(envs, sampled)
+        )
+    )
+    for i, (env, s, step_result) in enumerate(zip(envs, sampled, step_results)):
+        assistant_message = _completion_to_assistant_message(getattr(s, "text", "") or "")
+        trajectories[i].transitions.append(
+            _transition_from_sample(s, step_result, assistant_message=assistant_message)
+        )
+        if step_result.episode_done:
+            alive[i] = False
+        else:
+            per_env_messages[i] = per_env_messages[i] + [
+                assistant_message,
+                *step_result.next_messages,
+            ]
+
+    if max_turns <= 1 or not any(alive):
+        return trajectories
+
+    # -- Turn 2+ (per-env, concurrent) --------------------------------------
+    for _turn in range(1, max_turns):
+        live_indices = [i for i, a in enumerate(alive) if a]
+        if not live_indices:
+            break
+
+        samples = await asyncio.gather(
+            *(
+                sampler.sample_with_tokens(
+                    messages=per_env_messages[i], n=1, **sample_kwargs,
+                )
+                for i in live_indices
+            )
+        )
+
+        step_coros: list[Any] = []
+        carry: list[tuple[int, Any, Message]] = []
+        for idx, sampled_list in zip(live_indices, samples):
+            if not sampled_list:
+                alive[idx] = False
+                continue
+            s = sampled_list[0]
+            assistant_message = _completion_to_assistant_message(getattr(s, "text", "") or "")
+            step_coros.append(envs[idx].step(assistant_message))
+            carry.append((idx, s, assistant_message))
+
+        if not step_coros:
+            break
+
+        results = await asyncio.gather(*step_coros)
+        for (idx, s, assistant_message), step_result in zip(carry, results):
+            trajectories[idx].transitions.append(
+                _transition_from_sample(s, step_result, assistant_message=assistant_message)
+            )
+            if step_result.episode_done:
+                alive[idx] = False
+            else:
+                per_env_messages[idx] = per_env_messages[idx] + [
+                    assistant_message,
+                    *step_result.next_messages,
+                ]
+
+    return trajectories

--- a/training/utils/rl/sample_fn_factory.py
+++ b/training/utils/rl/sample_fn_factory.py
@@ -1,0 +1,165 @@
+"""Builds the ``sample_fn`` the async loop consumes.
+
+Dispatches among the three rollout regimes exposed by
+:mod:`training.recipes.rl_loop_async`:
+
+1. ``reward_fn(completion, row) -> float`` — single-turn shortcut.  The
+   factory wraps it into a :class:`SingleTurnEnv` so the env path is used
+   under the hood.
+2. ``env_builder(row) -> MessageEnv`` — any single- or multi-turn env.
+3. ``rollout_source(row, *, n) -> list[Trajectory] | None`` — user brings
+   their own rollouts (remote agent, pre-recorded data, LLM judge output).
+
+All three paths converge on :func:`trajectories_to_prompt_group`, which
+computes advantages and packs the training datums.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import logging
+from typing import Any, Awaitable, Callable, Coroutine
+
+from training.utils.rl.env import Trajectory
+from training.utils.rl.env_adapters import wrap_reward_fn
+from training.utils.rl.losses import PromptGroup
+from training.utils.rl.rollout_builder import trajectories_to_prompt_group
+from training.utils.rl.rollout_runner import run_env_group_to_trajectories
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "RewardFn",
+    "EnvBuilder",
+    "RolloutSource",
+    "build_sample_fn",
+    "validate_rollout_regime",
+]
+
+
+RewardFn = Callable[[str, dict], "float | Awaitable[float]"]
+EnvBuilder = Callable[[dict], Any]
+RolloutSource = Callable[..., "list[Trajectory] | Awaitable[list[Trajectory] | None] | None"]
+
+
+def validate_rollout_regime(
+    *,
+    reward_fn: RewardFn | None,
+    env_builder: EnvBuilder | None,
+    rollout_source: RolloutSource | None,
+) -> None:
+    """Ensure exactly one of the three rollout entry points is set."""
+    provided = [
+        name for name, val in (
+            ("reward_fn", reward_fn),
+            ("env_builder", env_builder),
+            ("rollout_source", rollout_source),
+        ) if val is not None
+    ]
+    if len(provided) == 0:
+        raise ValueError(
+            "rl_loop_async requires one of: reward_fn, env_builder, rollout_source."
+        )
+    if len(provided) > 1:
+        raise ValueError(
+            f"rl_loop_async accepts exactly one of reward_fn / env_builder / "
+            f"rollout_source, got: {', '.join(provided)}."
+        )
+
+
+async def _maybe_await(value: Any) -> Any:
+    if inspect.isawaitable(value):
+        return await value
+    return value
+
+
+def build_sample_fn(
+    *,
+    reward_fn: RewardFn | None = None,
+    env_builder: EnvBuilder | None = None,
+    rollout_source: RolloutSource | None = None,
+    group_reward_fn: Callable[..., Any] | None = None,
+    sampler: Any,
+    completions_per_prompt: int,
+    sample_kwargs: dict[str, Any],
+    max_turns: int = 1,
+    tokenizer: Any = None,
+    inference_url: str | None = None,
+    api_key: str | None = None,
+    model: str | None = None,
+    router_replay: bool = False,
+    router_replay_completion_only: bool = False,
+    keep_trajectory_logs: bool = False,
+) -> Callable[[dict], Coroutine[Any, Any, PromptGroup | None]]:
+    """Return ``async def sample_fn(row) -> PromptGroup | None``."""
+    validate_rollout_regime(
+        reward_fn=reward_fn, env_builder=env_builder, rollout_source=rollout_source,
+    )
+
+    if reward_fn is not None:
+        effective_env_builder: EnvBuilder | None = wrap_reward_fn(reward_fn)
+    else:
+        effective_env_builder = env_builder
+
+    async def _sample_via_envs(row: dict) -> PromptGroup | None:
+        assert effective_env_builder is not None
+        envs = [effective_env_builder(row) for _ in range(completions_per_prompt)]
+        trajectories = await run_env_group_to_trajectories(
+            envs,
+            sampler,
+            completions_per_prompt=completions_per_prompt,
+            max_turns=max_turns,
+            sample_kwargs=sample_kwargs,
+        )
+        if trajectories is None:
+            return None
+        if group_reward_fn is not None:
+            deltas = await _maybe_await(group_reward_fn(trajectories, row))
+            if deltas is not None:
+                for traj, delta in zip(trajectories, deltas):
+                    traj.add_turn_reward(float(delta))
+        return trajectories_to_prompt_group(
+            trajectories,
+            need_reference=True,
+            tokenizer=tokenizer,
+            inference_url=inference_url,
+            api_key=api_key,
+            model=model,
+            router_replay=router_replay,
+            router_replay_completion_only=router_replay_completion_only,
+            keep_trajectory_logs=keep_trajectory_logs,
+            row_meta={"ground_truth": row.get("ground_truth", "")} if keep_trajectory_logs else None,
+        )
+
+    async def _sample_via_rollout_source(row: dict) -> PromptGroup | None:
+        assert rollout_source is not None
+        try:
+            raw = rollout_source(row, n=completions_per_prompt)
+        except TypeError:
+            # Rollout source signatures that don't accept `n` keyword.
+            raw = rollout_source(row)
+        trajectories = await _maybe_await(raw)
+        if not trajectories:
+            return None
+        if group_reward_fn is not None:
+            deltas = await _maybe_await(group_reward_fn(trajectories, row))
+            if deltas is not None:
+                for traj, delta in zip(trajectories, deltas):
+                    traj.add_turn_reward(float(delta))
+        return trajectories_to_prompt_group(
+            trajectories,
+            need_reference=True,
+            tokenizer=tokenizer,
+            inference_url=inference_url,
+            api_key=api_key,
+            model=model,
+            router_replay=router_replay,
+            router_replay_completion_only=router_replay_completion_only,
+            keep_trajectory_logs=keep_trajectory_logs,
+            row_meta={"ground_truth": row.get("ground_truth", "")} if keep_trajectory_logs else None,
+        )
+
+    if rollout_source is not None:
+        return _sample_via_rollout_source
+    return _sample_via_envs

--- a/training/utils/rl/tokenize.py
+++ b/training/utils/rl/tokenize.py
@@ -1,0 +1,146 @@
+"""Client-side tokenization helpers used by RL rollout plumbing.
+
+The training loop needs two things no external rollout source reliably
+provides:
+
+1. **Chat-template tokenization** — turning a message list + assistant reply
+   into the exact prompt/completion token IDs the trainer expects.
+2. **Inference-logprob recovery** — for importance-sampling-family losses
+   (GRPO/DAPO/CISPO/GSPO) we need per-token logprobs aligned with the
+   tokenized completion.  Samplers that produce text-only responses
+   (remote agents, EP rollouts, judge pipelines) do not return these, so
+   we recover them via an ``echo=True`` prefill call.
+
+Both helpers are dependency-light and framework-neutral: they expect an
+HF-compatible tokenizer and an HTTP endpoint speaking the OpenAI
+``/v1/completions`` schema.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import requests
+
+
+def tokenize_chat_turn(
+    messages: list[dict[str, Any]],
+    assistant_message: dict[str, Any],
+    tokenizer: Any,
+    *,
+    add_generation_prompt: bool = True,
+) -> tuple[list[int], list[int]]:
+    """Return ``(prompt_ids, completion_ids)`` for one assistant turn.
+
+    ``prompt_ids`` are what the sampler would have seen (rendered via the
+    tokenizer's chat template with ``add_generation_prompt=True``).
+    ``completion_ids`` are the delta introduced by appending the assistant
+    turn — computed as ``apply_chat_template([*messages, assistant_message])``
+    minus the prompt prefix, so it includes any template-added assistant
+    role markers / end-of-turn tokens.
+
+    Args:
+        messages: Conversation before this turn (system/user/tool messages).
+        assistant_message: The assistant turn to encode.
+        tokenizer: HuggingFace-compatible tokenizer with
+            ``apply_chat_template``.
+        add_generation_prompt: Passed through when rendering the prompt.
+    """
+    prompt_ids = list(
+        tokenizer.apply_chat_template(
+            list(messages),
+            add_generation_prompt=add_generation_prompt,
+            tokenize=True,
+        )
+    )
+    full_ids = list(
+        tokenizer.apply_chat_template(
+            [*messages, assistant_message],
+            add_generation_prompt=False,
+            tokenize=True,
+        )
+    )
+    if len(full_ids) < len(prompt_ids) or full_ids[: len(prompt_ids)] != prompt_ids:
+        raise RuntimeError(
+            "Chat-template rendering is not a strict prefix extension. "
+            "Tokenizer likely rewrote earlier tokens when the assistant "
+            "turn was appended; cannot derive completion_ids by diff."
+        )
+    completion_ids = full_ids[len(prompt_ids) :]
+    return prompt_ids, completion_ids
+
+
+def _normalize_inference_base_url(url: str) -> str:
+    """Strip trailing ``/inference`` or ``/inference/v1`` from ``url``."""
+    normalized = url.rstrip("/")
+    for suffix in ("/inference/v1", "/inference"):
+        if normalized.endswith(suffix):
+            return normalized[: -len(suffix)]
+    return normalized
+
+
+def get_prefill_logprobs(
+    *,
+    url: str,
+    tokens: list[int],
+    api_key: str,
+    model: str,
+    timeout: float = 180.0,
+) -> list[float]:
+    """Recover per-token inference logprobs for a known token sequence.
+
+    Issues an ``echo=True`` + ``max_tokens=1`` completion so the server
+    scores ``tokens`` under the current (possibly hotloaded) policy without
+    generating anything new.  Returns ``len(tokens) - 1`` logprobs aligned
+    so that index ``i`` is the logprob of ``tokens[i + 1]`` conditioned on
+    ``tokens[:i + 1]``.
+
+    Used when the rollout source returned text only (no token-aligned
+    logprobs) and the configured loss needs ``inf_logprobs`` for
+    importance-sampling correction.
+    """
+    if not tokens:
+        return []
+    if len(tokens) < 2:
+        return [0.0] * (len(tokens) - 1)
+
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {api_key}",
+        "X-Api-Key": api_key,
+    }
+    payload: dict[str, Any] = {
+        "prompt": tokens,
+        "max_tokens": 1,
+        "echo": True,
+        "logprobs": True,
+        "prompt_cache_max_len": 0,
+    }
+    if model:
+        payload["model"] = model
+
+    base_url = _normalize_inference_base_url(url)
+    response = requests.post(
+        f"{base_url}/inference/v1/completions",
+        json=payload,
+        headers=headers,
+        timeout=timeout,
+    )
+    response.raise_for_status()
+    result = response.json()
+
+    choices = result.get("choices") or []
+    if not choices:
+        return [0.0] * (len(tokens) - 1)
+
+    logprobs_data = choices[0].get("logprobs") or {}
+    token_logprobs = logprobs_data.get("token_logprobs") or []
+
+    # Echo returns one logprob per token; the first is always ``None`` (no
+    # conditioning).  Drop it and pad to the expected length so the caller
+    # can assume ``len(out) == len(tokens) - 1``.
+    aligned = [float(lp) if lp is not None else 0.0 for lp in token_logprobs[1 : len(tokens)]]
+    expected = len(tokens) - 1
+    if len(aligned) < expected:
+        aligned.extend([0.0] * (expected - len(aligned)))
+    return aligned

--- a/training/utils/rl/train_async.py
+++ b/training/utils/rl/train_async.py
@@ -1,0 +1,241 @@
+"""Async off-policy RL training loop for Fireworks recipes.
+
+Provides ``run_rl_loop_async`` -- a 3-loop async runner where generation
+overlaps with training.  Pipeline depth is bounded by the results queue
+maxsize of ``(max_steps_off_policy + 1) * groups_per_batch``, which
+guarantees that the oldest unconsumed sample is at most
+``max_steps_off_policy`` training steps behind.  Within that window the
+existing TIS correction handles residual off-policy mismatch.
+
+Architecture (inspired by tinker-cookbook ``do_async_training``):
+
+* **Dataloader loop** -- iterates over rows, pushes into a bounded queue.
+* **Worker loops** (``groups_per_batch`` concurrent tasks) -- pull rows,
+  call ``sample_fn``, push results.  Backpressure from the bounded
+  results queue prevents workers from getting too far ahead.
+* **Training loop** -- drains results, applies ``dynamic_filter_fn``,
+  accumulates ``groups_per_batch`` valid groups, then calls ``train_step``.
+
+The staleness-bounded async design is informed by AReaL
+(https://arxiv.org/abs/2505.24298), which introduced version-aware
+capacity gating and decoupled PPO for fully asynchronous RL training.
+For <=2 steps off-policy the cookbook's simpler TIS correction is
+sufficient; deeper async would require AReaL's decoupled PPO objective.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass
+from typing import Any, Callable, Coroutine
+
+from training.utils.rl.losses import PromptGroup
+from training.utils.rl.metrics import build_loop_metrics
+from training.utils.rl.train import DynamicFilterFn, TrainStepFns
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "AsyncConfig",
+    "run_rl_loop_async",
+]
+
+
+@dataclass
+class AsyncConfig:
+    """Configuration for async off-policy RL training."""
+
+    max_steps_off_policy: int = 2
+    groups_per_batch: int = 8
+
+    def __post_init__(self) -> None:
+        if self.max_steps_off_policy > 2:
+            raise ValueError(
+                f"max_steps_off_policy={self.max_steps_off_policy} exceeds the "
+                "supported limit of 2. Deeper async needs AReaL-style decoupled PPO."
+            )
+        if self.max_steps_off_policy < 0:
+            raise ValueError("max_steps_off_policy must be >= 0")
+        if self.groups_per_batch < 1:
+            raise ValueError("groups_per_batch must be >= 1")
+
+
+@dataclass
+class _WrappedPromptGroup:
+    prompt_group: PromptGroup | None
+    row: dict
+    generation_step: int
+
+
+_ROW_SENTINEL = object()
+_WORKER_DONE = object()
+
+
+async def run_rl_loop_async(
+    sample_fn: Callable[[dict], Coroutine[Any, Any, PromptGroup | None]],
+    rows: list[dict],
+    *,
+    train_fns: TrainStepFns,
+    async_config: AsyncConfig,
+    dynamic_filter_fn: DynamicFilterFn | None = None,
+    global_step: int = 0,
+    metrics_callback: Callable[[dict[str, Any]], None] | None = None,
+) -> int:
+    """Run the async off-policy RL training loop.
+
+    Generation and training overlap: while ``train_step`` runs via
+    ``asyncio.to_thread``, worker tasks keep sampling.  Pipeline depth is
+    bounded by ``results_queue`` maxsize; workers block on ``put()`` when
+    the queue is full, so the oldest unconsumed sample is at most
+    ``max_steps_off_policy`` steps behind.
+    """
+    gpb = async_config.groups_per_batch
+    total_steps = len(rows) // gpb
+    if total_steps == 0:
+        logger.warning(
+            "Not enough rows (%d) for even one batch of %d groups", len(rows), gpb,
+        )
+        return global_step
+
+    pipeline_depth = (async_config.max_steps_off_policy + 1) * gpb + gpb
+    rows_queue: asyncio.Queue[dict | object] = asyncio.Queue(maxsize=gpb)
+    results_queue: asyncio.Queue[_WrappedPromptGroup | object] = asyncio.Queue(
+        maxsize=pipeline_depth,
+    )
+
+    current_step = global_step
+
+    async def _dataloader_loop() -> None:
+        for row in rows:
+            await rows_queue.put(row)
+        for _ in range(gpb):
+            await rows_queue.put(_ROW_SENTINEL)
+
+    async def _worker_loop(worker_id: int) -> None:
+        while True:
+            item = await rows_queue.get()
+            if item is _ROW_SENTINEL:
+                results_queue.put_nowait(_WORKER_DONE)
+                return
+
+            row: dict = item  # type: ignore[assignment]
+            generation_step = current_step
+
+            try:
+                pg = await sample_fn(row)
+            except Exception as exc:
+                logger.warning("Worker %d: sample_fn failed: %s", worker_id, exc)
+                pg = None
+
+            if pg is not None:
+                pg.generation_step = generation_step
+
+            await results_queue.put(
+                _WrappedPromptGroup(
+                    prompt_group=pg,
+                    row=row,
+                    generation_step=generation_step,
+                )
+            )
+
+    async def _training_loop() -> None:
+        nonlocal current_step
+
+        workers_alive = gpb
+        steps_done = 0
+        while steps_done < total_steps:
+            step_prompt_groups: list[PromptGroup] = []
+            sample_fails = 0
+            filter_drops = 0
+            all_raw_rewards: list[float] = []
+            staleness_steps: list[int] = []
+            step_start_time = time.time()
+
+            while len(step_prompt_groups) < gpb:
+                item = await results_queue.get()
+
+                if item is _WORKER_DONE:
+                    workers_alive -= 1
+                    if workers_alive == 0:
+                        if step_prompt_groups:
+                            logger.info(
+                                "[step %d] all workers done with %d/%d groups, training partial batch",
+                                current_step + 1, len(step_prompt_groups), gpb,
+                            )
+                            break
+                        return
+                    continue
+
+                wrapped: _WrappedPromptGroup = item  # type: ignore[assignment]
+
+                if wrapped.prompt_group is None:
+                    sample_fails += 1
+                    continue
+
+                staleness = current_step - wrapped.generation_step
+                staleness_steps.append(staleness)
+                all_raw_rewards.extend(wrapped.prompt_group.rewards)
+
+                if dynamic_filter_fn is not None and not dynamic_filter_fn(wrapped.prompt_group):
+                    filter_drops += 1
+                    continue
+
+                step_prompt_groups.append(wrapped.prompt_group)
+
+            if not step_prompt_groups:
+                logger.warning("[step %d] no valid groups, skipping", current_step + 1)
+                continue
+
+            step_wall_time = time.time() - step_start_time
+            total_sampled = len(step_prompt_groups) + sample_fails + filter_drops
+            loop_stats = {
+                "valid_prompt_groups": len(step_prompt_groups),
+                "total_sampled": total_sampled,
+                "filter_drops": filter_drops,
+                "sample_fails": sample_fails,
+                "sample_wait_time": 0.0,
+                "step_wall_time": step_wall_time,
+                "all_raw_rewards": all_raw_rewards,
+            }
+
+            current_step, _ = await asyncio.to_thread(
+                train_fns.train_step,
+                current_step,
+                step_prompt_groups,
+                loop_stats,
+            )
+            steps_done += 1
+
+            if metrics_callback is not None:
+                loop_metrics = build_loop_metrics(
+                    train_step=current_step,
+                    sample_fails=sample_fails,
+                    staleness_steps=staleness_steps,
+                )
+                metrics_callback(loop_metrics)
+
+            if workers_alive == 0:
+                return
+
+    dataloader_task = asyncio.create_task(_dataloader_loop(), name="dataloader")
+    worker_tasks = [
+        asyncio.create_task(_worker_loop(i), name=f"worker_{i}") for i in range(gpb)
+    ]
+    training_task = asyncio.create_task(_training_loop(), name="training")
+
+    try:
+        await training_task
+    finally:
+        dataloader_task.cancel()
+        for t in worker_tasks:
+            t.cancel()
+
+        for t in [dataloader_task, *worker_tasks]:
+            try:
+                await t
+            except asyncio.CancelledError:
+                pass
+
+    return current_step


### PR DESCRIPTION
## Summary

Parallel async RL recipe (`training/recipes/rl_loop_async.py`) that is fully decoupled from rollout scheduling and evaluation/reward. The existing `rl_loop.py` is untouched; this is an additive entry point.

**Supersedes #375** (which contained the foundation-only MessageEnv abstractions). Closing #375 in favor of this end-to-end PR — the foundation commit is included here as the first commit.

## Why

A customer (see workspace `rollr_cispo/`) had to fork ~1,000 lines of `rl_loop.py` to swap in their own multi-turn remote agent + async grader. Goal: let any recipe plug in rollout scheduling and reward/evaluation without forking, while keeping `rl_loop.py` stable.

## User surface

Users pick **exactly one** rollout regime:

```python
from training.recipes.rl_loop_async import Config, main

# Option A — single-turn shortcut (drop-in for rl_loop.py's reward_fn)
main(cfg, reward_fn=lambda completion, row: ...)

# Option B — multi-turn MessageEnv (custom task simulator, tool use, etc.)
main(cfg, env_builder=lambda row: MyEnv(row))

# Option C — bring-your-own rollouts (remote agent, pre-recorded, LLM judge)
main(cfg, rollout_source=lambda row, n: list_of_trajectories)
```

Optional `group_reward_fn(trajectories, row) -> list[float]` adds a group-level reward delta (pairwise RM, etc.) before GRPO centering.

## Architecture

Staleness-bounded 3-loop async runner (ported from #166): dataloader → N worker tasks → training, with results-queue backpressure capped at `(max_steps_off_policy + 1) * groups_per_batch`. Within ≤2 steps off-policy the cookbook's TIS correction handles residual mismatch.

New modules (`training/utils/rl/`):
- `train_async.py` — `run_rl_loop_async` + `AsyncConfig`
- `rollout_runner.py` — group-batched first turn (one API call for N completions, matching sync loop), per-env fan-out on later turns
- `rollout_builder.py` — `trajectories_to_prompt_group` with auto-recovery of `inference_logprobs` via `echo=True` prefill when the rollout source returned text only
- `sample_fn_factory.py` — dispatches the three regimes

Examples (`training/examples/custom_env/`) — three neutral templates (no EP, no Rollr):
- `reward_fn/train.py`
- `message_env/train.py`
- `rollout_source/train.py`

## Design constraints preserved

- **`rl_loop.py` not touched.** Only `losses.py` gets a new optional `PromptGroup.generation_step` field (default `None`) — required by the async runner, backward-compatible with sync callers.
- **Cookbook stays eval-framework-neutral.** No imports of `eval_protocol`, `rollr`, or any grader. Users bring their own via the three hooks above.
- **Group batching preserved.** Single-turn rollouts still issue one `sample_with_tokens(n=N)` call per row, matching the sync loop's API-call count per step.

## Test plan

- [x] 29 new unit tests pass (`test_async_loop.py`, `test_rl_rollout_runner.py`, `test_rl_rollout_builder.py`, `test_rl_sample_fn_factory.py`).
- [x] 42 existing env-foundation tests still pass.
- [x] 86 pre-existing non-env tests still pass (`test_rl_loop.py`, `test_rl_train.py`, `test_rl_metrics_aliases.py`, `test_smoke_imports.py`).
- [ ] Integration: port DeepMath to `train_deepmath_async.py` using `reward_fn=...`, compare reward curve vs sync `rl_loop.py` on same dataset.
- [ ] Customer validation: port `rollr_cispo/train_cispo_cookbook.py` to `rollout_source=...`. Expect ≤100 lines of customer code and full deletion of their `cispo_lib.py`.
- [ ] Perf: group API-call count per step matches sync loop (one call per prompt for `n` completions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)