### PR TITLE
fix(supervised): preserve thinking on every assistant turn for Kimi/Qwen3/DeepSeek-thinking

### DIFF
--- a/training/recipes/sft_loop.py
+++ b/training/recipes/sft_loop.py
@@ -50,7 +50,7 @@ from training.utils import (
     build_renderer,
     parse_train_on_what,
     auto_select_training_shape,
-    render_messages_to_datum,
+    render_messages_to_datums,
     resolve_renderer_name,
 )
 from training.utils.client import DEFAULT_TIMEOUT_S
@@ -440,29 +440,40 @@ def main(
         max_seq_len = cfg.max_seq_len
         filtered_count = 0
 
-        def _map_fn(row: dict) -> tinker.Datum | None:
+        def _map_fn(row: dict) -> list[tinker.Datum]:
+            """Render one raw row into zero or more training data.
+
+            For renderers without the sequence-extension property (Kimi K2/K2.5,
+            Qwen3-thinking, DeepSeek V3-thinking), a multi-turn conversation
+            expands into one datum per assistant turn so each turn's
+            chain-of-thought is preserved in the sequence it is trained on.
+            Renderers that satisfy the extension property still yield a single
+            datum, so behavior for plain instruct models is unchanged.
+            """
             nonlocal filtered_count
             messages = row.get("messages", [])
             if not messages:
                 filtered_count += 1
-                return None
-            rendered = render_messages_to_datum(
+                return []
+            rendered_examples = render_messages_to_datums(
                 messages,
                 renderer=renderer,
                 train_on_what=train_on_what,
             )
-            if len(rendered.token_ids) > max_seq_len or len(rendered.token_ids) < 2:
-                filtered_count += 1
-                return None
-            return rendered.datum
+            kept: list[tinker.Datum] = []
+            for rendered in rendered_examples:
+                token_len = len(rendered.token_ids)
+                if token_len > max_seq_len or token_len < 2:
+                    filtered_count += 1
+                    continue
+                kept.append(rendered.datum)
+            return kept
 
         total_raw = len(raw_data)
         log_interval = max(1, total_raw // 20)  # ~5% increments
         training_data: List[tinker.Datum] = []
         for i, row in enumerate(raw_data):
-            d = _map_fn(row)
-            if d is not None:
-                training_data.append(d)
+            training_data.extend(_map_fn(row))
             if (i + 1) % log_interval == 0 or (i + 1) == total_raw:
                 runner.report_rendering_progress(i + 1, total_raw)
         if filtered_count > 0:
@@ -491,9 +502,7 @@ def main(
             eval_log_interval = max(1, total_eval // 10)
             eval_data = []
             for i, row in enumerate(raw_eval):
-                d = _map_fn(row)
-                if d is not None:
-                    eval_data.append(d)
+                eval_data.extend(_map_fn(row))
                 if (i + 1) % eval_log_interval == 0 or (i + 1) == total_eval:
                     runner.report_rendering_progress(i + 1, total_eval, label="rendering eval data")
             logger.info("Loaded %d eval examples from %s", len(eval_data), cfg.evaluation_dataset)

--- a/training/tests/unit/test_sft_loop.py
+++ b/training/tests/unit/test_sft_loop.py
@@ -19,6 +19,11 @@ class StubRenderer:
         self.calls.append((messages, train_on_what))
         return self.tokens, self.weights
 
+    def build_supervised_examples(self, messages, train_on_what):
+        # Mimic renderers that satisfy the extension property: a single example
+        # wrapping the same (model_input, weights) pair.
+        return [self.build_supervised_example(messages, train_on_what)]
+
 
 def _write_dataset(tmp_path, rows):
     dataset_path = tmp_path / "sft.jsonl"
@@ -138,8 +143,8 @@ def test_main_raises_when_all_examples_are_filtered(tmp_path, monkeypatch):
     )
     monkeypatch.setattr(
         module,
-        "render_messages_to_datum",
-        lambda *args, **kwargs: SimpleNamespace(token_ids=[1], datum={"id": "too-short"}),
+        "render_messages_to_datums",
+        lambda *args, **kwargs: [SimpleNamespace(token_ids=[1], datum={"id": "too-short"})],
     )
     monkeypatch.setattr(module, "ReconnectableClient", FakeClient)
 
@@ -225,17 +230,19 @@ def test_main_reduces_batch_size_when_examples_fewer_than_batch_size(tmp_path, m
     )
     monkeypatch.setattr(
         module,
-        "render_messages_to_datum",
-        lambda *args, **kwargs: SimpleNamespace(
-            token_ids=[1, 2, 3],
-            datum=SimpleNamespace(
-                model_input=SimpleNamespace(chunks=[SimpleNamespace(tokens=[1, 2, 3])]),
-                loss_fn_inputs={
-                    "target_tokens": SimpleNamespace(data=[2, 3]),
-                    "weights": SimpleNamespace(data=[1.0, 1.0]),
-                },
-            ),
-        ),
+        "render_messages_to_datums",
+        lambda *args, **kwargs: [
+            SimpleNamespace(
+                token_ids=[1, 2, 3],
+                datum=SimpleNamespace(
+                    model_input=SimpleNamespace(chunks=[SimpleNamespace(tokens=[1, 2, 3])]),
+                    loss_fn_inputs={
+                        "target_tokens": SimpleNamespace(data=[2, 3]),
+                        "weights": SimpleNamespace(data=[1.0, 1.0]),
+                    },
+                ),
+            )
+        ],
     )
     monkeypatch.setattr(module, "ReconnectableClient", FakeClient)
 
@@ -328,19 +335,21 @@ def test_main_infers_documented_training_shape_for_supported_model(tmp_path, mon
     monkeypatch.setattr(module, "auto_select_training_shape", _record_auto_select)
     monkeypatch.setattr(
         module,
-        "render_messages_to_datum",
-        lambda *args, **kwargs: SimpleNamespace(
-            token_ids=[1, 2, 3],
-            datum=SimpleNamespace(
-                model_input=SimpleNamespace(
-                    chunks=[SimpleNamespace(tokens=[1, 2, 3])],
+        "render_messages_to_datums",
+        lambda *args, **kwargs: [
+            SimpleNamespace(
+                token_ids=[1, 2, 3],
+                datum=SimpleNamespace(
+                    model_input=SimpleNamespace(
+                        chunks=[SimpleNamespace(tokens=[1, 2, 3])],
+                    ),
+                    loss_fn_inputs={
+                        "target_tokens": SimpleNamespace(data=[2, 3]),
+                        "weights": SimpleNamespace(data=[1.0, 1.0]),
+                    },
                 ),
-                loss_fn_inputs={
-                    "target_tokens": SimpleNamespace(data=[2, 3]),
-                    "weights": SimpleNamespace(data=[1.0, 1.0]),
-                },
-            ),
-        ),
+            )
+        ],
     )
     monkeypatch.setattr(module, "ReconnectableClient", FakeClient)
 
@@ -562,9 +571,9 @@ def test_each_batch_triggers_its_own_optim_step(tmp_path, monkeypatch):
             },
             _test_id=content,
         )
-        return SimpleNamespace(token_ids=[1, 2, 3], datum=datum)
+        return [SimpleNamespace(token_ids=[1, 2, 3], datum=datum)]
 
-    monkeypatch.setattr(module, "render_messages_to_datum", _fake_render)
+    monkeypatch.setattr(module, "render_messages_to_datums", _fake_render)
 
     cfg = module.Config(
         dataset=str(dataset_path),
@@ -718,9 +727,9 @@ def test_eval_auto_carveout_splits_data_and_runs_eval(tmp_path, monkeypatch):
             },
             _test_id=f"example-{idx}",
         )
-        return SimpleNamespace(token_ids=[1, 2, 3], datum=datum)
+        return [SimpleNamespace(token_ids=[1, 2, 3], datum=datum)]
 
-    monkeypatch.setattr(module, "render_messages_to_datum", _fake_render)
+    monkeypatch.setattr(module, "render_messages_to_datums", _fake_render)
 
     cfg = module.Config(
         dataset=str(dataset_path),

--- a/training/tests/unit/test_supervised_rendering.py
+++ b/training/tests/unit/test_supervised_rendering.py
@@ -16,6 +16,7 @@ from training.utils.supervised import (
     render_preference_pair,
     normalize_messages,
     render_messages_to_datum,
+    render_messages_to_datums,
 )
 
 
@@ -48,6 +49,34 @@ class SequenceRenderer:
     ):
         self.calls.append((messages, train_on_what))
         return self.outputs[len(self.calls) - 1]
+
+
+class MultiExampleStubRenderer:
+    """Renderer mimicking KimiK2.build_supervised_examples: yields N examples
+    for a multi-turn conversation."""
+
+    def __init__(self, outputs: list[tuple[list[int], list[float]]]):
+        self.outputs = [
+            (
+                torch.tensor(tokens, dtype=torch.int64),
+                torch.tensor(weights, dtype=torch.float32),
+            )
+            for tokens, weights in outputs
+        ]
+        self.single_calls: list[tuple[list[dict], TrainOnWhat]] = []
+        self.plural_calls: list[tuple[list[dict], TrainOnWhat]] = []
+
+    def build_supervised_example(
+        self, messages, train_on_what=TrainOnWhat.LAST_ASSISTANT_MESSAGE
+    ):
+        self.single_calls.append((messages, train_on_what))
+        return self.outputs[0]
+
+    def build_supervised_examples(
+        self, messages, train_on_what=TrainOnWhat.LAST_ASSISTANT_TURN
+    ):
+        self.plural_calls.append((messages, train_on_what))
+        return list(self.outputs)
 
 
 class ModelInputRenderer:
@@ -121,6 +150,98 @@ def test_render_messages_to_datum_preserves_multi_turn_weights():
         1.0,
         1.0,
     ]
+
+
+def test_render_messages_to_datums_uses_plural_build_supervised_examples():
+    """``render_messages_to_datums`` must call ``build_supervised_examples``
+    (plural) so renderers that strip thinking from history (KimiK2/K2.5/K2.6,
+    Qwen3-thinking, DeepSeekV3-thinking) yield one training example per
+    assistant turn. Calling the singular ``build_supervised_example`` with
+    ALL_ASSISTANT_MESSAGES produces a single sequence in which every
+    intermediate assistant turn has an empty ``<think></think>`` block, which
+    is exactly the regression that caused fine-tuned Kimi models to stop
+    emitting reasoning traces at inference.
+    """
+    renderer = MultiExampleStubRenderer(
+        outputs=[
+            ([10, 11, 12, 13], [0, 0, 1, 1]),
+            ([10, 11, 12, 13, 14, 15, 16, 17], [0, 0, 0, 0, 0, 0, 1, 1]),
+        ]
+    )
+
+    rendered = render_messages_to_datums(
+        [
+            {"role": "user", "content": "u1"},
+            {"role": "assistant", "reasoning_content": "t1", "content": "a1"},
+            {"role": "user", "content": "u2"},
+            {"role": "assistant", "reasoning_content": "t2", "content": "a2"},
+        ],
+        renderer=renderer,
+        train_on_what="all_assistant_messages",
+    )
+
+    assert renderer.single_calls == []
+    assert len(renderer.plural_calls) == 1
+    _, train_on_what = renderer.plural_calls[0]
+    assert train_on_what == TrainOnWhat.ALL_ASSISTANT_MESSAGES
+
+    assert len(rendered) == 2
+    assert rendered[0].token_ids == [10, 11, 12, 13]
+    assert rendered[1].token_ids == [10, 11, 12, 13, 14, 15, 16, 17]
+
+
+def test_render_messages_to_datums_filters_normalized_reasoning_content():
+    """``reasoning_content`` must be promoted to a ThinkingPart before the
+    normalized messages reach ``build_supervised_examples`` so the renderer's
+    per-turn rendering can fill the ``<think>...</think>`` block for every
+    assistant turn instead of emitting an empty placeholder."""
+    renderer = MultiExampleStubRenderer(
+        outputs=[
+            ([10, 11, 12, 13], [0, 0, 1, 1]),
+            ([10, 11, 12, 13, 14, 15, 16, 17], [0, 0, 0, 0, 0, 0, 1, 1]),
+        ]
+    )
+
+    render_messages_to_datums(
+        [
+            {"role": "user", "content": "u1"},
+            {"role": "assistant", "reasoning_content": "t1", "content": "a1"},
+            {"role": "user", "content": "u2"},
+            {"role": "assistant", "reasoning_content": "t2", "content": "a2"},
+        ],
+        renderer=renderer,
+    )
+
+    normalized_messages, _ = renderer.plural_calls[0]
+    assistant_messages = [m for m in normalized_messages if m["role"] == "assistant"]
+    assert len(assistant_messages) == 2
+    for msg in assistant_messages:
+        assert msg["content"][0] == {"type": "thinking", "thinking": msg["content"][0]["thinking"]}
+        assert msg["content"][0]["thinking"] in {"t1", "t2"}
+
+
+def test_render_messages_to_datum_still_uses_singular_for_back_compat():
+    """``render_messages_to_datum`` (singular) must keep calling
+    ``build_supervised_example`` for callers that expect a single datum; the
+    fix for multi-turn thinking lives in ``render_messages_to_datums``
+    (plural)."""
+    renderer = MultiExampleStubRenderer(
+        outputs=[
+            ([10, 11, 12, 13], [0, 0, 1, 1]),
+        ]
+    )
+
+    rendered = render_messages_to_datum(
+        [
+            {"role": "user", "content": "u1"},
+            {"role": "assistant", "content": "a1"},
+        ],
+        renderer=renderer,
+    )
+
+    assert renderer.plural_calls == []
+    assert len(renderer.single_calls) == 1
+    assert rendered.token_ids == [10, 11, 12, 13]
 
 
 def test_render_messages_to_datum_supports_multimodal_model_input():

--- a/training/utils/__init__.py
+++ b/training/utils/__init__.py
@@ -78,6 +78,7 @@ __all__ = [
     "parse_train_on_what",
     "render_preference_pair",
     "render_messages_to_datum",
+    "render_messages_to_datums",
     "resolve_renderer_name",
     "prepare_sampling_messages",
     "setup_deployment",
@@ -155,6 +156,7 @@ from training.utils.supervised import (
     parse_train_on_what,
     render_preference_pair,
     render_messages_to_datum,
+    render_messages_to_datums,
     resolve_renderer_name,
 )
 from training.utils.logging import (

--- a/training/utils/supervised.py
+++ b/training/utils/supervised.py
@@ -610,20 +610,14 @@ def build_datum_from_token_mask(
     )
 
 
-def render_messages_to_datum(
-    messages: Sequence[Mapping[str, Any]],
+def _datum_from_rendered_example(
+    rendered_input: Any,
+    weights: Any,
     *,
-    renderer: Renderer,
-    train_on_what: str | TrainOnWhat = TrainOnWhat.ALL_ASSISTANT_MESSAGES,
-    max_seq_len: int | None = None,
-    include_loss_mask: bool = False,
+    max_seq_len: int | None,
+    include_loss_mask: bool,
 ) -> RenderedSupervisedDatum:
-    """Render a multi-turn conversation into the shared weighted datum format."""
-    normalized_messages = normalize_messages(messages)
-    rendered_input, weights = renderer.build_supervised_example(
-        normalized_messages,
-        train_on_what=parse_train_on_what(train_on_what),
-    )
+    """Wrap a single ``(model_input, weights)`` pair as a ``RenderedSupervisedDatum``."""
     weight_values = weights.tolist() if hasattr(weights, "tolist") else list(weights)
     if isinstance(rendered_input, tinker.ModelInput):
         return build_datum_from_model_input_and_weights(
@@ -640,6 +634,77 @@ def render_messages_to_datum(
     return build_datum_from_tokens_and_weights(
         token_values,
         weight_values,
+        max_seq_len=max_seq_len,
+        include_loss_mask=include_loss_mask,
+    )
+
+
+def render_messages_to_datums(
+    messages: Sequence[Mapping[str, Any]],
+    *,
+    renderer: Renderer,
+    train_on_what: str | TrainOnWhat = TrainOnWhat.ALL_ASSISTANT_MESSAGES,
+    max_seq_len: int | None = None,
+    include_loss_mask: bool = False,
+) -> list[RenderedSupervisedDatum]:
+    """Render a multi-turn conversation into one or more weighted training data.
+
+    For renderers that strip thinking content from history (``has_extension_property``
+    is False — e.g. KimiK2/K2.5/K2.6, Qwen3, DeepSeekV3-thinking), a single call to
+    ``build_supervised_example`` with ``ALL_ASSISTANT_MESSAGES`` produces tokens in
+    which every intermediate assistant turn has an empty ``<think></think>`` block
+    while only the *last* assistant turn keeps its chain-of-thought. Training on
+    that sequence teaches the model to emit an empty ``<think></think>`` the
+    majority of the time at inference.
+
+    The fix is to delegate to ``build_supervised_examples`` (plural), which yields
+    one example per assistant turn for renderers without the extension property so
+    every CoT is preserved in the turn it is trained on. For renderers that do
+    have the extension property, the plural form returns a single example and
+    behavior is unchanged.
+    """
+    normalized_messages = normalize_messages(messages)
+    parsed_train_on_what = parse_train_on_what(train_on_what)
+    rendered_examples = renderer.build_supervised_examples(
+        normalized_messages,
+        train_on_what=parsed_train_on_what,
+    )
+    return [
+        _datum_from_rendered_example(
+            rendered_input,
+            weights,
+            max_seq_len=max_seq_len,
+            include_loss_mask=include_loss_mask,
+        )
+        for rendered_input, weights in rendered_examples
+    ]
+
+
+def render_messages_to_datum(
+    messages: Sequence[Mapping[str, Any]],
+    *,
+    renderer: Renderer,
+    train_on_what: str | TrainOnWhat = TrainOnWhat.ALL_ASSISTANT_MESSAGES,
+    max_seq_len: int | None = None,
+    include_loss_mask: bool = False,
+) -> RenderedSupervisedDatum:
+    """Render a multi-turn conversation into a single weighted datum.
+
+    Back-compat shim around ``renderer.build_supervised_example`` (singular). This
+    does *not* preserve chain-of-thought on intermediate turns for renderers that
+    strip thinking from history. Callers that want correct multi-turn thinking
+    behavior for Kimi/Qwen3/DeepSeek-thinking should prefer
+    ``render_messages_to_datums`` (plural), which delegates to
+    ``build_supervised_examples`` and yields one datum per assistant turn.
+    """
+    normalized_messages = normalize_messages(messages)
+    rendered_input, weights = renderer.build_supervised_example(
+        normalized_messages,
+        train_on_what=parse_train_on_what(train_on_what),
+    )
+    return _datum_from_rendered_example(
+        rendered_input,
+        weights,
         max_seq_len=max_seq_len,
         include_loss_mask=include_loss_mask,
     )


### PR DESCRIPTION
## Problem

After PR #378 fixed the `reasoning_content` alias, customers reported fine-tuned Kimi K2.5 models still emit an empty `<think></think>` on ~50% of responses at inference. Adding `reasoning_content` into the literal `content` as a `<think>...`` workaround restores CoT on all responses.

## Root cause

KimiK2/K2.5/K2.6, Qwen3-thinking, and DeepSeek V3-thinking renderers **strip `<think>` from every historical assistant turn** and only keep it on the last assistant turn (`has_extension_property=False`).

The SFT loop rendering path called `renderer.build_supervised_example` (singular) with `train_on_what=all_assistant_messages`. For an N-turn conversation, the trained sequence looked like:

```
turn 0..N-2:  <think></think>{answer}<|im_end|>
turn N-1:     <think>{cot}</think>{answer}<|im_end|>
```

even when **every turn** in the dataset had a non-empty `reasoning_content`. The fine-tuned model then directly learned to emit `<think></think>` for the majority of turns.

### Direct reproduction (Kimi K2.5 tokenizer + actual renderer)

Two-assistant conversation; both turns have `reasoning_content`:

```
BEFORE: render_messages_to_datum (singular)
  trained run 0: '<think></think>4<|im_end|>'                         <-- FIRST CoT DROPPED
  trained run 1: '<think>SECOND THINKING</think>6<|im_end|>'          <-- only last CoT kept

AFTER: render_messages_to_datums (plural)
  example 0 run 0: '<think>FIRST THINKING</think>4<|im_end|>'         <-- kept
  example 1 run 0: '<think>SECOND THINKING</think>6<|im_end|>'        <-- kept
```

This matches the customer's '`reasoning_content` added to content' workaround: literal-text thinking survives because the stripping only touches `ThinkingPart`.

## Fix

Add `render_messages_to_datums` (plural) which calls `renderer.build_supervised_examples` (plural). The plural method is already implemented on each thinking renderer:

- **KimiK2Renderer** splits multi-turn conversations into one example per user turn so every CoT is preserved in the turn it is trained on (kimi_k2.py#335).
- **Base renderer** (`has_extension_property=True` — Llama3, RoleColon, Qwen3 non-thinking, DeepSeek non-thinking) returns a singleton list, so behavior for plain instruct models is **unchanged**.

`sft_loop.py` `_map_fn` now returns a list, and the training/eval loops `extend` into their datum lists.

`render_messages_to_datum` (singular) is retained as a back-compat shim for paths that explicitly need a single datum (preference pairs, token-mask eval, etc.).

## Tests

- `test_render_messages_to_datums_uses_plural_build_supervised_examples`: plural form must delegate to `build_supervised_examples`.
- `test_render_messages_to_datums_filters_normalized_reasoning_content`: `reasoning_content` still flows through `normalize_messages` before rendering.
- `test_render_messages_to_datum_still_uses_singular_for_back_compat`: singular shim is unchanged.
- Existing `test_sft_loop` tests were updated to patch the plural name and wrap outputs in a list; `StubRenderer` now implements both singular and plural forms so extension-property renderers keep working.

Full unit test suite: `374 passed, 53 skipped` in `training/tests/unit/`.

## Surfaces

- `training/utils/supervised.py`: new public `render_messages_to_datums`; shared `_datum_from_rendered_example` helper.
- `training/utils/__init__.py`: re-export `render_messages_to_datums`.
- `training/recipes/sft_loop.py`: switch SFT training+eval rendering to the plural API.
- `training/tests/unit/test_supervised_rendering.py`: 3 new tests.
- `training/tests/unit/test_sft_loop.py`: update monkeypatches to use the plural name; extend `StubRenderer`.