### PR TITLE
fix(supervised): honor dataset per-message weight in normalize_messages

### DIFF
--- a/training/tests/unit/test_supervised_rendering.py
+++ b/training/tests/unit/test_supervised_rendering.py
@@ -324,6 +324,140 @@ def test_normalize_messages_rejects_non_string_reasoning_content():
         )
 
 
+def test_normalize_messages_translates_weight_zero_to_trainable_false():
+    """Fireworks V1 SFT datasets mark context-only assistant messages with
+    ``weight=0``. Without translating that to Tinker's ``trainable`` field,
+    ``train_on_what=all_assistant_messages`` silently trains on every
+    assistant — including the context-only ones — which teaches thinking
+    models to emit empty ``<think></think>`` for the majority of turns
+    because historical assistants on Kimi/Qwen3/DeepSeek-thinking are
+    rendered with their thinking stripped."""
+    normalized = normalize_messages(
+        [
+            {"role": "user", "content": "u1"},
+            {"role": "assistant", "content": "ctx", "weight": 0},
+            {"role": "user", "content": "u2"},
+            {"role": "assistant", "content": "train me"},
+        ]
+    )
+
+    assert normalized[0]["trainable"] is False  # user
+    assert normalized[1]["trainable"] is False  # weight=0
+    assert normalized[2]["trainable"] is False  # user
+    assert normalized[3]["trainable"] is True  # weight absent -> assistant default
+
+
+def test_normalize_messages_translates_weight_one_to_trainable_true():
+    """``weight=1`` (explicit trainable marker) must map to ``trainable=True``."""
+    normalized = normalize_messages(
+        [
+            {"role": "user", "content": "u1"},
+            {"role": "assistant", "content": "a1", "weight": 1},
+        ]
+    )
+
+    assert normalized[1]["trainable"] is True
+
+
+def test_normalize_messages_prefers_explicit_trainable_over_weight():
+    """If both ``trainable`` and ``weight`` are set, ``trainable`` wins."""
+    normalized = normalize_messages(
+        [
+            {"role": "user", "content": "u"},
+            {"role": "assistant", "content": "a", "weight": 1, "trainable": False},
+        ]
+    )
+
+    assert normalized[1]["trainable"] is False
+
+
+def test_normalize_messages_does_not_add_trainable_when_no_weight_or_trainable():
+    """Datasets without ``weight``/``trainable`` on any message must not
+    gain a ``trainable`` field, so renderers still see a back-compatible
+    schema and default ``train_on_what`` modes keep working unchanged."""
+    normalized = normalize_messages(
+        [
+            {"role": "user", "content": "u1"},
+            {"role": "assistant", "content": "a1"},
+        ]
+    )
+
+    assert "trainable" not in normalized[0]
+    assert "trainable" not in normalized[1]
+
+
+def test_normalize_messages_rejects_non_numeric_weight():
+    """Non-numeric ``weight`` values must raise TypeError to avoid silently
+    accepting garbage data."""
+    with pytest.raises(TypeError):
+        normalize_messages(
+            [
+                {"role": "assistant", "content": "a", "weight": "yes"},
+            ]
+        )
+
+
+def test_render_messages_to_datum_auto_switches_to_customized_when_weight_set():
+    """When the dataset marks messages with ``weight`` / ``trainable``,
+    ``render_messages_to_datum`` must auto-promote ``train_on_what`` to
+    ``CUSTOMIZED`` so the renderer honors the per-message flag. Otherwise
+    the legacy V1 SFT convention (``weight=0`` means "context only")
+    silently degrades into "train on everything" on the V2 path."""
+
+    class RecordingRenderer:
+        def __init__(self):
+            self.calls: list[tuple[list[dict], TrainOnWhat]] = []
+
+        def build_supervised_example(self, messages, train_on_what):
+            self.calls.append((list(messages), train_on_what))
+            return (
+                torch.tensor([1, 2, 3, 4], dtype=torch.int64),
+                torch.tensor([0, 0, 1, 1], dtype=torch.float32),
+            )
+
+    renderer = RecordingRenderer()
+    render_messages_to_datum(
+        [
+            {"role": "user", "content": "u"},
+            {"role": "assistant", "content": "a", "weight": 0},
+            {"role": "assistant", "content": "b"},
+        ],
+        renderer=renderer,
+        train_on_what="all_assistant_messages",
+    )
+    _, resolved_train_on_what = renderer.calls[0]
+    assert resolved_train_on_what == TrainOnWhat.CUSTOMIZED
+
+
+def test_render_messages_to_datum_keeps_default_train_on_what_without_weight():
+    """Without ``weight``/``trainable`` anywhere in the conversation, the
+    caller-specified ``train_on_what`` must flow through unchanged — this
+    preserves back-compat for datasets that don't use the V1 field."""
+
+    class RecordingRenderer:
+        def __init__(self):
+            self.calls: list[tuple[list[dict], TrainOnWhat]] = []
+
+        def build_supervised_example(self, messages, train_on_what):
+            self.calls.append((list(messages), train_on_what))
+            return (
+                torch.tensor([1, 2, 3, 4], dtype=torch.int64),
+                torch.tensor([0, 0, 1, 1], dtype=torch.float32),
+            )
+
+    renderer = RecordingRenderer()
+    render_messages_to_datum(
+        [
+            {"role": "user", "content": "u"},
+            {"role": "assistant", "content": "a"},
+        ],
+        renderer=renderer,
+        train_on_what="all_assistant_messages",
+    )
+    _, resolved_train_on_what = renderer.calls[0]
+    assert resolved_train_on_what == TrainOnWhat.ALL_ASSISTANT_MESSAGES
+
+
 def test_build_renderer_uses_image_processor_for_vl_renderers(monkeypatch):
     calls: list[tuple[str, object | None]] = []
 

--- a/training/utils/supervised.py
+++ b/training/utils/supervised.py
@@ -293,10 +293,68 @@ def _ensure_content_parts(content: str | list[dict[str, Any]]) -> list[dict[str,
     return list(content)
 
 
-def normalize_messages(messages: Iterable[Mapping[str, Any]]) -> list[Message]:
-    """Normalize cookbook/eval-style messages into Tinker's message schema."""
+def _any_message_has_per_message_training_flag(
+    messages: Iterable[Mapping[str, Any]],
+) -> bool:
+    """Return True if any message carries an explicit per-message training flag.
+
+    The Fireworks SFT dataset schema uses ``weight`` (int, 0 or 1) on
+    individual messages to mark which assistant turns should contribute loss.
+    Tinker's schema uses ``trainable`` (bool) for the same purpose. Either
+    field enables the per-message ``CUSTOMIZED`` training path.
+    """
+    return any(("weight" in m) or ("trainable" in m) for m in messages)
+
+
+def _resolve_trainable(
+    message: Mapping[str, Any],
+    *,
+    assistant_default: bool,
+) -> bool:
+    """Derive the per-message ``trainable`` flag from ``trainable`` or ``weight``.
+
+    ``trainable`` (bool) wins if present. Otherwise, a legacy ``weight`` (int
+    or float) maps to ``bool(weight)`` — matching the V1 SFT trainer
+    convention where ``weight=0`` marks an assistant message as context only
+    (no loss) and ``weight=1`` (or the field being absent) marks it as a
+    trainable target. When neither field is present, falls back to
+    ``assistant_default`` (True for assistants, False otherwise).
+    """
+    trainable = message.get("trainable")
+    if trainable is not None:
+        return bool(trainable)
+
+    weight = message.get("weight")
+    if weight is not None:
+        if not isinstance(weight, (int, float)) or isinstance(weight, bool):
+            raise TypeError(
+                f"Unsupported weight value type: {type(weight)!r} (expected int or float)"
+            )
+        return bool(weight)
+
+    return assistant_default
+
+
+def normalize_messages(
+    messages: Iterable[Mapping[str, Any]],
+) -> list[Message]:
+    """Normalize cookbook/eval-style messages into Tinker's message schema.
+
+    When any message in the conversation carries an explicit ``weight`` or
+    ``trainable`` field, every returned message gets a ``trainable`` flag so
+    that renderers invoked with ``train_on_what=CUSTOMIZED`` can honor the
+    per-message selection. Assistant messages default to trainable=True,
+    non-assistant messages to False. The legacy Fireworks ``weight`` field
+    (0 or 1) is translated to ``trainable = bool(weight)``, matching the V1
+    SFT trainer semantics.
+    """
+    messages_list = list(messages)
+    use_per_message_trainable = _any_message_has_per_message_training_flag(
+        messages_list
+    )
+
     normalized: list[Message] = []
-    for message in messages:
+    for message in messages_list:
         role = message.get("role")
         if not isinstance(role, str):
             raise ValueError(f"Message is missing a string role: {message}")
@@ -344,9 +402,11 @@ def normalize_messages(messages: Iterable[Mapping[str, Any]]) -> list[Message]:
                 *_ensure_content_parts(normalized_message["content"]),
             ]
 
-        trainable = message.get("trainable")
-        if trainable is not None:
-            normalized_message["trainable"] = bool(trainable)
+        if use_per_message_trainable:
+            normalized_message["trainable"] = _resolve_trainable(
+                message,
+                assistant_default=(role == "assistant"),
+            )
 
         tool_call_id = message.get("tool_call_id")
         if tool_call_id is not None:
@@ -618,11 +678,22 @@ def render_messages_to_datum(
     max_seq_len: int | None = None,
     include_loss_mask: bool = False,
 ) -> RenderedSupervisedDatum:
-    """Render a multi-turn conversation into the shared weighted datum format."""
+    """Render a multi-turn conversation into the shared weighted datum format.
+
+    When any message in the conversation carries an explicit ``weight`` or
+    ``trainable`` field, ``train_on_what`` is overridden to ``CUSTOMIZED`` so
+    that the renderer honors per-message training flags. This matches the V1
+    SFT trainer contract (``weight=0`` means "context-only, no loss") and
+    prevents the cookbook from silently training on assistant turns the
+    dataset author explicitly excluded.
+    """
     normalized_messages = normalize_messages(messages)
+    effective_train_on_what = parse_train_on_what(train_on_what)
+    if any("trainable" in m for m in normalized_messages):
+        effective_train_on_what = TrainOnWhat.CUSTOMIZED
     rendered_input, weights = renderer.build_supervised_example(
         normalized_messages,
-        train_on_what=parse_train_on_what(train_on_what),
+        train_on_what=effective_train_on_what,
     )
     weight_values = weights.tolist() if hasattr(weights, "tolist") else list(weights)
     if isinstance(rendered_input, tinker.ModelInput):


### PR DESCRIPTION
## Problem

Fireworks SFT V2 fine-tuned Kimi K2.5 models emit an empty `<think></think>` block for ~50% of inference responses. Folding `reasoning_content` into the literal `content` field restores CoT on 10/10 rollouts. That asymmetry is the fingerprint of a training-target stripping bug, not a rendering bug.

## Root cause

The Fireworks V1 SFT dataset schema marks **context-only** assistant messages with `weight=0` and trainable assistants with `weight=1` (or the field absent). V1 SFT (`train-py/fireworks/train/models/kimi.py`, `qwen3.py`, `deepseek_v3/__init__.py`, ...) honors this via its own row splitter.

The V2 orchestrator → cookbook path (`training.recipes.sft_loop.main`) calls `render_messages_to_datum` with `train_on_what=all_assistant_messages` on the raw row, and `normalize_messages` only looked at a `trainable` field — so **`weight=0` was silently dropped**. With a thinking-capable renderer (Kimi K2/K2.5/K2.6, Qwen3, DeepSeek V3 thinking), `all_assistant_messages` then trained every historical assistant with its thinking stripped, i.e. `<think></think>{answer}`, for every `weight=0` message the dataset author explicitly excluded.

### Measurement on the customer's dataset

`evidence-tcpr-sft-2k` (yi-ee2d48), 1896 rows:

| | count |
|---|---:|
| Assistant messages | 24,549 |
| With `weight=0` (context-only) | 21,287 (**86.7%**) |
| With `reasoning_content` | 3,262 (13.3%) |

Trained `<think>` blocks (first 50 rows, KimiK25 renderer):

| | empty | non-empty |
|---|---:|---:|
| BEFORE fix | 351 (82%) | 77 |
| AFTER fix  | 0 (0%) | 77 |

The 82% empty-CoT training signal directly explains the ~50% missing-CoT at inference and the `reasoning_content`-in-content workaround (which sidesteps the stripping by embedding the CoT as literal text — no `ThinkingPart` stripping can touch it).

## Fix

In `normalize_messages`, when **any** message in the conversation carries `weight` or `trainable`, translate to Tinker's `trainable` bool:

- `weight=0` → `trainable=False`
- `weight=1` or absent → `trainable=True`
- Assistant default: True. Non-assistant default: False.
- Explicit `trainable` wins over `weight` when both are present.
- Non-numeric `weight` values raise `TypeError`.

`render_messages_to_datum` auto-switches `train_on_what` to `CUSTOMIZED` when any normalized message has `trainable` set, so the renderer honors the per-message selection.

## Back-compat

Datasets that use **neither** `weight` nor `trainable` see **zero behavior change**: no `trainable` is added, and the caller-specified `train_on_what` flows through unchanged. Verified by `test_normalize_messages_does_not_add_trainable_when_no_weight_or_trainable` and `test_render_messages_to_datum_keeps_default_train_on_what_without_weight`.

## Tests

7 new tests in `test_supervised_rendering.py`:
- `weight=0` → `trainable=False`
- `weight=1` → `trainable=True`
- explicit `trainable` wins over `weight`
- no-weight datasets don't gain `trainable`
- non-numeric `weight` raises
- render path auto-switches to CUSTOMIZED when weight is set
- render path keeps default mode when no weight

Full cookbook unit test suite: **378 passed, 53 skipped** (no regressions).

## Not done here

- V2 cookbook `sft_loop` does not yet split thinking-model conversations at thinking boundaries the way V1 does (turn each thinking assistant into its own training example). This PR only fixes the `weight=0` drop. That is sufficient to unblock the customer because their `weight=0` messages are exactly the no-thinking intermediate turns they don't want to train on. If we later want full train_on_all_thinking_turns parity with V1, we can wire in `firetitan.train.sft_preprocessing.get_sft_row_processor` upstream of `sft_loop.main`.