### PR TITLE
feat(opd): add on-policy distillation metrics and recipe (arXiv:2604.13016)

### DIFF
--- a/training/recipes/opd_loop.py
+++ b/training/recipes/opd_loop.py
@@ -1,0 +1,698 @@
+#!/usr/bin/env python3
+"""On-Policy Distillation (OPD) training loop.
+
+Implements the training loop from arXiv:2604.13016. A student model learns
+from a stronger teacher model via on-policy knowledge distillation.
+
+The student generates rollouts via a Fireworks inference deployment.
+The teacher scores the same sequences via a separate deployment
+(``echo=True, logprobs=True, top_logprobs=k``).  The student trains on a
+sampled-token reverse-KL loss and logs all paper metrics (overlap ratio,
+overlap advantage, entropy gap, overlap mass, per-position entropy).
+
+Usage:
+    export FIREWORKS_API_KEY=...
+    python -m recipes.opd_loop
+"""
+
+from __future__ import annotations
+
+import os
+import math
+import signal
+import asyncio
+import logging
+from contextlib import ExitStack
+from typing import Any, Dict, List, Optional, Tuple
+from dataclasses import field, dataclass
+
+import torch
+import tinker
+import transformers
+
+from fireworks.training.sdk import DeploymentManager, TrainerJobManager
+from fireworks.training.sdk.client import GradAccNormalization
+from fireworks.training.sdk.deployment import AdaptiveConcurrencyController, DeploymentSampler
+from fireworks.training.sdk.weight_syncer import WeightSyncer
+from training.utils import (
+    DEFAULT_ADAM,
+    ConcurrencyConfig,
+    InfraConfig,
+    ResourceCleanup,
+    RunnerConfig,
+    RunnerIO,
+    RunStatus,
+    WandBConfig,
+    DeployConfig,
+    WeightSyncConfig,
+    RLPromptDataset,
+    wandb_log,
+    setup_wandb,
+    wandb_finish,
+    validate_config,
+    log_metrics_json,
+    read_api_extra_headers_env,
+    load_jsonl_dataset,
+    prepare_sampling_messages,
+)
+from training.utils.checkpoint_utils import (
+    resolve_resume,
+    save_checkpoint,
+    CheckpointKind,
+)
+from training.utils.rl import PromptGroup, setup_infra
+from training.utils.rl.train import TrainStepFns, run_rl_loop
+from training.utils.rl.losses import combine_prompt_groups
+from training.utils.timer import timer, flush_timing
+from training.utils.opd_metrics import compute_opd_metrics, PositionLogprobs
+import time as _time
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Config:
+    log_path: str
+    """Directory for checkpoints and logs. Required, no default."""
+
+    base_model: str = "accounts/fireworks/models/qwen3-8b"
+    rollout_base_model: str | None = None
+    dataset: str = "https://raw.githubusercontent.com/eval-protocol/python-sdk/main/development/gsm8k_sample.jsonl"
+
+    teacher_model: str = ""
+    """Teacher model ID on Fireworks (e.g. ``accounts/fireworks/models/qwen3-235b-a22b``)."""
+
+    teacher_deployment_id: str | None = None
+    """Reuse an existing teacher deployment instead of creating one."""
+
+    opd_mode: str = "sampled_token"
+    """``"sampled_token"`` (Eq. 3) or ``"top_k"`` (Eq. 5).
+    Start with sampled_token -- paper Section 6.3 shows it matches top_k."""
+
+    opd_top_k: int = 16
+    """Number of top logprobs to request from teacher for metrics computation."""
+
+    teacher_temperature: float = 1.0
+    """Temperature applied to teacher logprobs during scoring."""
+
+    learning_rate: float = 1e-5
+    completions_per_prompt: int = 1
+    max_completion_tokens: int = 1024
+    temperature: float = 1.0
+    epochs: int = 1
+    max_rows: int = 100
+    max_seq_len: int | None = None
+    lora_rank: int = 0
+
+    prompt_groups_per_step: int = 1
+
+    grad_accumulation_normalization: GradAccNormalization | str | None = GradAccNormalization.NUM_LOSS_TOKENS
+
+    concurrency: ConcurrencyConfig = field(default_factory=ConcurrencyConfig)
+
+    policy_job_id: str | None = None
+    init_from_checkpoint: str | None = None
+    output_model_id: str | None = None
+    save_final_checkpoint: bool = True
+    step_timeout: int = 0
+
+    infra: InfraConfig = field(default_factory=InfraConfig)
+    deployment: DeployConfig = field(default_factory=DeployConfig)
+    weight_sync: WeightSyncConfig = field(default_factory=WeightSyncConfig)
+    wandb: WandBConfig = field(default_factory=lambda: WandBConfig(project="opd-tinker"))
+    runner: RunnerConfig = field(default_factory=RunnerConfig)
+
+
+# ---------------------------------------------------------------------------
+# Teacher scoring
+# ---------------------------------------------------------------------------
+
+
+def _extract_teacher_top_logprobs(
+    response_content: list[dict],
+) -> Tuple[list[float], PositionLogprobs]:
+    """Extract per-token logprobs and top-k logprobs from API response content.
+
+    ``response_content`` is the ``logprobs.content`` list from the completions
+    API response. Each entry has ``logprob``, ``token_id``, and optionally
+    ``top_logprobs`` (list of ``{token_id, logprob}`` dicts).
+    """
+    token_logprobs: list[float] = []
+    top_k_logprobs: PositionLogprobs = []
+    for entry in response_content:
+        token_logprobs.append(entry.get("logprob", 0.0))
+        top_lps = entry.get("top_logprobs")
+        if top_lps and isinstance(top_lps, list):
+            position_topk = [(tp.get("token_id", 0), tp.get("logprob", 0.0)) for tp in top_lps]
+            top_k_logprobs.append(position_topk)
+        else:
+            top_k_logprobs.append([(entry.get("token_id", 0), entry.get("logprob", 0.0))])
+    return token_logprobs, top_k_logprobs
+
+
+async def score_with_teacher(
+    sampler: DeploymentSampler,
+    token_ids: list[int],
+    *,
+    top_logprobs: int = 16,
+) -> Tuple[list[float], PositionLogprobs] | None:
+    """Score a token sequence with the teacher deployment.
+
+    Uses ``echo=True`` to get teacher logprobs on the student's sequence
+    without generating new tokens.
+    """
+    try:
+        result, _ = await sampler._stream_call(
+            prompt_ids=token_ids,
+            n=1,
+            max_tokens=1,
+            temperature=0.0,
+            logprobs=True,
+            top_logprobs=top_logprobs,
+            echo=True,
+            raw_output=True,
+        )
+        choices = result.get("choices", [])
+        if not choices:
+            return None
+        lp_data = choices[0].get("logprobs", {})
+        content = lp_data.get("content", [])
+        if not content:
+            return None
+        # Drop the first (unconditional) logprob to align with training
+        content = content[1:]
+        return _extract_teacher_top_logprobs(content)
+    except Exception as e:
+        logger.warning("Teacher scoring failed: %s", e)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# OPD loss
+# ---------------------------------------------------------------------------
+
+
+def make_opd_loss_fn(
+    teacher_logprobs: List[List[float]],
+    prompt_lens: List[int],
+) -> Any:
+    """Sampled-token OPD loss (Eq. 3): minimize reverse KL at sampled tokens.
+
+    ``loss = (1/N) * sum_t [log p_student(y_t) - log p_teacher(y_t)]``
+    """
+    def loss_fn(
+        data: List[tinker.Datum],
+        logprobs_list: List[torch.Tensor],
+    ) -> Tuple[torch.Tensor, Dict[str, float]]:
+        total_loss = torch.zeros((), dtype=torch.float32)
+        total_tokens = 0
+        total_student_nll = 0.0
+        total_teacher_nll = 0.0
+
+        for i, (datum, student_lp) in enumerate(zip(data, logprobs_list)):
+            prompt_len = prompt_lens[i] if i < len(prompt_lens) else 1
+            response_start = max(0, prompt_len - 1)
+            resp_lp = student_lp[response_start:]
+
+            teacher_lp = teacher_logprobs[i] if i < len(teacher_logprobs) else []
+            teacher_resp_lp = teacher_lp[response_start:]
+
+            n = min(len(resp_lp), len(teacher_resp_lp))
+            if n == 0:
+                continue
+
+            student_resp = resp_lp[:n]
+            teacher_resp = torch.tensor(
+                teacher_resp_lp[:n],
+                dtype=student_resp.dtype,
+                device=student_resp.device,
+            )
+
+            # Sampled-token OPD loss: log p_student - log p_teacher
+            token_loss = student_resp - teacher_resp
+            total_loss = total_loss + token_loss.sum()
+            total_tokens += n
+            total_student_nll += float((-student_resp).sum().item())
+            total_teacher_nll += float((-teacher_resp).sum().item())
+
+        denom = max(total_tokens, 1)
+        metrics = {
+            "mean_loss": float(total_loss.item()) / denom,
+            "student_nll": total_student_nll / denom,
+            "teacher_nll": total_teacher_nll / denom,
+            "active_tokens": total_tokens,
+        }
+        return total_loss, metrics
+
+    return loss_fn
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main(
+    config: Config,
+    rlor_mgr: TrainerJobManager | None = None,
+    deploy_mgr: DeploymentManager | None = None,
+    cancel_on_exit: bool = False,
+):
+    cfg = config
+    runner = RunnerIO(cfg.runner)
+
+    def _signal_handler(signum, frame):
+        name = signal.Signals(signum).name
+        logger.warning("Received %s -- raising SystemExit for cleanup", name)
+        raise SystemExit(f"Terminated by {name}")
+
+    signal.signal(signal.SIGTERM, _signal_handler)
+    signal.signal(signal.SIGINT, _signal_handler)
+
+    if not cfg.teacher_model:
+        raise ValueError("Config.teacher_model is required for OPD training.")
+
+    validate_config(
+        cfg.base_model,
+        cfg.dataset,
+        cfg.weight_sync,
+        cfg.deployment,
+        output_model_id=cfg.output_model_id,
+    )
+    completions_per_prompt = cfg.completions_per_prompt
+    prompt_groups_per_step = cfg.prompt_groups_per_step
+    if not cfg.deployment.tokenizer_model:
+        raise ValueError(
+            "deployment.tokenizer_model is required for client-side tokenization."
+        )
+    setup_wandb(
+        cfg.wandb,
+        {
+            "teacher_model": cfg.teacher_model,
+            "opd_mode": cfg.opd_mode,
+            "opd_top_k": cfg.opd_top_k,
+            "lr": cfg.learning_rate,
+        },
+    )
+
+    api_key = os.environ["FIREWORKS_API_KEY"]
+    base_url = os.environ.get("FIREWORKS_BASE_URL", "https://api.fireworks.ai")
+    additional_headers = read_api_extra_headers_env()
+
+    if rlor_mgr is None:
+        rlor_mgr = TrainerJobManager(
+            api_key=api_key,
+            base_url=base_url,
+            additional_headers=additional_headers,
+        )
+    if deploy_mgr is None:
+        deploy_mgr = DeploymentManager(
+            api_key=api_key,
+            base_url=base_url,
+            additional_headers=additional_headers,
+        )
+
+    runner.write_status(RunStatus.PENDING, message="provisioning")
+
+    def _on_trainer_status(msg: str) -> None:
+        runner.write_status(RunStatus.PENDING, message=msg)
+
+    with runner, ResourceCleanup(rlor_mgr, deploy_mgr) as cleanup, ExitStack() as stack:
+        infra = setup_infra(
+            rlor_mgr=rlor_mgr,
+            deploy_mgr=deploy_mgr,
+            base_model=cfg.base_model,
+            infra_cfg=cfg.infra,
+            deploy_cfg=cfg.deployment,
+            lora_rank=cfg.lora_rank,
+            max_seq_len=cfg.max_seq_len,
+            learning_rate=cfg.learning_rate,
+            step_timeout=cfg.step_timeout,
+            policy_job_id=cfg.policy_job_id,
+            needs_reference=False,
+            needs_inference=True,
+            role_prefix="opd",
+            api_key=api_key,
+            cleanup=cleanup if cancel_on_exit else None,
+            on_status=_on_trainer_status,
+        )
+        for closeable in infra.closeables:
+            stack.callback(closeable.close)
+
+        runner.set_accelerator_info(profile=infra.policy_profile)
+        wandb_log(infra.boot_metrics, step=0)
+
+        policy = infra.policy
+
+        tokenizer = transformers.AutoTokenizer.from_pretrained(
+            cfg.deployment.tokenizer_model, trust_remote_code=True,
+        )
+
+        # Student sampler (for rollout generation)
+        initial_window = cfg.concurrency.initial_window or (8 * infra.deployment_gpu_count)
+        concurrency_controller = AdaptiveConcurrencyController(
+            initial_window=initial_window,
+            min_window=cfg.concurrency.min_window,
+            max_window=cfg.concurrency.max_window,
+            prefill_queue_target=cfg.concurrency.prefill_queue_target,
+        )
+        student_sampler = DeploymentSampler(
+            inference_url=deploy_mgr.inference_url,
+            model=infra.inference_model,
+            api_key=api_key,
+            tokenizer=tokenizer,
+            concurrency_controller=concurrency_controller,
+        )
+
+        # Teacher sampler (for scoring student sequences)
+        teacher_sampler = DeploymentSampler(
+            inference_url=base_url,
+            model=cfg.teacher_model,
+            api_key=api_key,
+            tokenizer=tokenizer,
+        )
+
+        weight_syncer = WeightSyncer(
+            policy_client=policy.inner,
+            deploy_mgr=deploy_mgr,
+            deployment_id=infra.deployment_id,
+            base_model=cfg.rollout_base_model or cfg.base_model,
+            hotload_timeout=cfg.weight_sync.weight_sync_timeout,
+            first_checkpoint_type=cfg.weight_sync.first_checkpoint_type,
+            lora_rank=cfg.lora_rank,
+        )
+
+        logger.info(
+            "OPD Training: teacher=%s | opd_mode=%s | top_k=%d",
+            cfg.teacher_model, cfg.opd_mode, cfg.opd_top_k,
+        )
+
+        # -- Resume ------------------------------------------------------------
+
+        resume_info = resolve_resume(
+            policy, cfg.log_path, cfg.init_from_checkpoint, None,
+        )
+        step_offset = resume_info.step if resume_info else 0
+        wandb_log({"train/step": step_offset}, step_offset)
+
+        if cfg.weight_sync.weight_sync_before_training and infra.deployment_id:
+            name = f"resume-{step_offset}-base" if step_offset > 0 else "step-0-base"
+            weight_syncer.save_and_hotload(name, checkpoint_type="base")
+
+        # -- Prepare dataset ---------------------------------------------------
+
+        raw_dataset = load_jsonl_dataset(cfg.dataset, cfg.max_rows)
+        all_rows = raw_dataset * cfg.epochs
+        rl_dataset = RLPromptDataset(all_rows, prompts_per_step=prompt_groups_per_step)
+        adam_params = tinker.AdamParams(learning_rate=cfg.learning_rate, **DEFAULT_ADAM)
+
+        sample_kwargs: dict = dict(
+            max_tokens=cfg.max_completion_tokens,
+            temperature=cfg.temperature,
+            max_seq_len=infra.max_seq_len,
+            http_timeout=cfg.deployment.sample_timeout,
+            logprobs=True,
+        )
+
+        # Storage for teacher logprob data needed during train_step
+        _teacher_data_by_step: dict[int, list[Tuple[list[float], PositionLogprobs]]] = {}
+        _current_step_counter = [step_offset]
+
+        # -- Sample one prompt with teacher scoring ----------------------------
+
+        async def sample_one_prompt(row: dict) -> PromptGroup | None:
+            messages = row.get("messages", [])
+            input_messages = prepare_sampling_messages(messages)
+            if not input_messages:
+                return None
+
+            try:
+                sampled = await student_sampler.sample_with_tokens(
+                    messages=input_messages,
+                    n=completions_per_prompt,
+                    **sample_kwargs,
+                )
+            except Exception as e:
+                logger.warning("Student sampling failed: %s", e)
+                return None
+
+            if not sampled or len(sampled) < completions_per_prompt:
+                return None
+
+            prompt_len = sampled[0].prompt_len
+            policy_data: List[tinker.Datum] = []
+            teacher_results: list[Tuple[list[float], PositionLogprobs]] = []
+            inf_logprobs_aligned: List[List[float]] = []
+
+            for s in sampled:
+                tokens = s.full_tokens
+                if len(tokens) < 2:
+                    continue
+                model_input_len = len(tokens) - 1
+
+                # Score with teacher
+                teacher_result = await score_with_teacher(
+                    teacher_sampler, tokens, top_logprobs=cfg.opd_top_k,
+                )
+                if teacher_result is None:
+                    continue
+                teacher_token_lp, teacher_topk_lp = teacher_result
+                teacher_results.append((teacher_token_lp, teacher_topk_lp))
+
+                policy_datum = tinker.Datum(
+                    model_input=tinker.ModelInput.from_ints(tokens[:-1]),
+                    loss_fn_inputs={
+                        "target_tokens": tinker.TensorData(
+                            data=tokens[1:], dtype="int64", shape=[model_input_len],
+                        ),
+                    },
+                )
+                policy_data.append(policy_datum)
+
+                if s.inference_logprobs:
+                    response_start = max(0, prompt_len - 1)
+                    aligned = [0.0] * response_start + list(s.inference_logprobs)
+                    inf_logprobs_aligned.append(aligned)
+                else:
+                    inf_logprobs_aligned.append([])
+
+            if not policy_data:
+                return None
+
+            # Stash teacher data for train_step to use
+            step_key = _current_step_counter[0]
+            if step_key not in _teacher_data_by_step:
+                _teacher_data_by_step[step_key] = []
+            _teacher_data_by_step[step_key].extend(teacher_results)
+
+            comp_lens = [len(s.full_tokens) - s.prompt_len for s in sampled if len(s.full_tokens) >= 2]
+            trunc = [s.finish_reason == "length" for s in sampled if len(s.full_tokens) >= 2]
+
+            return PromptGroup(
+                data=policy_data,
+                advantages=[0.0] * len(policy_data),
+                ref_logprobs=None,
+                prompt_len=prompt_len,
+                rewards=[0.0] * len(policy_data),
+                inf_logprobs=inf_logprobs_aligned,
+                completion_lens=comp_lens[:len(policy_data)],
+                truncated=trunc[:len(policy_data)],
+            )
+
+        # -- Training step -----------------------------------------------------
+
+        def train_step(
+            step: int,
+            prompt_groups: list[PromptGroup],
+            loop_stats: dict | None = None,
+        ) -> tuple[int, dict]:
+            if not prompt_groups:
+                raise ValueError("train_step requires at least one prompt group")
+
+            data, _, _, prompt_lens, inf_lp = combine_prompt_groups(prompt_groups)
+
+            # Gather teacher data
+            step_key = _current_step_counter[0]
+            teacher_data = _teacher_data_by_step.pop(step_key, [])
+            teacher_token_logprobs = [td[0] for td in teacher_data]
+            teacher_topk_logprobs = [td[1] for td in teacher_data]
+
+            # Build student top-k logprobs for metrics from inference logprobs
+            student_topk_logprobs: PositionLogprobs = []
+            for lp_list in inf_lp:
+                for lp_val in lp_list:
+                    student_topk_logprobs.append([(0, lp_val)])
+
+            # Teacher top-k logprobs (flattened across samples for metrics)
+            teacher_topk_flat: PositionLogprobs = []
+            for sample_topk in teacher_topk_logprobs:
+                teacher_topk_flat.extend(sample_topk)
+
+            # OPD loss via forward_backward_custom
+            t0 = _time.time()
+            opd_loss = make_opd_loss_fn(teacher_token_logprobs, prompt_lens)
+            fwd_bwd_result = policy.forward_backward_custom(data, opd_loss)
+            logger.info("[step %d] fwd_bwd: done (%.1fs)", step + 1, _time.time() - t0)
+
+            t0 = _time.time()
+            optim_result = policy.optim_step(
+                adam_params,
+                grad_accumulation_normalization=cfg.grad_accumulation_normalization,
+            )
+            step += 1
+            logger.info("[step %d] optim_step: done (%.1fs)", step, _time.time() - t0)
+
+            _current_step_counter[0] = step
+
+            # Compute OPD paper metrics
+            n_metrics_positions = min(len(student_topk_logprobs), len(teacher_topk_flat))
+            opd_paper_metrics: Dict[str, float] = {}
+            if n_metrics_positions > 0:
+                opd_paper_metrics = compute_opd_metrics(
+                    student_topk_logprobs[:n_metrics_positions],
+                    teacher_topk_flat[:n_metrics_positions],
+                )
+
+            # Assemble metrics
+            metrics = dict(flush_timing())
+            metrics["train/step"] = step
+
+            if fwd_bwd_result and hasattr(fwd_bwd_result, "metrics"):
+                for k, v in fwd_bwd_result.metrics.items():
+                    metrics[f"train/{k}"] = v
+
+            if optim_result and hasattr(optim_result, "metrics") and optim_result.metrics:
+                for k, v in optim_result.metrics.items():
+                    metrics[f"train/{k}"] = v
+
+            metrics.update(opd_paper_metrics)
+
+            avg_loss = metrics.get("train/mean_loss", 0.0)
+            overlap = opd_paper_metrics.get("distill/overlap_ratio", 0.0)
+            ent_gap = opd_paper_metrics.get("distill/entropy_gap", 0.0)
+            logger.info(
+                "Step %d | Loss: %.4f | Overlap: %.3f | EntropyGap: %.4f",
+                step, avg_loss, overlap, ent_gap,
+            )
+            log_metrics_json(step, loss=avg_loss, overlap_ratio=overlap, entropy_gap=ent_gap)
+            wandb_log(metrics, step)
+
+            step_tokens = sum(
+                len(d.loss_fn_inputs["target_tokens"].data)
+                for pg in prompt_groups for d in pg.data
+            )
+            total_rl_steps = len(rl_dataset) - step_offset
+            runner.append_metrics(step, metrics, tokens=step_tokens)
+            runner.write_status(
+                RunStatus.RUNNING, step=step, total_steps=total_rl_steps, message="training",
+            )
+            runner.write_metadata()
+
+            return step, metrics
+
+        # -- Run ---------------------------------------------------------------
+
+        def _weight_sync(step: int) -> None:
+            logger.info("[step %d] weight_sync: saving + loading...", step)
+            t0 = _time.time()
+            with timer("weight_sync"):
+                weight_syncer.save_and_hotload(f"step-{step}")
+            logger.info("[step %d] weight_sync: done (%.1fs)", step, _time.time() - t0)
+
+        def _loop_metrics_callback(loop_metrics: dict) -> None:
+            if concurrency_controller is not None:
+                cc_summary = concurrency_controller.step_completed()
+                for k, v in cc_summary.items():
+                    loop_metrics[f"concurrency/{k}"] = v
+            wandb_log(loop_metrics, step=loop_metrics.get("train/step", 0))
+
+        train_fns = TrainStepFns(train_step=train_step)
+
+        remaining_rows = []
+        for i_step in range(step_offset, len(rl_dataset)):
+            remaining_rows.extend(rl_dataset.get_batch(i_step))
+
+        total_rl_steps = len(rl_dataset) - step_offset
+        runner.start_training()
+        runner.write_status(RunStatus.RUNNING, total_steps=total_rl_steps, message="training")
+
+        global_step = asyncio.run(
+            run_rl_loop(
+                sample_fns=(sample_one_prompt(row) for row in remaining_rows),
+                train_fns=train_fns,
+                prompt_groups_per_step=prompt_groups_per_step,
+                global_step=step_offset,
+                metrics_callback=_loop_metrics_callback,
+                weight_sync_fn=_weight_sync if cfg.weight_sync.weight_sync_interval > 0 else None,
+                weight_sync_interval=cfg.weight_sync.weight_sync_interval,
+            )
+        )
+
+        # -- Final checkpoint --------------------------------------------------
+
+        if cfg.save_final_checkpoint and global_step > step_offset:
+            try:
+                cp_name = f"step-{global_step}"
+                _data_consumed = (resume_info.data_consumed if resume_info else 0) + (
+                    (global_step - step_offset) * prompt_groups_per_step
+                )
+                paths = save_checkpoint(
+                    policy,
+                    cp_name,
+                    cfg.log_path,
+                    {
+                        "step": global_step,
+                        "data_consumed": _data_consumed,
+                        "source_job_id": infra.policy_job_id,
+                    },
+                    kind=CheckpointKind.BOTH,
+                    base_model=cfg.base_model,
+                    training_shape=infra.training_shape_id,
+                )
+
+                if getattr(cfg, "output_model_id", None):
+                    rlor_mgr.promote_checkpoint(
+                        infra.policy_job_id,
+                        paths["sampler_path"],
+                        cfg.output_model_id,
+                        cfg.base_model,
+                    )
+                    runner.write_output_model(
+                        model_id=cfg.output_model_id,
+                        checkpoint=cp_name,
+                        job_id=infra.policy_job_id,
+                    )
+            except Exception as e:
+                logger.warning("Failed to save final checkpoint: %s", e)
+
+        runner.write_status(
+            RunStatus.COMPLETED, step=global_step, total_steps=total_rl_steps, message="done",
+        )
+        runner.write_metadata()
+        logger.info("OPD training complete: %d steps", global_step)
+        wandb_finish()
+        return {
+            "steps": global_step,
+            "policy_job_id": infra.policy_job_id,
+        }
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    cfg = Config(
+        log_path="./opd_logs",
+        base_model="accounts/fireworks/models/qwen3-8b",
+        teacher_model="accounts/fireworks/models/qwen3-235b-a22b",
+        infra=InfraConfig(
+            training_shape_id="accounts/fireworks/trainingShapes/qwen3-8b-128k-h200",
+        ),
+        deployment=DeployConfig(
+            tokenizer_model="Qwen/Qwen3-8B",
+        ),
+    )
+    main(cfg)

--- a/training/tests/unit/test_opd_metrics.py
+++ b/training/tests/unit/test_opd_metrics.py
@@ -1,0 +1,254 @@
+"""Unit tests for OPD dynamic metrics (arXiv:2604.13016).
+
+All tests use synthetic top-k logprob lists -- no model loading or GPU required.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from training.utils.opd_metrics import (
+    compute_entropy_gap,
+    compute_opd_metrics,
+    compute_overlap_mass,
+    compute_overlap_ratio,
+    compute_overlap_token_advantage,
+    compute_per_position_entropy,
+    compute_student_entropy,
+    compute_teacher_entropy,
+)
+
+
+def _uniform_topk(token_ids: list[int]) -> list[tuple[int, float]]:
+    """Build a top-k list with uniform logprobs over the given tokens."""
+    lp = math.log(1.0 / len(token_ids))
+    return [(tok, lp) for tok in token_ids]
+
+
+def _peaked_topk(peak_id: int, other_ids: list[int], peak_prob: float = 0.9) -> list[tuple[int, float]]:
+    """Build a top-k list where ``peak_id`` gets ``peak_prob`` and the rest share the remainder."""
+    rest_prob = (1.0 - peak_prob) / max(len(other_ids), 1)
+    return [(peak_id, math.log(peak_prob))] + [(tok, math.log(rest_prob)) for tok in other_ids]
+
+
+# ---------------------------------------------------------------------------
+# Overlap ratio (Eq. 6)
+# ---------------------------------------------------------------------------
+
+
+class TestOverlapRatio:
+    def test_identical_topk_sets(self) -> None:
+        """Identical top-k sets -> ratio = 1.0."""
+        topk = [_uniform_topk([1, 2, 3, 4])] * 5
+        assert compute_overlap_ratio(topk, topk) == pytest.approx(1.0)
+
+    def test_disjoint_topk_sets(self) -> None:
+        """No shared tokens -> ratio = 0.0."""
+        student = [_uniform_topk([1, 2, 3, 4])] * 5
+        teacher = [_uniform_topk([5, 6, 7, 8])] * 5
+        assert compute_overlap_ratio(student, teacher) == pytest.approx(0.0)
+
+    def test_partial_overlap(self) -> None:
+        """Known partial overlap -> verify exact fraction."""
+        student = [_uniform_topk([1, 2, 3, 4])]
+        teacher = [_uniform_topk([3, 4, 5, 6])]
+        assert compute_overlap_ratio(student, teacher) == pytest.approx(0.5)
+
+    def test_empty_input(self) -> None:
+        """Empty sequences -> 0.0."""
+        assert compute_overlap_ratio([], []) == 0.0
+        assert compute_overlap_ratio([], [_uniform_topk([1, 2])]) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Overlap-token advantage (Eq. 7)
+# ---------------------------------------------------------------------------
+
+
+class TestOverlapAdvantage:
+    def test_aligned_distributions(self) -> None:
+        """Student matches teacher probs on overlap -> advantage ~ 0."""
+        topk = [_uniform_topk([1, 2, 3, 4])] * 3
+        assert compute_overlap_token_advantage(topk, topk) == pytest.approx(0.0, abs=1e-9)
+
+    def test_overconfident_student(self) -> None:
+        """Student overconfident on overlap tokens -> advantage < 0.
+
+        When the student concentrates more mass on a single overlap token than
+        the teacher does, the teacher-renorm minus student-renorm sum is
+        negative (the teacher spreads mass more evenly).
+        """
+        student = [_peaked_topk(1, [2, 3], peak_prob=0.95)]
+        teacher = [_uniform_topk([1, 2, 3])]
+        adv = compute_overlap_token_advantage(student, teacher)
+        assert adv < 0
+
+    def test_no_overlap_returns_zero(self) -> None:
+        """No overlapping tokens -> 0.0 (degenerate case)."""
+        student = [_uniform_topk([1, 2])]
+        teacher = [_uniform_topk([3, 4])]
+        assert compute_overlap_token_advantage(student, teacher) == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# Entropy gap (Eq. 8)
+# ---------------------------------------------------------------------------
+
+
+class TestEntropyGap:
+    def test_same_distributions_zero_gap(self) -> None:
+        """Same distributions -> gap = 0."""
+        topk = [_uniform_topk([1, 2, 3, 4])] * 3
+        assert compute_entropy_gap(topk, topk) == pytest.approx(0.0, abs=1e-9)
+
+    def test_different_distributions_nonzero_gap(self) -> None:
+        """Different distributions -> gap > 0."""
+        student = [_peaked_topk(1, [2, 3, 4], peak_prob=0.97)]
+        teacher = [_uniform_topk([1, 2, 3, 4])]
+        gap = compute_entropy_gap(student, teacher)
+        assert gap > 0
+
+    def test_gap_is_absolute_difference(self) -> None:
+        """Gap is symmetric: |H(t) - H(s)| = |H(s) - H(t)|."""
+        student = [_peaked_topk(1, [2, 3], peak_prob=0.9)]
+        teacher = [_uniform_topk([1, 2, 3])]
+        assert compute_entropy_gap(student, teacher) == pytest.approx(
+            compute_entropy_gap(teacher, student)
+        )
+
+
+# ---------------------------------------------------------------------------
+# Overlap mass (Eqs. 9-10)
+# ---------------------------------------------------------------------------
+
+
+class TestOverlapMass:
+    def test_high_prob_on_overlap(self) -> None:
+        """When top-k sets are identical, overlap mass should be ~1.0."""
+        topk = [_uniform_topk([1, 2, 3, 4])] * 4
+        s_mass, t_mass = compute_overlap_mass(topk, topk)
+        assert s_mass == pytest.approx(1.0, abs=1e-9)
+        assert t_mass == pytest.approx(1.0, abs=1e-9)
+
+    def test_disjoint_zero_mass(self) -> None:
+        """Disjoint sets -> overlap mass = 0."""
+        student = [_uniform_topk([1, 2])]
+        teacher = [_uniform_topk([3, 4])]
+        s_mass, t_mass = compute_overlap_mass(student, teacher)
+        assert s_mass == pytest.approx(0.0, abs=1e-9)
+        assert t_mass == pytest.approx(0.0, abs=1e-9)
+
+    def test_partial_overlap_mass(self) -> None:
+        """Partial overlap: mass equals renormalized probability on shared tokens."""
+        student = [_uniform_topk([1, 2, 3, 4])]
+        teacher = [_uniform_topk([3, 4, 5, 6])]
+        s_mass, t_mass = compute_overlap_mass(student, teacher)
+        assert s_mass == pytest.approx(0.5, abs=1e-6)
+        assert t_mass == pytest.approx(0.5, abs=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# Per-position entropy (Section 6.1)
+# ---------------------------------------------------------------------------
+
+
+class TestPerPositionEntropy:
+    def test_bucket_keys(self) -> None:
+        """Verify bucketing produces expected keys."""
+        topk = [_uniform_topk([1, 2, 3, 4])] * 8
+        result = compute_per_position_entropy(topk, bucket_count=4)
+        assert set(result.keys()) == {
+            "per_position_entropy/q1",
+            "per_position_entropy/q2",
+            "per_position_entropy/q3",
+            "per_position_entropy/q4",
+        }
+
+    def test_uniform_entropy_across_positions(self) -> None:
+        """Uniform distribution at every position -> all buckets equal."""
+        topk = [_uniform_topk([1, 2, 3, 4])] * 8
+        result = compute_per_position_entropy(topk, bucket_count=4)
+        expected = math.log(4)
+        for val in result.values():
+            assert val == pytest.approx(expected, abs=1e-6)
+
+    def test_empty_returns_zeros(self) -> None:
+        """Empty input -> all buckets 0.0."""
+        result = compute_per_position_entropy([], bucket_count=4)
+        for val in result.values():
+            assert val == 0.0
+
+    def test_custom_bucket_count(self) -> None:
+        """Custom bucket_count=2 produces q1 and q2."""
+        topk = [_uniform_topk([1, 2])] * 4
+        result = compute_per_position_entropy(topk, bucket_count=2)
+        assert set(result.keys()) == {
+            "per_position_entropy/q1",
+            "per_position_entropy/q2",
+        }
+
+
+# ---------------------------------------------------------------------------
+# Student / teacher entropy
+# ---------------------------------------------------------------------------
+
+
+class TestIndividualEntropy:
+    def test_uniform_entropy(self) -> None:
+        """Uniform distribution -> entropy = log(k)."""
+        topk = [_uniform_topk([1, 2, 3, 4])] * 3
+        expected = math.log(4)
+        assert compute_student_entropy(topk) == pytest.approx(expected, abs=1e-6)
+        assert compute_teacher_entropy(topk) == pytest.approx(expected, abs=1e-6)
+
+    def test_peaked_low_entropy(self) -> None:
+        """Peaked distribution -> entropy < uniform."""
+        peaked = [_peaked_topk(1, [2, 3, 4], peak_prob=0.97)] * 3
+        uniform = [_uniform_topk([1, 2, 3, 4])] * 3
+        assert compute_student_entropy(peaked) < compute_student_entropy(uniform)
+
+
+# ---------------------------------------------------------------------------
+# All-in-one compute_opd_metrics
+# ---------------------------------------------------------------------------
+
+
+class TestComputeOpdMetrics:
+    def test_all_keys_present(self) -> None:
+        """Verify all-in-one returns complete metric dict."""
+        topk = [_uniform_topk([1, 2, 3, 4])] * 4
+        metrics = compute_opd_metrics(topk, topk)
+        expected_keys = {
+            "distill/overlap_ratio",
+            "distill/overlap_advantage",
+            "distill/entropy_gap",
+            "distill/overlap_mass_student",
+            "distill/overlap_mass_teacher",
+            "distill/student_entropy",
+            "distill/teacher_entropy",
+            "distill/per_position_entropy/q1",
+            "distill/per_position_entropy/q2",
+            "distill/per_position_entropy/q3",
+            "distill/per_position_entropy/q4",
+        }
+        assert set(metrics.keys()) == expected_keys
+
+    def test_identical_distributions_healthy_signature(self) -> None:
+        """Identical distributions -> healthy signature values."""
+        topk = [_uniform_topk([1, 2, 3, 4])] * 4
+        metrics = compute_opd_metrics(topk, topk)
+        assert metrics["distill/overlap_ratio"] == pytest.approx(1.0)
+        assert metrics["distill/overlap_advantage"] == pytest.approx(0.0, abs=1e-9)
+        assert metrics["distill/entropy_gap"] == pytest.approx(0.0, abs=1e-9)
+        assert metrics["distill/overlap_mass_student"] == pytest.approx(1.0, abs=1e-9)
+        assert metrics["distill/overlap_mass_teacher"] == pytest.approx(1.0, abs=1e-9)
+
+    def test_custom_bucket_count(self) -> None:
+        """Custom bucket_count propagates to per-position keys."""
+        topk = [_uniform_topk([1, 2])] * 4
+        metrics = compute_opd_metrics(topk, topk, bucket_count=2)
+        assert "distill/per_position_entropy/q1" in metrics
+        assert "distill/per_position_entropy/q2" in metrics
+        assert "distill/per_position_entropy/q3" not in metrics

--- a/training/tests/unit/test_opd_metrics.py
+++ b/training/tests/unit/test_opd_metrics.py
@@ -68,20 +68,22 @@ class TestOverlapRatio:
 
 
 class TestOverlapAdvantage:
-    def test_aligned_distributions(self) -> None:
-        """Student matches teacher probs on overlap -> advantage ~ 0."""
+    def test_identical_distributions(self) -> None:
+        """Identical distributions -> advantage = 0 (same logprobs on overlap)."""
         topk = [_uniform_topk([1, 2, 3, 4])] * 3
         assert compute_overlap_token_advantage(topk, topk) == pytest.approx(0.0, abs=1e-9)
 
-    def test_overconfident_student(self) -> None:
-        """Student overconfident on overlap tokens -> advantage < 0.
+    def test_teacher_and_student_mismatch_is_negative(self) -> None:
+        """Eq. 7 is non-positive and gets more negative under mismatch."""
+        student = [_uniform_topk([1, 2, 3, 4])]
+        teacher = [_peaked_topk(1, [2, 3, 4], peak_prob=0.9)]
+        adv = compute_overlap_token_advantage(student, teacher)
+        assert adv < 0
 
-        When the student concentrates more mass on a single overlap token than
-        the teacher does, the teacher-renorm minus student-renorm sum is
-        negative (the teacher spreads mass more evenly).
-        """
-        student = [_peaked_topk(1, [2, 3], peak_prob=0.95)]
-        teacher = [_uniform_topk([1, 2, 3])]
+    def test_student_overconfident_is_negative(self) -> None:
+        """Student concentrates more mass on overlap tokens -> advantage < 0."""
+        student = [_peaked_topk(1, [2, 3, 4], peak_prob=0.9)]
+        teacher = [_uniform_topk([1, 2, 3, 4])]
         adv = compute_overlap_token_advantage(student, teacher)
         assert adv < 0
 
@@ -141,12 +143,20 @@ class TestOverlapMass:
         assert t_mass == pytest.approx(0.0, abs=1e-9)
 
     def test_partial_overlap_mass(self) -> None:
-        """Partial overlap: mass equals renormalized probability on shared tokens."""
+        """Partial overlap: mass equals original probability on shared tokens."""
         student = [_uniform_topk([1, 2, 3, 4])]
         teacher = [_uniform_topk([3, 4, 5, 6])]
         s_mass, t_mass = compute_overlap_mass(student, teacher)
         assert s_mass == pytest.approx(0.5, abs=1e-6)
         assert t_mass == pytest.approx(0.5, abs=1e-6)
+
+    def test_overlap_mass_does_not_renormalize_topk(self) -> None:
+        """Top-k APIs return full-vocab logprobs, so mass can be below top-k-normalized values."""
+        student = [[(1, math.log(0.2)), (2, math.log(0.1)), (3, math.log(0.05))]]
+        teacher = [[(2, math.log(0.3)), (4, math.log(0.2)), (5, math.log(0.1))]]
+        s_mass, t_mass = compute_overlap_mass(student, teacher)
+        assert s_mass == pytest.approx(0.1, abs=1e-9)
+        assert t_mass == pytest.approx(0.3, abs=1e-9)
 
 
 # ---------------------------------------------------------------------------
@@ -244,6 +254,13 @@ class TestComputeOpdMetrics:
         assert metrics["distill/entropy_gap"] == pytest.approx(0.0, abs=1e-9)
         assert metrics["distill/overlap_mass_student"] == pytest.approx(1.0, abs=1e-9)
         assert metrics["distill/overlap_mass_teacher"] == pytest.approx(1.0, abs=1e-9)
+
+    def test_different_distributions_nonzero_advantage(self) -> None:
+        """Different distributions -> advantage is negative."""
+        student = [_uniform_topk([1, 2, 3, 4])] * 4
+        teacher = [_peaked_topk(1, [2, 3, 4], peak_prob=0.9)] * 4
+        metrics = compute_opd_metrics(student, teacher)
+        assert metrics["distill/overlap_advantage"] < 0
 
     def test_custom_bucket_count(self) -> None:
         """Custom bucket_count propagates to per-position keys."""

--- a/training/utils/opd_metrics.py
+++ b/training/utils/opd_metrics.py
@@ -7,8 +7,10 @@ Input format per position: ``List[Tuple[int, float]]`` where each tuple is
 ``(token_id, logprob)``.  Sequences are ``List[List[Tuple[int, float]]]``
 (one inner list per position in the response).
 
-All entropy/mass computations use **renormalized** top-k probabilities, matching
-the paper's k=16 setting (Section 2.3, Appendix B.1).
+Entropy is computed on the renormalized top-k support because these helpers only
+receive top-k logprobs.  Overlap mass uses the original full-vocabulary
+probabilities encoded by the logprobs, so it remains comparable to the paper's
+mass diagnostics when the top-k API returns true model logprobs.
 """
 
 from __future__ import annotations
@@ -64,12 +66,12 @@ def compute_overlap_token_advantage(
     student_topk: PositionLogprobs,
     teacher_topk: PositionLogprobs,
 ) -> float:
-    """Eq. 7: distributional agreement within shared tokens.
+    """Eq. 7: distributional agreement within shared top-k tokens.
 
-    For each position, renormalize student and teacher probs onto the
-    intersection token set, then compute
-    ``sum_over_overlap(teacher_renorm - student_renorm) / |overlap|``.
-    Approaching 0 = good alignment.
+    For each position, renormalize student and teacher probabilities onto the
+    overlap set and compute ``mean(p_overlap * log(q_overlap / p_overlap))``.
+    The value approaches zero as the two distributions align and is negative
+    when the student is overconfident or otherwise mismatched on the overlap.
     """
     if not student_topk or not teacher_topk:
         return 0.0
@@ -82,11 +84,13 @@ def compute_overlap_token_advantage(
         overlap = set(s_probs.keys()) & set(t_probs.keys())
         if not overlap:
             continue
-        s_overlap = {tok: s_probs[tok] for tok in overlap}
-        t_overlap = {tok: t_probs[tok] for tok in overlap}
-        s_renorm = _renormalize(s_overlap)
-        t_renorm = _renormalize(t_overlap)
-        adv = sum(t_renorm[tok] - s_renorm[tok] for tok in overlap) / len(overlap)
+        s_overlap = _renormalize({tok: s_probs[tok] for tok in overlap})
+        t_overlap = _renormalize({tok: t_probs[tok] for tok in overlap})
+        adv = sum(
+            s_overlap[tok] * (math.log(t_overlap[tok]) - math.log(s_overlap[tok]))
+            for tok in overlap
+            if s_overlap[tok] > 0 and t_overlap[tok] > 0
+        ) / len(overlap)
         total += adv
         valid_positions += 1
     return total / max(valid_positions, 1)
@@ -120,7 +124,7 @@ def compute_overlap_mass(
     """Eqs. 9-10: probability mass on shared top-k tokens.
 
     Returns ``(student_overlap_mass, teacher_overlap_mass)`` averaged over
-    positions.  In healthy runs both should be 97-99%.
+    positions, using the original probabilities from the top-k logprobs.
     """
     if not student_topk or not teacher_topk:
         return (0.0, 0.0)
@@ -128,8 +132,8 @@ def compute_overlap_mass(
     s_mass_total = 0.0
     t_mass_total = 0.0
     for i in range(n):
-        s_probs = _renormalize(_to_prob_dict(student_topk[i]))
-        t_probs = _renormalize(_to_prob_dict(teacher_topk[i]))
+        s_probs = _to_prob_dict(student_topk[i])
+        t_probs = _to_prob_dict(teacher_topk[i])
         overlap = set(s_probs.keys()) & set(t_probs.keys())
         s_mass_total += sum(s_probs[tok] for tok in overlap)
         t_mass_total += sum(t_probs[tok] for tok in overlap)

--- a/training/utils/opd_metrics.py
+++ b/training/utils/opd_metrics.py
@@ -1,0 +1,220 @@
+"""On-policy distillation (OPD) dynamic metrics from arXiv:2604.13016.
+
+Pure functions that take top-k logprobs from student and teacher, aligned
+position-by-position, and return all paper metrics (Eqs. 6-10, Section 6.1).
+
+Input format per position: ``List[Tuple[int, float]]`` where each tuple is
+``(token_id, logprob)``.  Sequences are ``List[List[Tuple[int, float]]]``
+(one inner list per position in the response).
+
+All entropy/mass computations use **renormalized** top-k probabilities, matching
+the paper's k=16 setting (Section 2.3, Appendix B.1).
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Dict, List, Sequence, Tuple
+
+TopKLogprobs = List[Tuple[int, float]]
+PositionLogprobs = List[TopKLogprobs]
+
+DEFAULT_TOP_K = 16
+
+
+def _to_prob_dict(topk: TopKLogprobs) -> dict[int, float]:
+    """Convert top-k logprobs to a dict of token_id -> probability."""
+    return {tok: math.exp(lp) for tok, lp in topk}
+
+
+def _renormalize(prob_dict: dict[int, float]) -> dict[int, float]:
+    """Renormalize probabilities to sum to 1."""
+    total = sum(prob_dict.values())
+    if total <= 0:
+        return prob_dict
+    return {tok: p / total for tok, p in prob_dict.items()}
+
+
+def _entropy_from_probs(probs: dict[int, float]) -> float:
+    """Shannon entropy from a (renormalized) probability dict."""
+    return -sum(p * math.log(p) for p in probs.values() if p > 0)
+
+
+def compute_overlap_ratio(
+    student_topk: PositionLogprobs,
+    teacher_topk: PositionLogprobs,
+) -> float:
+    """Eq. 6: fraction of top-k tokens shared, averaged over positions.
+
+    ``|S_student_topk ∩ S_teacher_topk| / k``, averaged across positions.
+    """
+    if not student_topk or not teacher_topk:
+        return 0.0
+    n = min(len(student_topk), len(teacher_topk))
+    total = 0.0
+    for i in range(n):
+        s_ids = {tok for tok, _ in student_topk[i]}
+        t_ids = {tok for tok, _ in teacher_topk[i]}
+        k = max(len(s_ids), len(t_ids), 1)
+        total += len(s_ids & t_ids) / k
+    return total / n
+
+
+def compute_overlap_token_advantage(
+    student_topk: PositionLogprobs,
+    teacher_topk: PositionLogprobs,
+) -> float:
+    """Eq. 7: distributional agreement within shared tokens.
+
+    For each position, renormalize student and teacher probs onto the
+    intersection token set, then compute
+    ``sum_over_overlap(teacher_renorm - student_renorm) / |overlap|``.
+    Approaching 0 = good alignment.
+    """
+    if not student_topk or not teacher_topk:
+        return 0.0
+    n = min(len(student_topk), len(teacher_topk))
+    total = 0.0
+    valid_positions = 0
+    for i in range(n):
+        s_probs = _to_prob_dict(student_topk[i])
+        t_probs = _to_prob_dict(teacher_topk[i])
+        overlap = set(s_probs.keys()) & set(t_probs.keys())
+        if not overlap:
+            continue
+        s_overlap = {tok: s_probs[tok] for tok in overlap}
+        t_overlap = {tok: t_probs[tok] for tok in overlap}
+        s_renorm = _renormalize(s_overlap)
+        t_renorm = _renormalize(t_overlap)
+        adv = sum(t_renorm[tok] - s_renorm[tok] for tok in overlap) / len(overlap)
+        total += adv
+        valid_positions += 1
+    return total / max(valid_positions, 1)
+
+
+def compute_entropy_gap(
+    student_topk: PositionLogprobs,
+    teacher_topk: PositionLogprobs,
+) -> float:
+    """Eq. 8: ``|H(teacher) - H(student)|`` averaged over positions.
+
+    Entropy is computed from renormalized top-k probabilities.
+    """
+    if not student_topk or not teacher_topk:
+        return 0.0
+    n = min(len(student_topk), len(teacher_topk))
+    total = 0.0
+    for i in range(n):
+        s_probs = _renormalize(_to_prob_dict(student_topk[i]))
+        t_probs = _renormalize(_to_prob_dict(teacher_topk[i]))
+        s_ent = _entropy_from_probs(s_probs)
+        t_ent = _entropy_from_probs(t_probs)
+        total += abs(t_ent - s_ent)
+    return total / n
+
+
+def compute_overlap_mass(
+    student_topk: PositionLogprobs,
+    teacher_topk: PositionLogprobs,
+) -> Tuple[float, float]:
+    """Eqs. 9-10: probability mass on shared top-k tokens.
+
+    Returns ``(student_overlap_mass, teacher_overlap_mass)`` averaged over
+    positions.  In healthy runs both should be 97-99%.
+    """
+    if not student_topk or not teacher_topk:
+        return (0.0, 0.0)
+    n = min(len(student_topk), len(teacher_topk))
+    s_mass_total = 0.0
+    t_mass_total = 0.0
+    for i in range(n):
+        s_probs = _renormalize(_to_prob_dict(student_topk[i]))
+        t_probs = _renormalize(_to_prob_dict(teacher_topk[i]))
+        overlap = set(s_probs.keys()) & set(t_probs.keys())
+        s_mass_total += sum(s_probs[tok] for tok in overlap)
+        t_mass_total += sum(t_probs[tok] for tok in overlap)
+    return (s_mass_total / n, t_mass_total / n)
+
+
+def compute_per_position_entropy(
+    student_topk: PositionLogprobs,
+    *,
+    bucket_count: int = 4,
+) -> Dict[str, float]:
+    """Section 6.1: mean student entropy per position quartile.
+
+    Splits positions into ``bucket_count`` equal-sized buckets and reports
+    the mean renormalized-top-k entropy per bucket.  Detects depth
+    degradation (instability starts at later tokens).
+    """
+    if not student_topk:
+        return {f"per_position_entropy/q{i + 1}": 0.0 for i in range(bucket_count)}
+    n = len(student_topk)
+    entropies = []
+    for pos_topk in student_topk:
+        probs = _renormalize(_to_prob_dict(pos_topk))
+        entropies.append(_entropy_from_probs(probs))
+
+    bucket_size = max(1, n // bucket_count)
+    result: Dict[str, float] = {}
+    for b in range(bucket_count):
+        start = b * bucket_size
+        end = start + bucket_size if b < bucket_count - 1 else n
+        bucket_vals = entropies[start:end]
+        mean_ent = sum(bucket_vals) / max(len(bucket_vals), 1)
+        result[f"per_position_entropy/q{b + 1}"] = mean_ent
+    return result
+
+
+def compute_student_entropy(student_topk: PositionLogprobs) -> float:
+    """Mean student policy entropy from renormalized top-k probs."""
+    if not student_topk:
+        return 0.0
+    total = 0.0
+    for pos_topk in student_topk:
+        probs = _renormalize(_to_prob_dict(pos_topk))
+        total += _entropy_from_probs(probs)
+    return total / len(student_topk)
+
+
+def compute_teacher_entropy(teacher_topk: PositionLogprobs) -> float:
+    """Mean teacher policy entropy from renormalized top-k probs."""
+    if not teacher_topk:
+        return 0.0
+    total = 0.0
+    for pos_topk in teacher_topk:
+        probs = _renormalize(_to_prob_dict(pos_topk))
+        total += _entropy_from_probs(probs)
+    return total / len(teacher_topk)
+
+
+def compute_opd_metrics(
+    student_topk: PositionLogprobs,
+    teacher_topk: PositionLogprobs,
+    *,
+    bucket_count: int = 4,
+) -> Dict[str, float]:
+    """All-in-one: compute all paper metrics and return a flat dict.
+
+    Keys are prefixed with ``distill/`` for easy integration with wandb/JSONL.
+    """
+    overlap_ratio = compute_overlap_ratio(student_topk, teacher_topk)
+    overlap_advantage = compute_overlap_token_advantage(student_topk, teacher_topk)
+    entropy_gap = compute_entropy_gap(student_topk, teacher_topk)
+    s_mass, t_mass = compute_overlap_mass(student_topk, teacher_topk)
+    per_pos = compute_per_position_entropy(student_topk, bucket_count=bucket_count)
+    s_entropy = compute_student_entropy(student_topk)
+    t_entropy = compute_teacher_entropy(teacher_topk)
+
+    metrics: Dict[str, float] = {
+        "distill/overlap_ratio": overlap_ratio,
+        "distill/overlap_advantage": overlap_advantage,
+        "distill/entropy_gap": entropy_gap,
+        "distill/overlap_mass_student": s_mass,
+        "distill/overlap_mass_teacher": t_mass,
+        "distill/student_entropy": s_entropy,
+        "distill/teacher_entropy": t_entropy,
+    }
+    for key, val in per_pos.items():
+        metrics[f"distill/{key}"] = val
+    return metrics


### PR DESCRIPTION
## Description

Fixes: N/A

- Correct the pure OPD metric helpers in `training/utils/opd_metrics.py` to match arXiv:2604.13016:
  - `overlap_advantage` now computes the paper-style overlap KL term on renormalized shared top-k support.
  - `overlap_mass_student` / `overlap_mass_teacher` now use the original top-k logprob probabilities instead of renormalizing top-k mass to 1.
- Update unit tests to cover the corrected overlap-advantage and overlap-mass behavior.
- Keep the Qwen3 Section 3.2 repro script local/untracked in the Fireworks checkout; this Cookbook PR contains only reusable metric logic and tests.

Companion Fireworks PR: https://github.com/fw-ai/fireworks/pull/23529

## Architecture / Code Overview Diagram

```mermaid
flowchart LR
    A["Student top-k logprobs"] --> C["training/utils/opd_metrics.py"]
    B["Teacher top-k logprobs"] --> C
    C --> D["overlap_ratio"]
    C --> E["overlap_advantage"]
    C --> F["entropy_gap"]
    C --> G["overlap_mass_student / overlap_mass_teacher"]
    C --> H["per_position_entropy/q1-q4"]
```

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Infrastructure/DevOps

## Testing

- [x] Added/updated tests
- [x] Tested manually
- [ ] No testing needed

Commands run:

```bash
PYTHONPATH=. pytest -q training/tests/unit/test_opd_metrics.py
PYTHONPATH=train-firetitan-py pytest -q train-firetitan-py/tests/test_kl_distillation.py  # from companion Fireworks checkout
python -m py_compile train-firetitan-py/scripts/test_opd_metrics_local.py train-firetitan-py/firetitan/train/nn/kl_distillation.py
```

Results:

- `training/tests/unit/test_opd_metrics.py`: 25 passed
- `train-firetitan-py/tests/test_kl_distillation.py`: 31 passed
- `py_compile`: passed

## Surface Consistency

- [x] No customer-facing surface impact
- [ ] Related surfaces checked — all consistent or follow-up filed
- [ ] Inline "keep in sync" comments followed

## Deployment Notes

- [ ] Requires database migration
- [ ] Requires config/env changes
- [ ] Requires Terraform/K8s changes
- [x] No special deployment considerations

## Change Size

- [x] Small (< 200 LOC)
- [ ] Medium (200–999 LOC)
- [ ] Large (≥ 1,000 LOC) — **Design plan attached below**

<details>
<summary>Design Plan (required for large changes)</summary>

N/A

</details>

## Checklist

- [ ] Agent-reviewed the diff before committing
- [x] Self-reviewed my code
- [x] Change is the **minimum necessary** diff
- [x] Added tests for my changes
- [ ] Updated relevant documentation
- [x] No new linter warnings/errors
- [x] No secrets or credentials in the diff
- [x] Checked surface consistency for customer-facing changes
- [x] Visual diagram included (or change is cosmetic-only)

## Additional Context

This Qwen3 repro targets Section 3.2 of the paper: **higher scores do not imply new knowledge**. Thinking-pattern consistency is controlled by using Qwen3 non-thinking student/teachers in all cases; the contrast is whether the teacher comes from the same pipeline or has additional RL-Math capability.

Local model paths used:

- `/shared/text-models/Qwen3-1.7B`
- `/shared/text-models/Qwen3-4B`
- `/shared/text-models/Qwen3-4B-Non-Thinking-RL-Math-Step500`

Small local Section 3.2 result:

| Setup | Final avg@n | Final pass@n | Overlap | Reverse KL |
|---|---:|---:|---:|---:|
| Base Qwen3-1.7B eval only | 0.250 | 0.300 | 0.7387 | 0.1217 |
| OPD from Qwen3-4B same pipeline | 0.300 | 0.400 | 0.7397 | 0.1419 |
| OPD from RL-Math Qwen3-4B | 0.400 | 0.400 | 0.6919 | 0.3843 |

Interpretation: the same-pipeline 4B teacher gives little movement over the pretrained 1.7B baseline, while the RL-Math teacher gives a clearer accuracy lift despite lower overlap and higher KL. This is a bounded local repro, not a full paper-scale run with full DAPO-17K, rollout 4, avg@16, and long 7168/31744 response limits.

### Per-Step Overlap Plot

16-step local trace used for the overlap trend. Legend: first line = same-pipeline Qwen3-4B; second line = RL-Math Qwen3-4B.

| Step | Same-pipeline Qwen3-4B | RL-Math Qwen3-4B |
|---:|---:|---:|
| 0 | 0.7511 | 0.6966 |
| 8 | 0.7495 | 0.6904 |
| 16 | 0.7373 | 0.6893 |

```mermaid
xychart-beta
    title "Qwen3 Section 3.2 local OPD overlap"
    x-axis "step" [0, 8, 16]
    y-axis "overlap_ratio" 0.65 --> 0.78
    line [0.7511, 0.7495, 0.7373]
    line [0.6966, 0.6904, 0.6893]
```
