### PR TITLE
fix(dpo): thread ckpt into _train_loop to fix NameError

### DIFF
--- a/training/recipes/dpo_loop.py
+++ b/training/recipes/dpo_loop.py
@@ -291,6 +291,7 @@ async def _train_loop(
     cfg: Config,
     step_offset: int,
     *,
+    ckpt: TrainingCheckpoints | None = None,
     worker_init_fn: Callable[[int], None] | None = None,
     on_ref_done: Callable[[], None] | None = None,
     runner: RunnerIO | None = None,
@@ -702,6 +703,7 @@ def main(
             _train_loop(
                 pair_dataset, ref_cache_log,
                 reference, policy, adam_params, cfg, step_offset,
+                ckpt=ckpt,
                 worker_init_fn=worker_init_fn,
                 on_ref_done=_on_ref_done,
                 runner=runner,


### PR DESCRIPTION
## Summary
- #393 (port all loops to `TrainingCheckpoints`) swapped `save_checkpoint()` for `ckpt.save()` inside dpo's nested `_run_train_step`, but `ckpt` is built in `main()` and `_train_loop` is a separate top-level function — its closure could not see `ckpt`.
- Result: any DPO run with `dcp_save_interval > 0` crashes at the first save with `NameError: name 'ckpt' is not defined`. Reproduced in fw-ai/fireworks training single-shape CI on `glm-5p1-200k-lora` (run https://github.com/fw-ai/fireworks/actions/runs/25087391135 — failed at step 3 of DPO).
- Other recipes (sft/rl/igpo/orpo) define their save sites inside `main()` so they capture `ckpt` via closure — only dpo is affected.

## Fix
Pass `ckpt` explicitly into `_train_loop` via a keyword-only parameter. Default `None` keeps existing `_train_loop` tests (which leave `dcp_save_interval=0` and never reach the save block) unchanged.

```diff
 async def _train_loop(
     ...
     step_offset: int,
     *,
+    ckpt: TrainingCheckpoints | None = None,
     worker_init_fn: ...
 ```

## Test plan
- [ ] Existing `training/tests/unit/test_dpo_loop.py` passes (no behavior change for `dcp_save_interval=0`)
- [ ] Re-run `fw-ai/fireworks` training single-shape CI on `glm-5p1-200k-lora` after bumping the cookbook submodule — DPO step 3 must save instead of crashing