### PR TITLE
fix(glm5): mask leading <think> token to match inference generation suffix

### DIFF
--- a/training/renderer/glm5.py
+++ b/training/renderer/glm5.py
@@ -18,15 +18,19 @@ Role tag layout (as the shipped Jinja template emits them):
 - ``<|assistant|>...``     — see below
 - ``<|observation|>{content}`` — same
 
-Assistant turn layout:
+Assistant turn layout (full token sequence; header/output split noted):
 
 - **Terminal turn, ``enable_thinking=True`` (default), no reasoning content**::
 
       <|assistant|><think></think>{content}
 
+  Header (masked) = ``<|assistant|><think>``, Output (trained) = ``</think>{content}``
+
 - **Terminal turn, reasoning content provided**::
 
       <|assistant|><think>{reasoning}</think>{content}
+
+  Header (masked) = ``<|assistant|><think>``, Output (trained) = ``{reasoning}</think>{content}``
 
 - **Terminal turn, ``enable_thinking=False``** (or non-thinking mode) — the
   shipped template emits ``</think>`` alone so the model skips the think
@@ -380,10 +384,15 @@ class GLM5Renderer(Renderer):
         return RenderedMessage(header=header, output=output)
 
     def _render_assistant(self, message: Message, ctx: RenderContext) -> RenderedMessage:
-        # The role tag ``<|assistant|>`` is the header; the ``<think>...
-        # </think>`` block lives in ``output`` so it is part of the training
-        # target for this assistant turn.
-        header_str = "<|assistant|>"
+        # The header includes ``<|assistant|>`` and, for terminal turns,
+        # the leading ``<think>`` token — matching the generation suffix
+        # ``<|assistant|><think>`` so the model never trains on a token
+        # that is always provided at inference time.
+        #
+        # Historical turns that strip thinking use ``</think>`` (not
+        # ``<think>``) which is part of the model output and stays in the
+        # trained span. Historical turns that preserve thinking include
+        # ``<think>`` in the header as well.
 
         before_last_user = (
             ctx.last_user_index >= 0
@@ -405,16 +414,23 @@ class GLM5Renderer(Renderer):
         # 5. Terminal turn without reasoning (thinking-mode default):
         #    ``<think></think>``.
         if before_last_user and self.strip_thinking_from_history:
-            think_block = "</think>"
+            header_str = "<|assistant|>"
+            output_str = "</think>"
         elif before_last_user and not reasoning:
-            think_block = "</think>"
+            header_str = "<|assistant|>"
+            output_str = "</think>"
+        elif before_last_user and reasoning:
+            header_str = "<|assistant|><think>"
+            output_str = f"{reasoning.strip()}</think>"
         elif reasoning:
-            think_block = f"<think>{reasoning.strip()}</think>"
+            header_str = "<|assistant|><think>"
+            output_str = f"{reasoning.strip()}</think>"
         else:
-            think_block = "<think></think>"
+            header_str = "<|assistant|><think>"
+            output_str = "</think>"
 
         visible_stripped = visible.strip()
-        output_str = think_block + visible_stripped
+        output_str = output_str + visible_stripped
 
         tool_calls = message.get("tool_calls")
         if tool_calls:

--- a/training/tests/unit/test_glm5_renderer.py
+++ b/training/tests/unit/test_glm5_renderer.py
@@ -802,7 +802,8 @@ def test_interleaved_tool_reasoning_and_params_are_trained(tokenizer, renderer):
     tokens, weights = _renderer_supervised_tokens(renderer, messages)
     trained_text = tokenizer.decode([t for t, w in zip(tokens, weights) if w > 0])
 
-    assert "<think>Need current weather.</think>" in trained_text
+    assert "Need current weather.</think>" in trained_text
+    assert "<think>" not in trained_text, "leading <think> should be masked"
     assert "<tool_call>get_weather" in trained_text
     assert "<arg_value>SF</arg_value>" in trained_text
 
@@ -1014,10 +1015,10 @@ def test_preserve_thinking_build_supervised_examples_keeps_single_example(
 def test_weight_mask_only_covers_assistant_output(tokenizer, renderer):
     """Every non-zero-weight position must decode to an assistant-output token.
 
-    Specifically: the trained span for the last assistant turn should be
-    ``<think></think>{content}<|endoftext|>`` — matching the shipped
-    Jinja template layout (no leading newline, no newline between the
-    think block and the content) plus the intentional trailing EOS.
+    The header ``<|assistant|><think>`` is masked (matching the generation
+    suffix at inference time). The trained span starts at ``</think>``
+    for a no-reasoning terminal turn, so the trained text is
+    ``</think>{content}<|endoftext|>``.
     """
     messages = [
         {"role": "user", "content": "What is the secret password?"},
@@ -1032,8 +1033,9 @@ def test_weight_mask_only_covers_assistant_output(tokenizer, renderer):
     trained_tokens = [t for t, w in zip(tokens, weights) if w > 0]
     trained_text = tokenizer.decode(trained_tokens)
 
-    # Should start with '<think></think>' (no leading newline) and end with EOS.
-    assert trained_text.startswith("<think></think>"), trained_text
+    # <think> is in the header (masked); trained span starts with </think>.
+    assert trained_text.startswith("</think>"), trained_text
+    assert "<think>" not in trained_text, "leading <think> should be masked"
     assert tokens[-1] == _eos(tokenizer), "last token must be <|endoftext|>"
     assert "ALPHA-BRAVO" in trained_text
 
@@ -1057,7 +1059,11 @@ def test_weight_mask_multi_turn_covers_all_assistant_turns(tokenizer, renderer):
 
 
 def test_weight_mask_with_thinking(tokenizer, renderer):
-    """Trained span includes the thinking block for terminal turns."""
+    """Trained span includes reasoning content but not the leading <think> tag.
+
+    The header ``<|assistant|><think>`` is masked to match the generation
+    suffix. The trained span is ``my reasoning</think>answer<|endoftext|>``.
+    """
     messages = [
         {"role": "user", "content": "q"},
         {"role": "assistant", "content": "<think>my reasoning</think>answer"},
@@ -1066,8 +1072,10 @@ def test_weight_mask_with_thinking(tokenizer, renderer):
     trained_tokens = [t for t, w in zip(tokens, weights) if w > 0]
     trained_text = tokenizer.decode(trained_tokens)
 
-    assert "<think>my reasoning</think>" in trained_text
+    assert "my reasoning" in trained_text
+    assert "</think>" in trained_text
     assert "answer" in trained_text
+    assert "<think>" not in trained_text, "leading <think> should be masked"
     assert "q" not in trained_text
 
 


### PR DESCRIPTION
## Summary

- Moves the leading `<think>` token from the trained output span (weight=1.0) to the masked header (weight=0.0) in the GLM-5.1 renderer, aligning with the inference generation suffix `<|assistant|><think>`.
- This fixes a train-inference mismatch where the model was trained to predict a token that is always provided at inference time, which is the likely root cause of repetitive thinking loops observed in SFT-tuned GLM-5.1 models.
- Updates 3 test assertions and docstring to reflect the new masking boundary. All 86 GLM5 renderer tests pass.

## Background

At inference time, the generation suffix for GLM-5.1 is `<|assistant|><think>` — the `<think>` token is always prepended to the model's generation. The V1 (`train-py`) renderer correctly masked this token via `commonprefix` logic. However, the V2 cookbook renderer was including `<think>` in the trained output, meaning the model was being trained to predict a token it would never need to generate. This one-token shift in the autoregressive training target likely caused the model to lose track of its generation start point, leading to repetitive reasoning loops.

## Changes

### `training/renderer/glm5.py`
- For **terminal turns**: header is now `<|assistant|><think>`, output starts at reasoning content or `</think>`
- For **historical turns with preserved thinking**: header includes `<|assistant|><think>`, output starts at reasoning content
- For **historical turns with stripped thinking**: header remains `<|assistant|>`, output is `</think>` (unchanged)
- Updated docstring to document the header/output split explicitly

### `training/tests/unit/test_glm5_renderer.py`
- `test_weight_mask_only_covers_assistant_output`: asserts trained text starts with `</think>`, not `<think></think>`
- `test_weight_mask_with_thinking`: asserts `<think>` is not in trained text
- Tool call test with reasoning: asserts `<think>` is not in trained text

## Test plan
- [x] All 86 GLM5 renderer unit tests pass
- [ ] Re-run SFT training with fixed renderer to verify looping is resolved


Made with [Cursor](https://cursor.com)