### PR TITLE
[codex] add sampled-token OPD recipe

### DIFF
--- a/training/README.md
+++ b/training/README.md
@@ -91,6 +91,32 @@ Each recipe has a `Config` dataclass at the top of the file. Open the recipe you
 | `deployment` | `DeployConfig(tokenizer_model="Qwen/Qwen3-8B")` for student rollouts |
 | `weight_sync` | `WeightSyncConfig(weight_sync_interval=1)` for strict on-policy updates |
 
+If `teacher_model` is a base model resource such as
+`accounts/fireworks/models/qwen3p5-9b`, the OPD recipe creates or reuses a
+separate frozen teacher deployment for scoring during the same provisioning
+phase as the trainer and hot-loaded student deployment. Set
+`teacher_deployment_id` to pin that deployment name. If `teacher_model` is
+already a deployment/deployed model resource, OPD uses it directly.
+
+OPD rows can include `teacher_messages` for privileged teacher context. The
+student samples from `messages`; the frozen teacher scores the sampled response
+under `teacher_messages`. If `teacher_messages` is absent, OPD falls back to
+the student prompt. The aliases `privileged_messages` and
+`teacher_prompt_messages` are also accepted.
+
+For privileged-context validation, `training.utils.opd_eval` provides
+`validate_privileged_opd_dataset(...)`,
+`make_teacher_trace_logprob_gap_eval(...)`, and
+`validate_opd_trace_result(...)` (also re-exported by `recipes/opd_loop.py`
+for convenience). Rows with `expected_answer` and completions that end in
+`Final: ...` can be linted before launch and then track exact final-answer
+accuracy plus the student/teacher logprob gap on the teacher's reasoning trace.
+
+`examples/opd/gsm8k_privileged/prepare_data.py` shows the recommended data
+preparation pattern for real math data: convert GSM8K-style `ground_truth`
+worked solutions into explicit `teacher_messages` before passing the JSONL to
+`recipes/opd_loop.py`.
+
 When `training_shape_id` is not set, the cookbook auto-selects validated
 trainer shapes at runtime from Fireworks control-plane data. RL-family
 recipes also auto-select a validated deployment shape, and DPO / KL

--- a/training/README.md
+++ b/training/README.md
@@ -10,6 +10,7 @@ Each recipe is a single Python file you can fork and customize.
 | Recipe | File | Description |
 | --- | --- | --- |
 | GRPO / IS / DAPO / DRO / GSPO / CISPO | `recipes/rl_loop.py` | On-policy RL with streaming rollouts. Set `policy_loss="grpo"`, `"importance_sampling"`, `"dapo"`, `"dro"`, `"gspo"`, or `"cispo"`. |
+| OPD | `recipes/opd_loop.py` | Sampled-token on-policy distillation. The student rolls out on policy, a teacher scores those same tokens, and training uses the server-side importance-sampling loss. |
 | DPO | `recipes/dpo_loop.py` | Direct preference optimization with cached reference logprobs. |
 | ORPO | `recipes/orpo_loop.py` | Odds-ratio preference optimization -- no reference model needed. |
 | SFT | `recipes/sft_loop.py` | Supervised fine-tuning with response-only cross-entropy loss. |
@@ -81,6 +82,14 @@ Each recipe has a `Config` dataclass at the top of the file. Open the recipe you
 | --- | --- |
 | `deployment` | `DeployConfig(tokenizer_model="Qwen/Qwen3-8B")` for inference rollouts |
 | `weight_sync` | `WeightSyncConfig(weight_sync_interval=1)` to sync weights to the deployment |
+
+**OPD** (`recipes/opd_loop.py`) -- also requires:
+
+| Field | What to set |
+| --- | --- |
+| `teacher_model` | Fireworks teacher model or deployment ID using the same tokenizer as the student |
+| `deployment` | `DeployConfig(tokenizer_model="Qwen/Qwen3-8B")` for student rollouts |
+| `weight_sync` | `WeightSyncConfig(weight_sync_interval=1)` for strict on-policy updates |
 
 When `training_shape_id` is not set, the cookbook auto-selects validated
 trainer shapes at runtime from Fireworks control-plane data. RL-family

--- a/training/README.md
+++ b/training/README.md
@@ -12,6 +12,7 @@ Each recipe is a single Python file you can fork and customize.
 | GRPO / IS / DAPO / DRO / GSPO / CISPO | `recipes/rl_loop.py` | On-policy RL with streaming rollouts. Set `policy_loss="grpo"`, `"importance_sampling"`, `"dapo"`, `"dro"`, `"gspo"`, or `"cispo"`. |
 | Async RL (any of the above losses) | `recipes/async_rl_loop.py` | Gate-native async RL: rollout/train overlap with bounded off-policy staleness. Strict superset of `rl_loop.py`; recommended for new RL work. |
 | IGPO (multi-turn turn-level Information Gain) | `recipes/igpo_loop.py` | GRPO + per-turn IG rewards for agent trajectories (Wang et al., ICLR 2026). |
+| OPD | `recipes/opd_loop.py` | Sampled-token on-policy distillation. The student rolls out on policy, a teacher scores those same tokens, and training uses the server-side importance-sampling loss. |
 | DPO | `recipes/dpo_loop.py` | Direct preference optimization with cached reference logprobs. |
 | ORPO | `recipes/orpo_loop.py` | Odds-ratio preference optimization -- no reference model needed. |
 | SFT | `recipes/sft_loop.py` | Supervised fine-tuning with response-only cross-entropy loss. |
@@ -80,6 +81,14 @@ Each recipe has a `Config` dataclass at the top of the file. Open the recipe you
 | --- | --- |
 | `deployment` | `DeployConfig(tokenizer_model="Qwen/Qwen3-8B")` for inference rollouts |
 | `weight_sync` | `WeightSyncConfig(weight_sync_interval=1)` to sync weights to the deployment |
+
+**OPD** (`recipes/opd_loop.py`) -- also requires:
+
+| Field | What to set |
+| --- | --- |
+| `teacher_model` | Fireworks teacher model or deployment ID using the same tokenizer as the student |
+| `deployment` | `DeployConfig(tokenizer_model="Qwen/Qwen3-8B")` for student rollouts |
+| `weight_sync` | `WeightSyncConfig(weight_sync_interval=1)` for strict on-policy updates |
 
 When `training_shape_id` is not set, the cookbook auto-selects validated
 trainer shapes at runtime from Fireworks control-plane data. RL-family

--- a/training/README.md
+++ b/training/README.md
@@ -90,6 +90,32 @@ Each recipe has a `Config` dataclass at the top of the file. Open the recipe you
 | `deployment` | `DeployConfig(tokenizer_model="Qwen/Qwen3-8B")` for student rollouts |
 | `weight_sync` | `WeightSyncConfig(weight_sync_interval=1)` for strict on-policy updates |
 
+If `teacher_model` is a base model resource such as
+`accounts/fireworks/models/qwen3p5-9b`, the OPD recipe creates or reuses a
+separate frozen teacher deployment for scoring during the same provisioning
+phase as the trainer and hot-loaded student deployment. Set
+`teacher_deployment_id` to pin that deployment name. If `teacher_model` is
+already a deployment/deployed model resource, OPD uses it directly.
+
+OPD rows can include `teacher_messages` for privileged teacher context. The
+student samples from `messages`; the frozen teacher scores the sampled response
+under `teacher_messages`. If `teacher_messages` is absent, OPD falls back to
+the student prompt. The aliases `privileged_messages` and
+`teacher_prompt_messages` are also accepted.
+
+For privileged-context validation, `training.utils.opd_eval` provides
+`validate_privileged_opd_dataset(...)`,
+`make_teacher_trace_logprob_gap_eval(...)`, and
+`validate_opd_trace_result(...)` (also re-exported by `recipes/opd_loop.py`
+for convenience). Rows with `expected_answer` and completions that end in
+`Final: ...` can be linted before launch and then track exact final-answer
+accuracy plus the student/teacher logprob gap on the teacher's reasoning trace.
+
+`examples/opd/gsm8k_privileged/prepare_data.py` shows the recommended data
+preparation pattern for real math data: convert GSM8K-style `ground_truth`
+worked solutions into explicit `teacher_messages` before passing the JSONL to
+`recipes/opd_loop.py`.
+
 When `training_shape_id` is not set, the cookbook auto-selects validated
 trainer shapes at runtime from Fireworks control-plane data. RL-family
 recipes also auto-select a validated deployment shape, and DPO / KL

--- a/training/examples/opd/gsm8k_privileged/prepare_data.py
+++ b/training/examples/opd/gsm8k_privileged/prepare_data.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Prepare GSM8K-style rows for privileged-context OPD.
+
+The OPD loop consumes normalized rows:
+
+  {
+    "messages": [...],          # student prompt, no privileged solution
+    "teacher_messages": [...],  # same problem plus privileged worked solution
+    "expected_answer": "..."
+  }
+
+This script converts the public GSM8K sample used elsewhere in the cookbook
+into that format. The student sees only the problem. The frozen teacher sees
+the problem plus the dataset's worked solution as privileged context.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import requests
+
+
+DEFAULT_SOURCE = "https://raw.githubusercontent.com/eval-protocol/python-sdk/main/development/gsm8k_sample.jsonl"
+DEFAULT_OUTPUT = Path(__file__).with_name("dataset.jsonl")
+
+STUDENT_SYSTEM_PROMPT = (
+    "You are a careful math reasoner. Solve the problem using normal reasoning. "
+    "End with exactly one line: Final: <answer>."
+)
+
+TEACHER_SYSTEM_PROMPT = (
+    "You are a careful math reasoner. Use the privileged worked solution as private context. "
+    "Solve the problem with normal reasoning. End with exactly one line: Final: {answer}."
+)
+
+
+def normalize_answer(answer: Any) -> str:
+    normalized = re.sub(r"\s+", " ", str(answer).strip())
+    return normalized.rstrip(".")
+
+
+def extract_ground_truth_answer(ground_truth: Any) -> str:
+    text = str(ground_truth or "")
+    answer_tag_match = re.search(r"<answer>\s*(.*?)\s*</answer>", text, flags=re.DOTALL | re.IGNORECASE)
+    if answer_tag_match:
+        return normalize_answer(answer_tag_match.group(1))
+
+    gsm8k_match = re.search(r"####\s*([^\n\r]+)", text)
+    if gsm8k_match:
+        return normalize_answer(gsm8k_match.group(1))
+
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    if not lines:
+        raise ValueError("ground_truth does not contain a final answer")
+    return normalize_answer(lines[-1])
+
+
+def load_jsonl(path_or_url: str) -> list[dict[str, Any]]:
+    if path_or_url.startswith(("http://", "https://")):
+        response = requests.get(path_or_url, timeout=30)
+        response.raise_for_status()
+        lines = response.text.splitlines()
+    else:
+        lines = Path(path_or_url).read_text(encoding="utf-8").splitlines()
+    return [json.loads(line) for line in lines if line.strip()]
+
+
+def problem_messages(row: dict[str, Any]) -> list[dict[str, Any]]:
+    messages = row.get("messages")
+    if not isinstance(messages, list):
+        raise ValueError("row is missing messages")
+    kept = [
+        dict(message)
+        for message in messages
+        if str(message.get("role", "")).lower() not in {"assistant", "system"}
+    ]
+    if not kept:
+        raise ValueError("row does not contain a user problem message")
+    return kept
+
+
+def convert_row(row: dict[str, Any]) -> dict[str, Any]:
+    ground_truth = row.get("ground_truth")
+    if ground_truth is None:
+        raise ValueError("row is missing ground_truth")
+    answer = extract_ground_truth_answer(ground_truth)
+    problem = problem_messages(row)
+
+    return {
+        "messages": [
+            {"role": "system", "content": STUDENT_SYSTEM_PROMPT},
+            *problem,
+        ],
+        "teacher_messages": [
+            {"role": "system", "content": TEACHER_SYSTEM_PROMPT.format(answer=answer)},
+            *problem,
+            {
+                "role": "user",
+                "content": (
+                    "Privileged worked solution for the teacher only:\n"
+                    f"{str(ground_truth).strip()}\n\n"
+                    "Use this privileged context when scoring or answering. "
+                    f"The final line must be exactly: Final: {answer}."
+                ),
+            },
+        ],
+        "expected_answer": answer,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Prepare GSM8K privileged OPD JSONL")
+    parser.add_argument("--source", default=DEFAULT_SOURCE)
+    parser.add_argument("--output", default=str(DEFAULT_OUTPUT))
+    parser.add_argument("--max-rows", type=int, default=0)
+    args = parser.parse_args()
+
+    rows = load_jsonl(args.source)
+    if args.max_rows > 0:
+        rows = rows[: args.max_rows]
+    converted = [convert_row(row) for row in rows]
+
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with output.open("w", encoding="utf-8") as handle:
+        for row in converted:
+            handle.write(json.dumps(row, ensure_ascii=False, separators=(",", ":")) + "\n")
+
+    print(f"Wrote {len(converted)} rows to {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/training/examples/opd/gsm8k_privileged/train_gsm8k_privileged.py
+++ b/training/examples/opd/gsm8k_privileged/train_gsm8k_privileged.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Run privileged-context OPD on prepared GSM8K rows.
+
+Run prepare_data.py first, then:
+
+  python train_gsm8k_privileged.py --training-shape accounts/fireworks/trainingShapes/qwen3p5-9b-256k
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import cast
+
+from dotenv import load_dotenv
+
+_SRC = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+if _SRC not in sys.path:
+    sys.path.insert(0, _SRC)
+
+import training.recipes.opd_loop as opd_loop
+from training.utils import DeployConfig, InfraConfig, RunnerConfig, WeightSyncConfig
+from training.utils.opd_eval import (
+    make_teacher_trace_logprob_gap_eval,
+    validate_opd_trace_result,
+    validate_privileged_opd_dataset,
+)
+
+
+DATASET_PATH = Path(__file__).with_name("dataset.jsonl")
+LOG_ROOT = Path(__file__).resolve().parents[2] / "opd_logs"
+
+
+@dataclass
+class TrainArgs:
+    base_model: str = "accounts/fireworks/models/qwen3p5-9b"
+    tokenizer_model: str = "Qwen/Qwen3.5-9B"
+    dataset_path: str = field(default_factory=lambda: str(DATASET_PATH))
+    training_shape: str = ""
+    max_rows: int = 8
+    epochs: int = 25
+    prompt_groups_per_step: int = 8
+    completions_per_prompt: int = 4
+    learning_rate: float = 2e-5
+    max_completion_tokens: int = 2048
+    min_pre_final_tokens: int = 64
+    run_id: str = field(default_factory=lambda: f"gsm8k-opd-{int(time.time())}")
+    skip_cleanup: bool = False
+
+
+def parse_args() -> TrainArgs:
+    defaults = TrainArgs()
+    parser = argparse.ArgumentParser(description="Privileged OPD on prepared GSM8K rows")
+    parser.add_argument("--base-model")
+    parser.add_argument("--tokenizer-model")
+    parser.add_argument("--dataset-path")
+    parser.add_argument("--training-shape", required=True)
+    parser.add_argument("--max-rows", type=int)
+    parser.add_argument("--epochs", type=int)
+    parser.add_argument("--prompt-groups-per-step", type=int)
+    parser.add_argument("--completions-per-prompt", type=int)
+    parser.add_argument("--learning-rate", type=float)
+    parser.add_argument("--max-completion-tokens", type=int)
+    parser.add_argument("--min-pre-final-tokens", type=int)
+    parser.add_argument("--run-id")
+    parser.add_argument("--skip-cleanup", action="store_true")
+    return cast(TrainArgs, parser.parse_args(namespace=defaults))
+
+
+def main() -> None:
+    load_dotenv()
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    args = parse_args()
+
+    dataset_path = Path(args.dataset_path)
+    if not dataset_path.exists():
+        raise FileNotFoundError(
+            f"Dataset not found at {dataset_path}. Run prepare_data.py first."
+        )
+    validate_privileged_opd_dataset(dataset_path, min_rows=args.max_rows)
+
+    log_dir = LOG_ROOT / args.run_id
+    metrics_file = log_dir / "metrics.jsonl"
+    trace_file = log_dir / "teacher_trace_eval.jsonl"
+    step_eval = make_teacher_trace_logprob_gap_eval(
+        trace_log_path=trace_file,
+        min_pre_final_tokens=args.min_pre_final_tokens,
+    )
+
+    cfg = opd_loop.Config(
+        log_path=str(log_dir),
+        base_model=args.base_model,
+        teacher_model=args.base_model,
+        teacher_deployment_id=f"opd-teacher-{args.run_id}",
+        dataset=str(dataset_path),
+        infra=InfraConfig(training_shape_id=args.training_shape),
+        deployment=DeployConfig(tokenizer_model=args.tokenizer_model),
+        weight_sync=WeightSyncConfig(weight_sync_interval=1),
+        runner=RunnerConfig(metrics_file=str(metrics_file)),
+        step_eval=step_eval,
+        step_eval_interval=1,
+        eval_before_training=True,
+        lora_rank=0,
+        learning_rate=args.learning_rate,
+        max_rows=args.max_rows,
+        epochs=args.epochs,
+        prompt_groups_per_step=args.prompt_groups_per_step,
+        completions_per_prompt=args.completions_per_prompt,
+        max_completion_tokens=args.max_completion_tokens,
+        temperature=1.0,
+        max_seq_len=None,
+        save_final_checkpoint=False,
+    )
+
+    result = opd_loop.main(cfg, cancel_on_exit=not args.skip_cleanup)
+    validate_opd_trace_result(
+        cfg,
+        result,
+        min_abs_advantage=1e-4,
+        min_teacher_final_accuracy=1.0,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/training/recipes/opd_loop.py
+++ b/training/recipes/opd_loop.py
@@ -1,0 +1,645 @@
+#!/usr/bin/env python3
+"""Sampled-token on-policy distillation (OPD) training loop.
+
+The student samples responses from its own hot-loaded deployment.  A teacher
+deployment then scores those exact token sequences.  Training uses Tinker's
+server-side ``importance_sampling`` loss with per-token advantages equal to
+``teacher_logprob - sampling_logprob`` on response tokens.
+
+This is intentionally not a reward-model RL loop: there is no outcome reward
+and no reference trainer.  The dense teacher/student log-ratio is the OPD
+signal.
+
+Usage:
+    export FIREWORKS_API_KEY=...
+    python -m recipes.opd_loop
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import asyncio
+import logging
+from contextlib import ExitStack
+from typing import Any
+from dataclasses import field, dataclass
+
+import tinker
+import transformers
+
+from fireworks.training.sdk import DeploymentManager, TrainerJobManager
+from fireworks.training.sdk.client import GradAccNormalization
+from fireworks.training.sdk.deployment import AdaptiveConcurrencyController, DeploymentSampler
+from fireworks.training.sdk.weight_syncer import WeightSyncer
+from training.utils import (
+    DEFAULT_ADAM,
+    ConcurrencyConfig,
+    DeployConfig,
+    InfraConfig,
+    RLPromptDataset,
+    ResourceCleanup,
+    RunnerConfig,
+    RunnerIO,
+    RunStatus,
+    WandBConfig,
+    WeightSyncConfig,
+    load_jsonl_dataset,
+    log_metrics_json,
+    prepare_sampling_messages,
+    read_api_extra_headers_env,
+    setup_wandb,
+    validate_config,
+    wandb_finish,
+    wandb_log,
+)
+from training.utils.checkpoint_utils import (
+    CheckpointKind,
+    resolve_resume,
+    save_checkpoint,
+    validate_warm_start_config,
+)
+from training.utils.opd import (
+    OPDPromptGroup,
+    build_opd_server_datums,
+    combine_opd_prompt_groups,
+)
+from training.utils.rl import setup_infra
+from training.utils.rl.train import TrainStepFns, run_rl_loop
+from training.utils.timer import flush_timing, timer
+
+import time as _time
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Config:
+    log_path: str
+    """Directory for checkpoints and logs. Required, no default."""
+
+    base_model: str = "accounts/fireworks/models/qwen3-8b"
+    rollout_base_model: str | None = None
+    dataset: str = "https://raw.githubusercontent.com/eval-protocol/python-sdk/main/development/gsm8k_sample.jsonl"
+
+    teacher_model: str = ""
+    """Teacher model/deployment ID on the same tokenizer as ``base_model``."""
+
+    teacher_inference_url: str | None = None
+    """Optional inference base URL for the teacher. Defaults to FIREWORKS_BASE_URL."""
+
+    teacher_top_logprobs: int = 0
+    """Optional top-logprob count to request while scoring. The loss needs only sampled-token logprobs."""
+
+    learning_rate: float = 1e-5
+    opd_loss_scale: float = 1.0
+    """Scalar multiplier on ``teacher_logprob - sampling_logprob``."""
+
+    ratio_log_cap: float = 20.0
+    """Numerical clamp for the server-side importance ratio log."""
+
+    completions_per_prompt: int = 1
+    max_completion_tokens: int = 1024
+    temperature: float = 1.0
+    epochs: int = 1
+    max_rows: int = 100
+    max_seq_len: int | None = None
+    lora_rank: int = 0
+    prompt_groups_per_step: int = 1
+
+    grad_accumulation_normalization: GradAccNormalization | str | None = GradAccNormalization.NUM_LOSS_TOKENS
+
+    concurrency: ConcurrencyConfig = field(default_factory=ConcurrencyConfig)
+    policy_job_id: str | None = None
+    init_from_checkpoint: str | None = None
+    warm_start_from_adapter: str | None = None
+    output_model_id: str | None = None
+    save_final_checkpoint: bool = True
+    step_timeout: int = 0
+
+    infra: InfraConfig = field(default_factory=InfraConfig)
+    deployment: DeployConfig = field(default_factory=DeployConfig)
+    weight_sync: WeightSyncConfig = field(default_factory=WeightSyncConfig)
+    wandb: WandBConfig = field(default_factory=lambda: WandBConfig(project="opd-tinker"))
+    runner: RunnerConfig = field(default_factory=RunnerConfig)
+
+
+def _align_completion_logprobs(
+    completion_logprobs: list[float],
+    *,
+    prompt_len: int,
+    target_len: int,
+    echoed: bool,
+) -> list[float]:
+    """Align API completion logprobs to ``target_tokens`` length."""
+    if echoed:
+        aligned = list(completion_logprobs)
+    else:
+        response_start = max(0, prompt_len - 1)
+        aligned = [0.0] * response_start + list(completion_logprobs)
+
+    if len(aligned) < target_len:
+        aligned.extend([0.0] * (target_len - len(aligned)))
+    return aligned[:target_len]
+
+
+def _extract_scored_token_logprobs(
+    response: dict[str, Any],
+    *,
+    target_len: int,
+) -> list[float] | None:
+    """Extract echo logprobs for ``tokens[1:]`` from a completions response."""
+    choices = response.get("choices", [])
+    if not choices:
+        return None
+
+    logprobs = choices[0].get("logprobs")
+    if not isinstance(logprobs, dict):
+        return None
+
+    content = logprobs.get("content")
+    if not isinstance(content, list) or len(content) < 2:
+        return None
+
+    # Echo responses include an unconditional first-token logprob, then one
+    # logprob per next-token target.  A generated extra token may follow; trim it.
+    target_content = content[1 : 1 + target_len]
+    if len(target_content) < target_len:
+        return None
+    return [float(item.get("logprob", 0.0)) for item in target_content]
+
+
+async def _score_with_teacher(
+    sampler: DeploymentSampler,
+    token_ids: list[int],
+    *,
+    top_logprobs: int,
+    http_timeout: int,
+) -> list[float] | None:
+    """Score a full student sequence with the teacher deployment."""
+    target_len = max(0, len(token_ids) - 1)
+    if target_len == 0:
+        return None
+
+    request_kwargs: dict[str, Any] = {
+        "logprobs": True,
+        "echo": True,
+        "raw_output": True,
+        "http_timeout": http_timeout,
+    }
+    if top_logprobs > 0:
+        request_kwargs["top_logprobs"] = top_logprobs
+
+    try:
+        response, _metrics = await sampler.async_completions_stream(
+            prompt=token_ids,
+            max_tokens=1,
+            temperature=0.0,
+            **request_kwargs,
+        )
+    except Exception as exc:
+        logger.warning("Teacher scoring failed: %s", exc)
+        return None
+
+    return _extract_scored_token_logprobs(response, target_len=target_len)
+
+
+def main(
+    config: Config,
+    rlor_mgr: TrainerJobManager | None = None,
+    deploy_mgr: DeploymentManager | None = None,
+    cancel_on_exit: bool = False,
+):
+    cfg = config
+    runner = RunnerIO(cfg.runner)
+
+    def _signal_handler(signum, frame):
+        name = signal.Signals(signum).name
+        logger.warning("Received %s; raising SystemExit for cleanup", name)
+        raise SystemExit(f"Terminated by {name}")
+
+    signal.signal(signal.SIGTERM, _signal_handler)
+    signal.signal(signal.SIGINT, _signal_handler)
+
+    if not cfg.teacher_model:
+        raise ValueError("Config.teacher_model is required for OPD training.")
+
+    validate_config(
+        cfg.base_model,
+        cfg.dataset,
+        cfg.weight_sync,
+        cfg.deployment,
+        output_model_id=cfg.output_model_id,
+    )
+    validate_warm_start_config(
+        warm_start_from_adapter=cfg.warm_start_from_adapter,
+        init_from_checkpoint=cfg.init_from_checkpoint,
+        lora_rank=cfg.lora_rank,
+    )
+    if not cfg.deployment.tokenizer_model:
+        raise ValueError(
+            "deployment.tokenizer_model is required for client-side tokenization. "
+            "Use the HuggingFace tokenizer that matches both student and teacher."
+        )
+
+    setup_wandb(
+        cfg.wandb,
+        {
+            "teacher_model": cfg.teacher_model,
+            "opd_loss_scale": cfg.opd_loss_scale,
+            "ratio_log_cap": cfg.ratio_log_cap,
+            "completions_per_prompt": cfg.completions_per_prompt,
+            "prompt_groups_per_step": cfg.prompt_groups_per_step,
+            "lr": cfg.learning_rate,
+        },
+    )
+
+    api_key = os.environ["FIREWORKS_API_KEY"]
+    base_url = os.environ.get("FIREWORKS_BASE_URL", "https://api.fireworks.ai")
+    additional_headers = read_api_extra_headers_env()
+
+    if rlor_mgr is None:
+        rlor_mgr = TrainerJobManager(
+            api_key=api_key,
+            base_url=base_url,
+            additional_headers=additional_headers,
+        )
+    if deploy_mgr is None:
+        deploy_mgr = DeploymentManager(
+            api_key=api_key,
+            base_url=base_url,
+            additional_headers=additional_headers,
+        )
+
+    runner.write_status(RunStatus.PENDING, message="provisioning")
+
+    def _on_trainer_status(msg: str) -> None:
+        runner.write_status(RunStatus.PENDING, message=msg)
+
+    with runner, ResourceCleanup(rlor_mgr, deploy_mgr) as cleanup, ExitStack() as stack:
+        infra = setup_infra(
+            rlor_mgr=rlor_mgr,
+            deploy_mgr=deploy_mgr,
+            base_model=cfg.base_model,
+            infra_cfg=cfg.infra,
+            deploy_cfg=cfg.deployment,
+            lora_rank=cfg.lora_rank,
+            max_seq_len=cfg.max_seq_len,
+            learning_rate=cfg.learning_rate,
+            step_timeout=cfg.step_timeout,
+            policy_job_id=cfg.policy_job_id,
+            needs_reference=False,
+            needs_inference=True,
+            role_prefix="opd",
+            api_key=api_key,
+            cleanup=cleanup if cancel_on_exit else None,
+            on_status=_on_trainer_status,
+        )
+        for closeable in infra.closeables:
+            stack.callback(closeable.close)
+
+        runner.set_accelerator_info(profile=infra.policy_profile)
+        wandb_log(infra.boot_metrics, step=0)
+
+        policy = infra.policy
+        policy_job_id = infra.policy_job_id
+        tokenizer = transformers.AutoTokenizer.from_pretrained(
+            cfg.deployment.tokenizer_model,
+            trust_remote_code=True,
+        )
+
+        initial_window = cfg.concurrency.initial_window or (8 * infra.deployment_gpu_count)
+        concurrency_controller = AdaptiveConcurrencyController(
+            initial_window=initial_window,
+            min_window=cfg.concurrency.min_window,
+            max_window=cfg.concurrency.max_window,
+            prefill_queue_target=cfg.concurrency.prefill_queue_target,
+        )
+        student_sampler = DeploymentSampler(
+            inference_url=deploy_mgr.inference_url,
+            model=infra.inference_model,
+            api_key=api_key,
+            tokenizer=tokenizer,
+            concurrency_controller=concurrency_controller,
+        )
+        teacher_sampler = DeploymentSampler(
+            inference_url=cfg.teacher_inference_url or base_url,
+            model=cfg.teacher_model,
+            api_key=api_key,
+            tokenizer=tokenizer,
+        )
+        weight_syncer = WeightSyncer(
+            policy_client=policy.inner,
+            deploy_mgr=deploy_mgr,
+            deployment_id=infra.deployment_id,
+            base_model=cfg.rollout_base_model or cfg.base_model,
+            hotload_timeout=cfg.weight_sync.weight_sync_timeout,
+            first_checkpoint_type=cfg.weight_sync.first_checkpoint_type,
+            lora_rank=cfg.lora_rank,
+        )
+
+        logger.info(
+            "OPD training: teacher=%s | completions_per_prompt=%d | groups_per_step=%d",
+            cfg.teacher_model,
+            cfg.completions_per_prompt,
+            cfg.prompt_groups_per_step,
+        )
+
+        resume_info = resolve_resume(
+            policy,
+            cfg.log_path,
+            cfg.init_from_checkpoint,
+            cfg.warm_start_from_adapter,
+        )
+        step_offset = resume_info.step if resume_info else 0
+        wandb_log({"train/step": step_offset}, step_offset)
+
+        if cfg.weight_sync.weight_sync_before_training and infra.deployment_id:
+            name = f"resume-{step_offset}-base" if step_offset > 0 else "step-0-base"
+            weight_syncer.save_and_hotload(name, checkpoint_type="base")
+
+        raw_dataset = load_jsonl_dataset(cfg.dataset, cfg.max_rows)
+        all_rows = raw_dataset * cfg.epochs
+        rl_dataset = RLPromptDataset(all_rows, prompts_per_step=cfg.prompt_groups_per_step)
+        adam_params = tinker.AdamParams(learning_rate=cfg.learning_rate, **DEFAULT_ADAM)
+        server_loss_config = {"ratio_log_cap": cfg.ratio_log_cap}
+
+        sample_kwargs: dict[str, Any] = {
+            "max_tokens": cfg.max_completion_tokens,
+            "temperature": cfg.temperature,
+            "max_seq_len": infra.max_seq_len,
+            "http_timeout": cfg.deployment.sample_timeout,
+            "logprobs": True,
+        }
+
+        async def sample_one_prompt(row: dict) -> OPDPromptGroup | None:
+            messages = row.get("messages", [])
+            input_messages = prepare_sampling_messages(messages)
+            if not input_messages:
+                return None
+
+            try:
+                sampled = await student_sampler.sample_with_tokens(
+                    messages=input_messages,
+                    n=cfg.completions_per_prompt,
+                    **sample_kwargs,
+                )
+            except Exception as exc:
+                logger.warning("Student sampling failed: %s", exc)
+                return None
+
+            sampled = [s for s in sampled if len(s.full_tokens) >= 2]
+            if not sampled:
+                return None
+
+            teacher_scores = await asyncio.gather(
+                *[
+                    _score_with_teacher(
+                        teacher_sampler,
+                        s.full_tokens,
+                        top_logprobs=cfg.teacher_top_logprobs,
+                        http_timeout=cfg.deployment.sample_timeout,
+                    )
+                    for s in sampled
+                ]
+            )
+
+            policy_data: list[tinker.Datum] = []
+            teacher_logprobs: list[list[float]] = []
+            sampling_logprobs: list[list[float]] = []
+            rewards: list[float] = []
+            completion_lens: list[int] = []
+            truncated: list[bool] = []
+            prompt_len = sampled[0].prompt_len
+
+            for sample, teacher_lp in zip(sampled, teacher_scores, strict=True):
+                if teacher_lp is None:
+                    continue
+                if not sample.inference_logprobs:
+                    logger.warning("Skipping OPD sample without student inference logprobs")
+                    continue
+
+                tokens = sample.full_tokens
+                target_tokens = tokens[1:]
+                target_len = len(target_tokens)
+                aligned_sampling_lp = _align_completion_logprobs(
+                    list(sample.inference_logprobs),
+                    prompt_len=sample.prompt_len,
+                    target_len=target_len,
+                    echoed=getattr(sample, "logprobs_echoed", False),
+                )
+
+                policy_data.append(
+                    tinker.Datum(
+                        model_input=tinker.ModelInput.from_ints(tokens[:-1]),
+                        loss_fn_inputs={
+                            "target_tokens": tinker.TensorData(
+                                data=target_tokens,
+                                dtype="int64",
+                                shape=[target_len],
+                            ),
+                        },
+                    )
+                )
+                teacher_logprobs.append(teacher_lp[:target_len])
+                sampling_logprobs.append(aligned_sampling_lp)
+                rewards.append(0.0)
+                completion_lens.append(sample.completion_len)
+                truncated.append(sample.finish_reason == "length")
+
+            if not policy_data:
+                return None
+
+            return OPDPromptGroup(
+                data=policy_data,
+                teacher_logprobs=teacher_logprobs,
+                sampling_logprobs=sampling_logprobs,
+                prompt_len=prompt_len,
+                rewards=rewards,
+                completion_lens=completion_lens,
+                truncated=truncated,
+            )
+
+        def train_step(
+            step: int,
+            prompt_groups: list[OPDPromptGroup],
+            loop_stats: dict | None = None,
+        ) -> tuple[int, dict]:
+            if not prompt_groups:
+                raise ValueError("train_step requires at least one prompt group")
+
+            data, teacher_lp, prompt_lens, sampling_lp = combine_opd_prompt_groups(prompt_groups)
+            opd_datums, opd_input_metrics = build_opd_server_datums(
+                data,
+                teacher_lp,
+                sampling_lp,
+                prompt_lens,
+                loss_scale=cfg.opd_loss_scale,
+            )
+
+            t0 = _time.time()
+            with timer("fwd_bwd"):
+                fwd_bwd_result = policy.forward_backward(
+                    opd_datums,
+                    "importance_sampling",
+                    loss_fn_config=server_loss_config,
+                )
+            logger.info("[step %d] fwd_bwd: done (%.1fs)", step + 1, _time.time() - t0)
+
+            t0 = _time.time()
+            with timer("optim_step"):
+                optim_result = policy.optim_step(
+                    adam_params,
+                    grad_accumulation_normalization=cfg.grad_accumulation_normalization,
+                )
+            step += 1
+            logger.info("[step %d] optim_step: done (%.1fs)", step, _time.time() - t0)
+
+            rollouts_completed = step - step_offset
+            dcp_interval = cfg.weight_sync.dcp_save_interval
+            if dcp_interval > 0 and rollouts_completed > 0 and rollouts_completed % dcp_interval == 0:
+                data_consumed = (resume_info.data_consumed if resume_info else 0) + (
+                    rollouts_completed * cfg.prompt_groups_per_step
+                )
+                save_checkpoint(
+                    policy,
+                    f"step-{step}",
+                    cfg.log_path,
+                    {
+                        "step": step,
+                        "data_consumed": data_consumed,
+                        "source_job_id": policy_job_id,
+                    },
+                    kind=CheckpointKind.STATE,
+                    base_model=cfg.base_model,
+                    training_shape=infra.training_shape_id,
+                )
+
+            metrics: dict[str, Any] = dict(flush_timing())
+            metrics["train/step"] = step
+            for key, value in opd_input_metrics.items():
+                metrics[f"train/{key}"] = value
+
+            if fwd_bwd_result and hasattr(fwd_bwd_result, "metrics"):
+                for key, value in fwd_bwd_result.metrics.items():
+                    metrics[f"train/{key}"] = value
+            if optim_result and hasattr(optim_result, "metrics") and optim_result.metrics:
+                for key, value in optim_result.metrics.items():
+                    metrics[f"train/{key}"] = value
+
+            sampled_kl = metrics.get("train/opd_sampled_reverse_kl", 0.0)
+            active_tokens = int(metrics.get("train/opd_active_tokens", 0.0))
+            logger.info(
+                "Step %d | sampled reverse KL: %.4f | OPD advantage: %.4f | tokens=%d",
+                step,
+                sampled_kl,
+                metrics.get("train/opd_advantage", 0.0),
+                active_tokens,
+            )
+            log_metrics_json(
+                step,
+                opd_sampled_reverse_kl=sampled_kl,
+                opd_advantage=metrics.get("train/opd_advantage", 0.0),
+                active_tokens=active_tokens,
+            )
+            wandb_log(metrics, step)
+
+            total_steps = len(rl_dataset) - step_offset
+            runner.append_metrics(step, metrics, tokens=active_tokens)
+            runner.write_status(
+                RunStatus.RUNNING,
+                step=step,
+                total_steps=total_steps,
+                message="training",
+            )
+            runner.write_metadata()
+            return step, metrics
+
+        def _weight_sync(step: int) -> None:
+            logger.info("[step %d] weight_sync: saving + loading...", step)
+            t0 = _time.time()
+            with timer("weight_sync"):
+                weight_syncer.save_and_hotload(f"step-{step}")
+            logger.info("[step %d] weight_sync: done (%.1fs)", step, _time.time() - t0)
+
+        def _loop_metrics_callback(loop_metrics: dict) -> None:
+            cc_summary = concurrency_controller.step_completed()
+            for key, value in cc_summary.items():
+                loop_metrics[f"concurrency/{key}"] = value
+            wandb_log(loop_metrics, step=loop_metrics.get("train/step", 0))
+
+        remaining_rows = []
+        for i_step in range(step_offset, len(rl_dataset)):
+            remaining_rows.extend(rl_dataset.get_batch(i_step))
+
+        total_steps = len(rl_dataset) - step_offset
+        runner.start_training()
+        runner.write_status(RunStatus.RUNNING, total_steps=total_steps, message="training")
+
+        global_step = asyncio.run(
+            run_rl_loop(
+                sample_fns=(sample_one_prompt(row) for row in remaining_rows),
+                train_fns=TrainStepFns(train_step=train_step),
+                prompt_groups_per_step=cfg.prompt_groups_per_step,
+                global_step=step_offset,
+                metrics_callback=_loop_metrics_callback,
+                weight_sync_fn=_weight_sync if cfg.weight_sync.weight_sync_interval > 0 else None,
+                weight_sync_interval=cfg.weight_sync.weight_sync_interval,
+            )
+        )
+
+        if cfg.save_final_checkpoint and global_step > step_offset:
+            try:
+                checkpoint_name = f"step-{global_step}"
+                data_consumed = (resume_info.data_consumed if resume_info else 0) + (
+                    (global_step - step_offset) * cfg.prompt_groups_per_step
+                )
+                paths = save_checkpoint(
+                    policy,
+                    checkpoint_name,
+                    cfg.log_path,
+                    {
+                        "step": global_step,
+                        "data_consumed": data_consumed,
+                        "source_job_id": policy_job_id,
+                    },
+                    kind=CheckpointKind.BOTH,
+                    base_model=cfg.base_model,
+                    training_shape=infra.training_shape_id,
+                )
+                if cfg.output_model_id:
+                    rlor_mgr.promote_checkpoint(
+                        policy_job_id,
+                        paths["sampler_path"],
+                        cfg.output_model_id,
+                        cfg.base_model,
+                    )
+                    runner.write_output_model(
+                        model_id=cfg.output_model_id,
+                        checkpoint=checkpoint_name,
+                        job_id=policy_job_id,
+                    )
+            except Exception as exc:
+                logger.warning("Failed to save final checkpoint: %s", exc)
+
+        runner.write_status(
+            RunStatus.COMPLETED,
+            step=global_step,
+            total_steps=total_steps,
+            message="done",
+        )
+        runner.write_metadata()
+        logger.info("OPD training complete: %d steps", global_step)
+        wandb_finish()
+        return {"steps": global_step, "policy_job_id": policy_job_id}
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    cfg = Config(
+        log_path="./opd_logs",
+        base_model="accounts/fireworks/models/qwen3-8b",
+        teacher_model="accounts/fireworks/models/qwen3-235b-a22b",
+        deployment=DeployConfig(tokenizer_model="Qwen/Qwen3-8B"),
+    )
+    main(cfg)

--- a/training/recipes/opd_loop.py
+++ b/training/recipes/opd_loop.py
@@ -21,6 +21,8 @@ import os
 import signal
 import asyncio
 import logging
+import warnings
+import time as _time
 from contextlib import ExitStack
 from typing import Any
 from dataclasses import field, dataclass
@@ -68,9 +70,12 @@ from training.utils.rl import setup_infra
 from training.utils.rl.train import TrainStepFns, run_rl_loop
 from training.utils.timer import flush_timing, timer
 
-import time as _time
-
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
 
 
 @dataclass
@@ -79,6 +84,8 @@ class Config:
     """Directory for checkpoints and logs. Required, no default."""
 
     base_model: str = "accounts/fireworks/models/qwen3-8b"
+    """Student model ID. Matches the default used by ``rl_loop.py``."""
+
     rollout_base_model: str | None = None
     dataset: str = "https://raw.githubusercontent.com/eval-protocol/python-sdk/main/development/gsm8k_sample.jsonl"
 
@@ -104,24 +111,45 @@ class Config:
     epochs: int = 1
     max_rows: int = 100
     max_seq_len: int | None = None
+    """Max sequence length for sampling and training."""
+
     lora_rank: int = 0
+
     prompt_groups_per_step: int = 1
+    """Number of prompt groups per optimizer step."""
 
     grad_accumulation_normalization: GradAccNormalization | str | None = GradAccNormalization.NUM_LOSS_TOKENS
+    """Normalization mode for accumulated gradients at optim_step."""
 
     concurrency: ConcurrencyConfig = field(default_factory=ConcurrencyConfig)
+    """Concurrency control for inference sampling."""
+
     policy_job_id: str | None = None
+    """Pre-created RLOR policy trainer job ID (skip creation if set)."""
+
     init_from_checkpoint: str | None = None
+    """Load pretrained DCP weights on a fresh dataset."""
+
     warm_start_from_adapter: str | None = None
+    """GCS URI of an HF PEFT adapter directory for LoRA warm start."""
+
     output_model_id: str | None = None
     save_final_checkpoint: bool = True
+
     step_timeout: int = 0
+    """Timeout in seconds for forward_backward / optim_step calls."""
 
     infra: InfraConfig = field(default_factory=InfraConfig)
     deployment: DeployConfig = field(default_factory=DeployConfig)
     weight_sync: WeightSyncConfig = field(default_factory=WeightSyncConfig)
     wandb: WandBConfig = field(default_factory=lambda: WandBConfig(project="opd-tinker"))
     runner: RunnerConfig = field(default_factory=RunnerConfig)
+    """Optional orchestration outputs written during training."""
+
+
+# ---------------------------------------------------------------------------
+# Teacher/student logprob helpers
+# ---------------------------------------------------------------------------
 
 
 def _align_completion_logprobs(
@@ -204,15 +232,30 @@ async def _score_with_teacher(
     return _extract_scored_token_logprobs(response, target_len=target_len)
 
 
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
 def main(
     config: Config,
     rlor_mgr: TrainerJobManager | None = None,
     deploy_mgr: DeploymentManager | None = None,
     cancel_on_exit: bool = False,
+    cleanup_on_exit: bool | None = None,
 ):
+    if cleanup_on_exit is not None:
+        warnings.warn(
+            "opd_loop.main(cleanup_on_exit=...) is deprecated; use cancel_on_exit=...",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        cancel_on_exit = cleanup_on_exit
+
     cfg = config
     runner = RunnerIO(cfg.runner)
 
+    # Convert SIGTERM/SIGINT into exceptions so the finally block runs cleanup.
     def _signal_handler(signum, frame):
         name = signal.Signals(signum).name
         logger.warning("Received %s; raising SystemExit for cleanup", name)
@@ -242,17 +285,22 @@ def main(
             "Use the HuggingFace tokenizer that matches both student and teacher."
         )
 
+    completions_per_prompt = cfg.completions_per_prompt
+    prompt_groups_per_step = cfg.prompt_groups_per_step
+
     setup_wandb(
         cfg.wandb,
         {
             "teacher_model": cfg.teacher_model,
             "opd_loss_scale": cfg.opd_loss_scale,
             "ratio_log_cap": cfg.ratio_log_cap,
-            "completions_per_prompt": cfg.completions_per_prompt,
-            "prompt_groups_per_step": cfg.prompt_groups_per_step,
+            "completions_per_prompt": completions_per_prompt,
+            "prompt_groups_per_step": prompt_groups_per_step,
             "lr": cfg.learning_rate,
         },
     )
+
+    # -- Setup infrastructure -----------------------------------------------
 
     api_key = os.environ["FIREWORKS_API_KEY"]
     base_url = os.environ.get("FIREWORKS_BASE_URL", "https://api.fireworks.ai")
@@ -277,6 +325,8 @@ def main(
         runner.write_status(RunStatus.PENDING, message=msg)
 
     with runner, ResourceCleanup(rlor_mgr, deploy_mgr) as cleanup, ExitStack() as stack:
+        # Shapes + trainer + deployment + trainer clients. OPD does not need a
+        # reference trainer because teacher scores come from inference.
         infra = setup_infra(
             rlor_mgr=rlor_mgr,
             deploy_mgr=deploy_mgr,
@@ -315,6 +365,13 @@ def main(
             max_window=cfg.concurrency.max_window,
             prefill_queue_target=cfg.concurrency.prefill_queue_target,
         )
+        logger.info(
+            "Concurrency: adaptive (initial=%d, range=%d-%d, target_pq=%.2fs)",
+            initial_window,
+            cfg.concurrency.min_window,
+            cfg.concurrency.max_window,
+            cfg.concurrency.prefill_queue_target,
+        )
         student_sampler = DeploymentSampler(
             inference_url=deploy_mgr.inference_url,
             model=infra.inference_model,
@@ -341,9 +398,11 @@ def main(
         logger.info(
             "OPD training: teacher=%s | completions_per_prompt=%d | groups_per_step=%d",
             cfg.teacher_model,
-            cfg.completions_per_prompt,
-            cfg.prompt_groups_per_step,
+            completions_per_prompt,
+            prompt_groups_per_step,
         )
+
+        # -- Resume ---------------------------------------------------------------
 
         resume_info = resolve_resume(
             policy,
@@ -358,9 +417,11 @@ def main(
             name = f"resume-{step_offset}-base" if step_offset > 0 else "step-0-base"
             weight_syncer.save_and_hotload(name, checkpoint_type="base")
 
+        # -- Prepare sampling and training --------------------------------------
+
         raw_dataset = load_jsonl_dataset(cfg.dataset, cfg.max_rows)
         all_rows = raw_dataset * cfg.epochs
-        rl_dataset = RLPromptDataset(all_rows, prompts_per_step=cfg.prompt_groups_per_step)
+        rl_dataset = RLPromptDataset(all_rows, prompts_per_step=prompt_groups_per_step)
         adam_params = tinker.AdamParams(learning_rate=cfg.learning_rate, **DEFAULT_ADAM)
         server_loss_config = {"ratio_log_cap": cfg.ratio_log_cap}
 
@@ -372,7 +433,10 @@ def main(
             "logprobs": True,
         }
 
+        # -- Sample one prompt (VISIBLE -- customise this) ----------------------
+
         async def sample_one_prompt(row: dict) -> OPDPromptGroup | None:
+            """Sample student completions and score the same tokens with the teacher."""
             messages = row.get("messages", [])
             input_messages = prepare_sampling_messages(messages)
             if not input_messages:
@@ -381,7 +445,7 @@ def main(
             try:
                 sampled = await student_sampler.sample_with_tokens(
                     messages=input_messages,
-                    n=cfg.completions_per_prompt,
+                    n=completions_per_prompt,
                     **sample_kwargs,
                 )
             except Exception as exc:
@@ -460,6 +524,8 @@ def main(
                 truncated=truncated,
             )
 
+        # -- Training callbacks ----------------------------------------------------
+
         def train_step(
             step: int,
             prompt_groups: list[OPDPromptGroup],
@@ -499,7 +565,7 @@ def main(
             dcp_interval = cfg.weight_sync.dcp_save_interval
             if dcp_interval > 0 and rollouts_completed > 0 and rollouts_completed % dcp_interval == 0:
                 data_consumed = (resume_info.data_consumed if resume_info else 0) + (
-                    rollouts_completed * cfg.prompt_groups_per_step
+                    rollouts_completed * prompt_groups_per_step
                 )
                 save_checkpoint(
                     policy,
@@ -568,6 +634,8 @@ def main(
                 loop_metrics[f"concurrency/{key}"] = value
             wandb_log(loop_metrics, step=loop_metrics.get("train/step", 0))
 
+        # -- Run loop -------------------------------------------------------------
+
         remaining_rows = []
         for i_step in range(step_offset, len(rl_dataset)):
             remaining_rows.extend(rl_dataset.get_batch(i_step))
@@ -580,7 +648,7 @@ def main(
             run_rl_loop(
                 sample_fns=(sample_one_prompt(row) for row in remaining_rows),
                 train_fns=TrainStepFns(train_step=train_step),
-                prompt_groups_per_step=cfg.prompt_groups_per_step,
+                prompt_groups_per_step=prompt_groups_per_step,
                 global_step=step_offset,
                 metrics_callback=_loop_metrics_callback,
                 weight_sync_fn=_weight_sync if cfg.weight_sync.weight_sync_interval > 0 else None,
@@ -588,11 +656,13 @@ def main(
             )
         )
 
+        # -- Final checkpoint --------------------------------------------------
+
         if cfg.save_final_checkpoint and global_step > step_offset:
             try:
                 checkpoint_name = f"step-{global_step}"
                 data_consumed = (resume_info.data_consumed if resume_info else 0) + (
-                    (global_step - step_offset) * cfg.prompt_groups_per_step
+                    (global_step - step_offset) * prompt_groups_per_step
                 )
                 paths = save_checkpoint(
                     policy,
@@ -639,7 +709,10 @@ if __name__ == "__main__":
     cfg = Config(
         log_path="./opd_logs",
         base_model="accounts/fireworks/models/qwen3-8b",
-        teacher_model="accounts/fireworks/models/qwen3-235b-a22b",
+        teacher_model=os.environ.get("OPD_TEACHER_MODEL", ""),
+        infra=InfraConfig(
+            training_shape_id="accounts/fireworks/trainingShapes/qwen3-8b-128k-h200",
+        ),
         deployment=DeployConfig(tokenizer_model="Qwen/Qwen3-8B"),
     )
     main(cfg)

--- a/training/recipes/opd_loop.py
+++ b/training/recipes/opd_loop.py
@@ -22,9 +22,10 @@ import signal
 import asyncio
 import logging
 import warnings
+import re
 import time as _time
 from contextlib import ExitStack
-from typing import Any
+from typing import Any, Callable
 from dataclasses import field, dataclass
 
 import tinker
@@ -66,6 +67,26 @@ from training.utils.opd import (
     build_opd_server_datums,
     combine_opd_prompt_groups,
 )
+
+# Re-export the OPD eval helpers from the recipe module for existing examples.
+from training.utils.opd_eval import (  # noqa: F401
+    evaluate_teacher_trace_logprob_gap,
+    extract_final_answer,
+    expected_final_answer,
+    make_teacher_trace_logprob_gap_eval,
+    normalize_final_answer,
+    validate_opd_trace_result,
+    validate_privileged_opd_dataset,
+)
+from training.utils.opd_sampling import (
+    _align_completion_logprobs,
+    _align_response_logprobs,
+    _build_teacher_scoring_tokens,
+    _score_with_teacher,
+    _teacher_messages_for_row,
+    _tokenize_teacher_prompt,
+)
+from training.utils.infra import request_deployment, wait_deployment
 from training.utils.rl import setup_infra
 from training.utils.rl.train import TrainStepFns, run_rl_loop
 from training.utils.timer import flush_timing, timer
@@ -90,7 +111,19 @@ class Config:
     dataset: str = "https://raw.githubusercontent.com/eval-protocol/python-sdk/main/development/gsm8k_sample.jsonl"
 
     teacher_model: str = ""
-    """Teacher model/deployment ID on the same tokenizer as ``base_model``."""
+    """Teacher base model or deployment ID on the same tokenizer as ``base_model``."""
+
+    teacher_deployment_id: str | None = None
+    """Deployment ID to create/reuse when ``teacher_model`` is a base model."""
+
+    teacher_deployment_shape: str | None = None
+    """Optional teacher deployment shape. Defaults to the resolved student deployment shape."""
+
+    teacher_replica_count: int = 1
+    """Replica count for an auto-created frozen teacher deployment."""
+
+    teacher_deployment_timeout_s: float = 5400
+    """Timeout for an auto-created frozen teacher deployment to become ready."""
 
     teacher_inference_url: str | None = None
     """Optional inference base URL for the teacher. Defaults to FIREWORKS_BASE_URL."""
@@ -146,90 +179,144 @@ class Config:
     runner: RunnerConfig = field(default_factory=RunnerConfig)
     """Optional orchestration outputs written during training."""
 
+    post_training_eval: Callable[[dict[str, Any]], dict[str, Any]] | None = None
+    """Optional validation callback run after training/weight-sync and before cleanup."""
+
+    step_eval: Callable[[dict[str, Any]], dict[str, Any]] | None = None
+    """Optional validation callback run during training after synced weights are serving."""
+
+    step_eval_interval: int = 0
+    """Run ``step_eval`` every N synced optimizer steps. Disabled when <= 0."""
+
+    eval_before_training: bool = False
+    """Run ``step_eval`` once at step 0 before sampling starts."""
+
 
 # ---------------------------------------------------------------------------
-# Teacher/student logprob helpers
+# Teacher deployment helpers
 # ---------------------------------------------------------------------------
 
 
-def _align_completion_logprobs(
-    completion_logprobs: list[float],
+def _is_base_model_resource(model: str) -> bool:
+    return "/models/" in model and "/deployments/" not in model and "/deployedModels/" not in model
+
+
+def _default_teacher_deployment_id(base_model: str) -> str:
+    slug = base_model.rstrip("/").split("/")[-1]
+    safe_slug = re.sub(r"[^a-z0-9-]+", "-", slug.lower()).strip("-")
+    return f"opd-teacher-{safe_slug}"[:63]
+
+
+@dataclass(frozen=True)
+class _TeacherDeploymentRequest:
+    deployment_id: str
+    deploy_cfg: DeployConfig
+    info: Any
+
+
+def _request_frozen_teacher_deployment(
+    deploy_mgr: DeploymentManager,
     *,
-    prompt_len: int,
-    target_len: int,
-    echoed: bool,
-) -> list[float]:
-    """Align API completion logprobs to ``target_tokens`` length."""
-    if echoed:
-        aligned = list(completion_logprobs)
-    else:
-        response_start = max(0, prompt_len - 1)
-        aligned = [0.0] * response_start + list(completion_logprobs)
-
-    if len(aligned) < target_len:
-        aligned.extend([0.0] * (target_len - len(aligned)))
-    return aligned[:target_len]
-
-
-def _extract_scored_token_logprobs(
-    response: dict[str, Any],
-    *,
-    target_len: int,
-) -> list[float] | None:
-    """Extract echo logprobs for ``tokens[1:]`` from a completions response."""
-    choices = response.get("choices", [])
-    if not choices:
-        return None
-
-    logprobs = choices[0].get("logprobs")
-    if not isinstance(logprobs, dict):
-        return None
-
-    content = logprobs.get("content")
-    if not isinstance(content, list) or len(content) < 2:
-        return None
-
-    # Echo responses include an unconditional first-token logprob, then one
-    # logprob per next-token target.  A generated extra token may follow; trim it.
-    target_content = content[1 : 1 + target_len]
-    if len(target_content) < target_len:
-        return None
-    return [float(item.get("logprob", 0.0)) for item in target_content]
-
-
-async def _score_with_teacher(
-    sampler: DeploymentSampler,
-    token_ids: list[int],
-    *,
-    top_logprobs: int,
-    http_timeout: int,
-) -> list[float] | None:
-    """Score a full student sequence with the teacher deployment."""
-    target_len = max(0, len(token_ids) - 1)
-    if target_len == 0:
-        return None
-
-    request_kwargs: dict[str, Any] = {
-        "logprobs": True,
-        "echo": True,
-        "raw_output": True,
-        "http_timeout": http_timeout,
-    }
-    if top_logprobs > 0:
-        request_kwargs["top_logprobs"] = top_logprobs
-
-    try:
-        response, _metrics = await sampler.async_completions_stream(
-            prompt=token_ids,
-            max_tokens=1,
-            temperature=0.0,
-            **request_kwargs,
+    infra_cfg: InfraConfig,
+    base_model: str,
+    deployment_id: str,
+    deployment_shape: str | None,
+    replica_count: int,
+    cleanup: ResourceCleanup | None,
+) -> _TeacherDeploymentRequest:
+    """Request a frozen teacher deployment with the same helper path as RL rollouts."""
+    existing = deploy_mgr.get(deployment_id)
+    if existing is not None:
+        state = getattr(existing, "state", None)
+        if state in {"FAILED", "DELETED", "DELETING"}:
+            raise RuntimeError(
+                f"Teacher deployment {deployment_id!r} is in terminal state {state!r}. "
+                "Use a different teacher_deployment_id or restore/delete the old resource."
+            )
+        logger.info("Re-using frozen teacher deployment: %s", deployment_id)
+        deploy_cfg = DeployConfig(deployment_id=deployment_id)
+        return _TeacherDeploymentRequest(
+            deployment_id=deployment_id,
+            deploy_cfg=deploy_cfg,
+            info=existing,
         )
-    except Exception as exc:
-        logger.warning("Teacher scoring failed: %s", exc)
-        return None
 
-    return _extract_scored_token_logprobs(response, target_len=target_len)
+    deploy_cfg = DeployConfig(
+        deployment_id=deployment_id,
+        deployment_shape=deployment_shape,
+        enable_hot_load=False,
+        hot_load_bucket_type=None,
+        replica_count=replica_count,
+    )
+    info = request_deployment(deploy_mgr, deploy_cfg, base_model, infra_cfg)
+    if cleanup is not None:
+        cleanup.deployment(deployment_id, action="scale_to_zero")
+    logger.info("Requested frozen teacher deployment: %s", deployment_id)
+    return _TeacherDeploymentRequest(
+        deployment_id=deployment_id,
+        deploy_cfg=deploy_cfg,
+        info=info,
+    )
+
+
+def _wait_frozen_teacher_deployment(
+    deploy_mgr: DeploymentManager,
+    request: _TeacherDeploymentRequest,
+    *,
+    timeout_s: float,
+) -> str:
+    request.deploy_cfg.deployment_timeout_s = timeout_s
+    ready = wait_deployment(deploy_mgr, request.info, request.deploy_cfg)
+    return ready.inference_model or f"accounts/{deploy_mgr.account_id}/deployments/{request.deployment_id}"
+
+
+def _make_teacher_deployment_provisioner(
+    cfg: Config,
+    deploy_mgr: DeploymentManager,
+    *,
+    cleanup: ResourceCleanup | None,
+    model_out: dict[str, str],
+) -> Callable[[str | None], tuple[str, Callable[[], None]] | None]:
+    """Build a setup hook for an auto-created frozen teacher deployment."""
+
+    def _provision(resolved_deployment_shape: str | None) -> tuple[str, Callable[[], None]] | None:
+        if not _is_base_model_resource(cfg.teacher_model):
+            return None
+
+        deployment_id = cfg.teacher_deployment_id or _default_teacher_deployment_id(cfg.teacher_model)
+        deployment_shape = cfg.teacher_deployment_shape or resolved_deployment_shape
+        request = _request_frozen_teacher_deployment(
+            deploy_mgr,
+            infra_cfg=cfg.infra,
+            base_model=cfg.teacher_model,
+            deployment_id=deployment_id,
+            deployment_shape=deployment_shape,
+            replica_count=cfg.teacher_replica_count,
+            cleanup=cleanup,
+        )
+
+        def _wait_and_capture() -> None:
+            model_out["teacher_model"] = _wait_frozen_teacher_deployment(
+                deploy_mgr,
+                request,
+                timeout_s=cfg.teacher_deployment_timeout_s,
+            )
+
+        return "teacher_deployment", _wait_and_capture
+
+    return _provision
+
+
+def _resolve_teacher_model_for_scoring(
+    cfg: Config,
+    infra_teacher_model: str | None,
+) -> str:
+    """Resolve ``cfg.teacher_model`` to an inference target for frozen scoring."""
+    if not _is_base_model_resource(cfg.teacher_model):
+        return cfg.teacher_model
+    if not infra_teacher_model:
+        raise RuntimeError("OPD teacher deployment was not provisioned")
+    return infra_teacher_model
 
 
 # ---------------------------------------------------------------------------
@@ -325,6 +412,18 @@ def main(
         runner.write_status(RunStatus.PENDING, message=msg)
 
     with runner, ResourceCleanup(rlor_mgr, deploy_mgr) as cleanup, ExitStack() as stack:
+        teacher_provisioners = []
+        teacher_model_out: dict[str, str] = {}
+        if _is_base_model_resource(cfg.teacher_model):
+            teacher_provisioners.append(
+                _make_teacher_deployment_provisioner(
+                    cfg,
+                    deploy_mgr,
+                    cleanup=cleanup if cancel_on_exit else None,
+                    model_out=teacher_model_out,
+                )
+            )
+
         # Shapes + trainer + deployment + trainer clients. OPD does not need a
         # reference trainer because teacher scores come from inference.
         infra = setup_infra(
@@ -344,6 +443,7 @@ def main(
             api_key=api_key,
             cleanup=cleanup if cancel_on_exit else None,
             on_status=_on_trainer_status,
+            post_shape_provisioners=teacher_provisioners,
         )
         for closeable in infra.closeables:
             stack.callback(closeable.close)
@@ -379,9 +479,13 @@ def main(
             tokenizer=tokenizer,
             concurrency_controller=concurrency_controller,
         )
+        teacher_model = _resolve_teacher_model_for_scoring(
+            cfg,
+            teacher_model_out.get("teacher_model"),
+        )
         teacher_sampler = DeploymentSampler(
             inference_url=cfg.teacher_inference_url or base_url,
-            model=cfg.teacher_model,
+            model=teacher_model,
             api_key=api_key,
             tokenizer=tokenizer,
         )
@@ -397,7 +501,7 @@ def main(
 
         logger.info(
             "OPD training: teacher=%s | completions_per_prompt=%d | groups_per_step=%d",
-            cfg.teacher_model,
+            teacher_model,
             completions_per_prompt,
             prompt_groups_per_step,
         )
@@ -436,10 +540,17 @@ def main(
         # -- Sample one prompt (VISIBLE -- customise this) ----------------------
 
         async def sample_one_prompt(row: dict) -> OPDPromptGroup | None:
-            """Sample student completions and score the same tokens with the teacher."""
+            """Sample student completions and score them with the teacher prompt."""
             messages = row.get("messages", [])
             input_messages = prepare_sampling_messages(messages)
             if not input_messages:
+                return None
+            teacher_messages = _teacher_messages_for_row(row, input_messages)
+
+            try:
+                teacher_prompt_tokens = _tokenize_teacher_prompt(tokenizer, teacher_messages)
+            except Exception as exc:
+                logger.warning("Teacher prompt tokenization failed: %s", exc)
                 return None
 
             try:
@@ -456,17 +567,33 @@ def main(
             if not sampled:
                 return None
 
-            teacher_scores = await asyncio.gather(
-                *[
+            teacher_scores: list[list[float] | None] = [None] * len(sampled)
+            teacher_task_indices: list[int] = []
+            teacher_tasks = []
+            for idx, sample in enumerate(sampled):
+                teacher_scoring_tokens = _build_teacher_scoring_tokens(
+                    teacher_prompt_tokens,
+                    sample.full_tokens,
+                    student_prompt_len=sample.prompt_len,
+                )
+                if teacher_scoring_tokens is None:
+                    continue
+                scoring_tokens, response_len = teacher_scoring_tokens
+                teacher_task_indices.append(idx)
+                teacher_tasks.append(
                     _score_with_teacher(
                         teacher_sampler,
-                        s.full_tokens,
+                        scoring_tokens,
+                        prompt_len=len(teacher_prompt_tokens),
+                        response_len=response_len,
                         top_logprobs=cfg.teacher_top_logprobs,
                         http_timeout=cfg.deployment.sample_timeout,
                     )
-                    for s in sampled
-                ]
-            )
+                )
+            if teacher_tasks:
+                teacher_results = await asyncio.gather(*teacher_tasks)
+                for idx, teacher_lp in zip(teacher_task_indices, teacher_results, strict=True):
+                    teacher_scores[idx] = teacher_lp
 
             policy_data: list[tinker.Datum] = []
             teacher_logprobs: list[list[float]] = []
@@ -492,6 +619,17 @@ def main(
                     target_len=target_len,
                     echoed=getattr(sample, "logprobs_echoed", False),
                 )
+                if aligned_sampling_lp is None:
+                    logger.warning("Skipping OPD sample with incomplete student logprobs")
+                    continue
+                aligned_teacher_lp = _align_response_logprobs(
+                    teacher_lp,
+                    prompt_len=sample.prompt_len,
+                    target_len=target_len,
+                )
+                if aligned_teacher_lp is None:
+                    logger.warning("Skipping OPD sample with incomplete teacher logprobs")
+                    continue
 
                 policy_data.append(
                     tinker.Datum(
@@ -505,7 +643,7 @@ def main(
                         },
                     )
                 )
-                teacher_logprobs.append(teacher_lp[:target_len])
+                teacher_logprobs.append(aligned_teacher_lp)
                 sampling_logprobs.append(aligned_sampling_lp)
                 rewards.append(0.0)
                 completion_lens.append(sample.completion_len)
@@ -523,6 +661,67 @@ def main(
                 completion_lens=completion_lens,
                 truncated=truncated,
             )
+
+        # -- Eval callbacks --------------------------------------------------------
+
+        latest_eval_metrics: dict[str, Any] = {}
+
+        def _eval_context(step: int) -> dict[str, Any]:
+            return {
+                "config": cfg,
+                "dataset": raw_dataset,
+                "student_sampler": student_sampler,
+                "teacher_sampler": teacher_sampler,
+                "student_model": infra.inference_model,
+                "teacher_model": teacher_model,
+                "tokenizer": tokenizer,
+                "global_step": step,
+                "max_seq_len": infra.max_seq_len,
+            }
+
+        def _run_eval_callback(
+            callback: Callable[[dict[str, Any]], dict[str, Any]],
+            *,
+            step: int,
+            phase: str,
+        ) -> dict[str, Any]:
+            logger.info("[step %d] %s eval: starting...", step, phase)
+            t0 = _time.time()
+            metrics = callback(_eval_context(step)) or {}
+            logger.info("[step %d] %s eval: done (%.1fs)", step, phase, _time.time() - t0)
+            if metrics:
+                runner.append_metrics(step, metrics)
+                wandb_log(metrics, step)
+                fixed_gap = metrics.get("eval/opd_fixed_target_student_minus_teacher_nll")
+                abs_gap = metrics.get("eval/opd_fixed_target_abs_logprob_gap")
+                if fixed_gap is not None or abs_gap is not None:
+                    logger.info(
+                        "[step %d] eval logprob gap: student-teacher NLL=%s | abs=%s",
+                        step,
+                        f"{float(fixed_gap):.4f}" if fixed_gap is not None else "n/a",
+                        f"{float(abs_gap):.4f}" if abs_gap is not None else "n/a",
+                    )
+                trace_gap = metrics.get("eval/opd_trace_student_minus_teacher_nll")
+                trace_final_gap = metrics.get("eval/opd_trace_final_student_minus_teacher_nll")
+                student_gen_acc = metrics.get("eval/opd_trace_student_generation_accuracy")
+                if trace_gap is not None or trace_final_gap is not None or student_gen_acc is not None:
+                    logger.info(
+                        "[step %d] eval teacher-trace gap: full=%s | final=%s | student_gen_acc=%s",
+                        step,
+                        f"{float(trace_gap):.4f}" if trace_gap is not None else "n/a",
+                        f"{float(trace_final_gap):.4f}" if trace_final_gap is not None else "n/a",
+                        f"{float(student_gen_acc):.3f}" if student_gen_acc is not None else "n/a",
+                    )
+            return metrics
+
+        def _run_step_eval(step: int, *, phase: str) -> None:
+            nonlocal latest_eval_metrics
+            if cfg.step_eval is None:
+                return
+            latest_eval_metrics = _run_eval_callback(cfg.step_eval, step=step, phase=phase)
+
+        if cfg.eval_before_training and cfg.step_eval is not None:
+            _run_step_eval(step_offset, phase="pre-training")
 
         # -- Training callbacks ----------------------------------------------------
 
@@ -627,6 +826,12 @@ def main(
             with timer("weight_sync"):
                 weight_syncer.save_and_hotload(f"step-{step}")
             logger.info("[step %d] weight_sync: done (%.1fs)", step, _time.time() - t0)
+            if (
+                cfg.step_eval is not None
+                and cfg.step_eval_interval > 0
+                and step % cfg.step_eval_interval == 0
+            ):
+                _run_step_eval(step, phase="post-sync")
 
         def _loop_metrics_callback(loop_metrics: dict) -> None:
             cc_summary = concurrency_controller.step_completed()
@@ -692,6 +897,14 @@ def main(
             except Exception as exc:
                 logger.warning("Failed to save final checkpoint: %s", exc)
 
+        eval_metrics: dict[str, Any] = dict(latest_eval_metrics)
+        if cfg.post_training_eval is not None:
+            eval_metrics = _run_eval_callback(
+                cfg.post_training_eval,
+                step=global_step,
+                phase="post-training",
+            )
+
         runner.write_status(
             RunStatus.COMPLETED,
             step=global_step,
@@ -701,7 +914,14 @@ def main(
         runner.write_metadata()
         logger.info("OPD training complete: %d steps", global_step)
         wandb_finish()
-        return {"steps": global_step, "policy_job_id": policy_job_id}
+        return {
+            "steps": global_step,
+            "policy_job_id": policy_job_id,
+            "eval": eval_metrics,
+            "max_seq_len": infra.max_seq_len,
+            "training_shape_id": infra.training_shape_id,
+            "deployment_shape": infra.deployment_shape,
+        }
 
 
 if __name__ == "__main__":

--- a/training/recipes/opd_loop.py
+++ b/training/recipes/opd_loop.py
@@ -22,9 +22,10 @@ import signal
 import asyncio
 import logging
 import warnings
+import re
 import time as _time
 from contextlib import ExitStack
-from typing import Any
+from typing import Any, Callable
 from dataclasses import field, dataclass
 
 import tinker
@@ -55,17 +56,32 @@ from training.utils import (
     wandb_finish,
     wandb_log,
 )
-from training.utils.checkpoint_utils import (
-    CheckpointKind,
-    resolve_resume,
-    save_checkpoint,
-    validate_warm_start_config,
-)
+from training.utils.checkpoints import TrainingCheckpoints, validate_warm_start_config
 from training.utils.opd import (
     OPDPromptGroup,
     build_opd_server_datums,
     combine_opd_prompt_groups,
 )
+
+# Re-export the OPD eval helpers from the recipe module for existing examples.
+from training.utils.opd_eval import (  # noqa: F401
+    evaluate_teacher_trace_logprob_gap,
+    extract_final_answer,
+    expected_final_answer,
+    make_teacher_trace_logprob_gap_eval,
+    normalize_final_answer,
+    validate_opd_trace_result,
+    validate_privileged_opd_dataset,
+)
+from training.utils.opd_sampling import (
+    _align_completion_logprobs,
+    _align_response_logprobs,
+    _build_teacher_scoring_tokens,
+    _score_with_teacher,
+    _teacher_messages_for_row,
+    _tokenize_teacher_prompt,
+)
+from training.utils.infra import request_deployment, wait_deployment
 from training.utils.rl import setup_infra
 from training.utils.rl.train import TrainStepFns, run_rl_loop
 from training.utils.timer import flush_timing, timer
@@ -90,7 +106,19 @@ class Config:
     dataset: str = "https://raw.githubusercontent.com/eval-protocol/python-sdk/main/development/gsm8k_sample.jsonl"
 
     teacher_model: str = ""
-    """Teacher model/deployment ID on the same tokenizer as ``base_model``."""
+    """Teacher base model or deployment ID on the same tokenizer as ``base_model``."""
+
+    teacher_deployment_id: str | None = None
+    """Deployment ID to create/reuse when ``teacher_model`` is a base model."""
+
+    teacher_deployment_shape: str | None = None
+    """Optional teacher deployment shape. Defaults to the resolved student deployment shape."""
+
+    teacher_replica_count: int = 1
+    """Replica count for an auto-created frozen teacher deployment."""
+
+    teacher_deployment_timeout_s: float = 5400
+    """Timeout for an auto-created frozen teacher deployment to become ready."""
 
     teacher_inference_url: str | None = None
     """Optional inference base URL for the teacher. Defaults to FIREWORKS_BASE_URL."""
@@ -146,90 +174,144 @@ class Config:
     runner: RunnerConfig = field(default_factory=RunnerConfig)
     """Optional orchestration outputs written during training."""
 
+    post_training_eval: Callable[[dict[str, Any]], dict[str, Any]] | None = None
+    """Optional validation callback run after training/weight-sync and before cleanup."""
+
+    step_eval: Callable[[dict[str, Any]], dict[str, Any]] | None = None
+    """Optional validation callback run during training after synced weights are serving."""
+
+    step_eval_interval: int = 0
+    """Run ``step_eval`` every N synced optimizer steps. Disabled when <= 0."""
+
+    eval_before_training: bool = False
+    """Run ``step_eval`` once at step 0 before sampling starts."""
+
 
 # ---------------------------------------------------------------------------
-# Teacher/student logprob helpers
+# Teacher deployment helpers
 # ---------------------------------------------------------------------------
 
 
-def _align_completion_logprobs(
-    completion_logprobs: list[float],
+def _is_base_model_resource(model: str) -> bool:
+    return "/models/" in model and "/deployments/" not in model and "/deployedModels/" not in model
+
+
+def _default_teacher_deployment_id(base_model: str) -> str:
+    slug = base_model.rstrip("/").split("/")[-1]
+    safe_slug = re.sub(r"[^a-z0-9-]+", "-", slug.lower()).strip("-")
+    return f"opd-teacher-{safe_slug}"[:63]
+
+
+@dataclass(frozen=True)
+class _TeacherDeploymentRequest:
+    deployment_id: str
+    deploy_cfg: DeployConfig
+    info: Any
+
+
+def _request_frozen_teacher_deployment(
+    deploy_mgr: DeploymentManager,
     *,
-    prompt_len: int,
-    target_len: int,
-    echoed: bool,
-) -> list[float]:
-    """Align API completion logprobs to ``target_tokens`` length."""
-    if echoed:
-        aligned = list(completion_logprobs)
-    else:
-        response_start = max(0, prompt_len - 1)
-        aligned = [0.0] * response_start + list(completion_logprobs)
-
-    if len(aligned) < target_len:
-        aligned.extend([0.0] * (target_len - len(aligned)))
-    return aligned[:target_len]
-
-
-def _extract_scored_token_logprobs(
-    response: dict[str, Any],
-    *,
-    target_len: int,
-) -> list[float] | None:
-    """Extract echo logprobs for ``tokens[1:]`` from a completions response."""
-    choices = response.get("choices", [])
-    if not choices:
-        return None
-
-    logprobs = choices[0].get("logprobs")
-    if not isinstance(logprobs, dict):
-        return None
-
-    content = logprobs.get("content")
-    if not isinstance(content, list) or len(content) < 2:
-        return None
-
-    # Echo responses include an unconditional first-token logprob, then one
-    # logprob per next-token target.  A generated extra token may follow; trim it.
-    target_content = content[1 : 1 + target_len]
-    if len(target_content) < target_len:
-        return None
-    return [float(item.get("logprob", 0.0)) for item in target_content]
-
-
-async def _score_with_teacher(
-    sampler: DeploymentSampler,
-    token_ids: list[int],
-    *,
-    top_logprobs: int,
-    http_timeout: int,
-) -> list[float] | None:
-    """Score a full student sequence with the teacher deployment."""
-    target_len = max(0, len(token_ids) - 1)
-    if target_len == 0:
-        return None
-
-    request_kwargs: dict[str, Any] = {
-        "logprobs": True,
-        "echo": True,
-        "raw_output": True,
-        "http_timeout": http_timeout,
-    }
-    if top_logprobs > 0:
-        request_kwargs["top_logprobs"] = top_logprobs
-
-    try:
-        response, _metrics = await sampler.async_completions_stream(
-            prompt=token_ids,
-            max_tokens=1,
-            temperature=0.0,
-            **request_kwargs,
+    infra_cfg: InfraConfig,
+    base_model: str,
+    deployment_id: str,
+    deployment_shape: str | None,
+    replica_count: int,
+    cleanup: ResourceCleanup | None,
+) -> _TeacherDeploymentRequest:
+    """Request a frozen teacher deployment with the same helper path as RL rollouts."""
+    existing = deploy_mgr.get(deployment_id)
+    if existing is not None:
+        state = getattr(existing, "state", None)
+        if state in {"FAILED", "DELETED", "DELETING"}:
+            raise RuntimeError(
+                f"Teacher deployment {deployment_id!r} is in terminal state {state!r}. "
+                "Use a different teacher_deployment_id or restore/delete the old resource."
+            )
+        logger.info("Re-using frozen teacher deployment: %s", deployment_id)
+        deploy_cfg = DeployConfig(deployment_id=deployment_id)
+        return _TeacherDeploymentRequest(
+            deployment_id=deployment_id,
+            deploy_cfg=deploy_cfg,
+            info=existing,
         )
-    except Exception as exc:
-        logger.warning("Teacher scoring failed: %s", exc)
-        return None
 
-    return _extract_scored_token_logprobs(response, target_len=target_len)
+    deploy_cfg = DeployConfig(
+        deployment_id=deployment_id,
+        deployment_shape=deployment_shape,
+        enable_hot_load=False,
+        hot_load_bucket_type=None,
+        replica_count=replica_count,
+    )
+    info = request_deployment(deploy_mgr, deploy_cfg, base_model, infra_cfg)
+    if cleanup is not None:
+        cleanup.deployment(deployment_id, action="scale_to_zero")
+    logger.info("Requested frozen teacher deployment: %s", deployment_id)
+    return _TeacherDeploymentRequest(
+        deployment_id=deployment_id,
+        deploy_cfg=deploy_cfg,
+        info=info,
+    )
+
+
+def _wait_frozen_teacher_deployment(
+    deploy_mgr: DeploymentManager,
+    request: _TeacherDeploymentRequest,
+    *,
+    timeout_s: float,
+) -> str:
+    request.deploy_cfg.deployment_timeout_s = timeout_s
+    ready = wait_deployment(deploy_mgr, request.info, request.deploy_cfg)
+    return ready.inference_model or f"accounts/{deploy_mgr.account_id}/deployments/{request.deployment_id}"
+
+
+def _make_teacher_deployment_provisioner(
+    cfg: Config,
+    deploy_mgr: DeploymentManager,
+    *,
+    cleanup: ResourceCleanup | None,
+    model_out: dict[str, str],
+) -> Callable[[str | None], tuple[str, Callable[[], None]] | None]:
+    """Build a setup hook for an auto-created frozen teacher deployment."""
+
+    def _provision(resolved_deployment_shape: str | None) -> tuple[str, Callable[[], None]] | None:
+        if not _is_base_model_resource(cfg.teacher_model):
+            return None
+
+        deployment_id = cfg.teacher_deployment_id or _default_teacher_deployment_id(cfg.teacher_model)
+        deployment_shape = cfg.teacher_deployment_shape or resolved_deployment_shape
+        request = _request_frozen_teacher_deployment(
+            deploy_mgr,
+            infra_cfg=cfg.infra,
+            base_model=cfg.teacher_model,
+            deployment_id=deployment_id,
+            deployment_shape=deployment_shape,
+            replica_count=cfg.teacher_replica_count,
+            cleanup=cleanup,
+        )
+
+        def _wait_and_capture() -> None:
+            model_out["teacher_model"] = _wait_frozen_teacher_deployment(
+                deploy_mgr,
+                request,
+                timeout_s=cfg.teacher_deployment_timeout_s,
+            )
+
+        return "teacher_deployment", _wait_and_capture
+
+    return _provision
+
+
+def _resolve_teacher_model_for_scoring(
+    cfg: Config,
+    infra_teacher_model: str | None,
+) -> str:
+    """Resolve ``cfg.teacher_model`` to an inference target for frozen scoring."""
+    if not _is_base_model_resource(cfg.teacher_model):
+        return cfg.teacher_model
+    if not infra_teacher_model:
+        raise RuntimeError("OPD teacher deployment was not provisioned")
+    return infra_teacher_model
 
 
 # ---------------------------------------------------------------------------
@@ -325,6 +407,18 @@ def main(
         runner.write_status(RunStatus.PENDING, message=msg)
 
     with runner, ResourceCleanup(rlor_mgr, deploy_mgr) as cleanup, ExitStack() as stack:
+        teacher_provisioners = []
+        teacher_model_out: dict[str, str] = {}
+        if _is_base_model_resource(cfg.teacher_model):
+            teacher_provisioners.append(
+                _make_teacher_deployment_provisioner(
+                    cfg,
+                    deploy_mgr,
+                    cleanup=cleanup if cancel_on_exit else None,
+                    model_out=teacher_model_out,
+                )
+            )
+
         # Shapes + trainer + deployment + trainer clients. OPD does not need a
         # reference trainer because teacher scores come from inference.
         infra = setup_infra(
@@ -344,6 +438,7 @@ def main(
             api_key=api_key,
             cleanup=cleanup if cancel_on_exit else None,
             on_status=_on_trainer_status,
+            post_shape_provisioners=teacher_provisioners,
         )
         for closeable in infra.closeables:
             stack.callback(closeable.close)
@@ -379,9 +474,13 @@ def main(
             tokenizer=tokenizer,
             concurrency_controller=concurrency_controller,
         )
+        teacher_model = _resolve_teacher_model_for_scoring(
+            cfg,
+            teacher_model_out.get("teacher_model"),
+        )
         teacher_sampler = DeploymentSampler(
             inference_url=cfg.teacher_inference_url or base_url,
-            model=cfg.teacher_model,
+            model=teacher_model,
             api_key=api_key,
             tokenizer=tokenizer,
         )
@@ -394,21 +493,26 @@ def main(
             first_checkpoint_type=cfg.weight_sync.first_checkpoint_type,
             lora_rank=cfg.lora_rank,
         )
+        ckpt = TrainingCheckpoints(
+            policy,
+            rlor_mgr,
+            trainer_id=policy_job_id,
+            log_path=cfg.log_path,
+            lora_rank=cfg.lora_rank,
+        )
 
         logger.info(
             "OPD training: teacher=%s | completions_per_prompt=%d | groups_per_step=%d",
-            cfg.teacher_model,
+            teacher_model,
             completions_per_prompt,
             prompt_groups_per_step,
         )
 
         # -- Resume ---------------------------------------------------------------
 
-        resume_info = resolve_resume(
-            policy,
-            cfg.log_path,
-            cfg.init_from_checkpoint,
-            cfg.warm_start_from_adapter,
+        resume_info = ckpt.resume(
+            init_from_checkpoint=cfg.init_from_checkpoint,
+            warm_start_from_adapter=cfg.warm_start_from_adapter,
         )
         step_offset = resume_info.step if resume_info else 0
         wandb_log({"train/step": step_offset}, step_offset)
@@ -436,10 +540,17 @@ def main(
         # -- Sample one prompt (VISIBLE -- customise this) ----------------------
 
         async def sample_one_prompt(row: dict) -> OPDPromptGroup | None:
-            """Sample student completions and score the same tokens with the teacher."""
+            """Sample student completions and score them with the teacher prompt."""
             messages = row.get("messages", [])
             input_messages = prepare_sampling_messages(messages)
             if not input_messages:
+                return None
+            teacher_messages = _teacher_messages_for_row(row, input_messages)
+
+            try:
+                teacher_prompt_tokens = _tokenize_teacher_prompt(tokenizer, teacher_messages)
+            except Exception as exc:
+                logger.warning("Teacher prompt tokenization failed: %s", exc)
                 return None
 
             try:
@@ -456,17 +567,33 @@ def main(
             if not sampled:
                 return None
 
-            teacher_scores = await asyncio.gather(
-                *[
+            teacher_scores: list[list[float] | None] = [None] * len(sampled)
+            teacher_task_indices: list[int] = []
+            teacher_tasks = []
+            for idx, sample in enumerate(sampled):
+                teacher_scoring_tokens = _build_teacher_scoring_tokens(
+                    teacher_prompt_tokens,
+                    sample.full_tokens,
+                    student_prompt_len=sample.prompt_len,
+                )
+                if teacher_scoring_tokens is None:
+                    continue
+                scoring_tokens, response_len = teacher_scoring_tokens
+                teacher_task_indices.append(idx)
+                teacher_tasks.append(
                     _score_with_teacher(
                         teacher_sampler,
-                        s.full_tokens,
+                        scoring_tokens,
+                        prompt_len=len(teacher_prompt_tokens),
+                        response_len=response_len,
                         top_logprobs=cfg.teacher_top_logprobs,
                         http_timeout=cfg.deployment.sample_timeout,
                     )
-                    for s in sampled
-                ]
-            )
+                )
+            if teacher_tasks:
+                teacher_results = await asyncio.gather(*teacher_tasks)
+                for idx, teacher_lp in zip(teacher_task_indices, teacher_results, strict=True):
+                    teacher_scores[idx] = teacher_lp
 
             policy_data: list[tinker.Datum] = []
             teacher_logprobs: list[list[float]] = []
@@ -492,6 +619,17 @@ def main(
                     target_len=target_len,
                     echoed=getattr(sample, "logprobs_echoed", False),
                 )
+                if aligned_sampling_lp is None:
+                    logger.warning("Skipping OPD sample with incomplete student logprobs")
+                    continue
+                aligned_teacher_lp = _align_response_logprobs(
+                    teacher_lp,
+                    prompt_len=sample.prompt_len,
+                    target_len=target_len,
+                )
+                if aligned_teacher_lp is None:
+                    logger.warning("Skipping OPD sample with incomplete teacher logprobs")
+                    continue
 
                 policy_data.append(
                     tinker.Datum(
@@ -505,7 +643,7 @@ def main(
                         },
                     )
                 )
-                teacher_logprobs.append(teacher_lp[:target_len])
+                teacher_logprobs.append(aligned_teacher_lp)
                 sampling_logprobs.append(aligned_sampling_lp)
                 rewards.append(0.0)
                 completion_lens.append(sample.completion_len)
@@ -523,6 +661,67 @@ def main(
                 completion_lens=completion_lens,
                 truncated=truncated,
             )
+
+        # -- Eval callbacks --------------------------------------------------------
+
+        latest_eval_metrics: dict[str, Any] = {}
+
+        def _eval_context(step: int) -> dict[str, Any]:
+            return {
+                "config": cfg,
+                "dataset": raw_dataset,
+                "student_sampler": student_sampler,
+                "teacher_sampler": teacher_sampler,
+                "student_model": infra.inference_model,
+                "teacher_model": teacher_model,
+                "tokenizer": tokenizer,
+                "global_step": step,
+                "max_seq_len": infra.max_seq_len,
+            }
+
+        def _run_eval_callback(
+            callback: Callable[[dict[str, Any]], dict[str, Any]],
+            *,
+            step: int,
+            phase: str,
+        ) -> dict[str, Any]:
+            logger.info("[step %d] %s eval: starting...", step, phase)
+            t0 = _time.time()
+            metrics = callback(_eval_context(step)) or {}
+            logger.info("[step %d] %s eval: done (%.1fs)", step, phase, _time.time() - t0)
+            if metrics:
+                runner.append_metrics(step, metrics)
+                wandb_log(metrics, step)
+                fixed_gap = metrics.get("eval/opd_fixed_target_student_minus_teacher_nll")
+                abs_gap = metrics.get("eval/opd_fixed_target_abs_logprob_gap")
+                if fixed_gap is not None or abs_gap is not None:
+                    logger.info(
+                        "[step %d] eval logprob gap: student-teacher NLL=%s | abs=%s",
+                        step,
+                        f"{float(fixed_gap):.4f}" if fixed_gap is not None else "n/a",
+                        f"{float(abs_gap):.4f}" if abs_gap is not None else "n/a",
+                    )
+                trace_gap = metrics.get("eval/opd_trace_student_minus_teacher_nll")
+                trace_final_gap = metrics.get("eval/opd_trace_final_student_minus_teacher_nll")
+                student_gen_acc = metrics.get("eval/opd_trace_student_generation_accuracy")
+                if trace_gap is not None or trace_final_gap is not None or student_gen_acc is not None:
+                    logger.info(
+                        "[step %d] eval teacher-trace gap: full=%s | final=%s | student_gen_acc=%s",
+                        step,
+                        f"{float(trace_gap):.4f}" if trace_gap is not None else "n/a",
+                        f"{float(trace_final_gap):.4f}" if trace_final_gap is not None else "n/a",
+                        f"{float(student_gen_acc):.3f}" if student_gen_acc is not None else "n/a",
+                    )
+            return metrics
+
+        def _run_step_eval(step: int, *, phase: str) -> None:
+            nonlocal latest_eval_metrics
+            if cfg.step_eval is None:
+                return
+            latest_eval_metrics = _run_eval_callback(cfg.step_eval, step=step, phase=phase)
+
+        if cfg.eval_before_training and cfg.step_eval is not None:
+            _run_step_eval(step_offset, phase="pre-training")
 
         # -- Training callbacks ----------------------------------------------------
 
@@ -567,18 +766,11 @@ def main(
                 data_consumed = (resume_info.data_consumed if resume_info else 0) + (
                     rollouts_completed * prompt_groups_per_step
                 )
-                save_checkpoint(
-                    policy,
+                ckpt.save(
                     f"step-{step}",
-                    cfg.log_path,
-                    {
-                        "step": step,
-                        "data_consumed": data_consumed,
-                        "source_job_id": policy_job_id,
-                    },
-                    kind=CheckpointKind.STATE,
-                    base_model=cfg.base_model,
-                    training_shape=infra.training_shape_id,
+                    resumable=True,
+                    promotable=False,
+                    data_consumed=data_consumed,
                 )
 
             metrics: dict[str, Any] = dict(flush_timing())
@@ -627,6 +819,12 @@ def main(
             with timer("weight_sync"):
                 weight_syncer.save_and_hotload(f"step-{step}")
             logger.info("[step %d] weight_sync: done (%.1fs)", step, _time.time() - t0)
+            if (
+                cfg.step_eval is not None
+                and cfg.step_eval_interval > 0
+                and step % cfg.step_eval_interval == 0
+            ):
+                _run_step_eval(step, phase="post-sync")
 
         def _loop_metrics_callback(loop_metrics: dict) -> None:
             cc_summary = concurrency_controller.step_completed()
@@ -664,26 +862,14 @@ def main(
                 data_consumed = (resume_info.data_consumed if resume_info else 0) + (
                     (global_step - step_offset) * prompt_groups_per_step
                 )
-                paths = save_checkpoint(
-                    policy,
+                ckpt.save(
                     checkpoint_name,
-                    cfg.log_path,
-                    {
-                        "step": global_step,
-                        "data_consumed": data_consumed,
-                        "source_job_id": policy_job_id,
-                    },
-                    kind=CheckpointKind.BOTH,
-                    base_model=cfg.base_model,
-                    training_shape=infra.training_shape_id,
+                    resumable=True,
+                    promotable=True,
+                    data_consumed=data_consumed,
                 )
                 if cfg.output_model_id:
-                    rlor_mgr.promote_checkpoint(
-                        policy_job_id,
-                        paths["sampler_path"],
-                        cfg.output_model_id,
-                        cfg.base_model,
-                    )
+                    ckpt.promote_latest(cfg.output_model_id, cfg.base_model)
                     runner.write_output_model(
                         model_id=cfg.output_model_id,
                         checkpoint=checkpoint_name,
@@ -691,6 +877,14 @@ def main(
                     )
             except Exception as exc:
                 logger.warning("Failed to save final checkpoint: %s", exc)
+
+        eval_metrics: dict[str, Any] = dict(latest_eval_metrics)
+        if cfg.post_training_eval is not None:
+            eval_metrics = _run_eval_callback(
+                cfg.post_training_eval,
+                step=global_step,
+                phase="post-training",
+            )
 
         runner.write_status(
             RunStatus.COMPLETED,
@@ -701,7 +895,14 @@ def main(
         runner.write_metadata()
         logger.info("OPD training complete: %d steps", global_step)
         wandb_finish()
-        return {"steps": global_step, "policy_job_id": policy_job_id}
+        return {
+            "steps": global_step,
+            "policy_job_id": policy_job_id,
+            "eval": eval_metrics,
+            "max_seq_len": infra.max_seq_len,
+            "training_shape_id": infra.training_shape_id,
+            "deployment_shape": infra.deployment_shape,
+        }
 
 
 if __name__ == "__main__":

--- a/training/tests/test_smoke_imports.py
+++ b/training/tests/test_smoke_imports.py
@@ -21,6 +21,7 @@ import pytest
 RECIPE_MODULES = [
     "training.recipes.sft_loop",
     "training.recipes.rl_loop",
+    "training.recipes.opd_loop",
     "training.recipes.dpo_loop",
     "training.recipes.orpo_loop",
 ]
@@ -40,6 +41,7 @@ UTIL_MODULES = [
     "training.utils.data",
     "training.utils.infra",
     "training.utils.losses",
+    "training.utils.opd",
     "training.utils.logging",
     "training.utils.checkpoint_utils",
     "training.utils.timer",
@@ -176,6 +178,13 @@ def test_rl_config_defaults():
     from training.recipes.rl_loop import Config
 
     cfg = Config(log_path="/tmp/test")
+    assert cfg.base_model
+
+
+def test_opd_config_defaults():
+    from training.recipes.opd_loop import Config
+
+    cfg = Config(log_path="/tmp/test", teacher_model="accounts/fireworks/models/qwen3-235b-a22b")
     assert cfg.base_model
 
 

--- a/training/tests/test_smoke_imports.py
+++ b/training/tests/test_smoke_imports.py
@@ -21,6 +21,7 @@ import pytest
 RECIPE_MODULES = [
     "training.recipes.sft_loop",
     "training.recipes.rl_loop",
+    "training.recipes.opd_loop",
     "training.recipes.dpo_loop",
     "training.recipes.orpo_loop",
 ]
@@ -40,6 +41,7 @@ UTIL_MODULES = [
     "training.utils.data",
     "training.utils.infra",
     "training.utils.losses",
+    "training.utils.opd",
     "training.utils.logging",
     "training.utils.checkpoints",
     "training.utils.timer",
@@ -177,6 +179,13 @@ def test_rl_config_defaults():
     from training.recipes.rl_loop import Config
 
     cfg = Config(log_path="/tmp/test")
+    assert cfg.base_model
+
+
+def test_opd_config_defaults():
+    from training.recipes.opd_loop import Config
+
+    cfg = Config(log_path="/tmp/test", teacher_model="accounts/fireworks/models/qwen3-235b-a22b")
     assert cfg.base_model
 
 

--- a/training/tests/unit/test_infra.py
+++ b/training/tests/unit/test_infra.py
@@ -21,46 +21,33 @@ def test_deploy_config_omits_region_for_shape_backed_deployments():
     assert config.region is None
 
 
-def test_setup_deployment_omits_placement_for_shape_backed_create():
+def test_setup_deployment_omits_placement_for_shape_backed_create(monkeypatch):
     captured = {}
 
-    class FakeResponse:
-        def __init__(self, payload=None):
-            self._payload = payload or {"name": "accounts/acct/deployments/dep-123", "state": "CREATING"}
+    class FakeShapeVersions:
+        def list(self, **kwargs):
+            captured["shape_list_kwargs"] = kwargs
+            return [SimpleNamespace(model_dump=lambda by_alias=True: {"snapshot": {}})]
 
-        def raise_for_status(self):
-            return None
+    class FakeFireworks:
+        def __init__(self, **kwargs):
+            captured["client_kwargs"] = kwargs
+            self.deployment_shape_versions = FakeShapeVersions()
 
-        def json(self):
-            return self._payload
+    monkeypatch.setattr("training.utils.infra.Fireworks", FakeFireworks)
 
     class FakeMgr:
         account_id = "acct"
+        api_key = "fake-api-key"
+        base_url = "https://api.fireworks.ai"
+        additional_headers = None
 
         def get(self, _deployment_id):
             return None
 
-        def _get(self, path, timeout):
-            captured["shape_path"] = path
-            captured["shape_timeout"] = timeout
-            return FakeResponse(
-                {
-                    "deploymentShapeVersions": [
-                        {
-                            "snapshot": {},
-                        }
-                    ]
-                }
-            )
-
-        def _post(self, path, json, timeout):
-            captured["path"] = path
-            captured["json"] = json
-            captured["timeout"] = timeout
-            return FakeResponse()
-
-        def _parse_deployment_info(self, deployment_id, data):
-            return SimpleNamespace(deployment_id=deployment_id, state=data["state"])
+        def create_or_get(self, config):
+            captured["config"] = config
+            return SimpleNamespace(deployment_id=config.deployment_id, state="CREATING")
 
         def wait_for_ready(self, deployment_id, timeout_s):
             return SimpleNamespace(deployment_id=deployment_id, state="READY")
@@ -76,43 +63,46 @@ def test_setup_deployment_omits_placement_for_shape_backed_create():
     )
 
     assert info.state == "READY"
-    assert captured["shape_timeout"] == 30
-    assert captured["timeout"] == 60
-    assert captured["json"]["deploymentShape"] == "accounts/fireworks/deploymentShapes/rft-kimi-k2p5-v2"
-    assert "placement" not in captured["json"]
+    assert captured["shape_list_kwargs"] == {
+        "account_id": "fireworks",
+        "deployment_shape_id": "rft-kimi-k2p5-v2",
+        "filter": "latest_validated=true",
+        "page_size": 1,
+        "timeout": 30,
+    }
+    assert captured["config"].deployment_shape == "accounts/fireworks/deploymentShapes/rft-kimi-k2p5-v2"
+    assert captured["config"].region is None
 
 
-def test_setup_deployment_infers_ohio_for_b200_shape():
+def test_setup_deployment_infers_ohio_for_b200_shape(monkeypatch):
     captured = {}
 
-    class FakeResponse:
-        def __init__(self, payload):
-            self._payload = payload
+    class FakeShapeVersions:
+        def list(self, **kwargs):
+            captured["shape_list_kwargs"] = kwargs
+            return [
+                SimpleNamespace(
+                    model_dump=lambda by_alias=True: {
+                        "snapshot": {"acceleratorType": "NVIDIA_B200_180GB"}
+                    }
+                )
+            ]
 
-        def raise_for_status(self):
-            return None
+    class FakeFireworks:
+        def __init__(self, **kwargs):
+            captured["client_kwargs"] = kwargs
+            self.deployment_shape_versions = FakeShapeVersions()
 
-        def json(self):
-            return self._payload
+    monkeypatch.setattr("training.utils.infra.Fireworks", FakeFireworks)
 
     class FakeMgr:
         account_id = "acct"
+        api_key = "fake-api-key"
+        base_url = "https://api.fireworks.ai"
+        additional_headers = None
 
         def get(self, _deployment_id):
             return None
-
-        def _get(self, path, timeout):
-            captured["shape_path"] = path
-            captured["shape_timeout"] = timeout
-            return FakeResponse(
-                {
-                    "deploymentShapeVersions": [
-                        {
-                            "snapshot": {"acceleratorType": "NVIDIA_B200_180GB"},
-                        }
-                    ]
-                }
-            )
 
         def create_or_get(self, config):
             captured["config"] = config
@@ -129,41 +119,38 @@ def test_setup_deployment_infers_ohio_for_b200_shape():
     )
 
     assert info.state == "READY"
-    assert captured["shape_timeout"] == 30
-    assert captured["shape_path"].startswith(
-        "/v1/accounts/fireworks/deploymentShapes/rft-kimi-k2p5-v2/versions?"
-    )
-    assert "pageSize=1" in captured["shape_path"]
+    assert captured["shape_list_kwargs"]["deployment_shape_id"] == "rft-kimi-k2p5-v2"
+    assert captured["shape_list_kwargs"]["page_size"] == 1
     assert captured["config"].region == "US_OHIO_1"
 
 
-def test_setup_deployment_infers_virginia_for_versioned_h200_shape():
+def test_setup_deployment_infers_virginia_for_versioned_h200_shape(monkeypatch):
     captured = {}
 
-    class FakeResponse:
-        def __init__(self, payload):
-            self._payload = payload
+    class FakeShapeVersions:
+        def get(self, **kwargs):
+            captured["shape_get_kwargs"] = kwargs
+            return SimpleNamespace(
+                model_dump=lambda by_alias=True: {
+                    "snapshot": {"acceleratorType": "NVIDIA_H200_141GB"}
+                }
+            )
 
-        def raise_for_status(self):
-            return None
+    class FakeFireworks:
+        def __init__(self, **kwargs):
+            captured["client_kwargs"] = kwargs
+            self.deployment_shape_versions = FakeShapeVersions()
 
-        def json(self):
-            return self._payload
+    monkeypatch.setattr("training.utils.infra.Fireworks", FakeFireworks)
 
     class FakeMgr:
         account_id = "acct"
+        api_key = "fake-api-key"
+        base_url = "https://api.fireworks.ai"
+        additional_headers = None
 
         def get(self, _deployment_id):
             return None
-
-        def _get(self, path, timeout):
-            captured["shape_path"] = path
-            captured["shape_timeout"] = timeout
-            return FakeResponse(
-                {
-                    "snapshot": {"acceleratorType": "NVIDIA_H200_141GB"},
-                }
-            )
 
         def create_or_get(self, config):
             captured["config"] = config
@@ -180,8 +167,12 @@ def test_setup_deployment_infers_virginia_for_versioned_h200_shape():
     )
 
     assert info.state == "READY"
-    assert captured["shape_path"] == "/v1/accounts/fireworks/deploymentShapes/qwen-h200/versions/rv1"
-    assert captured["shape_timeout"] == 30
+    assert captured["shape_get_kwargs"] == {
+        "account_id": "fireworks",
+        "deployment_shape_id": "qwen-h200",
+        "version_id": "rv1",
+        "timeout": 30,
+    }
     assert captured["config"].region == "US_VIRGINIA_1"
 
 

--- a/training/tests/unit/test_infra.py
+++ b/training/tests/unit/test_infra.py
@@ -22,37 +22,29 @@ def test_deploy_config_omits_region_for_shape_backed_deployments():
     assert config.region is None
 
 
-def test_setup_deployment_omits_placement_for_shape_backed_create():
+def test_setup_deployment_omits_placement_for_shape_backed_create(monkeypatch):
     captured = {}
 
-    class FakeResponse:
-        def __init__(self, payload=None):
-            self._payload = payload or {"name": "accounts/acct/deployments/dep-123", "state": "CREATING"}
+    class FakeShapeVersions:
+        def list(self, **kwargs):
+            captured["shape_list_kwargs"] = kwargs
+            return [SimpleNamespace(model_dump=lambda by_alias=True: {"snapshot": {}})]
 
-        def raise_for_status(self):
-            return None
+    class FakeFireworks:
+        def __init__(self, **kwargs):
+            captured["client_kwargs"] = kwargs
+            self.deployment_shape_versions = FakeShapeVersions()
 
-        def json(self):
-            return self._payload
+    monkeypatch.setattr("training.utils.infra.Fireworks", FakeFireworks)
 
     class FakeMgr:
         account_id = "acct"
+        api_key = "fake-api-key"
+        base_url = "https://api.fireworks.ai"
+        additional_headers = None
 
         def get(self, _deployment_id):
             return None
-
-        def _get(self, path, timeout):
-            captured["shape_path"] = path
-            captured["shape_timeout"] = timeout
-            return FakeResponse(
-                {
-                    "deploymentShapeVersions": [
-                        {
-                            "snapshot": {},
-                        }
-                    ]
-                }
-            )
 
         def create_or_get(self, config):
             captured["config"] = config
@@ -72,42 +64,46 @@ def test_setup_deployment_omits_placement_for_shape_backed_create():
     )
 
     assert info.state == "READY"
-    assert captured["shape_timeout"] == 30
+    assert captured["shape_list_kwargs"] == {
+        "account_id": "fireworks",
+        "deployment_shape_id": "rft-kimi-k2p5-v2",
+        "filter": "latest_validated=true",
+        "page_size": 1,
+        "timeout": 30,
+    }
     assert captured["config"].deployment_shape == "accounts/fireworks/deploymentShapes/rft-kimi-k2p5-v2"
-    assert captured["config"].accelerator_type is None
+    assert captured["config"].region is None
 
 
-def test_setup_deployment_infers_ohio_for_b200_shape():
+def test_setup_deployment_infers_ohio_for_b200_shape(monkeypatch):
     captured = {}
 
-    class FakeResponse:
-        def __init__(self, payload):
-            self._payload = payload
+    class FakeShapeVersions:
+        def list(self, **kwargs):
+            captured["shape_list_kwargs"] = kwargs
+            return [
+                SimpleNamespace(
+                    model_dump=lambda by_alias=True: {
+                        "snapshot": {"acceleratorType": "NVIDIA_B200_180GB"}
+                    }
+                )
+            ]
 
-        def raise_for_status(self):
-            return None
+    class FakeFireworks:
+        def __init__(self, **kwargs):
+            captured["client_kwargs"] = kwargs
+            self.deployment_shape_versions = FakeShapeVersions()
 
-        def json(self):
-            return self._payload
+    monkeypatch.setattr("training.utils.infra.Fireworks", FakeFireworks)
 
     class FakeMgr:
         account_id = "acct"
+        api_key = "fake-api-key"
+        base_url = "https://api.fireworks.ai"
+        additional_headers = None
 
         def get(self, _deployment_id):
             return None
-
-        def _get(self, path, timeout):
-            captured["shape_path"] = path
-            captured["shape_timeout"] = timeout
-            return FakeResponse(
-                {
-                    "deploymentShapeVersions": [
-                        {
-                            "snapshot": {"acceleratorType": "NVIDIA_B200_180GB"},
-                        }
-                    ]
-                }
-            )
 
         def create_or_get(self, config):
             captured["config"] = config
@@ -124,41 +120,38 @@ def test_setup_deployment_infers_ohio_for_b200_shape():
     )
 
     assert info.state == "READY"
-    assert captured["shape_timeout"] == 30
-    assert captured["shape_path"].startswith(
-        "/v1/accounts/fireworks/deploymentShapes/rft-kimi-k2p5-v2/versions?"
-    )
-    assert "pageSize=1" in captured["shape_path"]
+    assert captured["shape_list_kwargs"]["deployment_shape_id"] == "rft-kimi-k2p5-v2"
+    assert captured["shape_list_kwargs"]["page_size"] == 1
     assert captured["config"].region == "US_OHIO_1"
 
 
-def test_setup_deployment_infers_virginia_for_versioned_h200_shape():
+def test_setup_deployment_infers_virginia_for_versioned_h200_shape(monkeypatch):
     captured = {}
 
-    class FakeResponse:
-        def __init__(self, payload):
-            self._payload = payload
+    class FakeShapeVersions:
+        def get(self, **kwargs):
+            captured["shape_get_kwargs"] = kwargs
+            return SimpleNamespace(
+                model_dump=lambda by_alias=True: {
+                    "snapshot": {"acceleratorType": "NVIDIA_H200_141GB"}
+                }
+            )
 
-        def raise_for_status(self):
-            return None
+    class FakeFireworks:
+        def __init__(self, **kwargs):
+            captured["client_kwargs"] = kwargs
+            self.deployment_shape_versions = FakeShapeVersions()
 
-        def json(self):
-            return self._payload
+    monkeypatch.setattr("training.utils.infra.Fireworks", FakeFireworks)
 
     class FakeMgr:
         account_id = "acct"
+        api_key = "fake-api-key"
+        base_url = "https://api.fireworks.ai"
+        additional_headers = None
 
         def get(self, _deployment_id):
             return None
-
-        def _get(self, path, timeout):
-            captured["shape_path"] = path
-            captured["shape_timeout"] = timeout
-            return FakeResponse(
-                {
-                    "snapshot": {"acceleratorType": "NVIDIA_H200_141GB"},
-                }
-            )
 
         def create_or_get(self, config):
             captured["config"] = config
@@ -175,8 +168,12 @@ def test_setup_deployment_infers_virginia_for_versioned_h200_shape():
     )
 
     assert info.state == "READY"
-    assert captured["shape_path"] == "/v1/accounts/fireworks/deploymentShapes/qwen-h200/versions/rv1"
-    assert captured["shape_timeout"] == 30
+    assert captured["shape_get_kwargs"] == {
+        "account_id": "fireworks",
+        "deployment_shape_id": "qwen-h200",
+        "version_id": "rv1",
+        "timeout": 30,
+    }
     assert captured["config"].region == "US_VIRGINIA_1"
 
 

--- a/training/tests/unit/test_infra_setup.py
+++ b/training/tests/unit/test_infra_setup.py
@@ -520,6 +520,91 @@ def test_parallel_request_phase_precedes_wait_phase(monkeypatch):
     )
 
 
+def test_auxiliary_provisioner_waits_with_trainers_and_deployment(monkeypatch):
+    """Auxiliary resources request before waits and wait in the shared pool."""
+    _FakeClient.instances = []
+    events: list[str] = []
+    auxiliary_result = {}
+    sleep_s = 0.05
+
+    def fake_request_trainer(_rlor, *, display_name, **kwargs):
+        events.append(f"request:{display_name}")
+        return _trainer_handle("policy-job")
+
+    def fake_wait_trainer(_rlor, created, *, display_name="", **kwargs):
+        events.append(f"wait_start:{display_name}")
+        time.sleep(sleep_s)
+        events.append(f"wait_done:{display_name}")
+        return _trainer_ep(getattr(created, "job_id", "policy-job"))
+
+    def fake_request_deployment(_deploy, deploy_cfg, _base_model, _infra):
+        events.append("request:student-deployment")
+        return SimpleNamespace(
+            deployment_id=deploy_cfg.deployment_id,
+            state="CREATING",
+            inference_model="student-model",
+        )
+
+    def fake_wait_deployment(_deploy, info, _deploy_cfg):
+        events.append("wait_start:student-deployment")
+        time.sleep(sleep_s)
+        events.append("wait_done:student-deployment")
+        return SimpleNamespace(
+            deployment_id=info.deployment_id,
+            state="READY",
+            inference_model="student-model",
+        )
+
+    def provision_teacher(resolved_deployment_shape: str | None):
+        events.append(f"request:teacher-deployment:{resolved_deployment_shape}")
+
+        def wait_teacher():
+            events.append("wait_start:teacher-deployment")
+            time.sleep(sleep_s)
+            events.append("wait_done:teacher-deployment")
+            auxiliary_result["teacher_deployment"] = "teacher-model"
+
+        return "teacher_deployment", wait_teacher
+
+    monkeypatch.setattr(infra_setup_mod, "request_trainer_job", fake_request_trainer)
+    monkeypatch.setattr(infra_setup_mod, "wait_trainer_job", fake_wait_trainer)
+    monkeypatch.setattr(infra_setup_mod, "request_deployment", fake_request_deployment)
+    monkeypatch.setattr(infra_setup_mod, "wait_deployment", fake_wait_deployment)
+    monkeypatch.setattr(infra_setup_mod, "ReconnectableClient", _FakeClient)
+    monkeypatch.setattr(
+        infra_setup_mod, "auto_select_training_shape",
+        lambda _rlor, **kw: f"auto-{kw['trainer_role']}",
+    )
+
+    rlor, deploy = _make_mgrs(profile=_profile(dep_shape="ds-v1"))
+    deploy.get.return_value = None
+    cfg = _make_cfg(lora_rank=0, deployment_id="dep-1")
+
+    infra = setup_infra(
+        rlor_mgr=rlor, deploy_mgr=deploy,
+        base_model=cfg.base_model,
+        infra_cfg=cfg.infra,
+        deploy_cfg=cfg.deployment,
+        lora_rank=cfg.lora_rank,
+        max_seq_len=cfg.max_seq_len,
+        learning_rate=cfg.learning_rate,
+        step_timeout=cfg.step_timeout,
+        policy_job_id=cfg.policy_job_id,
+        reference_job_id=cfg.reference_job_id,
+        needs_reference=False, needs_inference=True,
+        role_prefix="opd", api_key="key",
+        post_shape_provisioners=[provision_teacher],
+    )
+
+    assert infra.inference_model == "student-model"
+    assert auxiliary_result["teacher_deployment"] == "teacher-model"
+    request_indices = [i for i, event in enumerate(events) if event.startswith("request:")]
+    wait_start_indices = [i for i, event in enumerate(events) if event.startswith("wait_start:")]
+    wait_done_indices = [i for i, event in enumerate(events) if event.startswith("wait_done:")]
+    assert max(request_indices) < min(wait_start_indices), events
+    assert max(wait_start_indices) < min(wait_done_indices), events
+
+
 def test_parallel_wait_timing(monkeypatch):
     """Both trainer waits run in parallel; elapsed grows by ~SLEEP_S, not 2×.
 

--- a/training/tests/unit/test_infra_setup.py
+++ b/training/tests/unit/test_infra_setup.py
@@ -590,6 +590,91 @@ def test_parallel_request_phase_precedes_wait_phase(monkeypatch):
     )
 
 
+def test_auxiliary_provisioner_waits_with_trainers_and_deployment(monkeypatch):
+    """Auxiliary resources request before waits and wait in the shared pool."""
+    _FakeClient.instances = []
+    events: list[str] = []
+    auxiliary_result = {}
+    sleep_s = 0.05
+
+    def fake_request_trainer(_rlor, *, display_name, **kwargs):
+        events.append(f"request:{display_name}")
+        return _trainer_handle("policy-job")
+
+    def fake_wait_trainer(_rlor, created, *, display_name="", **kwargs):
+        events.append(f"wait_start:{display_name}")
+        time.sleep(sleep_s)
+        events.append(f"wait_done:{display_name}")
+        return _trainer_ep(getattr(created, "job_id", "policy-job"))
+
+    def fake_request_deployment(_deploy, deploy_cfg, _base_model, _infra):
+        events.append("request:student-deployment")
+        return SimpleNamespace(
+            deployment_id=deploy_cfg.deployment_id,
+            state="CREATING",
+            inference_model="student-model",
+        )
+
+    def fake_wait_deployment(_deploy, info, _deploy_cfg):
+        events.append("wait_start:student-deployment")
+        time.sleep(sleep_s)
+        events.append("wait_done:student-deployment")
+        return SimpleNamespace(
+            deployment_id=info.deployment_id,
+            state="READY",
+            inference_model="student-model",
+        )
+
+    def provision_teacher(resolved_deployment_shape: str | None):
+        events.append(f"request:teacher-deployment:{resolved_deployment_shape}")
+
+        def wait_teacher():
+            events.append("wait_start:teacher-deployment")
+            time.sleep(sleep_s)
+            events.append("wait_done:teacher-deployment")
+            auxiliary_result["teacher_deployment"] = "teacher-model"
+
+        return "teacher_deployment", wait_teacher
+
+    monkeypatch.setattr(infra_setup_mod, "request_trainer_job", fake_request_trainer)
+    monkeypatch.setattr(infra_setup_mod, "wait_trainer_job", fake_wait_trainer)
+    monkeypatch.setattr(infra_setup_mod, "request_deployment", fake_request_deployment)
+    monkeypatch.setattr(infra_setup_mod, "wait_deployment", fake_wait_deployment)
+    monkeypatch.setattr(infra_setup_mod, "ReconnectableClient", _FakeClient)
+    monkeypatch.setattr(
+        infra_setup_mod, "auto_select_training_shape",
+        lambda _rlor, **kw: f"auto-{kw['trainer_role']}",
+    )
+
+    rlor, deploy = _make_mgrs(profile=_profile(dep_shape="ds-v1"))
+    deploy.get.return_value = None
+    cfg = _make_cfg(lora_rank=0, deployment_id="dep-1")
+
+    infra = setup_infra(
+        rlor_mgr=rlor, deploy_mgr=deploy,
+        base_model=cfg.base_model,
+        infra_cfg=cfg.infra,
+        deploy_cfg=cfg.deployment,
+        lora_rank=cfg.lora_rank,
+        max_seq_len=cfg.max_seq_len,
+        learning_rate=cfg.learning_rate,
+        step_timeout=cfg.step_timeout,
+        policy_job_id=cfg.policy_job_id,
+        reference_job_id=cfg.reference_job_id,
+        needs_reference=False, needs_inference=True,
+        role_prefix="opd", api_key="key",
+        post_shape_provisioners=[provision_teacher],
+    )
+
+    assert infra.inference_model == "student-model"
+    assert auxiliary_result["teacher_deployment"] == "teacher-model"
+    request_indices = [i for i, event in enumerate(events) if event.startswith("request:")]
+    wait_start_indices = [i for i, event in enumerate(events) if event.startswith("wait_start:")]
+    wait_done_indices = [i for i, event in enumerate(events) if event.startswith("wait_done:")]
+    assert max(request_indices) < min(wait_start_indices), events
+    assert max(wait_start_indices) < min(wait_done_indices), events
+
+
 def test_parallel_wait_timing(monkeypatch):
     """Both trainer waits enter before either one returns."""
     _FakeClient.instances = []

--- a/training/tests/unit/test_opd.py
+++ b/training/tests/unit/test_opd.py
@@ -1,0 +1,219 @@
+"""Unit tests for sampled-token OPD helpers."""
+
+from __future__ import annotations
+
+from math import exp
+
+import pytest
+import tinker
+
+from training.recipes.opd_loop import (
+    _align_completion_logprobs,
+    _extract_scored_token_logprobs,
+)
+from training.utils.opd import (
+    OPDPromptGroup,
+    build_opd_server_datums,
+    combine_opd_prompt_groups,
+)
+
+
+def _server_importance_sampling_loss(
+    current_logprobs: list[float],
+    sampling_logprobs: list[float],
+    advantages: list[float],
+) -> float:
+    return -sum(
+        exp(current_lp - sampling_lp) * advantage
+        for current_lp, sampling_lp, advantage in zip(
+            current_logprobs,
+            sampling_logprobs,
+            advantages,
+            strict=True,
+        )
+    )
+
+
+def _datum(
+    *,
+    tokens: list[int] | None = None,
+    loss_mask: list[float] | None = None,
+) -> tinker.Datum:
+    if tokens is None:
+        tokens = [10, 11, 12, 13, 14]
+    target_tokens = tokens[1:]
+    inputs = {
+        "target_tokens": tinker.TensorData(
+            data=target_tokens,
+            dtype="int64",
+            shape=[len(target_tokens)],
+        ),
+    }
+    if loss_mask is not None:
+        inputs["loss_mask"] = tinker.TensorData(
+            data=loss_mask,
+            dtype="float32",
+            shape=[len(loss_mask)],
+        )
+
+    return tinker.Datum(
+        model_input=tinker.ModelInput.from_ints(tokens[:-1]),
+        loss_fn_inputs=inputs,
+    )
+
+
+def test_build_opd_server_datums_encodes_teacher_minus_sampling_advantages() -> None:
+    datum = _datum()
+    teacher_lp = [[-9.0, -0.2, -1.0, -0.3]]
+    sampling_lp = [[-8.0, -0.5, -0.8, -0.7]]
+
+    server_datums, metrics = build_opd_server_datums(
+        [datum],
+        teacher_lp,
+        sampling_lp,
+        prompt_lens=[2],
+        loss_scale=2.0,
+    )
+
+    inputs = server_datums[0].loss_fn_inputs
+    assert inputs["target_tokens"].data == [11, 12, 13, 14]
+    assert inputs["logprobs"].data == sampling_lp[0]
+    assert inputs["advantages"].data == pytest.approx([0.0, 0.6, -0.4, 0.8])
+    assert metrics["opd_active_tokens"] == pytest.approx(3.0)
+    assert metrics["opd_sampled_reverse_kl"] == pytest.approx((-0.3 + 0.2 - 0.4) / 3)
+    assert metrics["opd_advantage"] == pytest.approx((0.6 - 0.4 + 0.8) / 3)
+
+
+def test_opd_datums_make_server_loss_equal_sampled_reverse_kl_at_rollout_policy() -> None:
+    datum = _datum()
+    teacher_lp = [[-9.0, -0.2, -1.0, -0.3]]
+    sampling_lp = [[-8.0, -0.5, -0.8, -0.7]]
+
+    server_datums, _metrics = build_opd_server_datums(
+        [datum],
+        teacher_lp,
+        sampling_lp,
+        prompt_lens=[2],
+    )
+
+    inputs = server_datums[0].loss_fn_inputs
+    old_lp = inputs["logprobs"].data
+    advantages = inputs["advantages"].data
+    loss = _server_importance_sampling_loss(old_lp, old_lp, advantages)
+
+    active_positions = [1, 2, 3]
+    expected_sampled_reverse_kl = sum(
+        sampling_lp[0][pos] - teacher_lp[0][pos] for pos in active_positions
+    )
+    assert loss == pytest.approx(expected_sampled_reverse_kl)
+
+    pos = 1
+    eps = 1e-6
+    plus_lp = list(old_lp)
+    minus_lp = list(old_lp)
+    plus_lp[pos] += eps
+    minus_lp[pos] -= eps
+    finite_difference_grad = (
+        _server_importance_sampling_loss(plus_lp, old_lp, advantages)
+        - _server_importance_sampling_loss(minus_lp, old_lp, advantages)
+    ) / (2 * eps)
+    assert finite_difference_grad == pytest.approx(sampling_lp[0][pos] - teacher_lp[0][pos])
+
+
+def test_build_opd_server_datums_folds_loss_mask_into_advantages() -> None:
+    datum = _datum(loss_mask=[1.0, 1.0, 0.0, 1.0])
+
+    server_datums, metrics = build_opd_server_datums(
+        [datum],
+        teacher_logprobs=[[-1.0, -0.1, -0.1, -0.1]],
+        sampling_logprobs=[[-1.0, -0.5, -0.5, -0.5]],
+        prompt_lens=[2],
+    )
+
+    assert server_datums[0].loss_fn_inputs["advantages"].data == pytest.approx(
+        [0.0, 0.4, 0.0, 0.4]
+    )
+    assert metrics["opd_active_tokens"] == pytest.approx(2.0)
+
+
+def test_combine_opd_prompt_groups_uses_explicit_teacher_and_sampling_fields() -> None:
+    datum = _datum()
+    group = OPDPromptGroup(
+        data=[datum],
+        teacher_logprobs=[[-0.1, -0.2, -0.3, -0.4]],
+        sampling_logprobs=[[-0.5, -0.6, -0.7, -0.8]],
+        prompt_len=2,
+        rewards=[0.0],
+    )
+
+    data, teacher_logprobs, prompt_lens, sampling_logprobs = combine_opd_prompt_groups([group])
+
+    assert data == [datum]
+    assert teacher_logprobs == group.teacher_logprobs
+    assert prompt_lens == [2]
+    assert sampling_logprobs == group.sampling_logprobs
+
+
+def test_combine_opd_prompt_groups_rejects_mismatched_teacher_scores() -> None:
+    group = OPDPromptGroup(
+        data=[_datum()],
+        teacher_logprobs=[],
+        sampling_logprobs=[[-0.5, -0.6, -0.7, -0.8]],
+        prompt_len=2,
+        rewards=[0.0],
+    )
+
+    with pytest.raises(ValueError, match="teacher_logprobs length"):
+        combine_opd_prompt_groups([group])
+
+
+def test_build_opd_server_datums_rejects_mismatched_inputs() -> None:
+    with pytest.raises(ValueError, match="teacher_logprobs must have length 1"):
+        build_opd_server_datums(
+            [_datum()],
+            teacher_logprobs=[],
+            sampling_logprobs=[[-0.1, -0.2, -0.3, -0.4]],
+            prompt_lens=[2],
+        )
+
+
+def test_align_completion_logprobs_pads_prompt_prefix_for_non_echo_generation() -> None:
+    aligned = _align_completion_logprobs(
+        [-0.4, -0.5],
+        prompt_len=3,
+        target_len=4,
+        echoed=False,
+    )
+
+    assert aligned == [0.0, 0.0, -0.4, -0.5]
+
+
+def test_align_completion_logprobs_trims_echoed_logprobs() -> None:
+    aligned = _align_completion_logprobs(
+        [-0.1, -0.2, -0.3, -0.4, -0.5],
+        prompt_len=3,
+        target_len=4,
+        echoed=True,
+    )
+
+    assert aligned == [-0.1, -0.2, -0.3, -0.4]
+
+
+def test_extract_scored_token_logprobs_drops_unconditional_and_extra_token() -> None:
+    response = {
+        "choices": [
+            {
+                "logprobs": {
+                    "content": [
+                        {"logprob": 0.0},
+                        {"logprob": -0.1},
+                        {"logprob": -0.2},
+                        {"logprob": -0.3},
+                        {"logprob": -99.0},
+                    ],
+                },
+            }
+        ]
+    }
+
+    assert _extract_scored_token_logprobs(response, target_len=3) == [-0.1, -0.2, -0.3]

--- a/training/tests/unit/test_opd.py
+++ b/training/tests/unit/test_opd.py
@@ -3,19 +3,97 @@
 from __future__ import annotations
 
 from math import exp
+from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 import tinker
+from fireworks import omit
 
 from training.recipes.opd_loop import (
-    _align_completion_logprobs,
-    _extract_scored_token_logprobs,
+    Config,
+    _default_teacher_deployment_id,
+    _is_base_model_resource,
+    _make_teacher_deployment_provisioner,
+    _request_frozen_teacher_deployment,
 )
+from training.utils.opd_eval import (
+    evaluate_teacher_trace_logprob_gap,
+    extract_final_answer,
+    expected_final_answer,
+    make_teacher_trace_logprob_gap_eval,
+    normalize_final_answer,
+    validate_privileged_opd_dataset,
+    validate_opd_trace_result,
+)
+from training.utils.opd_sampling import (
+    _align_completion_logprobs,
+    _align_response_logprobs,
+    _build_teacher_scoring_tokens,
+    _extract_scored_token_logprobs,
+    _slice_response_logprobs,
+    _teacher_messages_for_row,
+    _tokenize_teacher_prompt,
+)
+from training.utils import DeployConfig, InfraConfig, RunnerConfig, WeightSyncConfig
 from training.utils.opd import (
     OPDPromptGroup,
     build_opd_server_datums,
     combine_opd_prompt_groups,
 )
+MAX_CONTEXT_LEN = 262_144
+
+
+def _build_qwen_opd_config(
+    *,
+    training_shape_id: str | None = None,
+    log_path: str = "/tmp/opd",
+    metrics_file: str | None = None,
+) -> Config:
+    return Config(
+        log_path=log_path,
+        base_model="accounts/fireworks/models/qwen3p5-9b",
+        teacher_model="accounts/fireworks/models/qwen3p5-9b",
+        teacher_deployment_id="opd-teacher-qwen3p5-9b-unit",
+        dataset="/tmp/opd_math.jsonl",
+        infra=InfraConfig(training_shape_id=training_shape_id),
+        deployment=DeployConfig(tokenizer_model="Qwen/Qwen3.5-9B"),
+        weight_sync=WeightSyncConfig(weight_sync_interval=1),
+        runner=RunnerConfig(metrics_file=metrics_file),
+        step_eval=make_teacher_trace_logprob_gap_eval(min_pre_final_tokens=4),
+        step_eval_interval=1,
+        eval_before_training=True,
+        lora_rank=0,
+        learning_rate=2e-5,
+        max_rows=8,
+        epochs=25,
+        prompt_groups_per_step=8,
+        completions_per_prompt=4,
+        max_completion_tokens=1024,
+        temperature=1.0,
+        max_seq_len=None if training_shape_id else MAX_CONTEXT_LEN,
+        save_final_checkpoint=False,
+    )
+
+
+def _passing_trace_logprob_eval() -> dict[str, float]:
+    return {
+        "eval/opd_trace_teacher_nll": 0.1,
+        "eval/opd_trace_student_nll": 0.2,
+        "eval/opd_trace_student_minus_teacher_nll": 0.1,
+        "eval/opd_trace_pre_final_teacher_nll": 0.1,
+        "eval/opd_trace_pre_final_student_nll": 0.2,
+        "eval/opd_trace_pre_final_student_minus_teacher_nll": 0.1,
+        "eval/opd_trace_final_teacher_nll": 0.1,
+        "eval/opd_trace_final_student_nll": 0.2,
+        "eval/opd_trace_final_student_minus_teacher_nll": 0.1,
+        "eval/opd_trace_teacher_final_accuracy": 1.0,
+        "eval/opd_trace_student_generation_accuracy": 1.0,
+        "eval/opd_trace_examples": 8.0,
+        "eval/opd_trace_tokens": 32.0,
+        "eval/opd_trace_pre_final_tokens": 24.0,
+        "eval/opd_trace_final_tokens": 8.0,
+    }
 
 
 def _server_importance_sampling_loss(
@@ -62,6 +140,129 @@ def _datum(
     )
 
 
+class _FakeTokenizer:
+    def __init__(self, token_map: dict[str, list[int]]):
+        self.token_map = token_map
+
+    def apply_chat_template(self, messages, **kwargs):
+        assert kwargs["tokenize"] is True
+        assert kwargs["add_generation_prompt"] is True
+        tokens: list[int] = []
+        for message in messages:
+            tokens.extend(self.token_map[message["content"]])
+        return tokens
+
+    def encode(self, text, **kwargs):
+        assert kwargs["add_special_tokens"] is False
+        return self.token_map[text]
+
+
+class _FakeScoringSampler:
+    def __init__(
+        self,
+        response_logprob: float = -0.1,
+        response_logprobs_by_token: dict[int, float] | None = None,
+        tokenizer: _FakeTokenizer | None = None,
+        sample_text: str = "",
+        sample_completion_tokens: list[int] | None = None,
+    ):
+        self.response_logprob = response_logprob
+        self.response_logprobs_by_token = response_logprobs_by_token or {}
+        self.tokenizer = tokenizer
+        self.sample_text = sample_text
+        self.sample_completion_tokens = sample_completion_tokens or []
+        self.calls = []
+        self.sample_calls = []
+
+    async def async_completions_stream(self, prompt, **kwargs):
+        self.calls.append((prompt, kwargs))
+        content = [{"logprob": 0.0}]
+        content.extend(
+            {"logprob": self.response_logprobs_by_token.get(int(token_id), self.response_logprob)}
+            for token_id in prompt[1:]
+        )
+        return {"choices": [{"logprobs": {"content": content}}]}, {}
+
+    async def sample_with_tokens(self, messages, **kwargs):
+        if self.tokenizer is None:
+            raise RuntimeError("fake sampler needs a tokenizer to sample")
+        self.sample_calls.append((messages, kwargs))
+        prompt_tokens = self.tokenizer.apply_chat_template(
+            messages,
+            tokenize=True,
+            add_generation_prompt=True,
+            return_dict=False,
+        )
+        completion_tokens = list(self.sample_completion_tokens)
+        return [
+            SimpleNamespace(
+                text=self.sample_text,
+                full_tokens=list(prompt_tokens) + completion_tokens,
+                prompt_len=len(prompt_tokens),
+                completion_len=len(completion_tokens),
+                finish_reason="stop",
+                inference_logprobs=None,
+                logprobs_echoed=False,
+            )
+        ]
+
+
+class _FakeResponse:
+    status_code = 200
+
+    def __init__(self, payload=None):
+        self._payload = payload or {}
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+class _FakeDeployMgr:
+    account_id = "acct"
+    api_key = "fake-api-key"
+    base_url = "https://api.fireworks.ai"
+    additional_headers = {"x-test": "yes"}
+
+    def __init__(self, existing=None):
+        self.existing = existing
+        self.created_config = None
+        self.waited = []
+
+    def get(self, deployment_id):
+        self.get_id = deployment_id
+        return self.existing
+
+    def create_or_get(self, config):
+        self.created_config = config
+        return SimpleNamespace(
+            deployment_id=config.deployment_id,
+            state="CREATING",
+            inference_model=None,
+        )
+
+    def _parse_deployment_info(self, deployment_id, payload):
+        return SimpleNamespace(
+            deployment_id=deployment_id,
+            state="CREATING",
+            inference_model=None,
+        )
+
+    def wait_for_ready(self, deployment_id, timeout_s):
+        self.waited.append((deployment_id, timeout_s))
+        return SimpleNamespace(inference_model=f"accounts/acct/deployedModels/{deployment_id}")
+
+
+class _FakeCleanup:
+    def __init__(self):
+        self.deployments = []
+
+    def deployment(self, deployment_id, action="delete"):
+        self.deployments.append((deployment_id, action))
+
+
 def test_build_opd_server_datums_encodes_teacher_minus_sampling_advantages() -> None:
     datum = _datum()
     teacher_lp = [[-9.0, -0.2, -1.0, -0.3]]
@@ -82,6 +283,10 @@ def test_build_opd_server_datums_encodes_teacher_minus_sampling_advantages() -> 
     assert metrics["opd_active_tokens"] == pytest.approx(3.0)
     assert metrics["opd_sampled_reverse_kl"] == pytest.approx((-0.3 + 0.2 - 0.4) / 3)
     assert metrics["opd_advantage"] == pytest.approx((0.6 - 0.4 + 0.8) / 3)
+    assert metrics["opd_abs_advantage"] == pytest.approx((0.6 + 0.4 + 0.8) / 3)
+    assert metrics["opd_student_logprob_minus_teacher_logprob"] == metrics["opd_sampled_reverse_kl"]
+    assert metrics["opd_teacher_logprob_minus_student_logprob"] == metrics["opd_advantage"]
+    assert metrics["opd_abs_logprob_gap"] == metrics["opd_abs_advantage"]
 
 
 def test_opd_datums_make_server_loss_equal_sampled_reverse_kl_at_rollout_policy() -> None:
@@ -177,6 +382,26 @@ def test_build_opd_server_datums_rejects_mismatched_inputs() -> None:
         )
 
 
+def test_build_opd_server_datums_rejects_missing_active_teacher_logprobs() -> None:
+    with pytest.raises(ValueError, match="teacher_logprobs has length 2"):
+        build_opd_server_datums(
+            [_datum()],
+            teacher_logprobs=[[-1.0, -0.1]],
+            sampling_logprobs=[[-1.0, -0.5, -0.5, -0.5]],
+            prompt_lens=[2],
+        )
+
+
+def test_build_opd_server_datums_rejects_missing_active_sampling_logprobs() -> None:
+    with pytest.raises(ValueError, match="sampling_logprobs has length 2"):
+        build_opd_server_datums(
+            [_datum()],
+            teacher_logprobs=[[-1.0, -0.1, -0.1, -0.1]],
+            sampling_logprobs=[[-1.0, -0.5]],
+            prompt_lens=[2],
+        )
+
+
 def test_align_completion_logprobs_pads_prompt_prefix_for_non_echo_generation() -> None:
     aligned = _align_completion_logprobs(
         [-0.4, -0.5],
@@ -188,6 +413,18 @@ def test_align_completion_logprobs_pads_prompt_prefix_for_non_echo_generation() 
     assert aligned == [0.0, 0.0, -0.4, -0.5]
 
 
+def test_align_completion_logprobs_rejects_missing_active_generation_logprobs() -> None:
+    assert (
+        _align_completion_logprobs(
+            [-0.4],
+            prompt_len=3,
+            target_len=4,
+            echoed=False,
+        )
+        is None
+    )
+
+
 def test_align_completion_logprobs_trims_echoed_logprobs() -> None:
     aligned = _align_completion_logprobs(
         [-0.1, -0.2, -0.3, -0.4, -0.5],
@@ -197,6 +434,14 @@ def test_align_completion_logprobs_trims_echoed_logprobs() -> None:
     )
 
     assert aligned == [-0.1, -0.2, -0.3, -0.4]
+
+
+def test_align_response_logprobs_places_teacher_scores_on_student_response_tokens() -> None:
+    assert _align_response_logprobs(
+        [-0.4, -0.5],
+        prompt_len=3,
+        target_len=4,
+    ) == [0.0, 0.0, -0.4, -0.5]
 
 
 def test_extract_scored_token_logprobs_drops_unconditional_and_extra_token() -> None:
@@ -217,3 +462,409 @@ def test_extract_scored_token_logprobs_drops_unconditional_and_extra_token() -> 
     }
 
     assert _extract_scored_token_logprobs(response, target_len=3) == [-0.1, -0.2, -0.3]
+
+
+def test_slice_response_logprobs_extracts_teacher_completion_span() -> None:
+    assert _slice_response_logprobs(
+        [-0.1, -0.2, -0.3, -0.4],
+        prompt_len=3,
+        response_len=2,
+    ) == [-0.3, -0.4]
+
+
+def test_teacher_scoring_tokens_use_privileged_prompt_and_sampled_response() -> None:
+    row = {
+        "messages": [{"role": "user", "content": "student"}],
+        "teacher_messages": [
+            {"role": "system", "content": "privileged"},
+            {"role": "user", "content": "student"},
+        ],
+    }
+    student_messages = [{"role": "user", "content": "student"}]
+    tokenizer = _FakeTokenizer(
+        {
+            "privileged": [900, 901],
+            "student": [10, 11],
+        }
+    )
+
+    teacher_messages = _teacher_messages_for_row(row, student_messages)
+    teacher_prompt_tokens = _tokenize_teacher_prompt(tokenizer, teacher_messages)
+    scoring_tokens = _build_teacher_scoring_tokens(
+        teacher_prompt_tokens,
+        [10, 11, 40, 41],
+        student_prompt_len=2,
+    )
+
+    assert teacher_messages == row["teacher_messages"]
+    assert scoring_tokens == ([900, 901, 10, 11, 40, 41], 2)
+
+
+def test_teacher_messages_fallback_to_student_prompt() -> None:
+    student_messages = [{"role": "user", "content": "student"}]
+
+    assert _teacher_messages_for_row({"messages": student_messages}, student_messages) == student_messages
+
+
+def test_teacher_model_resource_detection() -> None:
+    assert _is_base_model_resource("accounts/fireworks/models/qwen3p5-9b")
+    assert not _is_base_model_resource("accounts/pyroworks/deployments/opd-teacher-qwen3p5-9b")
+    assert not _is_base_model_resource("accounts/pyroworks/deployedModels/qwen3p5-9b")
+
+
+def test_default_teacher_deployment_id_is_stable_and_safe() -> None:
+    assert (
+        _default_teacher_deployment_id("accounts/fireworks/models/Qwen_3.5_9B")
+        == "opd-teacher-qwen-3-5-9b"
+    )
+
+
+def test_teacher_deployment_provisioner_requests_frozen_deployment_and_waits(monkeypatch) -> None:
+    create_calls = []
+
+    class _FakeFireworks:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.deployments = self
+            self.deployment_shape_versions = self
+
+        def list(self, **kwargs):
+            return [
+                SimpleNamespace(
+                    model_dump=lambda by_alias=True: {
+                        "snapshot": {"acceleratorType": "NVIDIA_B200_180GB"}
+                    }
+                )
+            ]
+
+        def get(self, **kwargs):
+            return SimpleNamespace(
+                model_dump=lambda by_alias=True: {
+                    "snapshot": {"acceleratorType": "NVIDIA_B200_180GB"}
+                }
+            )
+
+        def create(self, **kwargs):
+            create_calls.append((self.kwargs, kwargs))
+            return SimpleNamespace(
+                name="ignored",
+                state="CREATING",
+                hot_load_bucket_url=None,
+                model_dump=lambda by_alias=True: {
+                    "name": "ignored",
+                    "state": "CREATING",
+                }
+            )
+
+    monkeypatch.setattr("training.utils.infra.Fireworks", _FakeFireworks)
+    deploy_mgr = _FakeDeployMgr()
+    cleanup = _FakeCleanup()
+    cfg = Config(
+        log_path="/tmp/opd",
+        teacher_model="accounts/fireworks/models/qwen3p5-9b",
+        teacher_deployment_id="opd-teacher-unit",
+        teacher_replica_count=2,
+        teacher_deployment_timeout_s=123,
+    )
+
+    model_out = {}
+    provisioner = _make_teacher_deployment_provisioner(
+        cfg,
+        deploy_mgr,
+        cleanup=cleanup,
+        model_out=model_out,
+    )
+    resource = provisioner("accounts/fireworks/deploymentShapes/qwen/versions/v1")
+
+    assert resource is not None
+    label, wait_fn = resource
+    assert label == "teacher_deployment"
+    assert deploy_mgr.created_config is None
+    assert len(create_calls) == 1
+    client_kwargs, create_kwargs = create_calls[0]
+    assert client_kwargs == {
+        "api_key": "fake-api-key",
+        "account_id": "acct",
+        "base_url": "https://api.fireworks.ai",
+        "default_headers": {"x-test": "yes"},
+    }
+    assert create_kwargs == {
+        "account_id": "acct",
+        "deployment_id": "opd-teacher-unit",
+        "base_model": "accounts/fireworks/models/qwen3p5-9b",
+        "enable_hot_load": False,
+        "min_replica_count": 2,
+        "max_replica_count": 2,
+        "deployment_shape": "accounts/fireworks/deploymentShapes/qwen/versions/v1",
+        "accelerator_type": omit,
+        "placement": {"region": "US_OHIO_1"},
+        "skip_shape_validation": omit,
+        "disable_speculative_decoding": True,
+        "timeout": 60,
+    }
+    assert cleanup.deployments == [("opd-teacher-unit", "scale_to_zero")]
+    wait_fn()
+    assert model_out["teacher_model"] == "accounts/acct/deployedModels/opd-teacher-unit"
+    assert deploy_mgr.waited == [("opd-teacher-unit", 123)]
+
+
+def test_request_frozen_teacher_reuses_existing_deployment_without_cleanup() -> None:
+    deploy_mgr = _FakeDeployMgr(existing=SimpleNamespace(state="READY"))
+    cleanup = _FakeCleanup()
+    cfg = Config(log_path="/tmp/opd")
+
+    request = _request_frozen_teacher_deployment(
+        deploy_mgr,
+        infra_cfg=cfg.infra,
+        base_model="accounts/fireworks/models/qwen3p5-9b",
+        deployment_id="opd-teacher-existing",
+        deployment_shape="shape-v1",
+        replica_count=1,
+        cleanup=cleanup,
+    )
+
+    assert request.deployment_id == "opd-teacher-existing"
+    assert request.info is deploy_mgr.existing
+    assert deploy_mgr.created_config is None
+    assert cleanup.deployments == []
+
+
+def test_qwen_opd_config_can_be_full_param_and_privileged() -> None:
+    cfg = _build_qwen_opd_config(training_shape_id=None)
+
+    assert cfg.lora_rank == 0
+    assert cfg.infra.training_shape_id is None
+    assert cfg.base_model == cfg.teacher_model
+    assert cfg.step_eval is not None
+    assert cfg.step_eval_interval == 1
+    assert cfg.eval_before_training is True
+    assert cfg.max_seq_len == MAX_CONTEXT_LEN
+    assert cfg.prompt_groups_per_step == cfg.max_rows
+    assert cfg.weight_sync.weight_sync_interval == 1
+
+
+def test_qwen_opd_config_lets_pinned_shape_own_context_length() -> None:
+    cfg = _build_qwen_opd_config(
+        training_shape_id="accounts/fireworks/trainingShapes/qwen3p5-9b-256k"
+    )
+
+    assert cfg.infra.training_shape_id == "accounts/fireworks/trainingShapes/qwen3p5-9b-256k"
+    assert cfg.max_seq_len is None
+
+
+def test_teacher_trace_eval_normalizes_expected_answers() -> None:
+    row = {"expected_answer": " 5. "}
+
+    assert expected_final_answer(row) == "5"
+    assert normalize_final_answer("  5.  ") == "5"
+    assert extract_final_answer("Reasoning...\nFinal: 5.") == "5"
+    assert extract_final_answer("Final: 5\nActually, continue") is None
+
+
+def test_validate_privileged_opd_dataset_rejects_bad_teacher_prompt() -> None:
+    rows = [
+        {
+            "messages": [
+                {
+                    "role": "system",
+                    "content": (
+                        "Solve using normal reasoning. Do not discuss the output format. "
+                        "End with exactly one line: Final: <answer>."
+                    ),
+                },
+                {"role": "user", "content": "What is the hidden result for case A?"},
+            ],
+            "teacher_messages": [
+                {
+                    "role": "system",
+                    "content": (
+                        "Use the privileged worked solution. "
+                        "End with exactly one line: Final: <answer>."
+                    ),
+                },
+                {"role": "user", "content": "Privileged worked solution: case A is 5."},
+            ],
+            "expected_answer": "5",
+        }
+    ]
+
+    with pytest.raises(ValueError, match="placeholder final-answer"):
+        validate_privileged_opd_dataset(rows)
+
+
+def test_teacher_trace_logprob_eval_scores_reasoning_trace(tmp_path) -> None:
+    eval_file = tmp_path / "teacher_trace_eval.jsonl"
+    tokenizer = _FakeTokenizer(
+        {
+            "student": [10, 11],
+            "teacher": [20, 21],
+            "Add 2 and 3.\nFinal: ": [30, 31, 32, 33],
+            "Add 2 and 3.\nFinal: 5": [30, 31, 32, 33, 40],
+            "Now I know it.\nFinal: 5": [50, 51, 52, 40],
+            "5": [40],
+        }
+    )
+    teacher_trace = "Add 2 and 3.\nFinal: 5"
+    student_generation = "Now I know it.\nFinal: 5"
+
+    metrics = evaluate_teacher_trace_logprob_gap(
+        {
+            "config": _build_qwen_opd_config(),
+            "dataset": [
+                {
+                    "messages": [{"role": "user", "content": "student"}],
+                    "teacher_messages": [{"role": "user", "content": "teacher"}],
+                    "expected_answer": "5",
+                }
+            ],
+            "teacher_sampler": _FakeScoringSampler(
+                response_logprob=-0.1,
+                response_logprobs_by_token={40: -0.05},
+                tokenizer=tokenizer,
+                sample_text=teacher_trace,
+                sample_completion_tokens=[30, 31, 32, 33, 40],
+            ),
+            "student_sampler": _FakeScoringSampler(
+                response_logprob=-0.5,
+                response_logprobs_by_token={40: -0.4},
+                tokenizer=tokenizer,
+                sample_text=student_generation,
+                sample_completion_tokens=[50, 51, 52, 40],
+            ),
+            "tokenizer": tokenizer,
+            "global_step": 3,
+            "max_seq_len": MAX_CONTEXT_LEN,
+        },
+        trace_log_path=eval_file,
+        min_pre_final_tokens=4,
+    )
+
+    assert metrics["eval/opd_trace_teacher_nll"] == pytest.approx((0.1 * 4 + 0.05) / 5)
+    assert metrics["eval/opd_trace_student_nll"] == pytest.approx((0.5 * 4 + 0.4) / 5)
+    assert metrics["eval/opd_trace_pre_final_student_minus_teacher_nll"] == pytest.approx(0.4)
+    assert metrics["eval/opd_trace_final_student_minus_teacher_nll"] == pytest.approx(0.35)
+    assert metrics["eval/opd_trace_teacher_final_accuracy"] == pytest.approx(1.0)
+    assert metrics["eval/opd_trace_student_generation_accuracy"] == pytest.approx(1.0)
+    assert metrics["eval/opd_trace_pre_final_tokens"] == pytest.approx(4.0)
+    assert metrics["eval/opd_trace_final_tokens"] == pytest.approx(1.0)
+    records = [line for line in eval_file.read_text(encoding="utf-8").splitlines() if line]
+    assert len(records) == 1
+    assert '"step":3' in records[0]
+    assert '"teacher_generated_final":"5"' in records[0]
+
+
+def test_opd_trace_result_validation_requires_opd_signal(tmp_path) -> None:
+    cfg = _build_qwen_opd_config(metrics_file=str(tmp_path / "metrics.jsonl"))
+    cfg.epochs = 1
+    Path(cfg.runner.metrics_file).write_text(
+        "\n".join(
+            [
+                '{"step":0,"eval/opd_trace_teacher_nll":0.1,'
+                '"eval/opd_trace_student_minus_teacher_nll":1.0}',
+                '{"step":1,"train/opd_active_tokens":4,"train/opd_abs_advantage":0.25}',
+                '{"step":1,"eval/opd_trace_teacher_nll":0.1,'
+                '"eval/opd_trace_student_minus_teacher_nll":0.5}',
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    validate_opd_trace_result(
+        cfg,
+        {
+            "steps": 1,
+            "max_seq_len": MAX_CONTEXT_LEN,
+            "eval": _passing_trace_logprob_eval(),
+        },
+        min_max_seq_len=MAX_CONTEXT_LEN,
+        min_teacher_final_accuracy=1.0,
+        min_student_generation_accuracy=1.0,
+        min_trace_gap_improvement=0.2,
+    )
+
+    Path(cfg.runner.metrics_file).write_text(
+        "\n".join(
+            [
+                '{"step":0,"eval/opd_trace_teacher_nll":0.1,'
+                '"eval/opd_trace_student_minus_teacher_nll":1.0}',
+                '{"step":1,"train/opd_active_tokens":4,"train/opd_abs_advantage":0.0}',
+                '{"step":1,"eval/opd_trace_teacher_nll":0.1,'
+                '"eval/opd_trace_student_minus_teacher_nll":0.5}',
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(RuntimeError, match="teacher/student logprob delta"):
+        validate_opd_trace_result(
+            cfg,
+            {
+                "steps": 1,
+                "max_seq_len": MAX_CONTEXT_LEN,
+                "eval": _passing_trace_logprob_eval(),
+            },
+            min_max_seq_len=MAX_CONTEXT_LEN,
+            min_teacher_final_accuracy=1.0,
+            min_student_generation_accuracy=1.0,
+            min_trace_gap_improvement=0.2,
+        )
+
+
+def test_opd_trace_result_validation_requires_trace_logprob_eval(tmp_path) -> None:
+    cfg = _build_qwen_opd_config(metrics_file=str(tmp_path / "metrics.jsonl"))
+    cfg.epochs = 1
+    Path(cfg.runner.metrics_file).write_text(
+        "\n".join(
+            [
+                '{"step":0,"eval/opd_trace_teacher_nll":0.1,'
+                '"eval/opd_trace_student_minus_teacher_nll":1.0}',
+                '{"step":1,"train/opd_active_tokens":4,"train/opd_abs_advantage":0.25}',
+                '{"step":1,"eval/opd_trace_teacher_nll":0.1,'
+                '"eval/opd_trace_student_minus_teacher_nll":0.5}',
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(RuntimeError, match="teacher-trace eval metric"):
+        validate_opd_trace_result(
+            cfg,
+            {
+                "steps": 1,
+                "max_seq_len": MAX_CONTEXT_LEN,
+                "eval": {},
+            },
+        )
+
+
+def test_opd_trace_result_validation_requires_gap_improvement(tmp_path) -> None:
+    cfg = _build_qwen_opd_config(metrics_file=str(tmp_path / "metrics.jsonl"))
+    cfg.epochs = 8
+    train_records = [
+        f'{{"step":{step},"train/opd_active_tokens":4,'
+        f'"train/opd_abs_advantage":1.0,"train/opd_sampled_reverse_kl":1.0}}'
+        for step in range(1, 9)
+    ]
+    eval_records = [
+        f'{{"step":{step},"eval/opd_trace_teacher_nll":0.1,'
+        f'"eval/opd_trace_student_minus_teacher_nll":1.0}}'
+        for step in range(0, 9)
+    ]
+    Path(cfg.runner.metrics_file).write_text(
+        "\n".join([*eval_records, *train_records]) + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(RuntimeError, match="logprob gap did not improve"):
+        validate_opd_trace_result(
+            cfg,
+            {
+                "steps": 8,
+                "max_seq_len": MAX_CONTEXT_LEN,
+                "eval": _passing_trace_logprob_eval(),
+            },
+            min_train_gap_improvement=0.2,
+            min_trace_gap_improvement=0.2,
+        )

--- a/training/utils/config.py
+++ b/training/utils/config.py
@@ -136,6 +136,8 @@ class DeployConfig:
     """Trainer job name whose hot-load bucket this deployment should use.
     Format: accounts/{account}/rlorTrainerJobs/{job_id}.
     When set, the deployment copies the trainer's bucket URL at creation."""
+    enable_hot_load: bool = True
+    """Whether to create a hot-load-capable deployment."""
     deployment_timeout_s: float = 5400
     reattach_settle_timeout_s: int = 600
     """How long to wait for the serving pod to cycle after a re-attach PATCH
@@ -202,4 +204,3 @@ class WandBConfig:
     entity: str | None = None
     project: str | None = None
     run_name: str | None = None
-

--- a/training/utils/config.py
+++ b/training/utils/config.py
@@ -144,6 +144,8 @@ class DeployConfig:
     """Trainer job name whose hot-load bucket this deployment should use.
     Format: accounts/{account}/rlorTrainerJobs/{job_id}.
     When set, the deployment copies the trainer's bucket URL at creation."""
+    enable_hot_load: bool = True
+    """Whether to create a hot-load-capable deployment."""
     deployment_timeout_s: float = 5400
     reattach_settle_timeout_s: int = 600
     """How long to wait for the serving pod to cycle after a re-attach PATCH

--- a/training/utils/infra.py
+++ b/training/utils/infra.py
@@ -27,9 +27,9 @@ import time
 import logging
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
-from typing import Any, Callable
-from urllib.parse import urlencode
+from typing import Any, Callable, Sequence
 
+from fireworks import ConflictError, Fireworks, omit
 from fireworks.training.sdk.client import (
     FiretitanServiceClient,
     FiretitanTrainingClient,
@@ -61,6 +61,9 @@ StatusCallback = Callable[[str], None]
 """Invoked with a human-readable provisioning status message at each
 lifecycle step (creating, waiting, ready, failed)."""
 
+
+_ProvisionedWaiter = tuple[str, Callable[[], Any]]
+
 logger = logging.getLogger(__name__)
 
 _DEPLOYMENT_ACCELERATOR_REGION_PREFIXES: tuple[tuple[str, str], ...] = (
@@ -73,6 +76,15 @@ _TRAINER_CANCEL_GRACE_ENV = "FW_TRAINER_CANCEL_GRACE_PERIOD_S"
 _TRAINER_DELETE_GRACE_ENV = "FW_TRAINER_DELETE_GRACE_PERIOD_S"
 
 _FIREWORKS_API_EXTRA_HEADERS_ENV = "FIREWORKS_API_EXTRA_HEADERS"
+
+
+def _fireworks_client(deploy_mgr: DeploymentManager) -> Fireworks:
+    return Fireworks(
+        api_key=deploy_mgr.api_key,
+        account_id=deploy_mgr.account_id,
+        base_url=deploy_mgr.base_url,
+        default_headers=deploy_mgr.additional_headers,
+    )
 
 
 def read_api_extra_headers_env() -> dict[str, str] | None:
@@ -524,8 +536,8 @@ def request_deployment(
         dep_config.region = _infer_region_from_deployment_shape(
             deploy_mgr, dep_config.deployment_shape
         )
-    if dep_config.region is None:
-        return _create_deployment_via_cookbook(deploy_mgr, dep_config, purpose=infra.purpose)
+    if not deploy_cfg.enable_hot_load:
+        return _create_non_hotload_deployment_via_sdk(deploy_mgr, dep_config)
     return deploy_mgr.create_or_get(dep_config)
 
 
@@ -724,24 +736,39 @@ def _get_deployment_shape_version(
     deployment_shape: str,
 ) -> dict[str, Any]:
     """Fetch an exact or latest-validated deployment-shape version."""
-    if "/versions/" in deployment_shape:
-        path = f"/v1/{deployment_shape}"
-    else:
-        path = (
-            f"/v1/{deployment_shape}/versions?"
-            f"{urlencode({'filter': 'latest_validated=true', 'pageSize': 1})}"
+    parts = deployment_shape.strip("/").split("/")
+    if len(parts) not in (4, 6) or parts[0] != "accounts" or parts[2] != "deploymentShapes":
+        raise ValueError(f"Invalid deployment shape resource name: {deployment_shape!r}")
+    if len(parts) == 6 and parts[4] != "versions":
+        raise ValueError(f"Invalid deployment shape version resource name: {deployment_shape!r}")
+
+    account_id = parts[1]
+    shape_id = parts[3]
+    version_id = parts[5] if len(parts) == 6 else None
+    client = _fireworks_client(deploy_mgr)
+    if version_id:
+        version = client.deployment_shape_versions.get(
+            account_id=account_id,
+            deployment_shape_id=shape_id,
+            version_id=version_id,
+            timeout=30,
         )
-    resp = deploy_mgr._get(path, timeout=30)
-    resp.raise_for_status()
-    data = resp.json()
-    if "/versions/" in deployment_shape:
-        return data
-    versions = data.get("deploymentShapeVersions", []) or []
+        return version.model_dump(by_alias=True)
+
+    versions = list(
+        client.deployment_shape_versions.list(
+            account_id=account_id,
+            deployment_shape_id=shape_id,
+            filter="latest_validated=true",
+            page_size=1,
+            timeout=30,
+        )
+    )
     if not versions:
         raise RuntimeError(
             f"No latest validated deployment-shape version was returned for '{deployment_shape}'"
         )
-    return versions[0]
+    return versions[0].model_dump(by_alias=True)
 
 
 def get_deployment_gpu_count(
@@ -784,46 +811,53 @@ def get_deployment_gpu_count(
         return replica_count
 
 
-def _create_deployment_via_cookbook(
+def _create_non_hotload_deployment_via_sdk(
     deploy_mgr: DeploymentManager,
     config: DeploymentConfig,
-    purpose: str | None = None,
 ) -> DeploymentInfo:
-    """Create a deployment while leaving placement selection to the control plane."""
-    path = f"/v1/accounts/{deploy_mgr.account_id}/deployments?deploymentId={config.deployment_id}"
-    if config.skip_shape_validation:
-        path += "&skipShapeValidation=true"
-    if config.disable_speculative_decoding:
-        path += "&disableSpeculativeDecoding=true"
-
-    body: dict[str, Any] = {
-        "baseModel": config.base_model,
-        "minReplicaCount": config.min_replica_count,
-        "maxReplicaCount": config.max_replica_count,
-        "enableHotLoad": True,
-    }
+    """Create a frozen, non-hotload deployment through the generated Fireworks API client."""
+    if config.hot_load_trainer_job:
+        raise ValueError("non-hotload deployments cannot set hot_load_trainer_job")
     if config.hot_load_bucket_type:
-        body["hotLoadBucketType"] = config.hot_load_bucket_type
-    if config.deployment_shape:
-        body["deploymentShape"] = config.deployment_shape
-    if config.accelerator_type:
-        body["acceleratorType"] = config.accelerator_type
+        raise ValueError("non-hotload deployments cannot set hot_load_bucket_type")
     if config.extra_args:
-        flat: list[str] = []
-        for arg in config.extra_args:
-            flat.extend(arg.split()) if " " in arg else flat.append(arg)
-        body["extraArgs"] = flat
+        raise ValueError("non-hotload deployment extra_args are not exposed by the generated SDK")
     if config.extra_values:
-        body["extraValues"] = config.extra_values
-    if purpose:
-        body["annotations"] = {
-            "internal/purpose": purpose.removeprefix("PURPOSE_").lower(),
-        }
+        raise ValueError("non-hotload deployment extra_values are not exposed by the generated SDK")
 
-    logger.info("Creating deployment: %s", config.deployment_id)
-    resp = deploy_mgr._post(path, json=body, timeout=60)
-    resp.raise_for_status()
-    return deploy_mgr._parse_deployment_info(config.deployment_id, resp.json())
+    client = _fireworks_client(deploy_mgr)
+    logger.info("Creating non-hotload deployment: %s", config.deployment_id)
+    try:
+        deployment = client.deployments.create(
+            account_id=deploy_mgr.account_id,
+            deployment_id=config.deployment_id,
+            base_model=config.base_model,
+            enable_hot_load=False,
+            min_replica_count=config.min_replica_count,
+            max_replica_count=config.max_replica_count,
+            deployment_shape=config.deployment_shape or omit,
+            accelerator_type=(
+                omit
+                if config.deployment_shape
+                else config.accelerator_type
+            ),
+            placement={"region": config.region} if config.region else omit,
+            skip_shape_validation=config.skip_shape_validation or omit,
+            disable_speculative_decoding=config.disable_speculative_decoding or omit,
+            timeout=60,
+        )
+    except ConflictError:
+        info = deploy_mgr.get(config.deployment_id)
+        if info is not None:
+            return info
+        raise
+    return DeploymentInfo(
+        deployment_id=config.deployment_id,
+        name=deployment.name or "",
+        state=deployment.state or "UNKNOWN",
+        hot_load_bucket_url=deployment.hot_load_bucket_url,
+        inference_model=f"accounts/{deploy_mgr.account_id}/deployments/{config.deployment_id}",
+    )
 
 
 def setup_training_client(
@@ -921,7 +955,6 @@ class Infra:
     the shape doesn't expose ``acceleratorCount``. Recipes use this to size
     concurrency windows, etc."""
 
-
 def setup_infra(
     *,
     rlor_mgr: TrainerJobManager,
@@ -941,6 +974,9 @@ def setup_infra(
     api_key: str,
     cleanup: ResourceCleanup | None = None,
     on_status: StatusCallback | None = None,
+    post_shape_provisioners: Sequence[
+        Callable[[str | None], _ProvisionedWaiter | None]
+    ] | None = None,
 ) -> Infra:
     """Build all training-side infrastructure in one call.
 
@@ -967,6 +1003,10 @@ def setup_infra(
             deployments for scale-to-zero on scope exit. Pass ``None`` to skip
             registration (e.g. when resuming and wanting resources to outlive the run).
         on_status: Optional callback receiving human-readable status messages.
+        post_shape_provisioners: Optional hooks that run after shape resolution
+            and before trainer/deployment waits. Each hook may request an
+            auxiliary resource and return a waiter to run in parallel with the
+            main trainer/deployment readiness waits.
 
     Returns:
         An :class:`Infra` bundle. Caller registers ``infra.closeables`` on an
@@ -1023,6 +1063,12 @@ def setup_infra(
         local_deploy_cfg.weight_sync_scope if local_deploy_cfg else WeightSyncScope.PER_TRAINER
     )
 
+    auxiliary_waiters: list[_ProvisionedWaiter] = []
+    for provisioner in post_shape_provisioners or ():
+        provisioned = provisioner(resolved_deploy_shape if needs_inference else None)
+        if provisioned is not None:
+            auxiliary_waiters.append(provisioned)
+
     # The two scopes differ only in who is created first: whichever side owns
     # the bucket needs its identifier before the other side can be wired up.
     trainer_kwargs = dict(
@@ -1074,6 +1120,7 @@ def setup_infra(
         base_model=base_model,
         role_prefix=role_prefix,
         on_status=emit,
+        auxiliary_waiters=auxiliary_waiters,
     )
 
     inference_model = None
@@ -1374,9 +1421,16 @@ def _await_in_parallel(
     base_model: str,
     role_prefix: str,
     on_status: Callable[[str], None],
+    auxiliary_waiters: Sequence[_ProvisionedWaiter] | None = None,
 ) -> tuple[Any, Any | None, "DeploymentInfo | None"]:
     """Wait for all pending resources in parallel using a thread pool."""
-    max_workers = 1 + (1 if ref_handle is not None else 0) + (1 if dep_info is not None else 0)
+    auxiliary_waiters = list(auxiliary_waiters or ())
+    max_workers = (
+        1
+        + (1 if ref_handle is not None else 0)
+        + (1 if dep_info is not None else 0)
+        + len(auxiliary_waiters)
+    )
 
     policy_ep = ref_ep = final_dep_info = None
     errors: list[str] = []
@@ -1417,6 +1471,10 @@ def _await_in_parallel(
             )
         else:
             dep_future = pool.submit(wait_deployment, deploy_mgr, dep_info, deploy_cfg)
+        auxiliary_futures = {
+            label: pool.submit(wait_fn)
+            for label, wait_fn in auxiliary_waiters
+        }
 
         try:
             policy_ep = policy_future.result()
@@ -1439,6 +1497,12 @@ def _await_in_parallel(
                 )
             except Exception as e:
                 errors.append(f"Deployment: {e}")
+
+        for label, future in auxiliary_futures.items():
+            try:
+                future.result()
+            except Exception as e:
+                errors.append(f"{label}: {e}")
 
     if errors:
         raise RuntimeError("Infrastructure provisioning failed:\n" + "\n".join(errors))
@@ -1502,5 +1566,3 @@ def _make_boot_metrics(boot_start: float, deploy_mgr: DeploymentManager | None) 
     if deploy_mgr is not None and deploy_mgr.boot_time_s is not None:
         metrics["infra/deploy_boot_time"] = deploy_mgr.boot_time_s
     return metrics
-
-

--- a/training/utils/infra.py
+++ b/training/utils/infra.py
@@ -29,10 +29,11 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from types import SimpleNamespace
-from typing import Any, Callable
+from typing import Any, Callable, Sequence
 from urllib.parse import urlencode
 
 import httpx
+from fireworks import ConflictError, Fireworks, omit
 from fireworks.training.sdk import (
     TrainerJobConfig,
     TrainerJobManager,
@@ -49,6 +50,7 @@ try:
 except ImportError:
     CreatedTrainerJob = Any
 from fireworks.training.sdk.deployment import (
+    DeploymentConfig,
     DeploymentInfo,
     DeploymentManager,
 )
@@ -67,6 +69,9 @@ for the reuse path (already polled)."""
 StatusCallback = Callable[[str], None]
 """Invoked with a human-readable provisioning status message at each
 lifecycle step (creating, waiting, ready, failed)."""
+
+
+_ProvisionedWaiter = tuple[str, Callable[[], Any]]
 
 logger = logging.getLogger(__name__)
 
@@ -90,6 +95,15 @@ _TRAINER_CANCEL_GRACE_ENV = "FW_TRAINER_CANCEL_GRACE_PERIOD_S"
 _TRAINER_DELETE_GRACE_ENV = "FW_TRAINER_DELETE_GRACE_PERIOD_S"
 
 _FIREWORKS_API_EXTRA_HEADERS_ENV = "FIREWORKS_API_EXTRA_HEADERS"
+
+
+def _fireworks_client(deploy_mgr: DeploymentManager) -> Fireworks:
+    return Fireworks(
+        api_key=deploy_mgr.api_key,
+        account_id=deploy_mgr.account_id,
+        base_url=deploy_mgr.base_url,
+        default_headers=deploy_mgr.additional_headers,
+    )
 
 
 def read_api_extra_headers_env() -> dict[str, str] | None:
@@ -561,6 +575,8 @@ def request_deployment(
         dep_config.region = _infer_region_from_deployment_shape(
             deploy_mgr, dep_config.deployment_shape
         )
+    if not deploy_cfg.enable_hot_load:
+        return _create_non_hotload_deployment_via_sdk(deploy_mgr, dep_config)
     return deploy_mgr.create_or_get(dep_config)
 
 
@@ -759,24 +775,39 @@ def _get_deployment_shape_version(
     deployment_shape: str,
 ) -> dict[str, Any]:
     """Fetch an exact or latest-validated deployment-shape version."""
-    if "/versions/" in deployment_shape:
-        path = f"/v1/{deployment_shape}"
-    else:
-        path = (
-            f"/v1/{deployment_shape}/versions?"
-            f"{urlencode({'filter': 'latest_validated=true', 'pageSize': 1})}"
+    parts = deployment_shape.strip("/").split("/")
+    if len(parts) not in (4, 6) or parts[0] != "accounts" or parts[2] != "deploymentShapes":
+        raise ValueError(f"Invalid deployment shape resource name: {deployment_shape!r}")
+    if len(parts) == 6 and parts[4] != "versions":
+        raise ValueError(f"Invalid deployment shape version resource name: {deployment_shape!r}")
+
+    account_id = parts[1]
+    shape_id = parts[3]
+    version_id = parts[5] if len(parts) == 6 else None
+    client = _fireworks_client(deploy_mgr)
+    if version_id:
+        version = client.deployment_shape_versions.get(
+            account_id=account_id,
+            deployment_shape_id=shape_id,
+            version_id=version_id,
+            timeout=30,
         )
-    resp = deploy_mgr._get(path, timeout=30)
-    resp.raise_for_status()
-    data = resp.json()
-    if "/versions/" in deployment_shape:
-        return data
-    versions = data.get("deploymentShapeVersions", []) or []
+        return version.model_dump(by_alias=True)
+
+    versions = list(
+        client.deployment_shape_versions.list(
+            account_id=account_id,
+            deployment_shape_id=shape_id,
+            filter="latest_validated=true",
+            page_size=1,
+            timeout=30,
+        )
+    )
     if not versions:
         raise RuntimeError(
             f"No latest validated deployment-shape version was returned for '{deployment_shape}'"
         )
-    return versions[0]
+    return versions[0].model_dump(by_alias=True)
 
 
 def get_deployment_gpu_count(
@@ -817,6 +848,55 @@ def get_deployment_gpu_count(
     except Exception as e:
         logger.warning("Could not determine GPU count from shape: %s", e)
         return replica_count
+
+
+def _create_non_hotload_deployment_via_sdk(
+    deploy_mgr: DeploymentManager,
+    config: DeploymentConfig,
+) -> DeploymentInfo:
+    """Create a frozen, non-hotload deployment through the generated Fireworks API client."""
+    if config.hot_load_trainer_job:
+        raise ValueError("non-hotload deployments cannot set hot_load_trainer_job")
+    if config.hot_load_bucket_type:
+        raise ValueError("non-hotload deployments cannot set hot_load_bucket_type")
+    if config.extra_args:
+        raise ValueError("non-hotload deployment extra_args are not exposed by the generated SDK")
+    if config.extra_values:
+        raise ValueError("non-hotload deployment extra_values are not exposed by the generated SDK")
+
+    client = _fireworks_client(deploy_mgr)
+    logger.info("Creating non-hotload deployment: %s", config.deployment_id)
+    try:
+        deployment = client.deployments.create(
+            account_id=deploy_mgr.account_id,
+            deployment_id=config.deployment_id,
+            base_model=config.base_model,
+            enable_hot_load=False,
+            min_replica_count=config.min_replica_count,
+            max_replica_count=config.max_replica_count,
+            deployment_shape=config.deployment_shape or omit,
+            accelerator_type=(
+                omit
+                if config.deployment_shape
+                else config.accelerator_type
+            ),
+            placement={"region": config.region} if config.region else omit,
+            skip_shape_validation=config.skip_shape_validation or omit,
+            disable_speculative_decoding=config.disable_speculative_decoding or omit,
+            timeout=60,
+        )
+    except ConflictError:
+        info = deploy_mgr.get(config.deployment_id)
+        if info is not None:
+            return info
+        raise
+    return DeploymentInfo(
+        deployment_id=config.deployment_id,
+        name=deployment.name or "",
+        state=deployment.state or "UNKNOWN",
+        hot_load_bucket_url=deployment.hot_load_bucket_url,
+        inference_model=f"accounts/{deploy_mgr.account_id}/deployments/{config.deployment_id}",
+    )
 
 
 def setup_training_client(
@@ -1016,7 +1096,6 @@ class Infra:
     the shape doesn't expose ``acceleratorCount``. Recipes use this to size
     concurrency windows, etc."""
 
-
 def setup_infra(
     *,
     rlor_mgr: TrainerJobManager,
@@ -1036,6 +1115,9 @@ def setup_infra(
     api_key: str,
     cleanup: ResourceCleanup | None = None,
     on_status: StatusCallback | None = None,
+    post_shape_provisioners: Sequence[
+        Callable[[str | None], _ProvisionedWaiter | None]
+    ] | None = None,
 ) -> Infra:
     """Build all training-side infrastructure in one call.
 
@@ -1062,6 +1144,10 @@ def setup_infra(
             deployments for scale-to-zero on scope exit. Pass ``None`` to skip
             registration (e.g. when resuming and wanting resources to outlive the run).
         on_status: Optional callback receiving human-readable status messages.
+        post_shape_provisioners: Optional hooks that run after shape resolution
+            and before trainer/deployment waits. Each hook may request an
+            auxiliary resource and return a waiter to run in parallel with the
+            main trainer/deployment readiness waits.
 
     Returns:
         An :class:`Infra` bundle. Caller registers ``infra.closeables`` on an
@@ -1118,6 +1204,12 @@ def setup_infra(
         local_deploy_cfg.weight_sync_scope if local_deploy_cfg else WeightSyncScope.PER_TRAINER
     )
 
+    auxiliary_waiters: list[_ProvisionedWaiter] = []
+    for provisioner in post_shape_provisioners or ():
+        provisioned = provisioner(resolved_deploy_shape if needs_inference else None)
+        if provisioned is not None:
+            auxiliary_waiters.append(provisioned)
+
     # The two scopes differ only in who is created first: whichever side owns
     # the bucket needs its identifier before the other side can be wired up.
     trainer_kwargs = dict(
@@ -1169,6 +1261,7 @@ def setup_infra(
         base_model=base_model,
         role_prefix=role_prefix,
         on_status=emit,
+        auxiliary_waiters=auxiliary_waiters,
     )
 
     inference_model = None
@@ -1502,9 +1595,16 @@ def _await_in_parallel(
     base_model: str,
     role_prefix: str,
     on_status: Callable[[str], None],
+    auxiliary_waiters: Sequence[_ProvisionedWaiter] | None = None,
 ) -> tuple[Any, Any | None, "DeploymentInfo | None"]:
     """Wait for all pending resources in parallel using a thread pool."""
-    max_workers = 1 + (1 if ref_handle is not None else 0) + (1 if dep_info is not None else 0)
+    auxiliary_waiters = list(auxiliary_waiters or ())
+    max_workers = (
+        1
+        + (1 if ref_handle is not None else 0)
+        + (1 if dep_info is not None else 0)
+        + len(auxiliary_waiters)
+    )
 
     policy_ep = ref_ep = final_dep_info = None
     errors: list[str] = []
@@ -1545,6 +1645,10 @@ def _await_in_parallel(
             )
         else:
             dep_future = pool.submit(wait_deployment, deploy_mgr, dep_info, deploy_cfg)
+        auxiliary_futures = {
+            label: pool.submit(wait_fn)
+            for label, wait_fn in auxiliary_waiters
+        }
 
         try:
             policy_ep = policy_future.result()
@@ -1567,6 +1671,12 @@ def _await_in_parallel(
                 )
             except Exception as e:
                 errors.append(f"Deployment: {e}")
+
+        for label, future in auxiliary_futures.items():
+            try:
+                future.result()
+            except Exception as e:
+                errors.append(f"{label}: {e}")
 
     if errors:
         raise RuntimeError("Infrastructure provisioning failed:\n" + "\n".join(errors))

--- a/training/utils/opd.py
+++ b/training/utils/opd.py
@@ -1,0 +1,205 @@
+"""Utilities for sampled-token on-policy distillation (OPD).
+
+The Tinker server already has the primitive OPD needs: the built-in
+``importance_sampling`` loss computes
+
+    -exp(current_logprob - sampling_logprob) * advantage
+
+per token.  Sampled-token OPD uses the teacher/student log-ratio as the dense
+reward, so the per-token advantage is simply
+
+    teacher_logprob - sampling_logprob
+
+for response tokens.  These helpers build server-side datums that encode that
+reward in ``loss_fn_inputs["advantages"]``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, Sequence
+
+import tinker
+
+
+@dataclass
+class OPDPromptGroup:
+    """Processed rollouts for one prompt in sampled-token OPD.
+
+    This mirrors the small part of ``PromptGroup`` needed by the shared async
+    runner, but names the OPD-specific tensors directly instead of treating
+    teacher logprobs as RLHF reference logprobs.
+    """
+
+    data: list[tinker.Datum]
+    teacher_logprobs: list[list[float]]
+    sampling_logprobs: list[list[float]]
+    prompt_len: int
+    rewards: list[float]
+    completion_lens: list[int] = field(default_factory=list)
+    truncated: list[bool] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class OPDInputMetrics:
+    """Summary metrics computed while building OPD server-side datums."""
+
+    active_tokens: int
+    sampled_reverse_kl_sum: float
+    opd_advantage_sum: float
+    teacher_nll_sum: float
+    sampling_nll_sum: float
+
+    def as_dict(self) -> dict[str, float]:
+        denom = max(self.active_tokens, 1)
+        return {
+            "opd_active_tokens": float(self.active_tokens),
+            "opd_sampled_reverse_kl": self.sampled_reverse_kl_sum / denom,
+            "opd_advantage": self.opd_advantage_sum / denom,
+            "opd_teacher_nll": self.teacher_nll_sum / denom,
+            "opd_sampling_nll": self.sampling_nll_sum / denom,
+        }
+
+
+def _pad_or_trim(values: Sequence[float], length: int) -> list[float]:
+    result = [float(v) for v in values[:length]]
+    if len(result) < length:
+        result.extend([0.0] * (length - len(result)))
+    return result
+
+
+def _loss_mask_for_datum(datum: tinker.Datum, length: int) -> list[float]:
+    mask = datum.loss_fn_inputs.get("loss_mask")
+    if mask is None:
+        return [1.0] * length
+    return _pad_or_trim(mask.data, length)
+
+
+def _require_lengths_match(name: str, values: Iterable[object], expected: int) -> list[object]:
+    result = list(values)
+    if len(result) != expected:
+        raise ValueError(f"{name} must have length {expected}, got {len(result)}.")
+    return result
+
+
+def combine_opd_prompt_groups(
+    groups: Sequence[OPDPromptGroup],
+) -> tuple[list[tinker.Datum], list[list[float]], list[int], list[list[float]]]:
+    """Flatten OPD prompt groups into arrays for one server-side loss call."""
+    data: list[tinker.Datum] = []
+    teacher_logprobs: list[list[float]] = []
+    prompt_lens: list[int] = []
+    sampling_logprobs: list[list[float]] = []
+
+    for group_idx, group in enumerate(groups):
+        n = len(group.data)
+        if len(group.teacher_logprobs) != n:
+            raise ValueError(
+                f"Group {group_idx}: teacher_logprobs length ({len(group.teacher_logprobs)}) "
+                f"does not match data length ({n})."
+            )
+        if len(group.sampling_logprobs) != n:
+            raise ValueError(
+                f"Group {group_idx}: sampling_logprobs length ({len(group.sampling_logprobs)}) "
+                f"does not match data length ({n})."
+            )
+
+        data.extend(group.data)
+        teacher_logprobs.extend(group.teacher_logprobs)
+        prompt_lens.extend([group.prompt_len] * n)
+        sampling_logprobs.extend(group.sampling_logprobs)
+
+    return data, teacher_logprobs, prompt_lens, sampling_logprobs
+
+
+def build_opd_server_datums(
+    data: Sequence[tinker.Datum],
+    teacher_logprobs: Sequence[Sequence[float]],
+    sampling_logprobs: Sequence[Sequence[float]],
+    prompt_lens: Sequence[int],
+    *,
+    loss_scale: float = 1.0,
+) -> tuple[list[tinker.Datum], dict[str, float]]:
+    """Build datums for Tinker's server-side ``importance_sampling`` loss.
+
+    Args:
+        data: Training datums containing ``target_tokens`` and model inputs.
+        teacher_logprobs: Teacher logprobs aligned to ``target_tokens``.
+        sampling_logprobs: Student rollout logprobs aligned to ``target_tokens``.
+        prompt_lens: Full prompt token count per datum.  The first response
+            token has logprob index ``prompt_len - 1``.
+        loss_scale: Optional scalar multiplier for the OPD dense reward.
+
+    Returns:
+        ``(server_datums, metrics)``.  ``server_datums`` contain exactly the
+        fields required by Tinker's built-in RL losses:
+        ``target_tokens``, ``logprobs`` (sampling logprobs), and
+        ``advantages`` (teacher minus sampling on response tokens).
+    """
+    n = len(data)
+    teacher_logprobs = _require_lengths_match("teacher_logprobs", teacher_logprobs, n)
+    sampling_logprobs = _require_lengths_match("sampling_logprobs", sampling_logprobs, n)
+    prompt_lens = _require_lengths_match("prompt_lens", prompt_lens, n)
+
+    server_datums: list[tinker.Datum] = []
+    active_tokens = 0
+    sampled_reverse_kl_sum = 0.0
+    opd_advantage_sum = 0.0
+    teacher_nll_sum = 0.0
+    sampling_nll_sum = 0.0
+
+    for idx, datum in enumerate(data):
+        target_data = datum.loss_fn_inputs.get("target_tokens")
+        if target_data is None:
+            raise ValueError(f"Datum {idx} is missing loss_fn_inputs['target_tokens'].")
+
+        target_tokens = list(target_data.data)
+        target_len = len(target_tokens)
+        response_start = max(0, int(prompt_lens[idx]) - 1)
+        teacher_lp = _pad_or_trim(teacher_logprobs[idx], target_len)
+        sampling_lp = _pad_or_trim(sampling_logprobs[idx], target_len)
+        loss_mask = _loss_mask_for_datum(datum, target_len)
+
+        advantages = [0.0] * target_len
+        for pos in range(response_start, target_len):
+            if loss_mask[pos] <= 0.0:
+                continue
+            advantage = (teacher_lp[pos] - sampling_lp[pos]) * loss_scale * loss_mask[pos]
+            advantages[pos] = advantage
+            active_tokens += 1
+            sampled_reverse_kl_sum += (sampling_lp[pos] - teacher_lp[pos]) * loss_mask[pos]
+            opd_advantage_sum += advantage
+            teacher_nll_sum += -teacher_lp[pos] * loss_mask[pos]
+            sampling_nll_sum += -sampling_lp[pos] * loss_mask[pos]
+
+        server_datums.append(
+            tinker.Datum(
+                model_input=datum.model_input,
+                loss_fn_inputs={
+                    "target_tokens": tinker.TensorData(
+                        data=target_tokens,
+                        dtype="int64",
+                        shape=[target_len],
+                    ),
+                    "logprobs": tinker.TensorData(
+                        data=sampling_lp,
+                        dtype="float32",
+                        shape=[target_len],
+                    ),
+                    "advantages": tinker.TensorData(
+                        data=advantages,
+                        dtype="float32",
+                        shape=[target_len],
+                    ),
+                },
+            )
+        )
+
+    metrics = OPDInputMetrics(
+        active_tokens=active_tokens,
+        sampled_reverse_kl_sum=sampled_reverse_kl_sum,
+        opd_advantage_sum=opd_advantage_sum,
+        teacher_nll_sum=teacher_nll_sum,
+        sampling_nll_sum=sampling_nll_sum,
+    )
+    return server_datums, metrics.as_dict()

--- a/training/utils/opd.py
+++ b/training/utils/opd.py
@@ -47,15 +47,23 @@ class OPDInputMetrics:
     active_tokens: int
     sampled_reverse_kl_sum: float
     opd_advantage_sum: float
+    opd_abs_advantage_sum: float
     teacher_nll_sum: float
     sampling_nll_sum: float
 
     def as_dict(self) -> dict[str, float]:
         denom = max(self.active_tokens, 1)
+        sampled_reverse_kl = self.sampled_reverse_kl_sum / denom
+        opd_advantage = self.opd_advantage_sum / denom
+        abs_logprob_gap = self.opd_abs_advantage_sum / denom
         return {
             "opd_active_tokens": float(self.active_tokens),
-            "opd_sampled_reverse_kl": self.sampled_reverse_kl_sum / denom,
-            "opd_advantage": self.opd_advantage_sum / denom,
+            "opd_sampled_reverse_kl": sampled_reverse_kl,
+            "opd_advantage": opd_advantage,
+            "opd_abs_advantage": abs_logprob_gap,
+            "opd_student_logprob_minus_teacher_logprob": sampled_reverse_kl,
+            "opd_teacher_logprob_minus_student_logprob": opd_advantage,
+            "opd_abs_logprob_gap": abs_logprob_gap,
             "opd_teacher_nll": self.teacher_nll_sum / denom,
             "opd_sampling_nll": self.sampling_nll_sum / denom,
         }
@@ -80,6 +88,23 @@ def _require_lengths_match(name: str, values: Iterable[object], expected: int) -
     if len(result) != expected:
         raise ValueError(f"{name} must have length {expected}, got {len(result)}.")
     return result
+
+
+def _require_active_logprobs(
+    name: str,
+    values: Sequence[float],
+    active_positions: Sequence[int],
+    *,
+    datum_idx: int,
+) -> None:
+    if not active_positions:
+        return
+    required_len = max(active_positions) + 1
+    if len(values) < required_len:
+        raise ValueError(
+            f"Datum {datum_idx}: {name} has length {len(values)}, "
+            f"but active OPD tokens require at least {required_len} logprobs."
+        )
 
 
 def combine_opd_prompt_groups(
@@ -145,6 +170,7 @@ def build_opd_server_datums(
     active_tokens = 0
     sampled_reverse_kl_sum = 0.0
     opd_advantage_sum = 0.0
+    opd_abs_advantage_sum = 0.0
     teacher_nll_sum = 0.0
     sampling_nll_sum = 0.0
 
@@ -156,9 +182,26 @@ def build_opd_server_datums(
         target_tokens = list(target_data.data)
         target_len = len(target_tokens)
         response_start = max(0, int(prompt_lens[idx]) - 1)
-        teacher_lp = _pad_or_trim(teacher_logprobs[idx], target_len)
-        sampling_lp = _pad_or_trim(sampling_logprobs[idx], target_len)
+        raw_teacher_lp = [float(v) for v in teacher_logprobs[idx]]
+        raw_sampling_lp = [float(v) for v in sampling_logprobs[idx]]
         loss_mask = _loss_mask_for_datum(datum, target_len)
+        active_positions = [
+            pos for pos in range(response_start, target_len) if loss_mask[pos] > 0.0
+        ]
+        _require_active_logprobs(
+            "teacher_logprobs",
+            raw_teacher_lp,
+            active_positions,
+            datum_idx=idx,
+        )
+        _require_active_logprobs(
+            "sampling_logprobs",
+            raw_sampling_lp,
+            active_positions,
+            datum_idx=idx,
+        )
+        teacher_lp = _pad_or_trim(raw_teacher_lp, target_len)
+        sampling_lp = _pad_or_trim(raw_sampling_lp, target_len)
 
         advantages = [0.0] * target_len
         for pos in range(response_start, target_len):
@@ -169,6 +212,7 @@ def build_opd_server_datums(
             active_tokens += 1
             sampled_reverse_kl_sum += (sampling_lp[pos] - teacher_lp[pos]) * loss_mask[pos]
             opd_advantage_sum += advantage
+            opd_abs_advantage_sum += abs(advantage)
             teacher_nll_sum += -teacher_lp[pos] * loss_mask[pos]
             sampling_nll_sum += -sampling_lp[pos] * loss_mask[pos]
 
@@ -199,6 +243,7 @@ def build_opd_server_datums(
         active_tokens=active_tokens,
         sampled_reverse_kl_sum=sampled_reverse_kl_sum,
         opd_advantage_sum=opd_advantage_sum,
+        opd_abs_advantage_sum=opd_abs_advantage_sum,
         teacher_nll_sum=teacher_nll_sum,
         sampling_nll_sum=sampling_nll_sum,
     )

--- a/training/utils/opd_eval.py
+++ b/training/utils/opd_eval.py
@@ -1,0 +1,591 @@
+"""Evaluation and validation helpers for privileged-context OPD."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import math
+import re
+from pathlib import Path
+from typing import Any, Callable
+
+from fireworks.training.sdk.deployment import DeploymentSampler
+from training.utils.data import prepare_sampling_messages
+from training.utils.opd_sampling import (
+    _score_with_teacher,
+    _teacher_messages_for_row,
+    _tokenize_teacher_prompt,
+)
+
+
+FINAL_ANSWER_LINE_RE = re.compile(r"^\s*Final:\s*([^\n\r]+?)\s*$", re.IGNORECASE)
+PROMPT_FINAL_ANSWER_RE = re.compile(r"Final:\s*([^\n\r]+)", re.IGNORECASE)
+DEFAULT_PRIVILEGED_CONTEXT_MARKERS = (
+    "privileged",
+    "private",
+    "worked solution",
+    "gold solution",
+    "golden solution",
+    "teacher-only",
+    "hidden",
+)
+
+
+def normalize_final_answer(answer: Any) -> str:
+    """Normalize a final answer for lightweight exact-match evaluation."""
+    normalized = re.sub(r"\s+", " ", str(answer).strip())
+    return normalized.rstrip(".")
+
+
+def expected_final_answer(row: dict[str, Any]) -> str | None:
+    """Read the expected answer from common JSONL row fields."""
+    for key in ("expected_answer", "expected", "answer"):
+        if row.get(key) is not None:
+            normalized = normalize_final_answer(row[key])
+            return normalized or None
+    return None
+
+
+def extract_final_answer(text: str) -> str | None:
+    """Extract ``Final: ...`` only when it is the completion's last non-empty line."""
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    if not lines:
+        return None
+    match = FINAL_ANSWER_LINE_RE.match(lines[-1])
+    if not match:
+        return None
+    return normalize_final_answer(match.group(1))
+
+
+def _extract_prompt_final_answer(text: str) -> str | None:
+    """Extract a pinned ``Final: ...`` answer from prompt text."""
+    matches = list(PROMPT_FINAL_ANSWER_RE.finditer(text))
+    if not matches:
+        return None
+    return normalize_final_answer(matches[-1].group(1))
+
+
+def _load_opd_rows(dataset: str | Path | list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if isinstance(dataset, list):
+        return list(dataset)
+    path = Path(dataset)
+    return [
+        json.loads(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def validate_privileged_opd_dataset(
+    dataset: str | Path | list[dict[str, Any]],
+    *,
+    min_rows: int = 1,
+    privileged_markers: tuple[str, ...] = DEFAULT_PRIVILEGED_CONTEXT_MARKERS,
+    require_teacher_final_answer: bool = True,
+    require_expected_answer: bool = True,
+) -> None:
+    """Validate JSONL rows for privileged-context OPD before launching a job."""
+    errors: list[str] = []
+    try:
+        rows = _load_opd_rows(dataset)
+    except Exception as exc:
+        raise ValueError(f"Failed to load OPD dataset {dataset!r}: {exc}") from exc
+
+    if len(rows) < min_rows:
+        errors.append(f"expected at least {min_rows} rows, got {len(rows)}")
+    lower_markers = tuple(marker.lower() for marker in privileged_markers)
+    for idx, row in enumerate(rows, start=1):
+        messages = row.get("messages")
+        teacher_messages = (
+            row.get("teacher_messages")
+            or row.get("privileged_messages")
+            or row.get("teacher_prompt_messages")
+        )
+        if not messages:
+            errors.append(f"row {idx} must include student `messages`")
+            continue
+        if not teacher_messages:
+            errors.append(f"row {idx} must include privileged `teacher_messages`")
+            continue
+        if messages == teacher_messages:
+            errors.append(f"row {idx} teacher_messages must differ from student messages")
+
+        student_text = "\n".join(str(message.get("content", "")) for message in messages)
+        teacher_text = "\n".join(str(message.get("content", "")) for message in teacher_messages)
+        lower_student_text = student_text.lower()
+        lower_teacher_text = teacher_text.lower()
+        if any(marker in lower_student_text for marker in lower_markers):
+            errors.append(f"row {idx} leaks privileged context into student messages")
+        if not any(marker in lower_teacher_text for marker in lower_markers):
+            errors.append(f"row {idx} teacher_messages missing privileged context")
+        if "Final:" not in student_text or "Final:" not in teacher_text:
+            errors.append(f"row {idx} prompts must ask for a `Final:` answer")
+        if "Final: <" in teacher_text:
+            errors.append(f"row {idx} teacher prompt must not use a placeholder final-answer format")
+
+        expected = expected_final_answer(row)
+        if require_expected_answer and expected is None:
+            errors.append(f"row {idx} is missing expected_answer")
+        if require_teacher_final_answer and expected is not None:
+            teacher_final = _extract_prompt_final_answer(teacher_text)
+            if teacher_final != expected:
+                errors.append(
+                    f"row {idx} teacher prompt must pin exact final answer "
+                    f"`Final: {expected}`; parsed {teacher_final!r}"
+                )
+
+    if errors:
+        raise ValueError("Invalid privileged OPD dataset:\n" + "\n".join(f"- {error}" for error in errors))
+
+
+def _find_last_subsequence(haystack: list[int], needle: list[int]) -> int | None:
+    if not needle or len(needle) > len(haystack):
+        return None
+    for start in range(len(haystack) - len(needle), -1, -1):
+        if haystack[start : start + len(needle)] == needle:
+            return start
+    return None
+
+
+def _final_answer_span(
+    tokenizer: Any,
+    text: str,
+    completion_tokens: list[int],
+) -> tuple[int, int, str] | None:
+    non_empty_lines = [line for line in text.splitlines() if line.strip()]
+    if not non_empty_lines:
+        return None
+    final_line = non_empty_lines[-1]
+    line_match = FINAL_ANSWER_LINE_RE.match(final_line)
+    if not line_match:
+        return None
+    line_start = text.rfind(final_line)
+    answer_start = line_start + line_match.start(1)
+    answer_text = line_match.group(1)
+    answer = normalize_final_answer(answer_text)
+    prefix_tokens = tokenizer.encode(text[:answer_start], add_special_tokens=False)
+    answer_tokens = tokenizer.encode(answer_text, add_special_tokens=False)
+    start = len(prefix_tokens)
+    end = start + len(answer_tokens)
+    if not answer_tokens:
+        return None
+    if end > len(completion_tokens) or completion_tokens[start:end] != list(answer_tokens):
+        found_start = _find_last_subsequence(completion_tokens, list(answer_tokens))
+        if found_start is None:
+            return None
+        start = found_start
+        end = start + len(answer_tokens)
+    return start, end, answer
+
+
+def _span_nll(logprobs: list[float], start: int = 0, end: int | None = None) -> float:
+    span = logprobs[start:end]
+    if not span:
+        return 0.0
+    return -sum(float(lp) for lp in span) / len(span)
+
+
+async def _sample_eval_completion(
+    sampler: DeploymentSampler,
+    messages: list[dict[str, Any]],
+    config: Any,
+    *,
+    max_seq_len: int | None,
+    temperature: float,
+) -> Any:
+    samples = await sampler.sample_with_tokens(
+        messages=prepare_sampling_messages(messages),
+        n=1,
+        max_tokens=config.max_completion_tokens,
+        temperature=temperature,
+        max_seq_len=max_seq_len,
+        http_timeout=config.deployment.sample_timeout,
+        logprobs=True,
+    )
+    if not samples:
+        raise RuntimeError("deployment returned no samples during OPD trace eval")
+    sample = samples[0]
+    if len(sample.full_tokens) <= sample.prompt_len:
+        raise RuntimeError("deployment returned an empty completion during OPD trace eval")
+    return sample
+
+
+async def _score_eval_response_tokens(
+    sampler: DeploymentSampler,
+    tokenizer: Any,
+    messages: list[dict[str, Any]],
+    completion_tokens: list[int],
+    http_timeout: int,
+) -> list[float]:
+    prompt_tokens = _tokenize_teacher_prompt(tokenizer, prepare_sampling_messages(messages))
+    response_logprobs = await _score_with_teacher(
+        sampler,
+        list(prompt_tokens) + list(completion_tokens),
+        prompt_len=len(prompt_tokens),
+        response_len=len(completion_tokens),
+        top_logprobs=0,
+        http_timeout=http_timeout,
+    )
+    if response_logprobs is None:
+        raise RuntimeError("failed to score OPD trace response tokens")
+    if len(response_logprobs) < len(completion_tokens):
+        raise RuntimeError(
+            "trace scoring returned too few response logprobs: "
+            f"{len(response_logprobs)} < {len(completion_tokens)}"
+        )
+    return [float(lp) for lp in response_logprobs]
+
+
+async def _evaluate_teacher_trace_logprob_gap_async(
+    context: dict[str, Any],
+    *,
+    trace_log_path: str | Path | None = None,
+    min_pre_final_tokens: int = 0,
+) -> dict[str, Any]:
+    """Score teacher reasoning traces under teacher and student prompts.
+
+    This is meant for privileged-context OPD eval: the frozen teacher generates
+    a trace from ``teacher_messages``; the same trace tokens are then scored
+    under both the privileged teacher prompt and the ordinary student prompt.
+    """
+    config: Any = context["config"]
+    student_sampler = context["student_sampler"]
+    teacher_sampler = context["teacher_sampler"]
+    tokenizer = context["tokenizer"]
+    rows = list(context["dataset"])
+    step = int(context.get("global_step", 0))
+    max_seq_len = context.get("max_seq_len")
+
+    records: list[dict[str, Any]] = []
+    for row in rows:
+        expected = expected_final_answer(row)
+        if expected is None:
+            raise RuntimeError(f"row is missing an expected answer: {row!r}")
+
+        student_messages = prepare_sampling_messages(row.get("messages", []))
+        if not student_messages:
+            raise RuntimeError(f"row is missing messages: {row!r}")
+        teacher_messages = _teacher_messages_for_row(
+            row,
+            student_messages,
+        )
+
+        teacher_sample = await _sample_eval_completion(
+            teacher_sampler,
+            teacher_messages,
+            config,
+            max_seq_len=max_seq_len,
+            temperature=0.0,
+        )
+        completion_tokens = list(teacher_sample.full_tokens[teacher_sample.prompt_len :])
+        trace_text = str(getattr(teacher_sample, "text", ""))
+        span = _final_answer_span(tokenizer, trace_text, completion_tokens)
+        if span is None:
+            raise RuntimeError(f"teacher trace did not contain a parseable final answer: {trace_text!r}")
+        final_start, final_end, teacher_generated_final = span
+        if final_start < min_pre_final_tokens:
+            raise RuntimeError(
+                "teacher trace did not include enough pre-final tokens to validate "
+                f"thinking-token distillation ({final_start} < {min_pre_final_tokens})"
+            )
+
+        teacher_logprobs = await _score_eval_response_tokens(
+            teacher_sampler,
+            tokenizer,
+            teacher_messages,
+            completion_tokens,
+            config.deployment.sample_timeout,
+        )
+        student_logprobs = await _score_eval_response_tokens(
+            student_sampler,
+            tokenizer,
+            student_messages,
+            completion_tokens,
+            config.deployment.sample_timeout,
+        )
+        student_sample = await _sample_eval_completion(
+            student_sampler,
+            student_messages,
+            config,
+            max_seq_len=max_seq_len,
+            temperature=0.0,
+        )
+        student_text = str(getattr(student_sample, "text", ""))
+        student_generated_final = extract_final_answer(student_text)
+
+        teacher_nll = _span_nll(teacher_logprobs)
+        student_nll = _span_nll(student_logprobs)
+        pre_final_teacher_nll = _span_nll(teacher_logprobs, 0, final_start)
+        pre_final_student_nll = _span_nll(student_logprobs, 0, final_start)
+        final_teacher_nll = _span_nll(teacher_logprobs, final_start, final_end)
+        final_student_nll = _span_nll(student_logprobs, final_start, final_end)
+        records.append(
+            {
+                "step": step,
+                "expected_answer": expected,
+                "teacher_generated_final": teacher_generated_final,
+                "student_generated_final": student_generated_final,
+                "tokens": len(completion_tokens),
+                "pre_final_tokens": final_start,
+                "final_tokens": final_end - final_start,
+                "teacher_trace": trace_text,
+                "student_generation": student_text,
+                "teacher_nll": teacher_nll,
+                "student_nll": student_nll,
+                "student_minus_teacher_nll": student_nll - teacher_nll,
+                "pre_final_teacher_nll": pre_final_teacher_nll,
+                "pre_final_student_nll": pre_final_student_nll,
+                "pre_final_student_minus_teacher_nll": pre_final_student_nll - pre_final_teacher_nll,
+                "final_teacher_nll": final_teacher_nll,
+                "final_student_nll": final_student_nll,
+                "final_student_minus_teacher_nll": final_student_nll - final_teacher_nll,
+                "teacher_final_correct": normalize_final_answer(teacher_generated_final) == expected,
+                "student_generation_correct": (
+                    student_generated_final is not None
+                    and normalize_final_answer(student_generated_final) == expected
+                ),
+            }
+        )
+
+    total = len(records)
+    total_tokens = sum(int(record["tokens"]) for record in records)
+    pre_final_tokens = sum(int(record["pre_final_tokens"]) for record in records)
+    final_tokens = sum(int(record["final_tokens"]) for record in records)
+    denom = max(total_tokens, 1)
+    pre_final_denom = max(pre_final_tokens, 1)
+    final_denom = max(final_tokens, 1)
+    teacher_nll = sum(float(record["teacher_nll"]) * int(record["tokens"]) for record in records) / denom
+    student_nll = sum(float(record["student_nll"]) * int(record["tokens"]) for record in records) / denom
+    pre_final_teacher_nll = sum(
+        float(record["pre_final_teacher_nll"]) * int(record["pre_final_tokens"]) for record in records
+    ) / pre_final_denom
+    pre_final_student_nll = sum(
+        float(record["pre_final_student_nll"]) * int(record["pre_final_tokens"]) for record in records
+    ) / pre_final_denom
+    final_teacher_nll = sum(
+        float(record["final_teacher_nll"]) * int(record["final_tokens"]) for record in records
+    ) / final_denom
+    final_student_nll = sum(
+        float(record["final_student_nll"]) * int(record["final_tokens"]) for record in records
+    ) / final_denom
+    teacher_final_accuracy = sum(
+        1.0 for record in records if record["teacher_final_correct"]
+    ) / max(total, 1)
+    student_generation_accuracy = sum(
+        1.0 for record in records if record["student_generation_correct"]
+    ) / max(total, 1)
+
+    if trace_log_path is not None:
+        path = Path(trace_log_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(
+                "\n".join(json.dumps(record, separators=(",", ":")) for record in records) + "\n"
+            )
+
+    return {
+        "eval/opd_trace_teacher_nll": teacher_nll,
+        "eval/opd_trace_student_nll": student_nll,
+        "eval/opd_trace_student_minus_teacher_nll": student_nll - teacher_nll,
+        "eval/opd_trace_pre_final_teacher_nll": pre_final_teacher_nll,
+        "eval/opd_trace_pre_final_student_nll": pre_final_student_nll,
+        "eval/opd_trace_pre_final_student_minus_teacher_nll": (
+            pre_final_student_nll - pre_final_teacher_nll
+        ),
+        "eval/opd_trace_final_teacher_nll": final_teacher_nll,
+        "eval/opd_trace_final_student_nll": final_student_nll,
+        "eval/opd_trace_final_student_minus_teacher_nll": final_student_nll - final_teacher_nll,
+        "eval/opd_trace_teacher_final_accuracy": teacher_final_accuracy,
+        "eval/opd_trace_student_generation_accuracy": student_generation_accuracy,
+        "eval/opd_trace_examples": float(total),
+        "eval/opd_trace_tokens": float(total_tokens),
+        "eval/opd_trace_pre_final_tokens": float(pre_final_tokens),
+        "eval/opd_trace_final_tokens": float(final_tokens),
+    }
+
+
+def evaluate_teacher_trace_logprob_gap(
+    context: dict[str, Any],
+    *,
+    trace_log_path: str | Path | None = None,
+    min_pre_final_tokens: int = 0,
+) -> dict[str, Any]:
+    """Synchronous callback wrapper for ``Config.step_eval`` / ``post_training_eval``."""
+    return asyncio.run(
+        _evaluate_teacher_trace_logprob_gap_async(
+            context,
+            trace_log_path=trace_log_path,
+            min_pre_final_tokens=min_pre_final_tokens,
+        )
+    )
+
+
+def make_teacher_trace_logprob_gap_eval(
+    *,
+    trace_log_path: str | Path | None = None,
+    min_pre_final_tokens: int = 0,
+) -> Callable[[dict[str, Any]], dict[str, Any]]:
+    """Create a no-argument eval callback suitable for ``Config.step_eval``."""
+
+    def _callback(context: dict[str, Any]) -> dict[str, Any]:
+        return evaluate_teacher_trace_logprob_gap(
+            context,
+            trace_log_path=trace_log_path,
+            min_pre_final_tokens=min_pre_final_tokens,
+        )
+
+    return _callback
+
+
+def validate_opd_trace_result(
+    config: Any,
+    result: dict[str, Any],
+    *,
+    expected_steps: int | None = None,
+    min_abs_advantage: float = 1e-4,
+    min_train_gap_improvement: float | None = None,
+    min_trace_gap_improvement: float | None = None,
+    min_teacher_final_accuracy: float | None = None,
+    min_student_generation_accuracy: float | None = None,
+    min_max_seq_len: int | None = None,
+) -> None:
+    """Validate that an OPD run produced train and teacher-trace eval signal."""
+    errors: list[str] = []
+    if expected_steps is None:
+        expected_steps = (
+            config.max_rows * config.epochs + config.prompt_groups_per_step - 1
+        ) // config.prompt_groups_per_step
+
+    steps = int(result.get("steps", 0))
+    if steps < expected_steps:
+        errors.append(f"expected {expected_steps} optimizer steps, got {steps}")
+    resolved_max_seq_len = result.get("max_seq_len")
+    if min_max_seq_len is not None and resolved_max_seq_len is not None:
+        if int(resolved_max_seq_len) < min_max_seq_len:
+            errors.append(
+                f"expected resolved max_seq_len >= {min_max_seq_len}, got {resolved_max_seq_len}"
+            )
+
+    metrics_path = Path(config.runner.metrics_file or "")
+    records: list[dict[str, Any]] = []
+    if not metrics_path.exists():
+        errors.append(f"metrics file was not written: {metrics_path}")
+    else:
+        records = [
+            json.loads(line)
+            for line in metrics_path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        train_records = [record for record in records if "train/opd_active_tokens" in record]
+        if len(train_records) < expected_steps:
+            errors.append(
+                f"expected at least {expected_steps} train metric records, got {len(train_records)}"
+            )
+        active_tokens = sum(float(record.get("train/opd_active_tokens", 0.0)) for record in train_records)
+        max_abs_advantage = max(
+            (abs(float(record.get("train/opd_abs_advantage", 0.0))) for record in train_records),
+            default=0.0,
+        )
+        if active_tokens <= 0:
+            errors.append("no active OPD tokens were trained")
+        if max_abs_advantage < min_abs_advantage:
+            errors.append(
+                "teacher/student logprob delta was effectively zero "
+                f"(max train/opd_abs_advantage={max_abs_advantage:.6g})"
+            )
+
+        sampled_kl = [
+            float(record.get("train/opd_sampled_reverse_kl", 0.0))
+            for record in train_records
+            if "train/opd_sampled_reverse_kl" in record
+        ]
+        if min_train_gap_improvement is not None and len(sampled_kl) >= 4:
+            head = sampled_kl[1 : max(2, len(sampled_kl) // 2)]
+            tail = sampled_kl[-min(5, len(sampled_kl)) :]
+            head_mean = sum(head) / max(len(head), 1)
+            tail_mean = sum(tail) / max(len(tail), 1)
+            improvement = (head_mean - tail_mean) / max(abs(head_mean), 1e-9)
+            if improvement < min_train_gap_improvement:
+                errors.append(
+                    "sampled teacher/student logprob gap did not improve enough "
+                    f"(head_mean={head_mean:.4g}, tail_mean={tail_mean:.4g}, "
+                    f"improvement={improvement:.1%})"
+                )
+
+        eval_records = [
+            record for record in records if "eval/opd_trace_teacher_nll" in record
+        ]
+        expected_eval_records = expected_steps + (1 if config.eval_before_training else 0)
+        if len(eval_records) < expected_eval_records:
+            errors.append(
+                f"expected {expected_eval_records} teacher-trace eval records, got {len(eval_records)}"
+            )
+        if config.eval_before_training and not any(record.get("step") == 0 for record in eval_records):
+            errors.append("missing teacher-trace pre-training eval at step 0")
+        trace_gaps = [
+            float(record["eval/opd_trace_student_minus_teacher_nll"])
+            for record in eval_records
+            if "eval/opd_trace_student_minus_teacher_nll" in record
+        ]
+        if eval_records and len(trace_gaps) < len(eval_records):
+            errors.append("teacher-trace eval records are missing student/teacher logprob gap")
+        if min_trace_gap_improvement is not None and len(trace_gaps) >= 2 and trace_gaps[0] > 0:
+            improvement = (trace_gaps[0] - trace_gaps[-1]) / max(abs(trace_gaps[0]), 1e-9)
+            if improvement < min_trace_gap_improvement:
+                errors.append(
+                    "teacher-trace student/teacher logprob gap did not improve enough "
+                    f"(initial={trace_gaps[0]:.4g}, final={trace_gaps[-1]:.4g}, "
+                    f"improvement={improvement:.1%})"
+                )
+
+    eval_metrics = result.get("eval") or {}
+    required_eval_metrics = [
+        "eval/opd_trace_teacher_nll",
+        "eval/opd_trace_student_nll",
+        "eval/opd_trace_student_minus_teacher_nll",
+        "eval/opd_trace_pre_final_teacher_nll",
+        "eval/opd_trace_pre_final_student_nll",
+        "eval/opd_trace_pre_final_student_minus_teacher_nll",
+        "eval/opd_trace_final_teacher_nll",
+        "eval/opd_trace_final_student_nll",
+        "eval/opd_trace_final_student_minus_teacher_nll",
+        "eval/opd_trace_teacher_final_accuracy",
+        "eval/opd_trace_student_generation_accuracy",
+        "eval/opd_trace_examples",
+        "eval/opd_trace_tokens",
+        "eval/opd_trace_pre_final_tokens",
+        "eval/opd_trace_final_tokens",
+    ]
+    for key in required_eval_metrics:
+        value = eval_metrics.get(key)
+        if value is None or not math.isfinite(float(value)):
+            errors.append(f"missing or invalid teacher-trace eval metric: {key}")
+
+    teacher_accuracy = float(eval_metrics.get("eval/opd_trace_teacher_final_accuracy", 0.0))
+    student_accuracy = float(eval_metrics.get("eval/opd_trace_student_generation_accuracy", 0.0))
+    if min_teacher_final_accuracy is not None and teacher_accuracy < min_teacher_final_accuracy:
+        errors.append(
+            "frozen teacher does not reliably generate the privileged final answer "
+            f"(accuracy={teacher_accuracy:.3f}, required={min_teacher_final_accuracy:.3f})"
+        )
+    if (
+        min_student_generation_accuracy is not None
+        and student_accuracy < min_student_generation_accuracy
+    ):
+        errors.append(
+            "student did not reach the privileged-answer exact-match target by final eval "
+            f"(accuracy={student_accuracy:.3f}, required={min_student_generation_accuracy:.3f})"
+        )
+    if float(eval_metrics.get("eval/opd_trace_examples", 0.0)) <= 0:
+        errors.append("teacher-trace eval scored no examples")
+    if float(eval_metrics.get("eval/opd_trace_tokens", 0.0)) <= 0:
+        errors.append("teacher-trace eval scored no response tokens")
+    if float(eval_metrics.get("eval/opd_trace_pre_final_tokens", 0.0)) <= 0:
+        errors.append("teacher-trace eval scored no pre-final thinking/reasoning tokens")
+    if float(eval_metrics.get("eval/opd_trace_final_tokens", 0.0)) <= 0:
+        errors.append("teacher-trace eval scored no final-answer tokens")
+
+    if errors:
+        raise RuntimeError("OPD trace validation failed:\n" + "\n".join(f"- {error}" for error in errors))
+
+

--- a/training/utils/opd_eval.py
+++ b/training/utils/opd_eval.py
@@ -1,0 +1,589 @@
+"""Evaluation and validation helpers for privileged-context OPD."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import math
+import re
+from pathlib import Path
+from typing import Any, Callable
+
+from fireworks.training.sdk.deployment import DeploymentSampler
+from training.utils.data import prepare_sampling_messages
+from training.utils.opd_sampling import (
+    _score_with_teacher,
+    _teacher_messages_for_row,
+    _tokenize_teacher_prompt,
+)
+
+
+FINAL_ANSWER_LINE_RE = re.compile(r"^\s*Final:\s*([^\n\r]+?)\s*$", re.IGNORECASE)
+PROMPT_FINAL_ANSWER_RE = re.compile(r"Final:\s*([^\n\r]+)", re.IGNORECASE)
+DEFAULT_PRIVILEGED_CONTEXT_MARKERS = (
+    "privileged",
+    "private",
+    "worked solution",
+    "gold solution",
+    "golden solution",
+    "teacher-only",
+    "hidden",
+)
+
+
+def normalize_final_answer(answer: Any) -> str:
+    """Normalize a final answer for lightweight exact-match evaluation."""
+    normalized = re.sub(r"\s+", " ", str(answer).strip())
+    return normalized.rstrip(".")
+
+
+def expected_final_answer(row: dict[str, Any]) -> str | None:
+    """Read the expected answer from common JSONL row fields."""
+    for key in ("expected_answer", "expected", "answer"):
+        if row.get(key) is not None:
+            normalized = normalize_final_answer(row[key])
+            return normalized or None
+    return None
+
+
+def extract_final_answer(text: str) -> str | None:
+    """Extract ``Final: ...`` only when it is the completion's last non-empty line."""
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    if not lines:
+        return None
+    match = FINAL_ANSWER_LINE_RE.match(lines[-1])
+    if not match:
+        return None
+    return normalize_final_answer(match.group(1))
+
+
+def _extract_prompt_final_answer(text: str) -> str | None:
+    """Extract a pinned ``Final: ...`` answer from prompt text."""
+    matches = list(PROMPT_FINAL_ANSWER_RE.finditer(text))
+    if not matches:
+        return None
+    return normalize_final_answer(matches[-1].group(1))
+
+
+def _load_opd_rows(dataset: str | Path | list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if isinstance(dataset, list):
+        return list(dataset)
+    path = Path(dataset)
+    return [
+        json.loads(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def validate_privileged_opd_dataset(
+    dataset: str | Path | list[dict[str, Any]],
+    *,
+    min_rows: int = 1,
+    privileged_markers: tuple[str, ...] = DEFAULT_PRIVILEGED_CONTEXT_MARKERS,
+    require_teacher_final_answer: bool = True,
+    require_expected_answer: bool = True,
+) -> None:
+    """Validate JSONL rows for privileged-context OPD before launching a job."""
+    errors: list[str] = []
+    try:
+        rows = _load_opd_rows(dataset)
+    except Exception as exc:
+        raise ValueError(f"Failed to load OPD dataset {dataset!r}: {exc}") from exc
+
+    if len(rows) < min_rows:
+        errors.append(f"expected at least {min_rows} rows, got {len(rows)}")
+    lower_markers = tuple(marker.lower() for marker in privileged_markers)
+    for idx, row in enumerate(rows, start=1):
+        messages = row.get("messages")
+        teacher_messages = (
+            row.get("teacher_messages")
+            or row.get("privileged_messages")
+            or row.get("teacher_prompt_messages")
+        )
+        if not messages:
+            errors.append(f"row {idx} must include student `messages`")
+            continue
+        if not teacher_messages:
+            errors.append(f"row {idx} must include privileged `teacher_messages`")
+            continue
+        if messages == teacher_messages:
+            errors.append(f"row {idx} teacher_messages must differ from student messages")
+
+        student_text = "\n".join(str(message.get("content", "")) for message in messages)
+        teacher_text = "\n".join(str(message.get("content", "")) for message in teacher_messages)
+        lower_student_text = student_text.lower()
+        lower_teacher_text = teacher_text.lower()
+        if any(marker in lower_student_text for marker in lower_markers):
+            errors.append(f"row {idx} leaks privileged context into student messages")
+        if not any(marker in lower_teacher_text for marker in lower_markers):
+            errors.append(f"row {idx} teacher_messages missing privileged context")
+        if "Final:" not in student_text or "Final:" not in teacher_text:
+            errors.append(f"row {idx} prompts must ask for a `Final:` answer")
+        if "Final: <" in teacher_text:
+            errors.append(f"row {idx} teacher prompt must not use a placeholder final-answer format")
+
+        expected = expected_final_answer(row)
+        if require_expected_answer and expected is None:
+            errors.append(f"row {idx} is missing expected_answer")
+        if require_teacher_final_answer and expected is not None:
+            teacher_final = _extract_prompt_final_answer(teacher_text)
+            if teacher_final != expected:
+                errors.append(
+                    f"row {idx} teacher prompt must pin exact final answer "
+                    f"`Final: {expected}`; parsed {teacher_final!r}"
+                )
+
+    if errors:
+        raise ValueError("Invalid privileged OPD dataset:\n" + "\n".join(f"- {error}" for error in errors))
+
+
+def _find_last_subsequence(haystack: list[int], needle: list[int]) -> int | None:
+    if not needle or len(needle) > len(haystack):
+        return None
+    for start in range(len(haystack) - len(needle), -1, -1):
+        if haystack[start : start + len(needle)] == needle:
+            return start
+    return None
+
+
+def _final_answer_span(
+    tokenizer: Any,
+    text: str,
+    completion_tokens: list[int],
+) -> tuple[int, int, str] | None:
+    non_empty_lines = [line for line in text.splitlines() if line.strip()]
+    if not non_empty_lines:
+        return None
+    final_line = non_empty_lines[-1]
+    line_match = FINAL_ANSWER_LINE_RE.match(final_line)
+    if not line_match:
+        return None
+    line_start = text.rfind(final_line)
+    answer_start = line_start + line_match.start(1)
+    answer_text = line_match.group(1)
+    answer = normalize_final_answer(answer_text)
+    prefix_tokens = tokenizer.encode(text[:answer_start], add_special_tokens=False)
+    answer_tokens = tokenizer.encode(answer_text, add_special_tokens=False)
+    start = len(prefix_tokens)
+    end = start + len(answer_tokens)
+    if not answer_tokens:
+        return None
+    if end > len(completion_tokens) or completion_tokens[start:end] != list(answer_tokens):
+        found_start = _find_last_subsequence(completion_tokens, list(answer_tokens))
+        if found_start is None:
+            return None
+        start = found_start
+        end = start + len(answer_tokens)
+    return start, end, answer
+
+
+def _span_nll(logprobs: list[float], start: int = 0, end: int | None = None) -> float:
+    span = logprobs[start:end]
+    if not span:
+        return 0.0
+    return -sum(float(lp) for lp in span) / len(span)
+
+
+async def _sample_eval_completion(
+    sampler: DeploymentSampler,
+    messages: list[dict[str, Any]],
+    config: Any,
+    *,
+    max_seq_len: int | None,
+    temperature: float,
+) -> Any:
+    samples = await sampler.sample_with_tokens(
+        messages=prepare_sampling_messages(messages),
+        n=1,
+        max_tokens=config.max_completion_tokens,
+        temperature=temperature,
+        max_seq_len=max_seq_len,
+        http_timeout=config.deployment.sample_timeout,
+        logprobs=True,
+    )
+    if not samples:
+        raise RuntimeError("deployment returned no samples during OPD trace eval")
+    sample = samples[0]
+    if len(sample.full_tokens) <= sample.prompt_len:
+        raise RuntimeError("deployment returned an empty completion during OPD trace eval")
+    return sample
+
+
+async def _score_eval_response_tokens(
+    sampler: DeploymentSampler,
+    tokenizer: Any,
+    messages: list[dict[str, Any]],
+    completion_tokens: list[int],
+    http_timeout: int,
+) -> list[float]:
+    prompt_tokens = _tokenize_teacher_prompt(tokenizer, prepare_sampling_messages(messages))
+    response_logprobs = await _score_with_teacher(
+        sampler,
+        list(prompt_tokens) + list(completion_tokens),
+        prompt_len=len(prompt_tokens),
+        response_len=len(completion_tokens),
+        top_logprobs=0,
+        http_timeout=http_timeout,
+    )
+    if response_logprobs is None:
+        raise RuntimeError("failed to score OPD trace response tokens")
+    if len(response_logprobs) < len(completion_tokens):
+        raise RuntimeError(
+            "trace scoring returned too few response logprobs: "
+            f"{len(response_logprobs)} < {len(completion_tokens)}"
+        )
+    return [float(lp) for lp in response_logprobs]
+
+
+async def _evaluate_teacher_trace_logprob_gap_async(
+    context: dict[str, Any],
+    *,
+    trace_log_path: str | Path | None = None,
+    min_pre_final_tokens: int = 0,
+) -> dict[str, Any]:
+    """Score teacher reasoning traces under teacher and student prompts.
+
+    This is meant for privileged-context OPD eval: the frozen teacher generates
+    a trace from ``teacher_messages``; the same trace tokens are then scored
+    under both the privileged teacher prompt and the ordinary student prompt.
+    """
+    config: Any = context["config"]
+    student_sampler = context["student_sampler"]
+    teacher_sampler = context["teacher_sampler"]
+    tokenizer = context["tokenizer"]
+    rows = list(context["dataset"])
+    step = int(context.get("global_step", 0))
+    max_seq_len = context.get("max_seq_len")
+
+    records: list[dict[str, Any]] = []
+    for row in rows:
+        expected = expected_final_answer(row)
+        if expected is None:
+            raise RuntimeError(f"row is missing an expected answer: {row!r}")
+
+        student_messages = prepare_sampling_messages(row.get("messages", []))
+        if not student_messages:
+            raise RuntimeError(f"row is missing messages: {row!r}")
+        teacher_messages = _teacher_messages_for_row(
+            row,
+            student_messages,
+        )
+
+        teacher_sample = await _sample_eval_completion(
+            teacher_sampler,
+            teacher_messages,
+            config,
+            max_seq_len=max_seq_len,
+            temperature=0.0,
+        )
+        completion_tokens = list(teacher_sample.full_tokens[teacher_sample.prompt_len :])
+        trace_text = str(getattr(teacher_sample, "text", ""))
+        span = _final_answer_span(tokenizer, trace_text, completion_tokens)
+        if span is None:
+            raise RuntimeError(f"teacher trace did not contain a parseable final answer: {trace_text!r}")
+        final_start, final_end, teacher_generated_final = span
+        if final_start < min_pre_final_tokens:
+            raise RuntimeError(
+                "teacher trace did not include enough pre-final tokens to validate "
+                f"thinking-token distillation ({final_start} < {min_pre_final_tokens})"
+            )
+
+        teacher_logprobs = await _score_eval_response_tokens(
+            teacher_sampler,
+            tokenizer,
+            teacher_messages,
+            completion_tokens,
+            config.deployment.sample_timeout,
+        )
+        student_logprobs = await _score_eval_response_tokens(
+            student_sampler,
+            tokenizer,
+            student_messages,
+            completion_tokens,
+            config.deployment.sample_timeout,
+        )
+        student_sample = await _sample_eval_completion(
+            student_sampler,
+            student_messages,
+            config,
+            max_seq_len=max_seq_len,
+            temperature=0.0,
+        )
+        student_text = str(getattr(student_sample, "text", ""))
+        student_generated_final = extract_final_answer(student_text)
+
+        teacher_nll = _span_nll(teacher_logprobs)
+        student_nll = _span_nll(student_logprobs)
+        pre_final_teacher_nll = _span_nll(teacher_logprobs, 0, final_start)
+        pre_final_student_nll = _span_nll(student_logprobs, 0, final_start)
+        final_teacher_nll = _span_nll(teacher_logprobs, final_start, final_end)
+        final_student_nll = _span_nll(student_logprobs, final_start, final_end)
+        records.append(
+            {
+                "step": step,
+                "expected_answer": expected,
+                "teacher_generated_final": teacher_generated_final,
+                "student_generated_final": student_generated_final,
+                "tokens": len(completion_tokens),
+                "pre_final_tokens": final_start,
+                "final_tokens": final_end - final_start,
+                "teacher_trace": trace_text,
+                "student_generation": student_text,
+                "teacher_nll": teacher_nll,
+                "student_nll": student_nll,
+                "student_minus_teacher_nll": student_nll - teacher_nll,
+                "pre_final_teacher_nll": pre_final_teacher_nll,
+                "pre_final_student_nll": pre_final_student_nll,
+                "pre_final_student_minus_teacher_nll": pre_final_student_nll - pre_final_teacher_nll,
+                "final_teacher_nll": final_teacher_nll,
+                "final_student_nll": final_student_nll,
+                "final_student_minus_teacher_nll": final_student_nll - final_teacher_nll,
+                "teacher_final_correct": normalize_final_answer(teacher_generated_final) == expected,
+                "student_generation_correct": (
+                    student_generated_final is not None
+                    and normalize_final_answer(student_generated_final) == expected
+                ),
+            }
+        )
+
+    total = len(records)
+    total_tokens = sum(int(record["tokens"]) for record in records)
+    pre_final_tokens = sum(int(record["pre_final_tokens"]) for record in records)
+    final_tokens = sum(int(record["final_tokens"]) for record in records)
+    denom = max(total_tokens, 1)
+    pre_final_denom = max(pre_final_tokens, 1)
+    final_denom = max(final_tokens, 1)
+    teacher_nll = sum(float(record["teacher_nll"]) * int(record["tokens"]) for record in records) / denom
+    student_nll = sum(float(record["student_nll"]) * int(record["tokens"]) for record in records) / denom
+    pre_final_teacher_nll = sum(
+        float(record["pre_final_teacher_nll"]) * int(record["pre_final_tokens"]) for record in records
+    ) / pre_final_denom
+    pre_final_student_nll = sum(
+        float(record["pre_final_student_nll"]) * int(record["pre_final_tokens"]) for record in records
+    ) / pre_final_denom
+    final_teacher_nll = sum(
+        float(record["final_teacher_nll"]) * int(record["final_tokens"]) for record in records
+    ) / final_denom
+    final_student_nll = sum(
+        float(record["final_student_nll"]) * int(record["final_tokens"]) for record in records
+    ) / final_denom
+    teacher_final_accuracy = sum(
+        1.0 for record in records if record["teacher_final_correct"]
+    ) / max(total, 1)
+    student_generation_accuracy = sum(
+        1.0 for record in records if record["student_generation_correct"]
+    ) / max(total, 1)
+
+    if trace_log_path is not None:
+        path = Path(trace_log_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(
+                "\n".join(json.dumps(record, separators=(",", ":")) for record in records) + "\n"
+            )
+
+    return {
+        "eval/opd_trace_teacher_nll": teacher_nll,
+        "eval/opd_trace_student_nll": student_nll,
+        "eval/opd_trace_student_minus_teacher_nll": student_nll - teacher_nll,
+        "eval/opd_trace_pre_final_teacher_nll": pre_final_teacher_nll,
+        "eval/opd_trace_pre_final_student_nll": pre_final_student_nll,
+        "eval/opd_trace_pre_final_student_minus_teacher_nll": (
+            pre_final_student_nll - pre_final_teacher_nll
+        ),
+        "eval/opd_trace_final_teacher_nll": final_teacher_nll,
+        "eval/opd_trace_final_student_nll": final_student_nll,
+        "eval/opd_trace_final_student_minus_teacher_nll": final_student_nll - final_teacher_nll,
+        "eval/opd_trace_teacher_final_accuracy": teacher_final_accuracy,
+        "eval/opd_trace_student_generation_accuracy": student_generation_accuracy,
+        "eval/opd_trace_examples": float(total),
+        "eval/opd_trace_tokens": float(total_tokens),
+        "eval/opd_trace_pre_final_tokens": float(pre_final_tokens),
+        "eval/opd_trace_final_tokens": float(final_tokens),
+    }
+
+
+def evaluate_teacher_trace_logprob_gap(
+    context: dict[str, Any],
+    *,
+    trace_log_path: str | Path | None = None,
+    min_pre_final_tokens: int = 0,
+) -> dict[str, Any]:
+    """Synchronous callback wrapper for ``Config.step_eval`` / ``post_training_eval``."""
+    return asyncio.run(
+        _evaluate_teacher_trace_logprob_gap_async(
+            context,
+            trace_log_path=trace_log_path,
+            min_pre_final_tokens=min_pre_final_tokens,
+        )
+    )
+
+
+def make_teacher_trace_logprob_gap_eval(
+    *,
+    trace_log_path: str | Path | None = None,
+    min_pre_final_tokens: int = 0,
+) -> Callable[[dict[str, Any]], dict[str, Any]]:
+    """Create a no-argument eval callback suitable for ``Config.step_eval``."""
+
+    def _callback(context: dict[str, Any]) -> dict[str, Any]:
+        return evaluate_teacher_trace_logprob_gap(
+            context,
+            trace_log_path=trace_log_path,
+            min_pre_final_tokens=min_pre_final_tokens,
+        )
+
+    return _callback
+
+
+def validate_opd_trace_result(
+    config: Any,
+    result: dict[str, Any],
+    *,
+    expected_steps: int | None = None,
+    min_abs_advantage: float = 1e-4,
+    min_train_gap_improvement: float | None = None,
+    min_trace_gap_improvement: float | None = None,
+    min_teacher_final_accuracy: float | None = None,
+    min_student_generation_accuracy: float | None = None,
+    min_max_seq_len: int | None = None,
+) -> None:
+    """Validate that an OPD run produced train and teacher-trace eval signal."""
+    errors: list[str] = []
+    if expected_steps is None:
+        expected_steps = (
+            config.max_rows * config.epochs + config.prompt_groups_per_step - 1
+        ) // config.prompt_groups_per_step
+
+    steps = int(result.get("steps", 0))
+    if steps < expected_steps:
+        errors.append(f"expected {expected_steps} optimizer steps, got {steps}")
+    resolved_max_seq_len = result.get("max_seq_len")
+    if min_max_seq_len is not None and resolved_max_seq_len is not None:
+        if int(resolved_max_seq_len) < min_max_seq_len:
+            errors.append(
+                f"expected resolved max_seq_len >= {min_max_seq_len}, got {resolved_max_seq_len}"
+            )
+
+    metrics_path = Path(config.runner.metrics_file or "")
+    records: list[dict[str, Any]] = []
+    if not metrics_path.exists():
+        errors.append(f"metrics file was not written: {metrics_path}")
+    else:
+        records = [
+            json.loads(line)
+            for line in metrics_path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        train_records = [record for record in records if "train/opd_active_tokens" in record]
+        if len(train_records) < expected_steps:
+            errors.append(
+                f"expected at least {expected_steps} train metric records, got {len(train_records)}"
+            )
+        active_tokens = sum(float(record.get("train/opd_active_tokens", 0.0)) for record in train_records)
+        max_abs_advantage = max(
+            (abs(float(record.get("train/opd_abs_advantage", 0.0))) for record in train_records),
+            default=0.0,
+        )
+        if active_tokens <= 0:
+            errors.append("no active OPD tokens were trained")
+        if max_abs_advantage < min_abs_advantage:
+            errors.append(
+                "teacher/student logprob delta was effectively zero "
+                f"(max train/opd_abs_advantage={max_abs_advantage:.6g})"
+            )
+
+        sampled_kl = [
+            float(record.get("train/opd_sampled_reverse_kl", 0.0))
+            for record in train_records
+            if "train/opd_sampled_reverse_kl" in record
+        ]
+        if min_train_gap_improvement is not None and len(sampled_kl) >= 4:
+            head = sampled_kl[1 : max(2, len(sampled_kl) // 2)]
+            tail = sampled_kl[-min(5, len(sampled_kl)) :]
+            head_mean = sum(head) / max(len(head), 1)
+            tail_mean = sum(tail) / max(len(tail), 1)
+            improvement = (head_mean - tail_mean) / max(abs(head_mean), 1e-9)
+            if improvement < min_train_gap_improvement:
+                errors.append(
+                    "sampled teacher/student logprob gap did not improve enough "
+                    f"(head_mean={head_mean:.4g}, tail_mean={tail_mean:.4g}, "
+                    f"improvement={improvement:.1%})"
+                )
+
+        eval_records = [
+            record for record in records if "eval/opd_trace_teacher_nll" in record
+        ]
+        expected_eval_records = expected_steps + (1 if config.eval_before_training else 0)
+        if len(eval_records) < expected_eval_records:
+            errors.append(
+                f"expected {expected_eval_records} teacher-trace eval records, got {len(eval_records)}"
+            )
+        if config.eval_before_training and not any(record.get("step") == 0 for record in eval_records):
+            errors.append("missing teacher-trace pre-training eval at step 0")
+        trace_gaps = [
+            float(record["eval/opd_trace_student_minus_teacher_nll"])
+            for record in eval_records
+            if "eval/opd_trace_student_minus_teacher_nll" in record
+        ]
+        if eval_records and len(trace_gaps) < len(eval_records):
+            errors.append("teacher-trace eval records are missing student/teacher logprob gap")
+        if min_trace_gap_improvement is not None and len(trace_gaps) >= 2 and trace_gaps[0] > 0:
+            improvement = (trace_gaps[0] - trace_gaps[-1]) / max(abs(trace_gaps[0]), 1e-9)
+            if improvement < min_trace_gap_improvement:
+                errors.append(
+                    "teacher-trace student/teacher logprob gap did not improve enough "
+                    f"(initial={trace_gaps[0]:.4g}, final={trace_gaps[-1]:.4g}, "
+                    f"improvement={improvement:.1%})"
+                )
+
+    eval_metrics = result.get("eval") or {}
+    required_eval_metrics = [
+        "eval/opd_trace_teacher_nll",
+        "eval/opd_trace_student_nll",
+        "eval/opd_trace_student_minus_teacher_nll",
+        "eval/opd_trace_pre_final_teacher_nll",
+        "eval/opd_trace_pre_final_student_nll",
+        "eval/opd_trace_pre_final_student_minus_teacher_nll",
+        "eval/opd_trace_final_teacher_nll",
+        "eval/opd_trace_final_student_nll",
+        "eval/opd_trace_final_student_minus_teacher_nll",
+        "eval/opd_trace_teacher_final_accuracy",
+        "eval/opd_trace_student_generation_accuracy",
+        "eval/opd_trace_examples",
+        "eval/opd_trace_tokens",
+        "eval/opd_trace_pre_final_tokens",
+        "eval/opd_trace_final_tokens",
+    ]
+    for key in required_eval_metrics:
+        value = eval_metrics.get(key)
+        if value is None or not math.isfinite(float(value)):
+            errors.append(f"missing or invalid teacher-trace eval metric: {key}")
+
+    teacher_accuracy = float(eval_metrics.get("eval/opd_trace_teacher_final_accuracy", 0.0))
+    student_accuracy = float(eval_metrics.get("eval/opd_trace_student_generation_accuracy", 0.0))
+    if min_teacher_final_accuracy is not None and teacher_accuracy < min_teacher_final_accuracy:
+        errors.append(
+            "frozen teacher does not reliably generate the privileged final answer "
+            f"(accuracy={teacher_accuracy:.3f}, required={min_teacher_final_accuracy:.3f})"
+        )
+    if (
+        min_student_generation_accuracy is not None
+        and student_accuracy < min_student_generation_accuracy
+    ):
+        errors.append(
+            "student did not reach the privileged-answer exact-match target by final eval "
+            f"(accuracy={student_accuracy:.3f}, required={min_student_generation_accuracy:.3f})"
+        )
+    if float(eval_metrics.get("eval/opd_trace_examples", 0.0)) <= 0:
+        errors.append("teacher-trace eval scored no examples")
+    if float(eval_metrics.get("eval/opd_trace_tokens", 0.0)) <= 0:
+        errors.append("teacher-trace eval scored no response tokens")
+    if float(eval_metrics.get("eval/opd_trace_pre_final_tokens", 0.0)) <= 0:
+        errors.append("teacher-trace eval scored no pre-final thinking/reasoning tokens")
+    if float(eval_metrics.get("eval/opd_trace_final_tokens", 0.0)) <= 0:
+        errors.append("teacher-trace eval scored no final-answer tokens")
+
+    if errors:
+        raise RuntimeError("OPD trace validation failed:\n" + "\n".join(f"- {error}" for error in errors))

--- a/training/utils/opd_sampling.py
+++ b/training/utils/opd_sampling.py
@@ -1,0 +1,179 @@
+"""Shared OPD token alignment and teacher scoring helpers."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fireworks.training.sdk.deployment import DeploymentSampler
+from training.utils.data import prepare_sampling_messages
+
+logger = logging.getLogger(__name__)
+
+
+def _align_completion_logprobs(
+    completion_logprobs: list[float],
+    *,
+    prompt_len: int,
+    target_len: int,
+    echoed: bool,
+) -> list[float] | None:
+    """Align API completion logprobs to ``target_tokens`` length."""
+    if echoed:
+        response_start = max(0, prompt_len - 1)
+        if len(completion_logprobs) < target_len and target_len > response_start:
+            return None
+        aligned = list(completion_logprobs)
+        if len(aligned) < target_len:
+            aligned.extend([0.0] * (target_len - len(aligned)))
+        return aligned[:target_len]
+
+    return _align_response_logprobs(
+        completion_logprobs,
+        prompt_len=prompt_len,
+        target_len=target_len,
+    )
+
+
+def _align_response_logprobs(
+    response_logprobs: list[float],
+    *,
+    prompt_len: int,
+    target_len: int,
+) -> list[float] | None:
+    """Align response-only logprobs to ``target_tokens`` length."""
+    response_start = max(0, prompt_len - 1)
+    response_len = max(0, target_len - response_start)
+    if len(response_logprobs) < response_len:
+        return None
+    aligned = [0.0] * response_start + list(response_logprobs[:response_len])
+    if len(aligned) < target_len:
+        aligned.extend([0.0] * (target_len - len(aligned)))
+    return aligned[:target_len]
+
+
+def _extract_scored_token_logprobs(
+    response: dict[str, Any],
+    *,
+    target_len: int,
+) -> list[float] | None:
+    """Extract echo logprobs for ``tokens[1:]`` from a completions response."""
+    choices = response.get("choices", [])
+    if not choices:
+        return None
+
+    logprobs = choices[0].get("logprobs")
+    if not isinstance(logprobs, dict):
+        return None
+
+    content = logprobs.get("content")
+    if not isinstance(content, list) or len(content) < 2:
+        return None
+
+    # Echo responses include an unconditional first-token logprob, then one
+    # logprob per next-token target.  A generated extra token may follow; trim it.
+    target_content = content[1 : 1 + target_len]
+    if len(target_content) < target_len:
+        return None
+    return [float(item.get("logprob", 0.0)) for item in target_content]
+
+
+def _slice_response_logprobs(
+    token_logprobs: list[float],
+    *,
+    prompt_len: int,
+    response_len: int,
+) -> list[float] | None:
+    """Return only response-token logprobs from a full echoed sequence."""
+    if response_len <= 0:
+        return None
+    response_start = max(0, prompt_len - 1)
+    response_logprobs = token_logprobs[response_start : response_start + response_len]
+    if len(response_logprobs) < response_len:
+        return None
+    return response_logprobs
+
+
+def _teacher_messages_for_row(
+    row: dict[str, Any],
+    fallback_messages: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Pick privileged teacher messages when the dataset provides them."""
+    for key in ("teacher_messages", "privileged_messages", "teacher_prompt_messages"):
+        messages = row.get(key)
+        if messages:
+            return prepare_sampling_messages(messages)
+    return fallback_messages
+
+
+def _tokenize_teacher_prompt(
+    tokenizer: Any,
+    messages: list[dict[str, Any]],
+) -> list[int]:
+    """Tokenize the teacher-side prompt with the same chat-template path as sampling."""
+    token_ids = tokenizer.apply_chat_template(
+        messages,
+        tokenize=True,
+        add_generation_prompt=True,
+        return_dict=False,
+    )
+    if hasattr(token_ids, "tolist"):
+        token_ids = token_ids.tolist()
+    return [int(token_id) for token_id in token_ids]
+
+
+def _build_teacher_scoring_tokens(
+    teacher_prompt_tokens: list[int],
+    student_full_tokens: list[int],
+    *,
+    student_prompt_len: int,
+) -> tuple[list[int], int] | None:
+    """Combine the privileged teacher prompt with the sampled student response."""
+    completion_tokens = list(student_full_tokens[student_prompt_len:])
+    if not completion_tokens:
+        return None
+    return list(teacher_prompt_tokens) + completion_tokens, len(completion_tokens)
+
+
+async def _score_with_teacher(
+    sampler: DeploymentSampler,
+    token_ids: list[int],
+    *,
+    prompt_len: int,
+    response_len: int,
+    top_logprobs: int,
+    http_timeout: int,
+) -> list[float] | None:
+    """Score sampled response tokens with the teacher deployment."""
+    target_len = max(0, len(token_ids) - 1)
+    if target_len == 0 or response_len <= 0:
+        return None
+
+    request_kwargs: dict[str, Any] = {
+        "logprobs": True,
+        "echo": True,
+        "raw_output": True,
+        "http_timeout": http_timeout,
+    }
+    if top_logprobs > 0:
+        request_kwargs["top_logprobs"] = top_logprobs
+
+    try:
+        response, _metrics = await sampler.async_completions_stream(
+            prompt=token_ids,
+            max_tokens=1,
+            temperature=0.0,
+            **request_kwargs,
+        )
+    except Exception as exc:
+        logger.warning("Teacher scoring failed: %s", exc)
+        return None
+
+    token_logprobs = _extract_scored_token_logprobs(response, target_len=target_len)
+    if token_logprobs is None:
+        return None
+    return _slice_response_logprobs(
+        token_logprobs,
+        prompt_len=prompt_len,
+        response_len=response_len,
+    )


### PR DESCRIPTION
## Result

This PR adds a privileged-prompt OPD loop and validates it end-to-end on a real GSM8K-style privileged-context run with the same Qwen 3.5 9B model used as both student and frozen teacher.

The live run completed all requested OPD steps and showed the main teacher-trace logprob gap moving in the right direction:

| Metric | Start | End | Result |
| --- | ---: | ---: | --- |
| Teacher-trace NLL gap, student minus teacher | 0.2137 | 0.1684 | 21.2% lower |
| Prompt groups sampled | 200 | 200 | 0 filtered, 0 failed |
| OPD optimizer steps | 25 | 25 | completed |
| Active OPD tokens | - | 1,371,235 | trained over packed response tokens |

The key signal is the teacher-trace gap: the frozen teacher sees the privileged prompt, the student sees the normal prompt, and we score the same teacher trace under both prompts. Lower means the online student is getting closer to the privileged teacher on the target response distribution.

## What Changed

- The teacher path now supports privileged prompts instead of scoring the exact student prompt.
- Teacher and rollout logprobs are validated on active response tokens instead of silently padding missing values.
- OPD sampling/eval helpers were split out of the recipe so `opd_loop.py` is easier to audit.
- The example flow uses a real GSM8K-style privileged-context dataset path instead of synthetic memorization rows.
- Teacher deployment can be created without hot load, while the online student deployment keeps the normal weight-sync path.

## Live Run

- Run id: `gsm8k-opd-qwen3p5-9b-256k-202604250928-attached`
- Training shape: `accounts/fireworks/trainingShapes/qwen3p5-9b-256k`
- Base model for both student and teacher: Qwen 3.5 9B
- Teacher: frozen deployment with privileged prompt
- Student: online deployment synced from trainer
- Batch shape: 8 prompt groups per step, 4 completions per prompt, 25 OPD steps
- Completion cap: 2048 tokens, reasoning preserved
- Launch path: SDK / pyroworks-attached flow, no `firectl` launch/kill mutation commands

## Teacher-Trace Gap

Lower is better. This is the strongest OPD validation signal because it compares student vs frozen privileged teacher logprobs on the same teacher trace.

```mermaid
xychart-beta
  title "Teacher-trace gap: student NLL - teacher NLL"
  x-axis "step" [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]
  y-axis "NLL gap, lower is better" 0.16 --> 0.31
  line [0.2137, 0.3015, 0.2907, 0.2715, 0.2714, 0.2729, 0.2624, 0.2510, 0.2440, 0.2406, 0.2416, 0.2392, 0.2351, 0.2312, 0.2251, 0.2202, 0.2150, 0.2118, 0.2086, 0.2033, 0.1978, 0.1909, 0.1841, 0.1778, 0.1726, 0.1684]
```

## Final-Answer Token Gap

This isolates the final-answer token span on the teacher traces. It moves below zero early, meaning the trained student assigns at least as much probability as the privileged teacher to the final-answer tokens on these traces.

```mermaid
xychart-beta
  title "Final-answer token gap"
  x-axis "step" [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]
  y-axis "NLL gap, lower is better" -0.05 --> 0.22
  line [0.1019, 0.0758, 0.2063, 0.0051, -0.0365, -0.0371, -0.0372, -0.0372, -0.0372, -0.0371, -0.0371, -0.0371, -0.0371, -0.0372, -0.0372, -0.0372, -0.0372, -0.0372, -0.0372, -0.0372, -0.0372, -0.0372, -0.0371, -0.0370, -0.0369, -0.0366]
```

## Greedy Generation Accuracy

Exact-match generation is noisy on this small validation set, so this should not be treated as the primary OPD metric. It does show intermittent improvement, but the final point is not stable enough to claim deployed generation quality from this run alone.

```mermaid
xychart-beta
  title "Student greedy exact-match accuracy"
  x-axis "step" [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]
  y-axis "accuracy" 0 --> 1
  line [0.500, 0.000, 0.125, 1.000, 0.000, 0.000, 0.000, 0.125, 0.000, 0.000, 0.000, 0.000, 0.125, 0.250, 0.375, 0.125, 0.000, 0.125, 0.500, 0.250, 0.125, 0.250, 0.500, 0.000, 0.000, 0.000]
```

## On-Policy Sampled Reverse KL

This is the training-time OPD loss signal from sampled online completions. It is noisier than teacher-trace eval because the sampled responses change every step.

```mermaid
xychart-beta
  title "Sampled OPD reverse KL"
  x-axis "step" [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]
  y-axis "reverse KL" 0.08 --> 0.16
  line [0.0894, 0.1503, 0.1561, 0.1266, 0.1015, 0.1201, 0.1331, 0.1214, 0.1221, 0.1027, 0.1090, 0.0978, 0.0906, 0.0979, 0.0965, 0.1078, 0.0966, 0.0976, 0.0974, 0.0995, 0.0911, 0.0969, 0.0860, 0.0884, 0.0886]
```

## Active OPD Tokens

Each optimizer step receives packed datums rather than one single sample. The run trained over 1.37M active response tokens across 25 steps.

```mermaid
xychart-beta
  title "Active OPD tokens per step"
  x-axis "step" [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]
  y-axis "tokens" 35000 --> 66000
  bar [51383, 65095, 58537, 37109, 65536, 53392, 54190, 52371, 57527, 53531, 60109, 52201, 55755, 51058, 56166, 48333, 62156, 61324, 58282, 56972, 54009, 52330, 52431, 46363, 55075]
```

## Validation

- Unit suite: `483 passed, 32 skipped`
- Focused OPD tests: `28 passed`
- Static diff check: `git diff --check` clean
- Live OPD run: completed 25/25 steps with 200/200 prompt groups sampled and 0 failed/filtered

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared deployment/infra provisioning and adds a multi-deployment training loop, but changes are mostly additive with broad unit test coverage rather than altering existing RL/DPO recipe logic.
> 
> **Overview**
> Adds **sampled-token on-policy distillation (OPD)** as a first-class cookbook recipe: the student rolls out on policy, a frozen teacher scores the same token sequences under optional **privileged** `teacher_messages`, and training uses Tinker’s **`importance_sampling`** loss with per-token advantages `teacher_logprob − sampling_logprob`.
> 
> **New surface:** `recipes/opd_loop.py` plus `training.utils.opd`, `opd_sampling`, and `opd_eval` (dataset lint, teacher-trace logprob-gap eval, post-run validation). Documentation and a **GSM8K privileged-context** example (`prepare_data.py` → `train_gsm8k_privileged.py`) show the intended data shape and launch path.
> 
> **Infra extensions (shared with other loops):** `DeployConfig.enable_hot_load` and SDK-backed **non-hotload** deployments for auto-provisioned teachers; `setup_infra(..., post_shape_provisioners=...)` so auxiliary resources (e.g. teacher deployment) request before waits and ready in parallel with student trainer/deployment; deployment-shape resolution moved to the generated **Fireworks** client instead of raw HTTP.
> 
> **Tests:** smoke import for OPD, large `test_opd.py`, infra/provisioning tests updated for the new SDK and auxiliary waiter behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7904971a0d0ad6dc6d71e94c73842d6ef935a00b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->