### PR TITLE
feat(glm5): render assistant tool_calls byte-matching the upstream chat template

### DIFF
--- a/training/renderer/glm5.py
+++ b/training/renderer/glm5.py
@@ -52,12 +52,23 @@ Other invariants:
   ``<|assistant|><think>`` for thinking mode (default),
   ``<|assistant|></think>`` for non-thinking mode.
 
-Only text-only chat, with and without thinking, is implemented here.
-Tool calls and multimodal content are left for a future extension.
+Tool-call layout (assistant turns only — ``role: "tool"`` responses are
+rendered as ``<|observation|><tool_response>...</tool_response>`` and never
+contribute to loss):
+
+- Each call serialised right after the assistant's visible content with no
+  separator: ``<tool_call>{name}<arg_key>{k}</arg_key><arg_value>{v}</arg_value>...</tool_call>``.
+- Multiple calls in one assistant turn are concatenated end-to-end.
+- ``arguments`` is the JSON-string form Tinker's ``ToolCall`` schema uses;
+  string values are emitted raw, anything else is JSON-encoded with
+  ``ensure_ascii=False`` (matches the shipped Jinja's ``v | tojson`` branch).
+
+Multimodal content is left for a future extension.
 """
 
 from __future__ import annotations
 
+import json
 from collections.abc import Mapping
 from typing import Any
 
@@ -69,6 +80,7 @@ from tinker_cookbook.renderers.base import (
     RenderedMessage,
     Renderer,
     Role,
+    ToolCall,
     parse_response_for_stop_token,
     parse_think_blocks,
 )
@@ -95,6 +107,29 @@ def _visible_text(content: Any) -> str:
                 parts.append(item["text"])
         return "".join(parts)
     return str(content)
+
+
+def _format_arg_value(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    return json.dumps(value, ensure_ascii=False)
+
+
+def _format_tool_calls(tool_calls: list[ToolCall]) -> str:
+    parts: list[str] = []
+    for tc in tool_calls:
+        raw_args = tc.function.arguments
+        args = json.loads(raw_args) if raw_args else {}
+        if not isinstance(args, Mapping):
+            raise TypeError(
+                f"GLM-5.1 tool arguments must be a JSON object, got {type(args)!r}"
+            )
+        kv = "".join(
+            f"<arg_key>{k}</arg_key><arg_value>{_format_arg_value(v)}</arg_value>"
+            for k, v in args.items()
+        )
+        parts.append(f"<tool_call>{tc.function.name}{kv}</tool_call>")
+    return "".join(parts)
 
 
 def _extract_reasoning_and_text(content: Any) -> tuple[str, str]:
@@ -221,6 +256,10 @@ class GLM5Renderer(Renderer):
 
         visible_stripped = visible.strip()
         output_str = think_block + visible_stripped
+
+        tool_calls = message.get("tool_calls")
+        if tool_calls:
+            output_str += _format_tool_calls(tool_calls)
 
         output_tokens = self.tokenizer.encode(output_str, add_special_tokens=False)
         # Append <|endoftext|> only on the final message in the conversation.

--- a/training/tests/unit/test_glm5_renderer.py
+++ b/training/tests/unit/test_glm5_renderer.py
@@ -22,8 +22,20 @@ from pathlib import Path
 import pytest
 import transformers
 
+import json
+from typing import Any
+
 from training.renderer.glm5 import GLM5Renderer
-from tinker_cookbook.renderers.base import TrainOnWhat
+from tinker_cookbook.renderers.base import ToolCall, TrainOnWhat
+
+
+def _make_tool_call(name: str, arguments: dict[str, Any]) -> ToolCall:
+    return ToolCall(
+        function=ToolCall.FunctionBody(
+            name=name,
+            arguments=json.dumps(arguments, ensure_ascii=False),
+        )
+    )
 
 # Public HF tokenizer (ships the canonical GLM-5.1 chat template).
 _PUBLIC_TOKENIZER = "zai-org/GLM-5.1"
@@ -851,3 +863,118 @@ def test_supervised_parity(tokenizer, renderer, messages):
     hf = _hf_tokens(tokenizer, messages, add_generation_prompt=False)
     ours, _ = _renderer_supervised_tokens(renderer, messages)
     _assert_parity_modulo_trailing_eos(ours, hf, tokenizer, expect_eos=True)
+
+
+# ── Tool call parity ────────────────────────────────────────────────────────
+
+
+def _hf_tool_calls(specs: list[tuple[str, dict[str, Any]]]) -> list[dict[str, Any]]:
+    """Build HF-shaped tool_calls (dict args) from (name, args) specs."""
+    return [
+        {"type": "function", "function": {"name": name, "arguments": args}}
+        for name, args in specs
+    ]
+
+
+@pytest.mark.parametrize(
+    "build_messages",
+    [
+        # Single tool call, no preceding visible content.
+        lambda factory: [
+            {"role": "user", "content": "weather in SF?"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": factory([("get_weather", {"city": "SF", "unit": "F"})]),
+            },
+        ],
+        # Tool call with visible content before it.
+        lambda factory: [
+            {"role": "user", "content": "weather in SF?"},
+            {
+                "role": "assistant",
+                "content": "Let me check.",
+                "tool_calls": factory([("get_weather", {"city": "SF"})]),
+            },
+        ],
+        # Multiple tool calls in one assistant turn.
+        lambda factory: [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": factory([("a", {"x": 1}), ("b", {"y": "z"})]),
+            },
+        ],
+        # Mixed argument types: string passes through, others get JSON-encoded.
+        lambda factory: [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": factory(
+                    [("f", {"i": 7, "b": True, "s": "hello", "l": [1, 2]})]
+                ),
+            },
+        ],
+        # Full agent loop: assistant tool call -> tool response -> final answer.
+        lambda factory: [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": factory([("a", {"x": 1})]),
+            },
+            {"role": "tool", "content": "42"},
+            {"role": "assistant", "content": "answer"},
+        ],
+    ],
+    ids=[
+        "single_call_no_text",
+        "single_call_with_text",
+        "two_calls",
+        "mixed_arg_types",
+        "call_then_tool_then_final",
+    ],
+)
+def test_tool_call_supervised_parity(tokenizer, renderer, build_messages):
+    """Tool-call assistant turns match HF byte-for-byte (modulo EOS).
+
+    HF's chat template iterates ``arguments.items()`` so it needs dict-form
+    args; our renderer reads the Tinker ``ToolCall`` schema (JSON-string args).
+    Build both shapes from the same (name, args) spec so the two paths are
+    apples-to-apples.
+    """
+    renderer_messages = build_messages(
+        lambda specs: [_make_tool_call(name, args) for name, args in specs]
+    )
+    hf_messages = build_messages(_hf_tool_calls)
+    hf = _hf_tokens(tokenizer, hf_messages, add_generation_prompt=False)
+    ours, _ = _renderer_supervised_tokens(renderer, renderer_messages)
+    _assert_parity_modulo_trailing_eos(ours, hf, tokenizer, expect_eos=True)
+
+
+def test_tool_call_tokens_are_trained(tokenizer, renderer):
+    """Under all_assistant_messages, tool_call params get nonzero loss weight."""
+    messages = [
+        {"role": "user", "content": "hi"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [_make_tool_call("get_weather", {"city": "SF"})],
+        },
+    ]
+    tokens, weights = _renderer_supervised_tokens(renderer, messages)
+    assert len(tokens) == len(weights)
+    # The arg_value "SF" must land inside the trained span (weight > 0).
+    sf_token = tokenizer.encode("SF", add_special_tokens=False)
+    assert sf_token, "tokenizer produced empty encoding for 'SF'"
+    for i in range(len(tokens) - len(sf_token) + 1):
+        if tokens[i : i + len(sf_token)] == sf_token:
+            assert all(w > 0 for w in weights[i : i + len(sf_token)]), (
+                f"tool_call arg tokens at {i} have zero weight: "
+                f"{weights[i : i + len(sf_token)]}"
+            )
+            break
+    else:
+        raise AssertionError("'SF' tokens not found in rendered output")


### PR DESCRIPTION
The GLM-5.1 renderer previously dropped the structured `tool_calls` field on assistant messages, so any agentic SFT data using OpenAI-style tool calls silently produced training tokens that omitted the call params -- the model never learned to emit them. This change wires `tool_calls` into `_render_assistant` so calls become part of the assistant's output span, which means `train_on_what=all_assistant_messages` now applies loss to tool-call params alongside regular assistant text. `role: "tool"` responses remain context-only as before.

Format matches `zai-org/GLM-5.1`'s shipped Jinja template byte-for-byte: `<tool_call>{name}<arg_key>k</arg_key><arg_value>v</arg_value>...</tool_call>`, multiple calls concatenated with no separator. String args pass through; non-string args go through `json.dumps(..., ensure_ascii=False)` to mirror the template's `tojson` branch.

Tests cover five tool-call shapes (single call, call-with-text, multi-call, mixed arg types, full agent loop) for byte-parity against `apply_chat_template`, plus a weight-mask check confirming tool-call params land inside trained tokens under `all_assistant_messages`.