### PR TITLE
fix(rl): gate resolve_builtin_loss on kl_beta to avoid silent KL drop

### DIFF
--- a/skills/dev/references/rl/loss-paths.md
+++ b/skills/dev/references/rl/loss-paths.md
@@ -5,7 +5,7 @@
 | Path | SDK call | Cost | When |
 |---|---|---|---|
 | **Server-side built-in** (default) | `training_client.forward_backward(...)` | Single fused forward+backward on the trainer | `cfg.policy_loss` resolves to a built-in kernel via `training/utils/rl/losses.py:resolve_builtin_loss` — GRPO / DAPO / DRO / GSPO / CISPO — **and** the shape's `pipeline_parallelism == 1` |
-| **Client-side custom** | `training_client.forward_backward_custom(...)` | **Extra forward** — client computes logprobs (forward #1), runs the Python loss, server runs forward+backward (#2) with gradients flowing from the Python loss | `cfg.policy_loss` has no built-in kernel (registered client-only), PP > 1, or a custom Python loss |
+| **Client-side custom** | `training_client.forward_backward_custom(...)` | **Extra forward** — client computes logprobs (forward #1), runs the Python loss, server runs forward+backward (#2) with gradients flowing from the Python loss | `cfg.policy_loss` has no built-in kernel (registered client-only), `cfg.kl_beta > 0` (built-in kernels do not consume `ref_logprobs`, so KL would be silently dropped), PP > 1, or a custom Python loss |
 
 Default in stock `rl_loop.py` is **server-side built-in** — `cfg.policy_loss = "grpo"` resolves to the GRPO kernel. The recipe logs which path it picked at step 0; confirm from the boot logs.
 
@@ -17,6 +17,7 @@ Switching to a custom loss roughly doubles the forward cost per step. If you can
 
 - `pipeline_parallelism > 1` on the chosen training shape → `resolve_builtin_loss` raises and the recipe falls back to client-side. If you want server-side performance, pick a shape with PP=1.
 - GSPO with TP/CP is caught server-side only (the profile doesn't expose TP/CP). You can see the rejection in the trainer's startup logs if this happens.
+- `cfg.kl_beta > 0` → `resolve_builtin_loss` returns `None` so the KL penalty actually lands. The server-side built-in datums produced by `build_builtin_loss_datums` only carry `target_tokens` / `logprobs` / `advantages` — no `ref_logprobs` — so running the built-in kernel with `kl_beta > 0` would silently drop the `kl_beta * (pi - pi_ref)` term. If you want to stay on the fast path, set `kl_beta = 0` and let the policy-trainer base weights serve as the implicit KL anchor (LoRA RL) or accept policy drift (full-param RL).
 
 ## Related
 

--- a/training/examples/rl/frozen_lake/train_frozen_lake.py
+++ b/training/examples/rl/frozen_lake/train_frozen_lake.py
@@ -742,10 +742,14 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
 
             # Server-side fast path: resolve the builtin kernel/config used by
             # forward_backward(...). Returns None when this loss has no builtin
-            # implementation, and raises when the current profile is ineligible.
+            # implementation or when kl_beta > 0 (builtin kernels do not
+            # consume ref_logprobs, so the KL term would be silently dropped --
+            # see resolve_builtin_loss docstring), and raises when the current
+            # profile is ineligible.
             builtin_server_loss = resolve_builtin_loss(
                 cfg.policy_loss,
                 profile,
+                kl_beta=cfg.kl_beta,
                 ratio_log_cap=cfg.ratio_log_cap,
             )
 

--- a/training/recipes/rl_loop.py
+++ b/training/recipes/rl_loop.py
@@ -619,10 +619,14 @@ def main(
 
         # Server-side fast path: resolve the builtin kernel/config used by
         # forward_backward(...). Returns None when this loss has no builtin
-        # implementation, and raises when the current profile is ineligible.
+        # implementation, when kl_beta > 0 (builtin kernels do not consume
+        # ref_logprobs, so the KL term would be silently dropped -- see
+        # resolve_builtin_loss docstring), or raises when the current profile
+        # is ineligible.
         builtin_server_loss = resolve_builtin_loss(
             cfg.policy_loss,
             policy_profile,
+            kl_beta=cfg.kl_beta,
             dapo_config=cfg.dapo,
             gspo_config=cfg.gspo,
             cispo_config=cfg.cispo,
@@ -630,6 +634,15 @@ def main(
             eps_clip=cfg.eps_clip,
             eps_clip_high=cfg.eps_clip_high,
         )
+        if cfg.kl_beta > 0 and builtin_server_loss is None:
+            logger.info(
+                "policy_loss=%s + kl_beta=%g: routing to client-side "
+                "forward_backward_custom (server-side builtin kernels ignore "
+                "ref_logprobs, so KL would be silently dropped). Expect one "
+                "extra forward pass per step.",
+                cfg.policy_loss,
+                cfg.kl_beta,
+            )
 
         def fwd_bwd_minibatch(
             data, adv, ref_lp, prompt_lens, inf_lp, prox_lp,

--- a/training/tests/unit/test_batched_losses.py
+++ b/training/tests/unit/test_batched_losses.py
@@ -134,6 +134,92 @@ class TestBuiltinLossConfig:
             )
 
 
+class TestKLBetaRoutesToClientSide:
+    """Documents the silent-KL-drop bug and the fix contract.
+
+    Bug: the server-side builtin kernels receive datums produced by
+    :func:`training.utils.rl.losses.build_builtin_loss_datums`, whose
+    ``loss_fn_inputs`` are exactly ``{target_tokens, logprobs, advantages}``
+    -- no ``ref_logprobs`` field is ever sent to the trainer. So when a caller
+    sets ``kl_beta > 0`` expecting a KL penalty, the builtin PPO kernel
+    silently drops the ``kl_beta * (pi - pi_ref)`` term.
+
+    Fix: ``resolve_builtin_loss`` must gate on ``kl_beta`` and return ``None``
+    when positive, forcing the recipe onto ``forward_backward_custom(...)``,
+    which is the only path that actually applies the KL penalty.
+    """
+
+    @staticmethod
+    def _builtin_datum():
+        """Run the builtin datum packer the way rl_loop does."""
+        datum = build_datum_from_token_mask(
+            token_ids=[10, 11, 12, 13],
+            token_mask=[0, 1, 1, 1],
+        ).datum
+        rl_datums = build_builtin_loss_datums(
+            data=[datum],
+            advantages=[1.0],
+            prox_logprobs=[[-0.1, -0.2, -0.3, -0.4]],
+            inf_logprobs=[[-0.1, -0.2, -0.3, -0.4]],
+            prompt_lens=[2],
+            policy_loss="grpo",
+        )
+        return rl_datums[0]
+
+    def test_builtin_datum_has_no_ref_logprobs_field(self):
+        """Structural invariant: the server-side path carries no ref logprobs.
+
+        This is the root cause of the silent KL drop. Encoded as a test so the
+        motivation for the ``kl_beta`` gate remains explicit: if this invariant
+        ever changes (e.g. the server kernel learns to consume ref logprobs),
+        the gate below can be relaxed.
+        """
+        fields = set(self._builtin_datum().loss_fn_inputs.keys())
+
+        assert fields == {"target_tokens", "logprobs", "advantages"}, (
+            "build_builtin_loss_datums emitted unexpected fields "
+            f"{fields!r}; the server-side builtin kernel contract is "
+            "(target_tokens, logprobs, advantages) only."
+        )
+        assert "ref_logprobs" not in fields, (
+            "ref_logprobs leaked into the builtin datum -- if the server "
+            "kernel now consumes it, the kl_beta gate can be lifted."
+        )
+
+    def test_resolve_builtin_loss_gates_on_kl_beta_for_grpo(self):
+        """With ``kl_beta > 0`` the dispatch must return ``None`` (client-side)."""
+        try:
+            result = resolve_builtin_loss("grpo", profile=None, kl_beta=0.01)
+        except TypeError as exc:
+            pytest.fail(
+                "resolve_builtin_loss currently ignores kl_beta "
+                f"({exc}). The server-side builtin datum has no "
+                "ref_logprobs field (see "
+                "test_builtin_datum_has_no_ref_logprobs_field), so "
+                "kl_beta > 0 routed to the builtin kernel is silently "
+                "dropped. Add a `kl_beta: float = 0.0` parameter to "
+                "resolve_builtin_loss and return None when it is positive."
+            )
+
+        assert result is None, (
+            "kl_beta>0 requested a KL penalty, but resolve_builtin_loss "
+            f"returned the server-side builtin kernel {result!r}. That "
+            "kernel silently drops the KL term (no ref_logprobs in the "
+            "datum). Must return None to force forward_backward_custom."
+        )
+
+    def test_resolve_builtin_loss_kl_beta_zero_keeps_server_builtin(self):
+        """Regression guard: ``kl_beta == 0`` must still take the fast path."""
+        result = resolve_builtin_loss("grpo", profile=None)
+
+        assert result is not None, (
+            "GRPO with kl_beta=0 must keep the fast server-side PPO path. "
+            "The kl_beta gate must not over-broadly block the builtin path."
+        )
+        kernel, _config = result
+        assert kernel == "ppo"
+
+
 class TestBatchDPOLoss:
 
     def _make_ref_logprobs(self, seq_len: int, seed: int = 0) -> list[float]:

--- a/training/tests/unit/test_train_frozen_lake.py
+++ b/training/tests/unit/test_train_frozen_lake.py
@@ -616,13 +616,12 @@ def test_main_runs_sampling_and_training_with_reference(monkeypatch, tmp_path):
     ]
     assert "fwd_bwd_call" in events
     assert events["build_loss_fn_kwargs"]["ratio_log_cap"] == 9.0
-    from training.utils.rl.losses import get_builtin_loss_config
-    expected_kernel, expected_config = get_builtin_loss_config(
-        cfg.policy_loss,
-        ratio_log_cap=cfg.ratio_log_cap,
-    )
-    assert events["fwd_bwd_call"]["loss_fn"] == expected_kernel
-    assert events["fwd_bwd_call"]["loss_fn_config"] == expected_config
+    # kl_beta > 0 forces the client-side custom path (server builtin kernels
+    # do not consume ref_logprobs and would silently drop the KL penalty --
+    # see resolve_builtin_loss gate in training/utils/rl/losses.py).
+    assert cfg.kl_beta > 0
+    assert events["fwd_bwd_call"]["loss_fn"] == "loss-fn"
+    assert "loss_fn_config" not in events["fwd_bwd_call"]
     assert events["deleted_jobs"] == ["reference-job", "policy-job"]
     assert events["deleted_deployments"] == []
     assert events["wandb_finished"] == 1

--- a/training/utils/rl/losses.py
+++ b/training/utils/rl/losses.py
@@ -51,6 +51,7 @@ def resolve_builtin_loss(
     policy_loss: str,
     profile: Any | None = None,
     *,
+    kl_beta: float = 0.0,
     dapo_config: DAPOConfig | None = None,
     dro_config: DROConfig | None = None,
     gspo_config: GSPOConfig | None = None,
@@ -65,11 +66,20 @@ def resolve_builtin_loss(
     when it otherwise has no builtin kernel config. In both cases the caller
     should fall back to ``forward_backward_custom(...)``.
 
+    Also returns ``None`` when ``kl_beta > 0``. The server-side builtin path
+    packs datums with only ``target_tokens`` / ``logprobs`` / ``advantages``
+    (see :func:`build_builtin_loss_datums`) and never sends ``ref_logprobs``,
+    so the KL term ``kl_beta * (pi - pi_ref)`` would be silently dropped.
+    The caller must use ``forward_backward_custom(...)`` to apply a KL penalty.
+
     Raises ``ValueError`` when the current *profile* cannot use builtin losses
     (for example, PP > 1), instead of silently falling back.
     """
     spec = LOSS_REGISTRY.get(policy_loss)
     if spec is None or spec.builtin_config_builder is None:
+        return None
+
+    if kl_beta > 0.0:
         return None
 
     if profile is not None:
@@ -95,6 +105,8 @@ def resolve_builtin_loss(
 def check_builtin_loss_eligibility(
     policy_loss: str,
     profile: Any | None,
+    *,
+    kl_beta: float = 0.0,
 ) -> None:
     """Reject unsupported parallelism configurations early.
 
@@ -104,12 +116,13 @@ def check_builtin_loss_eligibility(
     - Any builtin loss is used with PP > 1 (server kernels don't support PP)
     - GSPO + TP/CP is caught server-side only (profile doesn't expose TP/CP)
     """
-    resolve_builtin_loss(policy_loss, profile)
+    resolve_builtin_loss(policy_loss, profile, kl_beta=kl_beta)
 
 
 def get_builtin_loss_config(
     policy_loss: str,
     *,
+    kl_beta: float = 0.0,
     dapo_config: DAPOConfig | None = None,
     dro_config: DROConfig | None = None,
     gspo_config: GSPOConfig | None = None,
@@ -126,6 +139,7 @@ def get_builtin_loss_config(
     return resolve_builtin_loss(
         policy_loss,
         None,
+        kl_beta=kl_beta,
         dapo_config=dapo_config,
         dro_config=dro_config,
         gspo_config=gspo_config,


### PR DESCRIPTION
## Problem

`cfg.kl_beta > 0` requests a KL penalty of the form `β · (logπ_policy − logπ_ref)`,
but when `cfg.policy_loss` has a server-side builtin kernel (GRPO / DAPO / DRO /
GSPO / CISPO), `rl_loop` dispatches to `training_client.forward_backward(...)`
and passes datums produced by `build_builtin_loss_datums`. Those datums' only
`loss_fn_inputs` are `{target_tokens, logprobs, advantages}` -- `ref_logprobs`
is never plumbed through. The builtin PPO kernel therefore silently drops the
KL term, even though the recipe still provisions a reference trainer, runs a
reference forward pass every step, and logs a `kl_pen` value that has no
effect on the gradient.

This is especially bad in the default config: `cfg.policy_loss = "grpo"` is the
happy path and silently ignores a user-supplied `kl_beta`.

## Change

Gate `resolve_builtin_loss` on `kl_beta`: when it is positive, return `None`
so the recipe falls back to `forward_backward_custom(...)`. That path is the
only one whose Python closure (see `training/utils/rl/grpo.py`) actually
applies `kl_beta * (pi_detached - resp_ref)`. This costs one extra forward
pass per step; the recipe logs the routing decision at INFO so users
understand the trade-off.

## Code Overview Diagram

\`\`\`mermaid
flowchart TD
    A[rl_loop.main step] --> B[resolve_builtin_loss]
    B --> C{spec has<br/>builtin_config_builder?}
    C -- no --> Z[return None]
    C -- yes --> D{kl_beta > 0?}
    D -- yes --> Z2[return None<br/>NEW gate]
    D -- no --> E{profile.pp > 1?}
    E -- yes --> F[raise ValueError]
    E -- no --> G[return builtin_config]

    Z --> H[forward_backward_custom<br/>client-side loss applies KL]
    Z2 --> H
    G --> I[forward_backward<br/>server-side kernel<br/>KL dropped]

    style Z2 fill:#d4edda
    style H fill:#d4edda
    style I fill:#f8d7da
\`\`\`

## Files

- `training/utils/rl/losses.py` -- add `kl_beta` kwarg to `resolve_builtin_loss`,
  `check_builtin_loss_eligibility`, `get_builtin_loss_config`; return `None`
  when `kl_beta > 0`.
- `training/recipes/rl_loop.py` + `training/examples/rl/frozen_lake/train_frozen_lake.py`
  -- thread `cfg.kl_beta` into the dispatch call; INFO-log on fallback.
- `training/tests/unit/test_batched_losses.py` -- new `TestKLBetaRoutesToClientSide`:
  - `test_builtin_datum_has_no_ref_logprobs_field` -- structural invariant
    that motivates the gate (passes on main; documents the root cause).
  - `test_resolve_builtin_loss_gates_on_kl_beta_for_grpo` -- fails loudly
    on main with a behavior-focused `pytest.fail(...)` message; passes
    after the fix.
  - `test_resolve_builtin_loss_kl_beta_zero_keeps_server_builtin` -- regression
    guard that the fast path is untouched for `kl_beta == 0`.
- `training/tests/unit/test_train_frozen_lake.py` -- the existing
  `test_main_runs_sampling_and_training_with_reference` had `kl_beta=0.1`
  and was asserting the server-side `ppo` kernel path (i.e. encoding the
  bug). Updated to assert the custom path now and reference the new gate.
- `skills/dev/references/rl/loss-paths.md` -- document the new fallback
  condition.

## Test plan

- [x] `pytest training/tests/unit/` (319 passed).
- [x] Confirmed the new test `test_resolve_builtin_loss_gates_on_kl_beta_for_grpo`
      fails on unmodified code with the behavior-focused message, not just a
      `TypeError`.
- [x] Confirmed `test_resolve_builtin_loss_kl_beta_zero_keeps_server_builtin`
      still passes (fast path regression guard).
- [ ] Optional: run a short `train_frozen_lake` smoke with `kl_beta=0.01` on
      dev to verify the INFO log fires and training converges.

Made with [Cursor](https://cursor.com)