### PR TITLE
[codex] Fix GLM supervised role stop tokens

### DIFF
--- a/training/renderer/glm5.py
+++ b/training/renderer/glm5.py
@@ -61,6 +61,9 @@ Other invariants:
 - Generation suffix (``add_generation_prompt=True`` in Jinja):
   ``<|assistant|><think>`` for thinking mode (default),
   ``<|assistant|></think>`` for non-thinking mode.
+- In supervised examples, the opening ``<think>`` token is kept in the
+  rendered sequence for template parity but masked out of the loss because it
+  is already injected by the generation suffix.
 
 Tool-call layout (assistant turns only — ``role: "tool"`` responses are
 rendered as ``<|observation|><tool_response>...</tool_response>`` and never
@@ -271,6 +274,10 @@ class GLM5Renderer(Renderer):
     def _observation_token(self) -> int:
         return self._encode_single_special(_OBSERVATION_TEXT)
 
+    @property
+    def _think_open_token(self) -> int:
+        return self._encode_single_special("<think>")
+
     def get_stop_sequences(self) -> list[int]:
         return [self._user_token, self._observation_token]
 
@@ -346,6 +353,48 @@ class GLM5Renderer(Renderer):
         expected_role = "tool" if prev_message.get("tool_calls") else "user"
         return current_role == expected_role
 
+    def _append_output_chunks_with_weights(
+        self,
+        model_input_chunks_weights: list[tuple[tinker.ModelInputChunk, float]],
+        *,
+        message: Message,
+        output_parts: list[tinker.ModelInputChunk],
+        output_has_weight: bool,
+        train_on_what: TrainOnWhat,
+    ) -> None:
+        for output_part in output_parts:
+            if not output_part:
+                continue
+
+            if (
+                message["role"] == "assistant"
+                and output_has_weight
+                and train_on_what != TrainOnWhat.ALL_TOKENS
+                and isinstance(output_part, tinker.types.EncodedTextChunk)
+                and output_part.tokens
+                and int(output_part.tokens[0]) == self._think_open_token
+            ):
+                # ``add_generation_prompt=True`` injects
+                # ``<|assistant|><think>``. Keep the token in the rendered
+                # sequence for template parity, but mask it because the model
+                # starts generating after that prefix.
+                model_input_chunks_weights.append(
+                    (tinker.types.EncodedTextChunk(tokens=[output_part.tokens[0]]), 0.0)
+                )
+                if len(output_part.tokens) > 1:
+                    model_input_chunks_weights.append(
+                        (
+                            tinker.types.EncodedTextChunk(
+                                tokens=list(output_part.tokens[1:])
+                            ),
+                            1.0,
+                        )
+                    )
+            else:
+                model_input_chunks_weights.append(
+                    (output_part, int(output_has_weight))
+                )
+
     def build_supervised_example(
         self,
         messages: list[Message],
@@ -411,11 +460,13 @@ class GLM5Renderer(Renderer):
                     header_weight = 1
                 model_input_chunks_weights.append((header_part, header_weight))
 
-            model_input_chunks_weights += [
-                (output_part, int(output_has_weight))
-                for output_part in rendered_message.output
-                if output_part
-            ]
+            self._append_output_chunks_with_weights(
+                model_input_chunks_weights,
+                message=message,
+                output_parts=rendered_message.output,
+                output_has_weight=output_has_weight,
+                train_on_what=train_on_what,
+            )
 
             if is_last_message and rendered_message.stop_overlap:
                 model_input_chunks_weights.append(
@@ -529,9 +580,10 @@ class GLM5Renderer(Renderer):
         return RenderedMessage(header=header, output=output)
 
     def _render_assistant(self, message: Message, ctx: RenderContext) -> RenderedMessage:
-        # The role tag ``<|assistant|>`` is the header; the ``<think>...
-        # </think>`` block lives in ``output`` so it is part of the training
-        # target for this assistant turn.
+        # The role tag ``<|assistant|>`` is the header. Thinking-mode
+        # assistants keep the template's opening ``<think>`` in ``output`` for
+        # token parity, but supervised rendering masks that prefix because
+        # ``add_generation_prompt=True`` injects it before model generation.
         header_str = "<|assistant|>"
 
         before_last_user = (

--- a/training/renderer/glm5.py
+++ b/training/renderer/glm5.py
@@ -5,9 +5,10 @@ Handles the GLM-5.1 chat format as shipped with ``zai-org/GLM-5.1``
 tokenizer and chat template).
 
 Token-level layout follows ``tokenizer.apply_chat_template`` byte-for-byte
-(verified by the unit tests in ``test_glm5_renderer.py``), modulo the
-intentional training EOS on the terminal assistant message. The registered
-renderer uses GLM preserved-thinking semantics by default; opt-in
+(verified by the unit tests in ``test_glm5_renderer.py``), modulo a synthetic
+terminal role sentinel used only for supervised examples that end on an
+assistant message. The registered renderer uses GLM preserved-thinking
+semantics by default; opt-in
 ``strip_thinking_from_history=True`` matches the template's standard
 ``clear_thinking`` behavior.
 
@@ -51,10 +52,12 @@ Other invariants:
 
 - ``[gMASK]<sop>`` is emitted once at the very start of the conversation.
 - The shipped Jinja template does **not** emit ``<|endoftext|>`` at message
-  boundaries. This renderer appends ``<|endoftext|>`` only to the *last*
-  message in the conversation so the trained model learns when to stop;
-  historical assistant turns still match the Jinja byte-for-byte without
-  any EOS adjustment.
+  boundaries. Assistant turns stop by generating the next role sentinel:
+  ``<|user|>`` for a normal assistant answer or ``<|observation|>`` for a
+  tool-call handoff. For supervised examples, this renderer gives those role
+  sentinels loss weight after trainable assistant turns. If a supervised row
+  ends on an assistant message, it appends the appropriate sentinel as
+  ``stop_overlap`` so the trained model still learns where to stop.
 - Generation suffix (``add_generation_prompt=True`` in Jinja):
   ``<|assistant|><think>`` for thinking mode (default),
   ``<|assistant|></think>`` for non-thinking mode.
@@ -82,6 +85,7 @@ from collections.abc import Mapping
 from typing import Any
 
 import tinker
+import torch
 from tinker_cookbook.renderers import register_renderer
 from tinker_cookbook.renderers.base import (
     Message,
@@ -250,16 +254,6 @@ class GLM5Renderer(Renderer):
     def _bos_tokens(self) -> list[int]:
         return self.tokenizer.encode(_BOS_TEXT, add_special_tokens=False)
 
-    @property
-    def _end_message_token(self) -> int:
-        eos = getattr(self.tokenizer, "eos_token_id", None)
-        if eos is None:
-            raise RuntimeError(
-                "GLM5Renderer requires tokenizer.eos_token_id to be set "
-                "(expected <|endoftext|>)."
-            )
-        return int(eos)
-
     def _encode_single_special(self, token_str: str) -> int:
         token_ids = self.tokenizer.encode(token_str, add_special_tokens=False)
         if len(token_ids) != 1:
@@ -278,7 +272,162 @@ class GLM5Renderer(Renderer):
         return self._encode_single_special(_OBSERVATION_TEXT)
 
     def get_stop_sequences(self) -> list[int]:
-        return [self._end_message_token, self._user_token, self._observation_token]
+        return [self._user_token, self._observation_token]
+
+    def _assistant_stop_token(self, message: Message) -> int:
+        return (
+            self._observation_token
+            if message.get("tool_calls")
+            else self._user_token
+        )
+
+    def _assistant_stop_overlap(self, message: Message) -> tinker.EncodedTextChunk:
+        return tinker.types.EncodedTextChunk(
+            tokens=[self._assistant_stop_token(message)]
+        )
+
+    @staticmethod
+    def _output_has_weight(
+        message: Message,
+        *,
+        idx: int,
+        is_last_message: bool,
+        last_user_idx: int,
+        train_on_what: TrainOnWhat,
+    ) -> bool:
+        is_assistant = message["role"] == "assistant"
+        is_user_or_system = message["role"] in ["user", "system"]
+        is_after_last_user = last_user_idx == -1 or idx > last_user_idx
+
+        match train_on_what:
+            case TrainOnWhat.LAST_ASSISTANT_MESSAGE:
+                return is_last_message and is_assistant
+            case TrainOnWhat.LAST_ASSISTANT_TURN:
+                return is_assistant and is_after_last_user
+            case TrainOnWhat.ALL_ASSISTANT_MESSAGES:
+                return is_assistant
+            case TrainOnWhat.ALL_MESSAGES:
+                return True
+            case TrainOnWhat.ALL_TOKENS:
+                return True
+            case TrainOnWhat.ALL_USER_AND_SYSTEM_MESSAGES:
+                return is_user_or_system
+            case TrainOnWhat.CUSTOMIZED:
+                return bool(message.get("trainable", False))
+            case _:
+                raise ValueError(f"Unknown train_on_what: {train_on_what}")
+
+    def _header_is_stop_for_previous_assistant(
+        self,
+        messages: list[Message],
+        *,
+        idx: int,
+        last_user_idx: int,
+        train_on_what: TrainOnWhat,
+    ) -> bool:
+        if idx == 0:
+            return False
+
+        prev_message = messages[idx - 1]
+        if prev_message["role"] != "assistant":
+            return False
+
+        prev_has_weight = self._output_has_weight(
+            prev_message,
+            idx=idx - 1,
+            is_last_message=(idx - 1 == len(messages) - 1),
+            last_user_idx=last_user_idx,
+            train_on_what=train_on_what,
+        )
+        if not prev_has_weight:
+            return False
+
+        current_role = messages[idx]["role"]
+        expected_role = "tool" if prev_message.get("tool_calls") else "user"
+        return current_role == expected_role
+
+    def build_supervised_example(
+        self,
+        messages: list[Message],
+        train_on_what: TrainOnWhat = TrainOnWhat.LAST_ASSISTANT_MESSAGE,
+    ) -> tuple[tinker.ModelInput, torch.Tensor]:
+        """Build a GLM supervised example with role-sentinel stop weights.
+
+        GLM-5.1 uses the next role tag, not EOS, as the assistant stop marker.
+        The base renderer masks headers, so it would not train ``<|user|>`` or
+        ``<|observation|>`` after historical assistant turns. This override
+        preserves the base token layout while assigning loss to those sentinels
+        when they close a trainable assistant turn.
+        """
+        model_input_chunks_weights: list[tuple[tinker.ModelInputChunk, float]] = []
+        if self._bos_tokens:
+            model_input_chunks_weights.append(
+                (tinker.types.EncodedTextChunk(tokens=self._bos_tokens), 0.0)
+            )
+
+        last_user_idx = max(
+            (idx for idx, message in enumerate(messages) if message["role"] == "user"),
+            default=-1,
+        )
+
+        for idx, message in enumerate(messages):
+            if train_on_what == TrainOnWhat.CUSTOMIZED:
+                assert "trainable" in message, (
+                    "When using CUSTOMIZED train_on_what, each message must have "
+                    "a trainable field."
+                )
+            else:
+                assert "trainable" not in message, (
+                    "When using non-CUSTOMIZED train_on_what, each message must "
+                    "not have a trainable field."
+                )
+
+            is_last_message = idx == len(messages) - 1
+            ctx = RenderContext(
+                idx=idx,
+                is_last=is_last_message,
+                prev_message=messages[idx - 1] if idx > 0 else None,
+                last_user_index=last_user_idx,
+            )
+            rendered_message = self.render_message(message, ctx)
+
+            output_has_weight = self._output_has_weight(
+                message,
+                idx=idx,
+                is_last_message=is_last_message,
+                last_user_idx=last_user_idx,
+                train_on_what=train_on_what,
+            )
+
+            header_part = rendered_message.header
+            if header_part:
+                header_weight = int(train_on_what == TrainOnWhat.ALL_TOKENS)
+                if self._header_is_stop_for_previous_assistant(
+                    messages,
+                    idx=idx,
+                    last_user_idx=last_user_idx,
+                    train_on_what=train_on_what,
+                ):
+                    header_weight = 1
+                model_input_chunks_weights.append((header_part, header_weight))
+
+            model_input_chunks_weights += [
+                (output_part, int(output_has_weight))
+                for output_part in rendered_message.output
+                if output_part
+            ]
+
+            if is_last_message and rendered_message.stop_overlap:
+                model_input_chunks_weights.append(
+                    (rendered_message.stop_overlap, int(output_has_weight))
+                )
+
+        weights_data = [
+            w for chunk, w in model_input_chunks_weights for _ in range(chunk.length)
+        ]
+        weights_tensor = torch.tensor(weights_data)
+        model_input_chunks = [chunk for chunk, _ in model_input_chunks_weights]
+        return tinker.ModelInput(chunks=model_input_chunks), weights_tensor
 
     def build_supervised_examples(
         self,
@@ -420,22 +569,21 @@ class GLM5Renderer(Renderer):
         if tool_calls:
             output_str += _format_tool_calls(tool_calls)
 
-        output_tokens = self.tokenizer.encode(output_str, add_special_tokens=False)
-        # Append <|endoftext|> only on the final message in the conversation.
-        # Historical assistant turns are delimited only by the next role tag
-        # in the GLM Jinja template, so emitting EOS there would add a token
-        # the template never produces. The final turn still gets EOS so the
-        # trained model learns when to stop.
-        if ctx.is_last:
-            output_tokens.append(self._end_message_token)
-
         header = tinker.types.EncodedTextChunk(
             tokens=self.tokenizer.encode(header_str, add_special_tokens=False),
         )
         output: list[tinker.ModelInputChunk] = [
-            tinker.types.EncodedTextChunk(tokens=output_tokens),
+            tinker.types.EncodedTextChunk(
+                tokens=self.tokenizer.encode(output_str, add_special_tokens=False),
+            ),
         ]
-        return RenderedMessage(header=header, output=output)
+        return RenderedMessage(
+            header=header,
+            output=output,
+            stop_overlap=(
+                self._assistant_stop_overlap(message) if ctx.is_last else None
+            ),
+        )
 
     def _get_generation_suffix(self, role: Role, ctx: RenderContext) -> list[int]:
         del ctx

--- a/training/tests/glm5_serverless_cases.py
+++ b/training/tests/glm5_serverless_cases.py
@@ -6,7 +6,6 @@ from typing import Any
 
 
 GLM5_SERVERLESS_STOP_TOKEN_IDS = {
-    "eos": 154820,
     "user": 154827,
     "observation": 154829,
 }

--- a/training/tests/unit/test_glm5_renderer.py
+++ b/training/tests/unit/test_glm5_renderer.py
@@ -1118,6 +1118,66 @@ def test_weight_mask_trains_role_stops_after_historical_assistants(
     assert weights[observation_positions[0]] == 1
 
 
+def test_weight_mask_multi_turn_tool_call_with_thinking_trains_observation_stop(
+    tokenizer, renderer_keep_thinking
+):
+    """Interleaved thinking/tool-call rows train the tool call and observation stop."""
+    messages = [
+        {"role": "system", "content": "Use tools when useful."},
+        {"role": "user", "content": "First question"},
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "thinking", "thinking": "answer directly"},
+                {"type": "text", "text": "first answer"},
+            ],
+        },
+        {"role": "user", "content": "Now lookup the weather"},
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "thinking", "thinking": "need weather tool"},
+                {"type": "text", "text": ""},
+            ],
+            "tool_calls": [_make_tool_call("get_weather", {"city": "SF"})],
+        },
+        {"role": "tool", "content": "sunny"},
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "thinking", "thinking": "tool says sunny"},
+                {"type": "text", "text": "It is sunny."},
+            ],
+        },
+    ]
+    tokens, weights = _renderer_supervised_tokens(renderer_keep_thinking, messages)
+
+    tool_call_open = _encode_single(tokenizer, "<tool_call>")
+    tool_call_close = _encode_single(tokenizer, "</tool_call>")
+    observation = _observation_token(tokenizer)
+    tool_response_open = _encode_single(tokenizer, "<tool_response>")
+    tool_response_close = _encode_single(tokenizer, "</tool_response>")
+
+    tool_call_start = tokens.index(tool_call_open)
+    tool_call_end = tokens.index(tool_call_close, tool_call_start)
+    observation_pos = tokens.index(observation, tool_call_end + 1)
+    tool_response_start = tokens.index(tool_response_open, observation_pos + 1)
+    tool_response_end = tokens.index(tool_response_close, tool_response_start)
+
+    assert observation_pos == tool_call_end + 1
+    assert all(w == 1 for w in weights[tool_call_start : tool_call_end + 1])
+    assert weights[observation_pos] == 1
+    assert all(
+        w == 0 for w in weights[tool_response_start : tool_response_end + 1]
+    )
+
+    trained_text = tokenizer.decode([t for t, w in zip(tokens, weights) if w > 0])
+    assert "<think>need weather tool</think>" in trained_text
+    assert "<tool_call>get_weather" in trained_text
+    assert "<|observation|>" in trained_text
+    assert "<tool_response>sunny</tool_response>" not in trained_text
+
+
 def test_weight_mask_multi_turn_covers_all_assistant_turns(tokenizer, renderer):
     """With TrainOnWhat.ALL_ASSISTANT_MESSAGES, every assistant turn gets trained."""
     messages = [

--- a/training/tests/unit/test_glm5_renderer.py
+++ b/training/tests/unit/test_glm5_renderer.py
@@ -1242,7 +1242,13 @@ def test_weight_mask_multi_turn_tool_call_with_thinking_trains_observation_stop(
 def test_weight_mask_parallel_tool_responses_train_single_observation_stop(
     tokenizer, renderer_keep_thinking
 ):
-    """Parallel tool-call responses share one trained observation stop."""
+    """Parallel tool responses share one observation stop.
+
+    The model generates the assistant tool-call block and should learn to stop
+    by producing ``<|observation|>``. The following tool responses are
+    environment-provided context, so their ``<tool_response>...</tool_response>``
+    spans must stay masked even when multiple tool messages follow.
+    """
     messages = [
         {"role": "user", "content": "Plan with two tools"},
         {
@@ -1270,14 +1276,8 @@ def test_weight_mask_parallel_tool_responses_train_single_observation_stop(
     observation = _observation_token(tokenizer)
     user = _user_token(tokenizer)
     tool_call_close = _encode_single(tokenizer, "</tool_call>")
-    first_response = tokenizer.encode(
-        "<tool_response>WEATHER_RESULT_ABC</tool_response>",
-        add_special_tokens=False,
-    )
-    second_response = tokenizer.encode(
-        "<tool_response>CONVERT_RESULT_XYZ</tool_response>",
-        add_special_tokens=False,
-    )
+    first_response_text = "<tool_response>WEATHER_RESULT_ABC</tool_response>"
+    second_response_text = "<tool_response>CONVERT_RESULT_XYZ</tool_response>"
 
     observation_positions = [
         i for i, token in enumerate(tokens) if token == observation
@@ -1285,24 +1285,32 @@ def test_weight_mask_parallel_tool_responses_train_single_observation_stop(
     tool_call_close_positions = [
         i for i, token in enumerate(tokens) if token == tool_call_close
     ]
-    first_response_pos = _find_subsequence(tokens, first_response)
-    second_response_pos = _find_subsequence(tokens, second_response)
 
+    # The two parallel tool calls are both model output. The single
+    # observation tag that follows the last tool call is the model's stop token.
     assert len(tool_call_close_positions) == 2
-    assert observation_positions == [tool_call_close_positions[-1] + 1]
-    assert weights[observation_positions[0]] == 1
-    assert all(
-        w == 0
-        for w in weights[
-            first_response_pos : first_response_pos + len(first_response)
+    assert len(observation_positions) == 1
+    observation_pos = observation_positions[0]
+    assert observation_pos == tool_call_close_positions[-1] + 1
+    assert weights[observation_pos] == 1
+
+    def assert_tool_response_span_is_masked(response_text: str) -> None:
+        response_tokens = tokenizer.encode(response_text, add_special_tokens=False)
+        response_start = _find_subsequence(tokens, response_tokens)
+        response_weights = weights[
+            response_start : response_start + len(response_tokens)
         ]
-    )
-    assert all(
-        w == 0
-        for w in weights[
-            second_response_pos : second_response_pos + len(second_response)
-        ]
-    )
+
+        assert response_weights == [0.0] * len(response_tokens), (
+            f"Tool response {response_text!r} is environment output and should "
+            f"be masked, got weights {response_weights}"
+        )
+
+    assert_tool_response_span_is_masked(first_response_text)
+    assert_tool_response_span_is_masked(second_response_text)
+
+    # The final assistant answer is a normal assistant turn, so its synthetic
+    # terminal stop is <|user|>, separate from the earlier tool-call stop.
     assert tokens[-1] == user
     assert weights[-1] == 1
 

--- a/training/tests/unit/test_glm5_renderer.py
+++ b/training/tests/unit/test_glm5_renderer.py
@@ -3,9 +3,9 @@
 Loads the public ``zai-org/GLM-5.1`` tokenizer (which ships the canonical
 chat template for GLM-5.1) and checks that every supported renderer
 output matches what ``tokenizer.apply_chat_template`` produces
-byte-for-byte, modulo the intentional training EOS on the terminal
-assistant message. Falls back to a local tokenizer path when the
-HuggingFace Hub isn't reachable (e.g. internal CI).
+byte-for-byte, modulo the terminal role stop token appended to supervised
+examples that end on an assistant message. Falls back to a local tokenizer
+path when the HuggingFace Hub isn't reachable (e.g. internal CI).
 
 The ``zai-org/GLM-5.1-FP8`` repo ships an identical tokenizer + chat
 template (verified: byte-for-byte equal). We use the bf16 repo here
@@ -137,33 +137,59 @@ def _eos(tokenizer) -> int:
     return int(tokenizer.eos_token_id)
 
 
-def _assert_parity_modulo_trailing_eos(
-    ours: list[int], hf: list[int], tokenizer, *, expect_eos: bool,
-) -> None:
-    """Compare token sequences, accounting for the intentional trailing EOS.
+def _encode_single(tokenizer, text: str) -> int:
+    token_ids = tokenizer.encode(text, add_special_tokens=False)
+    assert len(token_ids) == 1, f"{text!r} encoded to {token_ids}"
+    return int(token_ids[0])
 
-    GLM5Renderer appends ``<|endoftext|>`` only to the final message in a
-    conversation, so the trained model learns when to stop. The upstream
-    Jinja template does not emit EOS anywhere. When *expect_eos* is True,
-    strip exactly one trailing EOS from our output before the equality
-    check; historical assistant turns inside the sequence must already
-    match the Jinja byte-for-byte without any EOS adjustment.
+
+def _user_token(tokenizer) -> int:
+    return _encode_single(tokenizer, "<|user|>")
+
+
+def _observation_token(tokenizer) -> int:
+    return _encode_single(tokenizer, "<|observation|>")
+
+
+def _assistant_stop_token(tokenizer, message: dict[str, Any]) -> int:
+    return (
+        _observation_token(tokenizer)
+        if message.get("tool_calls")
+        else _user_token(tokenizer)
+    )
+
+
+def _assert_supervised_parity_with_role_stop(
+    ours: list[int],
+    hf: list[int],
+    tokenizer,
+    messages: list[dict[str, Any]],
+) -> None:
+    """Compare supervised tokens against HF, accounting for terminal stop overlap.
+
+    GLM-5.1 does not use ``<|endoftext|>`` as the chat stop token. Assistant
+    turns stop on the next role tag: ``<|user|>`` for normal answers and
+    ``<|observation|>`` for tool-call handoff. The HF template only emits that
+    tag when the following message exists, so a supervised example that ends on
+    an assistant appends the role tag as stop overlap.
     """
     our_cmp = list(ours)
-    if expect_eos:
-        assert our_cmp and our_cmp[-1] == _eos(tokenizer), (
-            f"expected trailing <|endoftext|> ({_eos(tokenizer)}), got {our_cmp[-1:]}"
+    if messages and messages[-1]["role"] == "assistant":
+        expected_stop = _assistant_stop_token(tokenizer, messages[-1])
+        assert our_cmp and our_cmp[-1] == expected_stop, (
+            "expected trailing assistant stop token "
+            f"({expected_stop}), got {our_cmp[-1:]}"
         )
         our_cmp = our_cmp[:-1]
     assert our_cmp == hf, (
-        f"Token mismatch (EOS stripped={expect_eos}):\n"
+        "Token mismatch (terminal role stop stripped if present):\n"
         f"  HF:   {hf}\n  ours: {our_cmp}\n"
         f"  HF text:   {tokenizer.decode(hf)!r}\n"
         f"  ours text: {tokenizer.decode(our_cmp)!r}"
     )
 
 
-# ── Single-turn generation prompts (no trailing EOS — compare as-is) ────────
+# ── Single-turn generation prompts (compare as-is) ─────────────────────────
 
 
 def test_generation_prompt_user_only(tokenizer, renderer):
@@ -216,7 +242,7 @@ def test_generation_prompt_after_tool(tokenizer, renderer):
     assert ours == hf
 
 
-# ── Supervised examples (trailing EOS expected on our side) ─────────────────
+# ── Supervised examples (terminal assistant uses role-stop overlap) ─────────
 
 
 def test_supervised_single_turn_no_thinking(tokenizer, renderer):
@@ -227,7 +253,7 @@ def test_supervised_single_turn_no_thinking(tokenizer, renderer):
     ]
     hf = _hf_tokens(tokenizer, messages, add_generation_prompt=False)
     ours, _ = _renderer_supervised_tokens(renderer, messages)
-    _assert_parity_modulo_trailing_eos(ours, hf, tokenizer, expect_eos=True)
+    _assert_supervised_parity_with_role_stop(ours, hf, tokenizer, messages)
 
 
 def test_supervised_single_turn_with_thinking(tokenizer, renderer):
@@ -238,7 +264,7 @@ def test_supervised_single_turn_with_thinking(tokenizer, renderer):
     ]
     hf = _hf_tokens(tokenizer, messages, add_generation_prompt=False)
     ours, _ = _renderer_supervised_tokens(renderer, messages)
-    _assert_parity_modulo_trailing_eos(ours, hf, tokenizer, expect_eos=True)
+    _assert_supervised_parity_with_role_stop(ours, hf, tokenizer, messages)
 
 
 def test_supervised_system_user_assistant(tokenizer, renderer):
@@ -250,7 +276,7 @@ def test_supervised_system_user_assistant(tokenizer, renderer):
     ]
     hf = _hf_tokens(tokenizer, messages, add_generation_prompt=False)
     ours, _ = _renderer_supervised_tokens(renderer, messages)
-    _assert_parity_modulo_trailing_eos(ours, hf, tokenizer, expect_eos=True)
+    _assert_supervised_parity_with_role_stop(ours, hf, tokenizer, messages)
 
 
 def test_supervised_memorization_pair(tokenizer, renderer):
@@ -267,7 +293,7 @@ def test_supervised_memorization_pair(tokenizer, renderer):
     ]
     hf = _hf_tokens(tokenizer, messages, add_generation_prompt=False)
     ours, _ = _renderer_supervised_tokens(renderer, messages)
-    _assert_parity_modulo_trailing_eos(ours, hf, tokenizer, expect_eos=True)
+    _assert_supervised_parity_with_role_stop(ours, hf, tokenizer, messages)
 
 
 def test_supervised_unicode_content(tokenizer, renderer):
@@ -278,7 +304,7 @@ def test_supervised_unicode_content(tokenizer, renderer):
     ]
     hf = _hf_tokens(tokenizer, messages, add_generation_prompt=False)
     ours, _ = _renderer_supervised_tokens(renderer, messages)
-    _assert_parity_modulo_trailing_eos(ours, hf, tokenizer, expect_eos=True)
+    _assert_supervised_parity_with_role_stop(ours, hf, tokenizer, messages)
 
 
 def test_supervised_long_content(tokenizer, renderer):
@@ -291,7 +317,7 @@ def test_supervised_long_content(tokenizer, renderer):
     ]
     hf = _hf_tokens(tokenizer, messages, add_generation_prompt=False)
     ours, _ = _renderer_supervised_tokens(renderer, messages)
-    _assert_parity_modulo_trailing_eos(ours, hf, tokenizer, expect_eos=True)
+    _assert_supervised_parity_with_role_stop(ours, hf, tokenizer, messages)
 
 
 def test_supervised_empty_assistant_content(tokenizer, renderer):
@@ -302,7 +328,7 @@ def test_supervised_empty_assistant_content(tokenizer, renderer):
     ]
     hf = _hf_tokens(tokenizer, messages, add_generation_prompt=False)
     ours, _ = _renderer_supervised_tokens(renderer, messages)
-    _assert_parity_modulo_trailing_eos(ours, hf, tokenizer, expect_eos=True)
+    _assert_supervised_parity_with_role_stop(ours, hf, tokenizer, messages)
 
 
 def test_supervised_whitespace_only_assistant_content(tokenizer, renderer):
@@ -313,7 +339,7 @@ def test_supervised_whitespace_only_assistant_content(tokenizer, renderer):
     ]
     hf = _hf_tokens(tokenizer, messages, add_generation_prompt=False)
     ours, _ = _renderer_supervised_tokens(renderer, messages)
-    _assert_parity_modulo_trailing_eos(ours, hf, tokenizer, expect_eos=True)
+    _assert_supervised_parity_with_role_stop(ours, hf, tokenizer, messages)
 
 
 # ── History thinking collapse ───────────────────────────────────────────────
@@ -340,7 +366,7 @@ def test_history_thinking_collapses_to_empty(tokenizer, renderer):
     ]
     hf = _hf_tokens(tokenizer, messages, add_generation_prompt=False)
     ours, _ = _renderer_supervised_tokens(renderer, messages)
-    _assert_parity_modulo_trailing_eos(ours, hf, tokenizer, expect_eos=True)
+    _assert_supervised_parity_with_role_stop(ours, hf, tokenizer, messages)
 
 
 def test_two_assistants_after_last_user_both_keep_thinking(tokenizer, renderer):
@@ -357,7 +383,7 @@ def test_two_assistants_after_last_user_both_keep_thinking(tokenizer, renderer):
     ]
     hf = _hf_tokens(tokenizer, messages, add_generation_prompt=False)
     ours, _ = _renderer_supervised_tokens(renderer, messages)
-    _assert_parity_modulo_trailing_eos(ours, hf, tokenizer, expect_eos=True)
+    _assert_supervised_parity_with_role_stop(ours, hf, tokenizer, messages)
 
 
 def test_history_no_thinking_in_source(tokenizer, renderer):
@@ -370,7 +396,7 @@ def test_history_no_thinking_in_source(tokenizer, renderer):
     ]
     hf = _hf_tokens(tokenizer, messages, add_generation_prompt=False)
     ours, _ = _renderer_supervised_tokens(renderer, messages)
-    _assert_parity_modulo_trailing_eos(ours, hf, tokenizer, expect_eos=True)
+    _assert_supervised_parity_with_role_stop(ours, hf, tokenizer, messages)
 
 
 def test_history_first_has_thinking_second_does_not(tokenizer, renderer):
@@ -384,7 +410,7 @@ def test_history_first_has_thinking_second_does_not(tokenizer, renderer):
     ]
     hf = _hf_tokens(tokenizer, messages, add_generation_prompt=False)
     ours, _ = _renderer_supervised_tokens(renderer, messages)
-    _assert_parity_modulo_trailing_eos(ours, hf, tokenizer, expect_eos=True)
+    _assert_supervised_parity_with_role_stop(ours, hf, tokenizer, messages)
 
 
 def test_history_first_no_thinking_second_has_thinking(tokenizer, renderer):
@@ -397,7 +423,7 @@ def test_history_first_no_thinking_second_has_thinking(tokenizer, renderer):
     ]
     hf = _hf_tokens(tokenizer, messages, add_generation_prompt=False)
     ours, _ = _renderer_supervised_tokens(renderer, messages)
-    _assert_parity_modulo_trailing_eos(ours, hf, tokenizer, expect_eos=True)
+    _assert_supervised_parity_with_role_stop(ours, hf, tokenizer, messages)
 
 
 def test_history_three_turn_middle_has_thinking(tokenizer, renderer):
@@ -413,7 +439,7 @@ def test_history_three_turn_middle_has_thinking(tokenizer, renderer):
     ]
     hf = _hf_tokens(tokenizer, messages, add_generation_prompt=False)
     ours, _ = _renderer_supervised_tokens(renderer, messages)
-    _assert_parity_modulo_trailing_eos(ours, hf, tokenizer, expect_eos=True)
+    _assert_supervised_parity_with_role_stop(ours, hf, tokenizer, messages)
 
 
 # ── Tool / observation rendering ────────────────────────────────────────────
@@ -482,7 +508,7 @@ def test_supervised_tool_user_assistant(tokenizer, renderer):
     ]
     hf = _hf_tokens(tokenizer, messages, add_generation_prompt=False)
     ours, _ = _renderer_supervised_tokens(renderer, messages)
-    _assert_parity_modulo_trailing_eos(ours, hf, tokenizer, expect_eos=True)
+    _assert_supervised_parity_with_role_stop(ours, hf, tokenizer, messages)
 
 
 # ── Structured content (list of {"type": "text", ...}) ─────────────────────
@@ -496,7 +522,7 @@ def test_structured_text_content_user(tokenizer, renderer):
     ]
     hf = _hf_tokens(tokenizer, messages, add_generation_prompt=False)
     ours, _ = _renderer_supervised_tokens(renderer, messages)
-    _assert_parity_modulo_trailing_eos(ours, hf, tokenizer, expect_eos=True)
+    _assert_supervised_parity_with_role_stop(ours, hf, tokenizer, messages)
 
 
 def test_structured_text_content_multi_parts(tokenizer, renderer):
@@ -510,7 +536,7 @@ def test_structured_text_content_multi_parts(tokenizer, renderer):
     ]
     hf = _hf_tokens(tokenizer, messages, add_generation_prompt=False)
     ours, _ = _renderer_supervised_tokens(renderer, messages)
-    _assert_parity_modulo_trailing_eos(ours, hf, tokenizer, expect_eos=True)
+    _assert_supervised_parity_with_role_stop(ours, hf, tokenizer, messages)
 
 
 # ── System message variations ───────────────────────────────────────────────
@@ -527,7 +553,7 @@ def test_multiple_system_messages(tokenizer, renderer):
     ]
     hf = _hf_tokens(tokenizer, messages, add_generation_prompt=False)
     ours, _ = _renderer_supervised_tokens(renderer, messages)
-    _assert_parity_modulo_trailing_eos(ours, hf, tokenizer, expect_eos=True)
+    _assert_supervised_parity_with_role_stop(ours, hf, tokenizer, messages)
 
 
 def test_system_mid_conversation(tokenizer, renderer):
@@ -541,7 +567,7 @@ def test_system_mid_conversation(tokenizer, renderer):
     ]
     hf = _hf_tokens(tokenizer, messages, add_generation_prompt=False)
     ours, _ = _renderer_supervised_tokens(renderer, messages)
-    _assert_parity_modulo_trailing_eos(ours, hf, tokenizer, expect_eos=True)
+    _assert_supervised_parity_with_role_stop(ours, hf, tokenizer, messages)
 
 
 # ── strip_thinking_from_history=False (clear_thinking=False) ────────────────
@@ -563,7 +589,7 @@ def test_keep_thinking_in_history(tokenizer, renderer_keep_thinking):
         tokenizer, messages, add_generation_prompt=False, clear_thinking=False,
     )
     ours, _ = _renderer_supervised_tokens(renderer_keep_thinking, messages)
-    _assert_parity_modulo_trailing_eos(ours, hf, tokenizer, expect_eos=True)
+    _assert_supervised_parity_with_role_stop(ours, hf, tokenizer, messages)
 
 
 def test_keep_thinking_history_no_thinking_source(tokenizer, renderer_keep_thinking):
@@ -578,7 +604,7 @@ def test_keep_thinking_history_no_thinking_source(tokenizer, renderer_keep_think
         tokenizer, messages, add_generation_prompt=False, clear_thinking=False,
     )
     ours, _ = _renderer_supervised_tokens(renderer_keep_thinking, messages)
-    _assert_parity_modulo_trailing_eos(ours, hf, tokenizer, expect_eos=True)
+    _assert_supervised_parity_with_role_stop(ours, hf, tokenizer, messages)
 
 
 def test_keep_thinking_generation_prompt(tokenizer, renderer_keep_thinking):
@@ -683,7 +709,9 @@ def test_preserve_thinking_supervised_matches_hf(tokenizer, renderer_keep_thinki
         clear_thinking=False,
     )
     ours, _ = _renderer_supervised_tokens(renderer_keep_thinking, renderer_messages)
-    _assert_parity_modulo_trailing_eos(ours, hf, tokenizer, expect_eos=True)
+    _assert_supervised_parity_with_role_stop(
+        ours, hf, tokenizer, renderer_messages
+    )
 
 
 def _interleaved_tool_raw_messages() -> list[dict[str, Any]]:
@@ -1015,9 +1043,8 @@ def test_weight_mask_only_covers_assistant_output(tokenizer, renderer):
     """Every non-zero-weight position must decode to an assistant-output token.
 
     Specifically: the trained span for the last assistant turn should be
-    ``<think></think>{content}<|endoftext|>`` — matching the shipped
-    Jinja template layout (no leading newline, no newline between the
-    think block and the content) plus the intentional trailing EOS.
+    ``<think></think>{content}<|user|>``. GLM-5.1 stops normal assistant
+    answers by generating the next user role tag, not EOS.
     """
     messages = [
         {"role": "user", "content": "What is the secret password?"},
@@ -1032,10 +1059,63 @@ def test_weight_mask_only_covers_assistant_output(tokenizer, renderer):
     trained_tokens = [t for t, w in zip(tokens, weights) if w > 0]
     trained_text = tokenizer.decode(trained_tokens)
 
-    # Should start with '<think></think>' (no leading newline) and end with EOS.
+    # Should start with '<think></think>' (no leading newline) and end with
+    # the normal assistant stop sentinel.
     assert trained_text.startswith("<think></think>"), trained_text
-    assert tokens[-1] == _eos(tokenizer), "last token must be <|endoftext|>"
+    assert tokens[-1] == _user_token(tokenizer), "last token must be <|user|>"
+    assert trained_tokens[-1] == _user_token(tokenizer)
     assert "ALPHA-BRAVO" in trained_text
+
+
+def test_weight_mask_tool_call_stop_uses_observation(tokenizer, renderer):
+    """Tool-call assistant turns stop on <|observation|>, not <|user|>."""
+    messages = [
+        {"role": "user", "content": "weather?"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [_make_tool_call("get_weather", {"city": "SF"})],
+        },
+    ]
+    tokens, weights = _renderer_supervised_tokens(renderer, messages)
+    trained_tokens = [t for t, w in zip(tokens, weights) if w > 0]
+
+    assert tokens[-1] == _observation_token(tokenizer)
+    assert trained_tokens[-1] == _observation_token(tokenizer)
+    assert _user_token(tokenizer) not in trained_tokens
+
+
+def test_weight_mask_trains_role_stops_after_historical_assistants(
+    tokenizer, renderer
+):
+    """Next role tags after trainable assistant turns must carry loss."""
+    messages = [
+        {"role": "user", "content": "q1"},
+        {"role": "assistant", "content": "a1"},
+        {"role": "user", "content": "q2"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [_make_tool_call("lookup", {"q": "q2"})],
+        },
+        {"role": "tool", "content": "result"},
+        {"role": "assistant", "content": "a2"},
+    ]
+    tokens, weights = _renderer_supervised_tokens(renderer, messages)
+    user = _user_token(tokenizer)
+    observation = _observation_token(tokenizer)
+
+    user_positions = [i for i, token in enumerate(tokens) if token == user]
+    observation_positions = [
+        i for i, token in enumerate(tokens) if token == observation
+    ]
+
+    assert len(user_positions) == 3
+    assert weights[user_positions[0]] == 0
+    assert weights[user_positions[1]] == 1
+    assert weights[user_positions[2]] == 1
+    assert len(observation_positions) == 1
+    assert weights[observation_positions[0]] == 1
 
 
 def test_weight_mask_multi_turn_covers_all_assistant_turns(tokenizer, renderer):
@@ -1100,15 +1180,14 @@ def test_bos_tokens_are_gMASK_sop(tokenizer, renderer):
     assert len(bos) == 2  # [gMASK]=154822, <sop>=154824 on GLM-5.1
 
 
-def test_stop_sequences_returns_eos_and_next_role_tags(tokenizer, renderer):
+def test_stop_sequences_returns_next_role_tags_not_eos(tokenizer, renderer):
     stops = renderer.get_stop_sequences()
     expected = [
-        GLM5_SERVERLESS_STOP_TOKEN_IDS["eos"],
         GLM5_SERVERLESS_STOP_TOKEN_IDS["user"],
         GLM5_SERVERLESS_STOP_TOKEN_IDS["observation"],
     ]
     assert stops == expected
-    assert _eos(tokenizer) == GLM5_SERVERLESS_STOP_TOKEN_IDS["eos"]
+    assert _eos(tokenizer) not in stops
     assert all(
         len(tokenizer.encode(tag, add_special_tokens=False)) == 1
         for tag in ("<|user|>", "<|observation|>")
@@ -1142,10 +1221,12 @@ def test_generation_suffix_is_role_tag(tokenizer, renderer):
 
 
 def test_parse_response_roundtrip(tokenizer, renderer):
-    """parse_response on <think>R</think>\\n{content}<|endoftext|> must extract content."""
-    # Simulate what the model would emit post <|assistant|>: "\n<think>reason</think>\nhello<|endoftext|>"
+    """parse_response on <think>R</think>{content}<|user|> must extract content."""
+    # Simulate what the model would emit after the <|assistant|><think> prompt.
     simulated = "\n<think>reason</think>\nhello"
-    ids = tokenizer.encode(simulated, add_special_tokens=False) + [_eos(tokenizer)]
+    ids = tokenizer.encode(simulated, add_special_tokens=False) + [
+        _user_token(tokenizer)
+    ]
     message, ok = renderer.parse_response(ids)
     assert ok is True
     # Content may be structured (think_blocks parsed) or a string — both should contain 'hello'.
@@ -1203,7 +1284,9 @@ def test_parse_response_no_stop_token(tokenizer, renderer):
 def test_parse_response_empty_thinking(tokenizer, renderer):
     """parse_response with empty think block extracts content correctly."""
     simulated = "<think></think>just the answer"
-    ids = tokenizer.encode(simulated, add_special_tokens=False) + [_eos(tokenizer)]
+    ids = tokenizer.encode(simulated, add_special_tokens=False) + [
+        _user_token(tokenizer)
+    ]
     message, ok = renderer.parse_response(ids)
     assert ok is True
     content = message["content"]
@@ -1417,10 +1500,10 @@ def test_recorded_fireworks_prompt_cases_cover_glm_role_and_tool_tokens(tokenize
     ],
 )
 def test_supervised_parity(tokenizer, renderer, messages):
-    """Parametrized: supervised tokens match HF byte-for-byte (modulo EOS)."""
+    """Supervised tokens match HF modulo terminal role-stop overlap."""
     hf = _hf_tokens(tokenizer, messages, add_generation_prompt=False)
     ours, _ = _renderer_supervised_tokens(renderer, messages)
-    _assert_parity_modulo_trailing_eos(ours, hf, tokenizer, expect_eos=True)
+    _assert_supervised_parity_with_role_stop(ours, hf, tokenizer, messages)
 
 
 # ── Tool call parity ────────────────────────────────────────────────────────
@@ -1496,7 +1579,7 @@ def _hf_tool_calls(specs: list[tuple[str, dict[str, Any]]]) -> list[dict[str, An
     ],
 )
 def test_tool_call_supervised_parity(tokenizer, renderer, build_messages):
-    """Tool-call assistant turns match HF byte-for-byte (modulo EOS).
+    """Tool-call assistant turns match HF modulo terminal role-stop overlap.
 
     HF's chat template iterates ``arguments.items()`` so it needs dict-form
     args; our renderer reads the Tinker ``ToolCall`` schema (JSON-string args).
@@ -1509,7 +1592,9 @@ def test_tool_call_supervised_parity(tokenizer, renderer, build_messages):
     hf_messages = build_messages(_hf_tool_calls)
     hf = _hf_tokens(tokenizer, hf_messages, add_generation_prompt=False)
     ours, _ = _renderer_supervised_tokens(renderer, renderer_messages)
-    _assert_parity_modulo_trailing_eos(ours, hf, tokenizer, expect_eos=True)
+    _assert_supervised_parity_with_role_stop(
+        ours, hf, tokenizer, renderer_messages
+    )
 
 
 def test_tool_call_tokens_are_trained(tokenizer, renderer):

--- a/training/tests/unit/test_glm5_renderer.py
+++ b/training/tests/unit/test_glm5_renderer.py
@@ -839,7 +839,8 @@ def test_interleaved_tool_reasoning_and_params_are_trained(tokenizer, renderer):
     tokens, weights = _renderer_supervised_tokens(renderer, messages)
     trained_text = tokenizer.decode([t for t, w in zip(tokens, weights) if w > 0])
 
-    assert "<think>Need current weather.</think>" in trained_text
+    assert "<think>" not in trained_text
+    assert "Need current weather.</think>" in trained_text
     assert "<tool_call>get_weather" in trained_text
     assert "<arg_value>SF</arg_value>" in trained_text
 
@@ -1051,9 +1052,10 @@ def test_preserve_thinking_build_supervised_examples_keeps_single_example(
 def test_weight_mask_only_covers_assistant_output(tokenizer, renderer):
     """Every non-zero-weight position must decode to an assistant-output token.
 
-    Specifically: the trained span for the last assistant turn should be
-    ``<think></think>{content}<|user|>``. GLM-5.1 stops normal assistant
-    answers by generating the next user role tag, not EOS.
+    Specifically: the rendered assistant turn contains
+    ``<think></think>{content}<|user|>``, but ``<think>`` is masked because
+    GLM-5.1 injects it in the generation prefix. The model trains from
+    ``</think>`` through the normal ``<|user|>`` stop.
     """
     messages = [
         {"role": "user", "content": "What is the secret password?"},
@@ -1068,9 +1070,9 @@ def test_weight_mask_only_covers_assistant_output(tokenizer, renderer):
     trained_tokens = [t for t, w in zip(tokens, weights) if w > 0]
     trained_text = tokenizer.decode(trained_tokens)
 
-    # Should start with '<think></think>' (no leading newline) and end with
-    # the normal assistant stop sentinel.
-    assert trained_text.startswith("<think></think>"), trained_text
+    # The opening '<think>' is part of the generation prefix, so it is masked.
+    assert trained_text.startswith("</think>"), trained_text
+    assert "<think>" not in trained_text
     assert tokens[-1] == _user_token(tokenizer), "last token must be <|user|>"
     assert trained_tokens[-1] == _user_token(tokenizer)
     assert "ALPHA-BRAVO" in trained_text
@@ -1125,7 +1127,8 @@ def test_weight_mask_terminal_tool_call_with_thinking_appends_observation_stop(
     assert trained_tokens[-1] == _observation_token(tokenizer)
 
     trained_text = tokenizer.decode(trained_tokens)
-    assert "<think>need lookup</think>" in trained_text
+    assert "<think>" not in trained_text
+    assert "need lookup</think>" in trained_text
     assert "<tool_call>lookup" in trained_text
 
 
@@ -1233,7 +1236,8 @@ def test_weight_mask_multi_turn_tool_call_with_thinking_trains_observation_stop(
     )
 
     trained_text = tokenizer.decode([t for t, w in zip(tokens, weights) if w > 0])
-    assert "<think>need weather tool</think>" in trained_text
+    assert "<think>" not in trained_text
+    assert "need weather tool</think>" in trained_text
     assert "<tool_call>get_weather" in trained_text
     assert "<|observation|>" in trained_text
     assert "<tool_response>sunny</tool_response>" not in trained_text
@@ -1350,7 +1354,8 @@ def test_weight_mask_parallel_tool_response_audit_table(
 
     # Each row is (position, token id, decoded token text, loss weight).
     # This makes the important boundaries visible:
-    # - positions 5-17 are model-generated thinking/tool-call/observation stop
+    # - position 5 is the injected <think> prefix and stays masked
+    # - positions 6-17 are model-generated thinking/tool-call/observation stop
     # - positions 18-25 are tool responses supplied by the environment
     # - positions 27-31 are the final assistant turn plus its <|user|> stop
     rows = [
@@ -1364,7 +1369,7 @@ def test_weight_mask_parallel_tool_response_audit_table(
         (2, 154827, "<|user|>", 0),
         (3, 80, "q", 0),
         (4, 154828, "<|assistant|>", 0),
-        (5, 154841, "<think>", 1),
+        (5, 154841, "<think>", 0),
         (6, 83, "t", 1),
         (7, 154842, "</think>", 1),
         (8, 154843, "<tool_call>", 1),
@@ -1386,7 +1391,7 @@ def test_weight_mask_parallel_tool_response_audit_table(
         (24, 17, "2", 0),
         (25, 154846, "</tool_response>", 0),
         (26, 154828, "<|assistant|>", 0),
-        (27, 154841, "<think>", 1),
+        (27, 154841, "<think>", 0),
         (28, 84, "u", 1),
         (29, 154842, "</think>", 1),
         (30, 64, "a", 1),
@@ -1422,7 +1427,8 @@ def test_weight_mask_with_thinking(tokenizer, renderer):
     trained_tokens = [t for t, w in zip(tokens, weights) if w > 0]
     trained_text = tokenizer.decode(trained_tokens)
 
-    assert "<think>my reasoning</think>" in trained_text
+    assert "<think>" not in trained_text
+    assert "my reasoning</think>" in trained_text
     assert "answer" in trained_text
     assert "q" not in trained_text
 

--- a/training/tests/unit/test_glm5_renderer.py
+++ b/training/tests/unit/test_glm5_renderer.py
@@ -1239,6 +1239,81 @@ def test_weight_mask_multi_turn_tool_call_with_thinking_trains_observation_stop(
     assert "<tool_response>sunny</tool_response>" not in trained_text
 
 
+def test_weight_mask_parallel_tool_responses_train_single_observation_stop(
+    tokenizer, renderer_keep_thinking
+):
+    """Parallel tool-call responses share one trained observation stop."""
+    messages = [
+        {"role": "user", "content": "Plan with two tools"},
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "thinking", "thinking": "need two tools"},
+                {"type": "text", "text": ""},
+            ],
+            "tool_calls": [
+                _make_tool_call("get_weather", {"city": "SF"}),
+                _make_tool_call("convert_units", {"value": 72, "from": "F"}),
+            ],
+        },
+        {"role": "tool", "content": "WEATHER_RESULT_ABC"},
+        {"role": "tool", "content": "CONVERT_RESULT_XYZ"},
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "thinking", "thinking": "combine tool results"},
+                {"type": "text", "text": "done"},
+            ],
+        },
+    ]
+    tokens, weights = _renderer_supervised_tokens(renderer_keep_thinking, messages)
+    observation = _observation_token(tokenizer)
+    user = _user_token(tokenizer)
+    tool_call_close = _encode_single(tokenizer, "</tool_call>")
+    first_response = tokenizer.encode(
+        "<tool_response>WEATHER_RESULT_ABC</tool_response>",
+        add_special_tokens=False,
+    )
+    second_response = tokenizer.encode(
+        "<tool_response>CONVERT_RESULT_XYZ</tool_response>",
+        add_special_tokens=False,
+    )
+
+    observation_positions = [
+        i for i, token in enumerate(tokens) if token == observation
+    ]
+    tool_call_close_positions = [
+        i for i, token in enumerate(tokens) if token == tool_call_close
+    ]
+    first_response_pos = _find_subsequence(tokens, first_response)
+    second_response_pos = _find_subsequence(tokens, second_response)
+
+    assert len(tool_call_close_positions) == 2
+    assert observation_positions == [tool_call_close_positions[-1] + 1]
+    assert weights[observation_positions[0]] == 1
+    assert all(
+        w == 0
+        for w in weights[
+            first_response_pos : first_response_pos + len(first_response)
+        ]
+    )
+    assert all(
+        w == 0
+        for w in weights[
+            second_response_pos : second_response_pos + len(second_response)
+        ]
+    )
+    assert tokens[-1] == user
+    assert weights[-1] == 1
+
+    trained_text = tokenizer.decode([t for t, w in zip(tokens, weights) if w > 0])
+    assert "<tool_call>get_weather" in trained_text
+    assert "<tool_call>convert_units" in trained_text
+    assert "<|observation|>" in trained_text
+    assert "WEATHER_RESULT_ABC" not in trained_text
+    assert "CONVERT_RESULT_XYZ" not in trained_text
+
+
 def test_weight_mask_multi_turn_covers_all_assistant_turns(tokenizer, renderer):
     """With TrainOnWhat.ALL_ASSISTANT_MESSAGES, every assistant turn gets trained."""
     messages = [

--- a/training/tests/unit/test_glm5_renderer.py
+++ b/training/tests/unit/test_glm5_renderer.py
@@ -1322,6 +1322,78 @@ def test_weight_mask_parallel_tool_responses_train_single_observation_stop(
     assert "CONVERT_RESULT_XYZ" not in trained_text
 
 
+def test_weight_mask_parallel_tool_response_audit_table(
+    tokenizer, renderer_keep_thinking
+):
+    """Explicit token/mask table for GLM parallel tool-response rendering."""
+    messages = [
+        {"role": "user", "content": "q"},
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "thinking", "thinking": "t"},
+                {"type": "text", "text": ""},
+            ],
+            "tool_calls": [_make_tool_call("f", {"x": 1})],
+        },
+        {"role": "tool", "content": "r1"},
+        {"role": "tool", "content": "r2"},
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "thinking", "thinking": "u"},
+                {"type": "text", "text": "a"},
+            ],
+        },
+    ]
+    tokens, weights = _renderer_supervised_tokens(renderer_keep_thinking, messages)
+
+    # Each row is (position, token id, decoded token text, loss weight).
+    # This makes the important boundaries visible:
+    # - positions 5-17 are model-generated thinking/tool-call/observation stop
+    # - positions 18-25 are tool responses supplied by the environment
+    # - positions 27-31 are the final assistant turn plus its <|user|> stop
+    rows = [
+        (idx, token_id, tokenizer.decode([token_id]), int(weight))
+        for idx, (token_id, weight) in enumerate(zip(tokens, weights))
+    ]
+
+    assert rows == [
+        (0, 154822, "[gMASK]", 0),
+        (1, 154824, "<sop>", 0),
+        (2, 154827, "<|user|>", 0),
+        (3, 80, "q", 0),
+        (4, 154828, "<|assistant|>", 0),
+        (5, 154841, "<think>", 1),
+        (6, 83, "t", 1),
+        (7, 154842, "</think>", 1),
+        (8, 154843, "<tool_call>", 1),
+        (9, 69, "f", 1),
+        (10, 154847, "<arg_key>", 1),
+        (11, 87, "x", 1),
+        (12, 154848, "</arg_key>", 1),
+        (13, 154849, "<arg_value>", 1),
+        (14, 16, "1", 1),
+        (15, 154850, "</arg_value>", 1),
+        (16, 154844, "</tool_call>", 1),
+        (17, 154829, "<|observation|>", 1),
+        (18, 154845, "<tool_response>", 0),
+        (19, 81, "r", 0),
+        (20, 16, "1", 0),
+        (21, 154846, "</tool_response>", 0),
+        (22, 154845, "<tool_response>", 0),
+        (23, 81, "r", 0),
+        (24, 17, "2", 0),
+        (25, 154846, "</tool_response>", 0),
+        (26, 154828, "<|assistant|>", 0),
+        (27, 154841, "<think>", 1),
+        (28, 84, "u", 1),
+        (29, 154842, "</think>", 1),
+        (30, 64, "a", 1),
+        (31, 154827, "<|user|>", 1),
+    ]
+
+
 def test_weight_mask_multi_turn_covers_all_assistant_turns(tokenizer, renderer):
     """With TrainOnWhat.ALL_ASSISTANT_MESSAGES, every assistant turn gets trained."""
     messages = [

--- a/training/tests/unit/test_glm5_renderer.py
+++ b/training/tests/unit/test_glm5_renderer.py
@@ -159,6 +159,15 @@ def _assistant_stop_token(tokenizer, message: dict[str, Any]) -> int:
     )
 
 
+def _find_subsequence(
+    tokens: list[int], subsequence: list[int], *, start: int = 0
+) -> int:
+    for i in range(start, len(tokens) - len(subsequence) + 1):
+        if tokens[i : i + len(subsequence)] == subsequence:
+            return i
+    raise AssertionError(f"Subsequence not found: {subsequence}")
+
+
 def _assert_supervised_parity_with_role_stop(
     ours: list[int],
     hf: list[int],
@@ -1085,10 +1094,45 @@ def test_weight_mask_tool_call_stop_uses_observation(tokenizer, renderer):
     assert _user_token(tokenizer) not in trained_tokens
 
 
+def test_weight_mask_terminal_tool_call_with_thinking_appends_observation_stop(
+    tokenizer, renderer_keep_thinking
+):
+    """Final assistant tool-call rows append/train <|observation|>."""
+    messages = [
+        {"role": "user", "content": "q1"},
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "thinking", "thinking": "answer first"},
+                {"type": "text", "text": "a1"},
+            ],
+        },
+        {"role": "user", "content": "lookup weather"},
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "thinking", "thinking": "need lookup"},
+                {"type": "text", "text": ""},
+            ],
+            "tool_calls": [_make_tool_call("lookup", {"q": "weather"})],
+        },
+    ]
+    tokens, weights = _renderer_supervised_tokens(renderer_keep_thinking, messages)
+    trained_tokens = [t for t, w in zip(tokens, weights) if w > 0]
+
+    assert tokens[-1] == _observation_token(tokenizer)
+    assert weights[-1] == 1
+    assert trained_tokens[-1] == _observation_token(tokenizer)
+
+    trained_text = tokenizer.decode(trained_tokens)
+    assert "<think>need lookup</think>" in trained_text
+    assert "<tool_call>lookup" in trained_text
+
+
 def test_weight_mask_trains_role_stops_after_historical_assistants(
     tokenizer, renderer
 ):
-    """Next role tags after trainable assistant turns must carry loss."""
+    """Only role tags that close assistant turns carry loss."""
     messages = [
         {"role": "user", "content": "q1"},
         {"role": "assistant", "content": "a1"},
@@ -1104,18 +1148,35 @@ def test_weight_mask_trains_role_stops_after_historical_assistants(
     tokens, weights = _renderer_supervised_tokens(renderer, messages)
     user = _user_token(tokenizer)
     observation = _observation_token(tokenizer)
+    first_user = tokenizer.encode("<|user|>q1", add_special_tokens=False)
+    second_user = tokenizer.encode("<|user|>q2", add_special_tokens=False)
+    tool_call_close = _encode_single(tokenizer, "</tool_call>")
 
-    user_positions = [i for i, token in enumerate(tokens) if token == user]
-    observation_positions = [
-        i for i, token in enumerate(tokens) if token == observation
-    ]
+    first_user_pos = _find_subsequence(tokens, first_user)
+    second_user_pos = _find_subsequence(tokens, second_user)
+    tool_call_end = tokens.index(tool_call_close)
+    observation_pos = tool_call_end + 1
 
-    assert len(user_positions) == 3
-    assert weights[user_positions[0]] == 0
-    assert weights[user_positions[1]] == 1
-    assert weights[user_positions[2]] == 1
-    assert len(observation_positions) == 1
-    assert weights[observation_positions[0]] == 1
+    assert tokens[first_user_pos] == user
+    assert weights[first_user_pos] == 0
+    assert all(
+        w == 0
+        for w in weights[first_user_pos + 1 : first_user_pos + len(first_user)]
+    )
+
+    assert tokens[second_user_pos] == user
+    assert weights[second_user_pos] == 1
+    assert all(
+        w == 0
+        for w in weights[
+            second_user_pos + 1 : second_user_pos + len(second_user)
+        ]
+    )
+
+    assert tokens[observation_pos] == observation
+    assert weights[observation_pos] == 1
+    assert tokens[-1] == user
+    assert weights[-1] == 1
 
 
 def test_weight_mask_multi_turn_tool_call_with_thinking_trains_observation_stop(


### PR DESCRIPTION
## Summary

Fix GLM-5.1 supervised rendering to use the model's role-sentinel stop behavior instead of treating `<|endoftext|>` as the assistant stop token.

## Root Cause

The GLM-5.1 chat template does not emit EOS at assistant turn boundaries. Assistant turns stop by generating the next role tag: `<|user|>` for normal answers and `<|observation|>` for tool-call handoff. The previous renderer appended/trained EOS for assistant-final supervised rows, and historical next-role headers were masked out instead of being trained as stop tokens. The template also injects `<|assistant|><think>` for generation prompts, so the opening `<think>` must remain in rendered supervised tokens for parity but should be masked out of loss.

## Changes

- Return only `<|user|>` and `<|observation|>` from `GLM5Renderer.get_stop_sequences()`.
- Add role-sentinel `stop_overlap` for supervised rows ending on assistant messages.
- Weight actual next role tags after trainable historical assistant turns while keeping real user/tool response content masked.
- Mask the injected opening `<think>` token in assistant supervised outputs while preserving token-level template parity.
- Update GLM tests to assert role-stop behavior for normal answers, terminal tool calls, tool-call handoff, multi-turn history, interleaved thinking/tool-call rows, and parallel tool responses.
- Add an explicit token/mask audit-table test with `(position, token id, decoded text, weight)` rows for easy inspection.

## Validation

- `training/.venv/bin/python -m pytest training/tests/unit/test_glm5_renderer.py -q` -> `92 passed`
- `training/.venv/bin/python -m pytest training/tests/smoke_test/test_glm5_serverless_prompt_tokens.py -q` -> `5 passed`
- `training/.venv/bin/python -m pytest training/tests/unit -q` -> `524 passed, 32 skipped`
- `git diff --check`