### PR TITLE
test(glm5): add comprehensive coverage for all chat template scenarios + fix renderer bugs

### DIFF
--- a/training/renderer/glm5.py
+++ b/training/renderer/glm5.py
@@ -164,7 +164,11 @@ class GLM5Renderer(Renderer):
             header_str = "<|system|>"
             output_str = _visible_text(message["content"])
         elif role == "tool":
-            header_str = "<|observation|>"
+            prev_is_tool = (
+                ctx.prev_message is not None
+                and ctx.prev_message.get("role") == "tool"
+            )
+            header_str = "" if prev_is_tool else "<|observation|>"
             output_str = (
                 f"<tool_response>{_visible_text(message['content'])}</tool_response>"
             )
@@ -187,23 +191,28 @@ class GLM5Renderer(Renderer):
         # target for this assistant turn.
         header_str = "<|assistant|>"
 
-        is_historical = (
-            self.strip_thinking_from_history
-            and ctx.last_user_index >= 0
+        before_last_user = (
+            ctx.last_user_index >= 0
             and ctx.idx < ctx.last_user_index
         )
 
         reasoning, visible = _extract_reasoning_and_text(message["content"])
 
-        # Match the shipped HF chat template:
-        # - Historical turns (strip_thinking): ``</think>`` alone, no
-        #   ``<think>`` opener.
-        # - Terminal turn with reasoning: ``<think>{reasoning}</think>``.
-        # - Terminal turn without reasoning: ``<think></think>`` (empty
-        #   think block, thinking-mode default).
+        # Match the shipped HF chat template thinking-block logic:
         #
-        # No newlines between the role tag, the think block, or the content.
-        if is_historical:
+        # 1. Historical turn with strip_thinking=True (the default):
+        #    always ``</think>`` (drops any reasoning).
+        # 2. Historical turn with strip_thinking=False AND reasoning
+        #    exists: ``<think>{reasoning}</think>`` (keep it).
+        # 3. Historical turn with strip_thinking=False AND no reasoning:
+        #    ``</think>`` — the template leaves ``reasoning_content``
+        #    undefined so it falls to the else branch.
+        # 4. Terminal turn with reasoning: ``<think>{reasoning}</think>``.
+        # 5. Terminal turn without reasoning (thinking-mode default):
+        #    ``<think></think>``.
+        if before_last_user and self.strip_thinking_from_history:
+            think_block = "</think>"
+        elif before_last_user and not reasoning:
             think_block = "</think>"
         elif reasoning:
             think_block = f"<think>{reasoning.strip()}</think>"

--- a/training/tests/unit/test_glm5_renderer.py
+++ b/training/tests/unit/test_glm5_renderer.py
@@ -70,14 +70,23 @@ def renderer(tokenizer):
     return GLM5Renderer(tokenizer, strip_thinking_from_history=True)
 
 
-def _hf_tokens(tokenizer, messages, add_generation_prompt: bool) -> list[int]:
+@pytest.fixture(scope="module")
+def renderer_keep_thinking(tokenizer):
+    """Renderer with ``strip_thinking_from_history=False``."""
+    return GLM5Renderer(tokenizer, strip_thinking_from_history=False)
+
+
+def _hf_tokens(tokenizer, messages, add_generation_prompt: bool, **kwargs) -> list[int]:
     """Tokenize via the HF jinja template, returning a plain list of ints.
 
     apply_chat_template(tokenize=True) returns a BatchEncoding in newer
     transformers and a list in older ones — normalize to a list either way.
+    Extra ``kwargs`` (e.g. ``enable_thinking``, ``clear_thinking``) are
+    forwarded to apply_chat_template.
     """
     text = tokenizer.apply_chat_template(
         messages, tokenize=False, add_generation_prompt=add_generation_prompt,
+        **kwargs,
     )
     return tokenizer.encode(text, add_special_tokens=False)
 
@@ -158,11 +167,30 @@ def test_generation_prompt_multi_turn_history(tokenizer, renderer):
     assert ours == hf
 
 
+def test_generation_prompt_system_only(tokenizer, renderer):
+    """System message only + generation prompt (no user message)."""
+    messages = [{"role": "system", "content": "You are helpful."}]
+    hf = _hf_tokens(tokenizer, messages, add_generation_prompt=True)
+    ours = _renderer_generation_tokens(renderer, messages)
+    assert ours == hf
+
+
+def test_generation_prompt_after_tool(tokenizer, renderer):
+    """Generation prompt when the last message is a tool response."""
+    messages = [
+        {"role": "user", "content": "weather?"},
+        {"role": "tool", "content": "sunny, 72F"},
+    ]
+    hf = _hf_tokens(tokenizer, messages, add_generation_prompt=True)
+    ours = _renderer_generation_tokens(renderer, messages)
+    assert ours == hf
+
+
 # ── Supervised examples (trailing EOS expected on our side) ─────────────────
 
 
 def test_supervised_single_turn_no_thinking(tokenizer, renderer):
-    """Single user → assistant without explicit thinking."""
+    """Single user -> assistant without explicit thinking."""
     messages = [
         {"role": "user", "content": "hi"},
         {"role": "assistant", "content": "bye"},
@@ -173,7 +201,7 @@ def test_supervised_single_turn_no_thinking(tokenizer, renderer):
 
 
 def test_supervised_single_turn_with_thinking(tokenizer, renderer):
-    """Single user → assistant with reasoning content."""
+    """Single user -> assistant with reasoning content."""
     messages = [
         {"role": "user", "content": "hi"},
         {"role": "assistant", "content": "<think>reason</think>\nbye"},
@@ -236,13 +264,35 @@ def test_supervised_long_content(tokenizer, renderer):
     _assert_parity_modulo_trailing_eos(ours, hf, tokenizer, expect_eos=True)
 
 
+def test_supervised_empty_assistant_content(tokenizer, renderer):
+    """Assistant message with empty string content — only think block emitted."""
+    messages = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": ""},
+    ]
+    hf = _hf_tokens(tokenizer, messages, add_generation_prompt=False)
+    ours, _ = _renderer_supervised_tokens(renderer, messages)
+    _assert_parity_modulo_trailing_eos(ours, hf, tokenizer, expect_eos=True)
+
+
+def test_supervised_whitespace_only_assistant_content(tokenizer, renderer):
+    """Assistant content with only whitespace — stripped to empty."""
+    messages = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "   "},
+    ]
+    hf = _hf_tokens(tokenizer, messages, add_generation_prompt=False)
+    ours, _ = _renderer_supervised_tokens(renderer, messages)
+    _assert_parity_modulo_trailing_eos(ours, hf, tokenizer, expect_eos=True)
+
+
 # ── History thinking collapse ───────────────────────────────────────────────
 
 
 def test_history_thinking_collapses_to_empty(tokenizer, renderer):
     """Assistant turns BEFORE the last user should have thinking stripped.
 
-    Template rule (Jinja line 60–64):
+    Template rule (Jinja line 60-64):
       If loop.index0 > ns.last_user_index AND reasoning_content:
           emit the reasoning
       else:
@@ -293,11 +343,54 @@ def test_history_no_thinking_in_source(tokenizer, renderer):
     _assert_parity_modulo_trailing_eos(ours, hf, tokenizer, expect_eos=True)
 
 
+def test_history_first_has_thinking_second_does_not(tokenizer, renderer):
+    """u-a(thinking)-u-a(no thinking): historical turn collapsed, terminal
+    gets empty <think></think>."""
+    messages = [
+        {"role": "user", "content": "q1"},
+        {"role": "assistant", "content": "<think>thinking</think>a1"},
+        {"role": "user", "content": "q2"},
+        {"role": "assistant", "content": "a2"},
+    ]
+    hf = _hf_tokens(tokenizer, messages, add_generation_prompt=False)
+    ours, _ = _renderer_supervised_tokens(renderer, messages)
+    _assert_parity_modulo_trailing_eos(ours, hf, tokenizer, expect_eos=True)
+
+
+def test_history_first_no_thinking_second_has_thinking(tokenizer, renderer):
+    """u-a(no thinking)-u-a(thinking): historical collapsed, terminal keeps."""
+    messages = [
+        {"role": "user", "content": "q1"},
+        {"role": "assistant", "content": "a1"},
+        {"role": "user", "content": "q2"},
+        {"role": "assistant", "content": "<think>thinking</think>a2"},
+    ]
+    hf = _hf_tokens(tokenizer, messages, add_generation_prompt=False)
+    ours, _ = _renderer_supervised_tokens(renderer, messages)
+    _assert_parity_modulo_trailing_eos(ours, hf, tokenizer, expect_eos=True)
+
+
+def test_history_three_turn_middle_has_thinking(tokenizer, renderer):
+    """u-a-u-a-u-a: three assistant turns. First two are historical (collapsed),
+    third is terminal and keeps its reasoning."""
+    messages = [
+        {"role": "user", "content": "q1"},
+        {"role": "assistant", "content": "a1"},
+        {"role": "user", "content": "q2"},
+        {"role": "assistant", "content": "<think>deep thought</think>a2"},
+        {"role": "user", "content": "q3"},
+        {"role": "assistant", "content": "<think>final reasoning</think>a3"},
+    ]
+    hf = _hf_tokens(tokenizer, messages, add_generation_prompt=False)
+    ours, _ = _renderer_supervised_tokens(renderer, messages)
+    _assert_parity_modulo_trailing_eos(ours, hf, tokenizer, expect_eos=True)
+
+
 # ── Tool / observation rendering ────────────────────────────────────────────
 
 
 def test_tool_observation_message(tokenizer, renderer):
-    """Single tool (observation) message — matches <|observation|>\n<tool_response>..."""
+    """Single tool (observation) message."""
     messages = [
         {"role": "user", "content": "weather?"},
         {"role": "tool", "content": "sunny, 72F"},
@@ -305,6 +398,61 @@ def test_tool_observation_message(tokenizer, renderer):
     hf = _hf_tokens(tokenizer, messages, add_generation_prompt=True)
     ours = _renderer_generation_tokens(renderer, messages)
     assert ours == hf
+
+
+def test_consecutive_tool_messages_observation_dedup(tokenizer, renderer):
+    """Consecutive tool messages: only the first gets <|observation|> tag.
+
+    The Jinja template checks ``loop.first or (messages[loop.index0-1].role
+    != 'tool')`` — subsequent tool messages omit the <|observation|> tag
+    and just emit <tool_response>...</tool_response>.
+    """
+    messages = [
+        {"role": "user", "content": "weather?"},
+        {"role": "tool", "content": "sunny"},
+        {"role": "tool", "content": "windy"},
+    ]
+    hf = _hf_tokens(tokenizer, messages, add_generation_prompt=True)
+    ours = _renderer_generation_tokens(renderer, messages)
+    assert ours == hf
+
+
+def test_three_consecutive_tool_messages(tokenizer, renderer):
+    """Three tool messages in a row — only first gets <|observation|>."""
+    messages = [
+        {"role": "user", "content": "check all"},
+        {"role": "tool", "content": "result1"},
+        {"role": "tool", "content": "result2"},
+        {"role": "tool", "content": "result3"},
+    ]
+    hf = _hf_tokens(tokenizer, messages, add_generation_prompt=True)
+    ours = _renderer_generation_tokens(renderer, messages)
+    assert ours == hf
+
+
+def test_tool_then_assistant_then_tool(tokenizer, renderer):
+    """Non-consecutive tool messages each get their own <|observation|>."""
+    messages = [
+        {"role": "user", "content": "q"},
+        {"role": "tool", "content": "first result"},
+        {"role": "assistant", "content": "got it"},
+        {"role": "tool", "content": "second result"},
+    ]
+    hf = _hf_tokens(tokenizer, messages, add_generation_prompt=True)
+    ours = _renderer_generation_tokens(renderer, messages)
+    assert ours == hf
+
+
+def test_supervised_tool_user_assistant(tokenizer, renderer):
+    """Supervised: user -> tool -> assistant."""
+    messages = [
+        {"role": "user", "content": "weather?"},
+        {"role": "tool", "content": "sunny, 72F"},
+        {"role": "assistant", "content": "It's sunny and 72F."},
+    ]
+    hf = _hf_tokens(tokenizer, messages, add_generation_prompt=False)
+    ours, _ = _renderer_supervised_tokens(renderer, messages)
+    _assert_parity_modulo_trailing_eos(ours, hf, tokenizer, expect_eos=True)
 
 
 # ── Structured content (list of {"type": "text", ...}) ─────────────────────
@@ -319,6 +467,102 @@ def test_structured_text_content_user(tokenizer, renderer):
     hf = _hf_tokens(tokenizer, messages, add_generation_prompt=False)
     ours, _ = _renderer_supervised_tokens(renderer, messages)
     _assert_parity_modulo_trailing_eos(ours, hf, tokenizer, expect_eos=True)
+
+
+def test_structured_text_content_multi_parts(tokenizer, renderer):
+    """Multiple {type:text} items concatenated."""
+    messages = [
+        {"role": "user", "content": [
+            {"type": "text", "text": "part1"},
+            {"type": "text", "text": "part2"},
+        ]},
+        {"role": "assistant", "content": "ack"},
+    ]
+    hf = _hf_tokens(tokenizer, messages, add_generation_prompt=False)
+    ours, _ = _renderer_supervised_tokens(renderer, messages)
+    _assert_parity_modulo_trailing_eos(ours, hf, tokenizer, expect_eos=True)
+
+
+# ── System message variations ───────────────────────────────────────────────
+
+
+def test_multiple_system_messages(tokenizer, renderer):
+    """Two system messages in the conversation."""
+    messages = [
+        {"role": "system", "content": "sys1"},
+        {"role": "user", "content": "q1"},
+        {"role": "system", "content": "sys2"},
+        {"role": "user", "content": "q2"},
+        {"role": "assistant", "content": "a1"},
+    ]
+    hf = _hf_tokens(tokenizer, messages, add_generation_prompt=False)
+    ours, _ = _renderer_supervised_tokens(renderer, messages)
+    _assert_parity_modulo_trailing_eos(ours, hf, tokenizer, expect_eos=True)
+
+
+def test_system_mid_conversation(tokenizer, renderer):
+    """System message appearing after a user-assistant exchange."""
+    messages = [
+        {"role": "user", "content": "q1"},
+        {"role": "assistant", "content": "a1"},
+        {"role": "system", "content": "new instructions"},
+        {"role": "user", "content": "q2"},
+        {"role": "assistant", "content": "a2"},
+    ]
+    hf = _hf_tokens(tokenizer, messages, add_generation_prompt=False)
+    ours, _ = _renderer_supervised_tokens(renderer, messages)
+    _assert_parity_modulo_trailing_eos(ours, hf, tokenizer, expect_eos=True)
+
+
+# ── strip_thinking_from_history=False (clear_thinking=False) ────────────────
+
+
+def test_keep_thinking_in_history(tokenizer, renderer_keep_thinking):
+    """With strip_thinking_from_history=False, historical reasoning is preserved.
+
+    Maps to the Jinja ``clear_thinking=False`` branch: historical assistant
+    turns emit ``<think>{reasoning}</think>`` instead of ``</think>``.
+    """
+    messages = [
+        {"role": "user", "content": "What is 2+2?"},
+        {"role": "assistant", "content": "<think>2+2=4</think>4"},
+        {"role": "user", "content": "What about 3+3?"},
+        {"role": "assistant", "content": "<think>3+3=6</think>6"},
+    ]
+    hf = _hf_tokens(
+        tokenizer, messages, add_generation_prompt=False, clear_thinking=False,
+    )
+    ours, _ = _renderer_supervised_tokens(renderer_keep_thinking, messages)
+    _assert_parity_modulo_trailing_eos(ours, hf, tokenizer, expect_eos=True)
+
+
+def test_keep_thinking_history_no_thinking_source(tokenizer, renderer_keep_thinking):
+    """strip_thinking_from_history=False with no thinking in source content."""
+    messages = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "hello"},
+        {"role": "user", "content": "bye"},
+        {"role": "assistant", "content": "see ya"},
+    ]
+    hf = _hf_tokens(
+        tokenizer, messages, add_generation_prompt=False, clear_thinking=False,
+    )
+    ours, _ = _renderer_supervised_tokens(renderer_keep_thinking, messages)
+    _assert_parity_modulo_trailing_eos(ours, hf, tokenizer, expect_eos=True)
+
+
+def test_keep_thinking_generation_prompt(tokenizer, renderer_keep_thinking):
+    """Generation prompt with strip_thinking_from_history=False."""
+    messages = [
+        {"role": "user", "content": "What is 2+2?"},
+        {"role": "assistant", "content": "<think>2+2=4</think>4"},
+        {"role": "user", "content": "What about 3+3?"},
+    ]
+    hf = _hf_tokens(
+        tokenizer, messages, add_generation_prompt=True, clear_thinking=False,
+    )
+    ours = _renderer_generation_tokens(renderer_keep_thinking, messages)
+    assert ours == hf
 
 
 # ── Weight mask correctness (independent of HF parity) ──────────────────────
@@ -367,6 +611,40 @@ def test_weight_mask_multi_turn_covers_all_assistant_turns(tokenizer, renderer):
     # And the user content should NOT appear in trained spans.
     assert "u1" not in trained
     assert "u2" not in trained
+
+
+def test_weight_mask_with_thinking(tokenizer, renderer):
+    """Trained span includes the thinking block for terminal turns."""
+    messages = [
+        {"role": "user", "content": "q"},
+        {"role": "assistant", "content": "<think>my reasoning</think>answer"},
+    ]
+    tokens, weights = _renderer_supervised_tokens(renderer, messages)
+    trained_tokens = [t for t, w in zip(tokens, weights) if w > 0]
+    trained_text = tokenizer.decode(trained_tokens)
+
+    assert "<think>my reasoning</think>" in trained_text
+    assert "answer" in trained_text
+    assert "q" not in trained_text
+
+
+def test_weight_mask_historical_turn_collapsed(tokenizer, renderer):
+    """Trained span of a historical turn uses collapsed form (</think>)."""
+    messages = [
+        {"role": "user", "content": "u1"},
+        {"role": "assistant", "content": "<think>long reasoning</think>a1"},
+        {"role": "user", "content": "u2"},
+        {"role": "assistant", "content": "a2"},
+    ]
+    tokens, weights = _renderer_supervised_tokens(renderer, messages)
+    trained_tokens = [t for t, w in zip(tokens, weights) if w > 0]
+    trained_text = tokenizer.decode(trained_tokens)
+
+    assert "a1" in trained_text
+    assert "a2" in trained_text
+    assert "long reasoning" not in trained_text
+    assert "u1" not in trained_text
+    assert "u2" not in trained_text
 
 
 # ── Renderer API surface ────────────────────────────────────────────────────
@@ -426,3 +704,150 @@ def test_parse_response_no_stop_token(tokenizer, renderer):
     ids = tokenizer.encode(simulated, add_special_tokens=False)
     _, ok = renderer.parse_response(ids)
     assert ok is False
+
+
+def test_parse_response_empty_thinking(tokenizer, renderer):
+    """parse_response with empty think block extracts content correctly."""
+    simulated = "<think></think>just the answer"
+    ids = tokenizer.encode(simulated, add_special_tokens=False) + [_eos(tokenizer)]
+    message, ok = renderer.parse_response(ids)
+    assert ok is True
+    content = message["content"]
+    text = content if isinstance(content, str) else "".join(
+        p.get("text", "") for p in content if p.get("type") == "text"
+    )
+    assert "just the answer" in text
+
+
+# ── Parametrized parity: generation prompt shapes ───────────────────────────
+
+
+@pytest.mark.parametrize(
+    "messages",
+    [
+        [{"role": "user", "content": "Hello"}],
+        [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Hello"},
+        ],
+        [
+            {"role": "user", "content": "What is 2+2?"},
+            {"role": "assistant", "content": "<think>2+2=4</think>4"},
+            {"role": "user", "content": "What about 3+3?"},
+        ],
+        [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+            {"role": "user", "content": "bye"},
+            {"role": "assistant", "content": "goodbye"},
+            {"role": "user", "content": "one more"},
+        ],
+        [{"role": "user", "content": "line one\nline two\nline three"}],
+        [{"role": "user", "content": "```python\nprint('hi')\n```"}],
+        [
+            {"role": "system", "content": "Réponds en français."},
+            {"role": "user", "content": "Bonjour 👋"},
+        ],
+        [{"role": "system", "content": "You are helpful."}],
+        [
+            {"role": "user", "content": "q"},
+            {"role": "tool", "content": "result"},
+        ],
+    ],
+    ids=[
+        "user_only",
+        "system_user",
+        "multi_turn_history",
+        "five_turn_conversation",
+        "multiline_content",
+        "code_block",
+        "unicode_emoji",
+        "system_only",
+        "user_tool",
+    ],
+)
+def test_generation_prompt_parity(tokenizer, renderer, messages):
+    """Parametrized: renderer generation tokens match HF byte-for-byte."""
+    hf = _hf_tokens(tokenizer, messages, add_generation_prompt=True)
+    ours = _renderer_generation_tokens(renderer, messages)
+    assert ours == hf, (
+        f"Token mismatch:\n"
+        f"  HF text:   {tokenizer.decode(hf)!r}\n"
+        f"  ours text: {tokenizer.decode(ours)!r}"
+    )
+
+
+# ── Parametrized parity: supervised shapes ──────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "messages",
+    [
+        [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "bye"},
+        ],
+        [
+            {"role": "user", "content": "q"},
+            {"role": "assistant", "content": "<think>reason</think>answer"},
+        ],
+        [
+            {"role": "system", "content": "Be helpful."},
+            {"role": "user", "content": "q"},
+            {"role": "assistant", "content": "a"},
+        ],
+        [
+            {"role": "user", "content": "q1"},
+            {"role": "assistant", "content": "<think>r1</think>a1"},
+            {"role": "user", "content": "q2"},
+            {"role": "assistant", "content": "<think>r2</think>a2"},
+        ],
+        [
+            {"role": "user", "content": "q1"},
+            {"role": "assistant", "content": "a1"},
+            {"role": "user", "content": "q2"},
+            {"role": "assistant", "content": "a2"},
+            {"role": "user", "content": "q3"},
+            {"role": "assistant", "content": "a3"},
+        ],
+        [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": ""},
+        ],
+        [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "   "},
+        ],
+        [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "<think>thought 1</think>\nReply 1"},
+            {"role": "assistant", "content": "<think>thought 2</think>\nReply 2"},
+        ],
+        [
+            {"role": "user", "content": "q"},
+            {"role": "tool", "content": "result"},
+            {"role": "assistant", "content": "answer"},
+        ],
+        [
+            {"role": "user", "content": [{"type": "text", "text": "structured"}]},
+            {"role": "assistant", "content": "ack"},
+        ],
+    ],
+    ids=[
+        "simple_pair",
+        "with_thinking",
+        "system_user_assistant",
+        "multi_turn_thinking",
+        "three_turn_no_thinking",
+        "empty_content",
+        "whitespace_content",
+        "two_assistants_after_user",
+        "tool_then_assistant",
+        "structured_content",
+    ],
+)
+def test_supervised_parity(tokenizer, renderer, messages):
+    """Parametrized: supervised tokens match HF byte-for-byte (modulo EOS)."""
+    hf = _hf_tokens(tokenizer, messages, add_generation_prompt=False)
+    ours, _ = _renderer_supervised_tokens(renderer, messages)
+    _assert_parity_modulo_trailing_eos(ours, hf, tokenizer, expect_eos=True)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Stacks on top of PR #384** (base branch is the PR #384 head commit).

## What

Adds 39 new tests (21→60 total) covering every branch of the shipped `zai-org/GLM-5.1` chat template, and fixes two renderer bugs discovered by the new tests.

## Test Coverage Added

### P0 — Core template branches previously untested:

- **Consecutive tool messages** (`test_consecutive_tool_messages_observation_dedup`, `test_three_consecutive_tool_messages`): Only the first tool message in a run emits `<|observation|>`; subsequent ones emit only `<tool_response>...</tool_response>`. The template's `loop.first or (messages[loop.index0-1].role != "tool")` check.
- **`strip_thinking_from_history=False`** (`test_keep_thinking_in_history`, `test_keep_thinking_history_no_thinking_source`, `test_keep_thinking_generation_prompt`): Maps to the Jinja `clear_thinking=False` branch. Historical turns with reasoning keep `<think>R</think>`, while those without reasoning emit bare `</think>`.
- **Empty / whitespace-only assistant content** (`test_supervised_empty_assistant_content`, `test_supervised_whitespace_only_assistant_content`): `content.strip()` is empty → only the think block is emitted.
- **System-only conversation** (`test_generation_prompt_system_only`): No user message; `last_user_index` stays -1.
- **Generation prompt after tool** (`test_generation_prompt_after_tool`).

### P1 — Structural and edge cases:

- **Multiple / mid-conversation system messages** (`test_multiple_system_messages`, `test_system_mid_conversation`)
- **Multi-part structured content** (`test_structured_text_content_multi_parts`)
- **Three-turn history** (`test_history_three_turn_middle_has_thinking`)
- **Mixed thinking patterns** (`test_history_first_has_thinking_second_does_not`, `test_history_first_no_thinking_second_has_thinking`)
- **Non-consecutive tool messages** (`test_tool_then_assistant_then_tool`)
- **Supervised tool→assistant** (`test_supervised_tool_user_assistant`)
- **Weight mask with thinking** (`test_weight_mask_with_thinking`, `test_weight_mask_historical_turn_collapsed`)
- **parse_response empty thinking** (`test_parse_response_empty_thinking`)
- **Parametrized parity suites**: 9 generation-prompt shapes + 10 supervised shapes

## Renderer Fixes

Two bugs found by the new tests:

1. **Consecutive tool observation dedup**: The renderer was emitting `<|observation|>` for every tool message. Fixed: check `ctx.prev_message` role — if the previous message is also a tool, omit the `<|observation|>` header.

2. **Historical turn think block for `strip_thinking_from_history=False`**: Historical assistant turns without reasoning were emitting `<think></think>` (wrong). The shipped template emits `</think>` when `reasoning_content` is undefined. Fixed: historical turns without reasoning now emit `</think>` regardless of the `strip_thinking` setting.

## Verification

All 60 tests pass against the live `zai-org/GLM-5.1` tokenizer with byte-for-byte HF parity.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://fireworks-ai.slack.com/archives/C0927VDGNAU/p1777010007601489?thread_ts=1777010007.601489&cid=C0927VDGNAU)

<div><a href="https://cursor.com/agents/bc-84e9cfc1-e990-5a53-a92a-0009b7a55dee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-84e9cfc1-e990-5a53-a92a-0009b7a55dee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

