### PR TITLE
fix(infra): strip pinned /versions/ suffix from shape IDs and enrich 400 error messages

### DIFF
--- a/training/tests/unit/test_infra_setup.py
+++ b/training/tests/unit/test_infra_setup.py
@@ -461,6 +461,93 @@ def test_setup_infra_does_not_auto_select_ref_for_lora(patch_sdk):
 
 
 # ---------------------------------------------------------------------------
+# Pinned /versions/ suffix stripping
+# ---------------------------------------------------------------------------
+
+
+def test_setup_infra_strips_pinned_policy_shape_version(patch_sdk, caplog):
+    """Explicit training_shape_id with /versions/... is stripped to bare path."""
+    rlor, deploy = _make_mgrs()
+    cfg = _make_cfg(
+        training_shape_id="accounts/fw/trainingShapes/ts-policy/versions/abc123",
+    )
+
+    with caplog.at_level("WARNING"):
+        infra = setup_infra(
+            rlor_mgr=rlor, deploy_mgr=deploy,
+            base_model=cfg.base_model,
+            infra_cfg=cfg.infra,
+            deploy_cfg=cfg.deployment,
+            lora_rank=cfg.lora_rank,
+            max_seq_len=cfg.max_seq_len,
+            learning_rate=cfg.learning_rate,
+            step_timeout=cfg.step_timeout,
+            policy_job_id=cfg.policy_job_id,
+            reference_job_id=cfg.reference_job_id,
+            needs_reference=False, needs_inference=True,
+            role_prefix="grpo", api_key="key",
+        )
+
+    assert infra.training_shape_id == "accounts/fw/trainingShapes/ts-policy"
+    assert "Stripping pinned version" in caplog.text
+    assert "training_shape_id" in caplog.text
+
+
+def test_setup_infra_strips_pinned_ref_shape_version(patch_sdk, caplog):
+    """Explicit ref_training_shape_id with /versions/... is stripped."""
+    rlor, _ = _make_mgrs()
+    cfg = _make_cfg(
+        lora_rank=0,
+        ref_training_shape_id="accounts/fw/trainingShapes/ts-ref/versions/xyz789",
+    )
+
+    with caplog.at_level("WARNING"):
+        infra = setup_infra(
+            rlor_mgr=rlor, deploy_mgr=None,
+            base_model=cfg.base_model,
+            infra_cfg=cfg.infra,
+            deploy_cfg=cfg.deployment,
+            lora_rank=cfg.lora_rank,
+            max_seq_len=cfg.max_seq_len,
+            learning_rate=cfg.learning_rate,
+            step_timeout=cfg.step_timeout,
+            policy_job_id=cfg.policy_job_id,
+            reference_job_id=cfg.reference_job_id,
+            needs_reference=True, needs_inference=False,
+            role_prefix="dpo", api_key="key",
+        )
+
+    assert infra.ref_training_shape_id == "accounts/fw/trainingShapes/ts-ref"
+    assert "Stripping pinned version" in caplog.text
+    assert "ref_training_shape_id" in caplog.text
+
+
+def test_setup_infra_bare_shape_id_not_stripped(patch_sdk, caplog):
+    """A bare shape path (no /versions/) passes through unchanged."""
+    rlor, deploy = _make_mgrs()
+    cfg = _make_cfg(training_shape_id="accounts/fw/trainingShapes/ts-policy")
+
+    with caplog.at_level("WARNING"):
+        infra = setup_infra(
+            rlor_mgr=rlor, deploy_mgr=deploy,
+            base_model=cfg.base_model,
+            infra_cfg=cfg.infra,
+            deploy_cfg=cfg.deployment,
+            lora_rank=cfg.lora_rank,
+            max_seq_len=cfg.max_seq_len,
+            learning_rate=cfg.learning_rate,
+            step_timeout=cfg.step_timeout,
+            policy_job_id=cfg.policy_job_id,
+            reference_job_id=cfg.reference_job_id,
+            needs_reference=False, needs_inference=True,
+            role_prefix="grpo", api_key="key",
+        )
+
+    assert infra.training_shape_id == "accounts/fw/trainingShapes/ts-policy"
+    assert "Stripping pinned version" not in caplog.text
+
+
+# ---------------------------------------------------------------------------
 # Closeables + boot metrics
 # ---------------------------------------------------------------------------
 

--- a/training/tests/unit/test_shape_override_paths.py
+++ b/training/tests/unit/test_shape_override_paths.py
@@ -195,3 +195,92 @@ def test_infra_fields_forwarded_to_config():
         infra=InfraConfig(purpose="PURPOSE_PILOT"), profile=PROFILE,
     )
     assert mgr.captured.purpose == "PURPOSE_PILOT"
+
+
+# -----------------------------------------------------------------------
+# Error hint enrichment for shape validation failures
+# -----------------------------------------------------------------------
+
+
+class TestShapeErrorHint:
+    """_shape_error_hint adds actionable guidance to 400 errors."""
+
+    def test_hint_for_pinned_version(self):
+        error = (
+            "no validated training shape exists for "
+            "training_shape=accounts/fw/trainingShapes/ts/versions/abc "
+            "base_model=accounts/fw/models/m trainer_mode=POLICY_TRAINER"
+        )
+        hint = infra_module._shape_error_hint(
+            error, forward_only=False, lora_rank=0,
+        )
+        assert hint is not None
+        assert "/versions/" in hint
+
+    def test_hint_for_forward_only_lora_mismatch(self):
+        error = (
+            "no validated training shape exists for "
+            "training_shape=accounts/fw/trainingShapes/ts "
+            "base_model=accounts/fw/models/m trainer_mode=FORWARD_ONLY"
+        )
+        hint = infra_module._shape_error_hint(
+            error, forward_only=True, lora_rank=32,
+        )
+        assert hint is not None
+        assert "ref_training_shape_id" in hint
+        assert "shared-session" in hint
+
+    def test_hint_for_custom_model(self):
+        error = (
+            "no validated training shape exists for "
+            "training_shape=accounts/fw/trainingShapes/ts "
+            "base_model=accounts/wix/models/c2s-merged-v4 "
+            "trainer_mode=LORA_TRAINER"
+        )
+        hint = infra_module._shape_error_hint(
+            error, forward_only=False, lora_rank=32,
+        )
+        assert hint is not None
+        assert "custom" in hint.lower() or "non-Fireworks" in hint
+
+    def test_hint_generic_fallback(self):
+        error = (
+            "no validated training shape exists for "
+            "training_shape=accounts/fw/trainingShapes/ts "
+            "base_model=accounts/fireworks/models/m trainer_mode=POLICY_TRAINER"
+        )
+        hint = infra_module._shape_error_hint(
+            error, forward_only=False, lora_rank=0,
+        )
+        assert hint is not None
+        assert "auto-selection" in hint
+
+    def test_no_hint_for_unrelated_error(self):
+        hint = infra_module._shape_error_hint(
+            "connection refused", forward_only=False, lora_rank=0,
+        )
+        assert hint is None
+
+    def test_hint_included_in_raised_error(self, caplog):
+        """The enriched hint appears in the RuntimeError from request_trainer_job."""
+        mgr = _FailingMgr(
+            "Client error '400 Bad Request'\n"
+            "no validated training shape exists for "
+            "training_shape=accounts/fw/trainingShapes/ts/versions/old "
+            "base_model=accounts/wix/models/custom trainer_mode=FORWARD_ONLY"
+        )
+
+        with pytest.raises(RuntimeError) as exc_info:
+            infra_module.create_trainer_job(
+                mgr,
+                base_model="accounts/wix/models/custom",
+                infra=InfraConfig(),
+                profile=PROFILE,
+                display_name="dpo-reference",
+                forward_only=True,
+                lora_rank=32,
+            )
+
+        error_str = str(exc_info.value)
+        assert "Hint:" in error_str
+        assert "/versions/" in error_str

--- a/training/utils/infra.py
+++ b/training/utils/infra.py
@@ -24,6 +24,7 @@ import dataclasses
 import inspect
 import json
 import os
+import re
 import time
 import logging
 from concurrent.futures import ThreadPoolExecutor
@@ -271,6 +272,58 @@ def _fetch_job_failure_reason(
         return None
 
 
+_NO_VALIDATED_SHAPE_RE = re.compile(
+    r"no validated training shape exists.*?"
+    r"training_shape=(\S+).*?"
+    r"base_model=(\S+).*?"
+    r"trainer_mode=(\S+)",
+    re.IGNORECASE,
+)
+
+
+def _shape_error_hint(error_text: str, *, forward_only: bool, lora_rank: int) -> str | None:
+    """Return actionable guidance when the server rejects a shape/model combo."""
+    m = _NO_VALIDATED_SHAPE_RE.search(error_text)
+    if not m:
+        return None
+
+    shape, base_model, server_mode = m.group(1), m.group(2), m.group(3)
+
+    parts: list[str] = []
+    if "/versions/" in shape:
+        parts.append(
+            "The training shape includes a pinned /versions/<id> suffix — "
+            "pass the bare shape path instead and let the platform pick the "
+            "latest validated version."
+        )
+    if server_mode == "FORWARD_ONLY" and lora_rank > 0:
+        parts.append(
+            f"The reference trainer was requested with lora_rank=0 / "
+            f"FORWARD_ONLY but the selected shape is LoRA-capable.  "
+            f"For LoRA DPO, leave ref_training_shape_id unset — the "
+            f"shared-session reference (policy.create_base_reference()) "
+            f"saves GPUs and avoids this mismatch."
+        )
+    if "accounts/" in base_model and "/models/" in base_model:
+        account = base_model.split("/models/")[0]
+        if "/fireworks/" not in account:
+            parts.append(
+                f"The base model {base_model!r} is a custom (non-Fireworks) model.  "
+                f"The platform validates that the training shape is registered "
+                f"for this exact base model.  Verify the shape supports your "
+                f"model, or omit training_shape_id to let auto-selection find "
+                f"a compatible shape."
+            )
+    if not parts:
+        parts.append(
+            "The training shape has no validated version for this base model "
+            "and trainer mode.  Omit training_shape_id to let auto-selection "
+            "find a compatible shape, or verify the shape is registered for "
+            "your model."
+        )
+    return "  ".join(parts)
+
+
 def request_trainer_job(
     rlor_mgr: TrainerJobManager,
     *,
@@ -378,10 +431,13 @@ def request_trainer_job(
     try:
         created_job = rlor_mgr.create(config)
     except Exception as e:
+        hint = _shape_error_hint(str(e), forward_only=forward_only, lora_rank=lora_rank)
         error_msg = (
             f"Failed to create {trainer_role} trainer job '{display_name}' "
             f"(forward_only={forward_only}): {e}"
         )
+        if hint:
+            error_msg = f"{error_msg}\n  Hint: {hint}"
         logger.error(error_msg)
         _emit(error_msg)
         raise RuntimeError(error_msg) from e
@@ -1155,6 +1211,30 @@ def _register_closeable(obj: Any, closeables: list[Any]) -> None:
         closeables.append(obj)
 
 
+_VERSIONS_SUFFIX_RE = re.compile(r"/versions/[^/]+$")
+
+
+def _strip_version_suffix(shape_id: str, field_name: str) -> str:
+    """Strip a ``/versions/<id>`` suffix from an explicit shape ID.
+
+    Pinning a version locks the run to a potentially stale or unvalidated
+    snapshot and prevents the platform from auto-selecting the latest
+    validated version.  When a pinned suffix is detected, it is stripped
+    and a warning is emitted so the caller can fix their config.
+    """
+    if _VERSIONS_SUFFIX_RE.search(shape_id):
+        bare = _VERSIONS_SUFFIX_RE.sub("", shape_id)
+        logger.warning(
+            "Stripping pinned version from %s=%r → %r.  "
+            "Pinning a /versions/<id> is almost always wrong — the platform "
+            "auto-selects the latest validated version.  Pass the bare shape "
+            "path instead.",
+            field_name, shape_id, bare,
+        )
+        return bare
+    return shape_id
+
+
 def _resolve_policy_shape(
     rlor_mgr: TrainerJobManager,
     *,
@@ -1166,6 +1246,10 @@ def _resolve_policy_shape(
     needs_inference: bool,
 ) -> tuple[Any, int, str | None, str | None]:
     """Return (profile, resolved_max_seq_len, resolved_shape_id, resolved_deploy_shape)."""
+    if training_shape_id is not None:
+        training_shape_id = _strip_version_suffix(
+            training_shape_id, "training_shape_id",
+        )
     if training_shape_id is None:
         training_shape_id = auto_select_training_shape(
             rlor_mgr,
@@ -1201,6 +1285,10 @@ def _resolve_reference_shape(
     needs_reference: bool,
 ) -> tuple[Any | None, str | None]:
     """Return (ref_profile, resolved_ref_shape_id)."""
+    if ref_training_shape_id:
+        ref_training_shape_id = _strip_version_suffix(
+            ref_training_shape_id, "ref_training_shape_id",
+        )
     if ref_training_shape_id:
         if lora_rank > 0:
             logger.info(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Clients are hitting HTTP 400 `no validated training shape exists` errors in two scenarios:

1. **Pinned `/versions/<id>` suffixes** on explicit shape IDs — these can reference stale or unvalidated snapshots. The platform auto-selects the latest validated version when given a bare shape path, but clients don't know this and pin old versions that break.

2. **Opaque server errors** — when the 400 comes back, the error message from the server mentions "no validated training shape exists" but provides no actionable guidance about *why* or *how to fix it*. This is especially confusing for custom (non-Fireworks) base models and LoRA DPO where the shape/mode interaction is subtle.

Example client error (LoRA DPO with custom model):
```
ERROR: RLOR job creation failed (HTTP 400)
  Cause: no validated training shape exists for
    training_shape=accounts/fireworks/trainingShapes/qwen3p5-35b-a3b-256k-lora/versions/bbmrqbzh
    base_model=accounts/wix/models/c2s-merged-v4
    trainer_mode=FORWARD_ONLY
```

## Changes

### `training/utils/infra.py`

- **`_strip_version_suffix()`**: Automatically strips `/versions/<id>` from explicit `training_shape_id` and `ref_training_shape_id` with a `WARNING` log, letting the platform auto-select the latest validated version. Applied in both `_resolve_policy_shape` and `_resolve_reference_shape`.

- **`_shape_error_hint()`**: Parses the server's "no validated training shape" error and returns actionable hints appended to the `RuntimeError`:
  - Pinned version detected → tells client to use bare shape path
  - `FORWARD_ONLY` + `lora_rank > 0` mismatch → suggests the shared-session reference (`policy.create_base_reference()`)
  - Custom (non-Fireworks) base model → explains shape registration requirements
  - Generic fallback → suggests auto-selection

### Tests

9 new tests across `test_infra_setup.py` and `test_shape_override_paths.py`:
- Version stripping for policy shape, ref shape, and bare (no-op) path
- Error hint for pinned version, FORWARD_ONLY/LoRA mismatch, custom model, generic fallback, unrelated errors, and integration with `request_trainer_job`

All 505 unit tests pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://fireworks-ai.slack.com/archives/D0AM5QM096Z/p1777290423227359?thread_ts=1777290423.227359&cid=D0AM5QM096Z)

<div><a href="https://cursor.com/agents/bc-a57b4f2e-25af-5444-b115-335fe4ba1cdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a57b4f2e-25af-5444-b115-335fe4ba1cdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

