### PR TITLE
feat(supervised): alias reasoning_content to thinking in normalize_me…

### DIFF
--- a/training/tests/unit/test_supervised_rendering.py
+++ b/training/tests/unit/test_supervised_rendering.py
@@ -236,6 +236,94 @@ def test_normalize_messages_keeps_tool_metadata_and_thinking_parts():
     ]
 
 
+def test_normalize_messages_promotes_reasoning_content_to_thinking_part():
+    """OpenAI-style ``reasoning_content`` should become a ThinkingPart.
+
+    Datasets produced by Fireworks/OpenAI-compatible APIs store the
+    assistant's chain-of-thought in a top-level ``reasoning_content``
+    field rather than Tinker's ``thinking`` field. Without this alias,
+    renderers like KimiK2Renderer see an empty ``thinking_content``
+    string and emit an empty ``<think></think>`` block, so the model
+    never learns to produce reasoning traces.
+    """
+    normalized = normalize_messages(
+        [
+            {
+                "role": "assistant",
+                "reasoning_content": "let me compute 2+2",
+                "content": "The answer is 4",
+            },
+        ]
+    )
+
+    assert normalized[0]["content"] == [
+        {"type": "thinking", "thinking": "let me compute 2+2"},
+        {"type": "text", "text": "The answer is 4"},
+    ]
+
+
+def test_normalize_messages_reasoning_content_with_no_text_content():
+    """``reasoning_content`` alone should still produce a ThinkingPart.
+
+    Some reasoning-only turns may carry an empty ``content`` string but
+    a non-empty ``reasoning_content``. The resulting content must keep
+    the ThinkingPart so downstream renderers can still fill the
+    ``<think>...</think>`` block during training.
+    """
+    normalized = normalize_messages(
+        [
+            {
+                "role": "assistant",
+                "reasoning_content": "some thoughts",
+                "content": "",
+            },
+        ]
+    )
+
+    assert normalized[0]["content"] == [
+        {"type": "thinking", "thinking": "some thoughts"},
+        {"type": "text", "text": ""},
+    ]
+
+
+def test_normalize_messages_thinking_wins_over_reasoning_content():
+    """If both fields are present, ``thinking`` is preserved as-is.
+
+    Keeps a single source of truth per message to avoid duplicating the
+    chain-of-thought when a caller supplies both the Tinker-native
+    ``thinking`` field and the OpenAI-style ``reasoning_content``.
+    """
+    normalized = normalize_messages(
+        [
+            {
+                "role": "assistant",
+                "thinking": "native thinking",
+                "reasoning_content": "openai reasoning",
+                "content": "answer",
+            },
+        ]
+    )
+
+    assert normalized[0]["content"] == [
+        {"type": "thinking", "thinking": "native thinking"},
+        {"type": "text", "text": "answer"},
+    ]
+
+
+def test_normalize_messages_rejects_non_string_reasoning_content():
+    """Non-string ``reasoning_content`` values should raise TypeError."""
+    with pytest.raises(TypeError):
+        normalize_messages(
+            [
+                {
+                    "role": "assistant",
+                    "reasoning_content": ["not", "a", "string"],
+                    "content": "answer",
+                },
+            ]
+        )
+
+
 def test_build_renderer_uses_image_processor_for_vl_renderers(monkeypatch):
     calls: list[tuple[str, object | None]] = []
 

--- a/training/utils/supervised.py
+++ b/training/utils/supervised.py
@@ -309,6 +309,31 @@ def normalize_messages(messages: Iterable[Mapping[str, Any]]) -> list[Message]:
                 *_ensure_content_parts(normalized_message["content"]),
             ]
 
+        # OpenAI/Fireworks chat convention: assistant turns carry their
+        # chain-of-thought in a top-level ``reasoning_content`` string
+        # (rather than Tinker's ``thinking`` field). Without this branch,
+        # reasoning traces in training datasets are silently dropped here
+        # before they ever reach a renderer, so ``<think>`` blocks show
+        # up empty in the training tokens and the fine-tuned model never
+        # learns to emit a CoT. Treat ``reasoning_content`` as an alias
+        # for ``thinking`` so both keys flow through every renderer that
+        # understands ThinkingPart (qwen3*, kimi_k2*, kimi_k25*,
+        # kimi_k26*, deepseekv3_thinking, nemotron3*, gpt_oss_*).
+        # ``reasoning_content`` takes precedence only when no ``thinking``
+        # field is present; if both are set the ``thinking`` value is
+        # preserved and ``reasoning_content`` is ignored to keep a single
+        # source of truth per message.
+        reasoning_content = message.get("reasoning_content")
+        if thinking is None and reasoning_content is not None:
+            if not isinstance(reasoning_content, str):
+                raise TypeError(
+                    f"Unsupported reasoning_content value type: {type(reasoning_content)!r}"
+                )
+            normalized_message["content"] = [
+                {"type": "thinking", "thinking": reasoning_content},
+                *_ensure_content_parts(normalized_message["content"]),
+            ]
+
         trainable = message.get("trainable")
         if trainable is not None:
             normalized_message["trainable"] = bool(trainable)


### PR DESCRIPTION
…ssages

OpenAI-compatible chat data (including datasets produced by the Fireworks API) stores assistant chain-of-thought in a top-level "reasoning_content" field, not in Tinker's "thinking" field. Previously "normalize_messages" only recognized "thinking", so reasoning traces were silently dropped before ever reaching a renderer. Thinking-capable renderers (KimiK2/K2.5/K2.6, Qwen3, DeepSeekV3Thinking, Nemotron3, GPT-OSS) then saw an empty thinking block and emitted a bare "<think></think>" in the training tokens, so SFT'd models never learned to produce a CoT at inference.

Treat "reasoning_content" as an alias for "thinking" and prepend it as a ThinkingPart. If both fields are set on a message, prefer the native "thinking" field to keep a single source of truth.

Unit tests cover the basic alias, reasoning-only turns with empty content, the precedence rule when both fields are present, and rejection of non-string reasoning_content values.