### PR TITLE
chore(training): bump Fireworks SDK

### DIFF
--- a/training/README.md
+++ b/training/README.md
@@ -29,12 +29,9 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 uv venv --python 3.12
 source .venv/bin/activate
 
-# Install the Fireworks training SDK prerelease that provides
-# `fireworks.training.sdk`.
-uv pip install --pre "fireworks-ai>=1.0.0a36" tinker-cookbook
-
-# Install this package in editable mode
-uv pip install -e .
+# Install this package in editable mode.
+# Dependencies, including the Fireworks training SDK, are pulled from pyproject.toml.
+uv pip install --pre -e .
 
 # If you skip `--pre`, pip may resolve to the stable `0.x` line,
 # which does not include `fireworks.training.sdk` and will cause

--- a/training/examples/multihop_qa/README.md
+++ b/training/examples/multihop_qa/README.md
@@ -40,11 +40,9 @@ This keeps the trainer exclusively for `forward_backward` and avoids GPU batchin
 
 ## Quick start
 
-### 1. Install dependencies
+### 1. Set up environment
 
-```bash
-pip install --pre "fireworks-ai>=1.0.0a36" tinker-cookbook eval-protocol datasets httpx
-```
+Follow the setup instructions in [../../README.md](../../README.md).
 
 ### 2. Prepare dataset
 

--- a/training/examples/multihop_qa/prepare_data.py
+++ b/training/examples/multihop_qa/prepare_data.py
@@ -18,7 +18,7 @@ Output format per row:
    "question_type": "bridge|comparison|..."}
 
 Usage:
-    pip install datasets
+    Follow the setup instructions in ../../README.md.
     python prepare_data.py --max-rows 2000 --difficulty hard
     python prepare_data.py --dataset musique --max-rows 1000
     python prepare_data.py --dataset all --max-rows 3000

--- a/training/examples/multihop_qa/run.sh
+++ b/training/examples/multihop_qa/run.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 # Multi-hop QA IGPO training example.
 #
 # Prerequisites:
-#   pip install --pre "fireworks-ai>=1.0.0a36" tinker-cookbook eval-protocol datasets
+#   Follow the setup instructions in ../../README.md.
 #   export FIREWORKS_API_KEY=...
 #
 # Step 1: Prepare dataset (downloads HotpotQA hard questions from HuggingFace)

--- a/training/examples/multihop_qa/train_multihop_qa_igpo.py
+++ b/training/examples/multihop_qa/train_multihop_qa_igpo.py
@@ -7,7 +7,7 @@ to finish.  IG scoring uses the ground-truth answer as the ``answer_tokens``
 and fires in parallel with generation via ``turn_callback``.
 
 Usage:
-    pip install --pre "fireworks-ai>=1.0.0a36" tinker-cookbook eval-protocol datasets
+    Follow the setup instructions in ../../README.md.
     python prepare_data.py                     # download HotpotQA → dataset.jsonl
     python train_multihop_qa_igpo.py --training-shape <shape_id> --output-model-id <id>
 """

--- a/training/examples/rl/frozen_lake/train_frozen_lake.py
+++ b/training/examples/rl/frozen_lake/train_frozen_lake.py
@@ -8,7 +8,7 @@ Demonstrates reinforcement learning with multi-turn tool-calling:
     it falls back to the client-side custom loss path
 
 Usage:
-    pip install --pre "fireworks-ai>=1.0.0a36" tinker-cookbook eval-protocol
+    Follow the setup instructions in ../../../README.md.
     export FIREWORKS_API_KEY=...
     python train_frozen_lake.py --training-shape <shape_id>
 """

--- a/training/pyproject.toml
+++ b/training/pyproject.toml
@@ -7,7 +7,7 @@ name = "fireworks-training-cookbook"
 version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [
-    "fireworks-ai[training]>=1.0.0a63,<2",  # >=a63 for FiretitanTrainingClient.load_adapter
+    "fireworks-ai[training]>=1.1.0a64,<2",
     "tqdm",
     "torch",
     "datasets",


### PR DESCRIPTION
## Summary
- bump the training package Fireworks SDK requirement to `fireworks-ai[training]>=1.1.0a64,<2`
- keep `training/README.md` as the single source of truth for install guidance
- replace duplicate example-level install commands with references to the core training setup instructions

## Validation
- `python -m pip index versions fireworks-ai --pre`
- `python -m pip install --dry-run --pre 'fireworks-ai[training]>=1.1.0a64,<2'`
- `python3.11 - <<'PY'
import pathlib, tomllib
project = tomllib.loads(pathlib.Path('training/pyproject.toml').read_text())['project']
print(project['dependencies'][0])
PY`
- `git diff --check`