### PR TITLE
docs(training): clarify Config.batch_size semantics for V2 jobs

### DIFF
--- a/training/recipes/dpo_loop.py
+++ b/training/recipes/dpo_loop.py
@@ -104,7 +104,9 @@ class Config:
     learning_rate: float = 1e-5
     epochs: int = 1
     batch_size: int = 4
-    """Number of preference pairs per optimizer step."""
+    """Number of preference pairs per optimizer step. For managed (V2) jobs
+    this is set from ``BaseTrainingConfig.batch_size_samples`` via the
+    cookbook orchestrator."""
     max_seq_len: int | None = None
     max_pairs: int | None = None
     """Cap on *valid rendered pairs* after schema/length filtering."""

--- a/training/recipes/orpo_loop.py
+++ b/training/recipes/orpo_loop.py
@@ -98,7 +98,9 @@ class Config:
     learning_rate: float = 1e-5
     epochs: int = 1
     batch_size: int = 4
-    """Number of preference pairs per optimizer step."""
+    """Number of preference pairs per optimizer step. For managed (V2) jobs
+    this is set from ``BaseTrainingConfig.batch_size_samples`` via the
+    cookbook orchestrator."""
     seed: int = 0
     """Seed for deterministic per-epoch shuffling of preference pairs."""
     max_seq_len: int | None = None

--- a/training/recipes/sft_loop.py
+++ b/training/recipes/sft_loop.py
@@ -466,6 +466,9 @@ class Config:
     learning_rate: float = 1e-4
     epochs: int = 3
     batch_size: int = 32
+    """Number of training samples per optimizer step. For managed (V2) jobs
+    this is set from ``BaseTrainingConfig.batch_size_samples`` via the
+    cookbook orchestrator."""
     max_seq_len: int | None = None
     max_examples: int | None = None
     lora_rank: int = 0


### PR DESCRIPTION
## Summary

Document that the SFT/DPO/ORPO recipes' `Config.batch_size` field is sourced from `BaseTrainingConfig.batch_size_samples` (samples per optimizer step) via the cookbook orchestrator when the job is managed by the V2 control plane workflow. Previously this was implicit; the docstring now makes it explicit so customers running the recipes directly know whether they are setting the trainer's source of truth or a value that V2 plumbing will overwrite.

Pairs with [fw-ai/fireworks#24769](https://github.com/fw-ai/fireworks/pull/24769), which wires `BatchSizeSamples` through the gateway into the cookbook `cfg.batch_size`.

## Scope reduction from previous revision

The previous revision of this PR also forwarded `cfg.grad_accum` through `setup_infra` / `request_trainer_job` / `create_trainer_job` into `TrainerJobConfig.gradient_accumulation_steps`. That change has been **dropped** because [#439 (`remove cookbook trainer-job grad_accum knob`)](https://github.com/fw-ai/cookbook/pull/439) explicitly removed that server-side knob to avoid a backward-time gradient-normalization bug (the Tinker/RLOR forward_backward call backprops a raw token-sum loss; cross-microbatch normalization is the caller's job at `optim_step` via `OptimStepRequest.grad_accumulation_normalization`). Forwarding `grad_accum` would silently re-introduce the bug shape.

This PR now contains the docstring change only.

## Code overview

```mermaid
flowchart LR
  subgraph control_plane["fw-ai/fireworks (parent PR)"]
    GW[Gateway admission<br>SFT / DPO / RFT / RLOR]
    DISP[V2 dispatcher<br>buildCookbookTrainingConfig]
    GW -->|BaseTrainingConfig<br>batch_size_samples<br>max_context_length| DISP
  end
  DISP -->|CookbookTrainingConfig<br>cfg.batch_size = samples<br>cfg.max_seq_len| RECIPE
  subgraph cookbook["fw-ai/cookbook (this PR)"]
    RECIPE[recipes: sft / dpo / orpo<br>Config.batch_size docstring<br>'set from BaseTrainingConfig.batch_size_samples<br>via the cookbook orchestrator']
  end
```

## Test plan

- [x] `ast.parse` on all touched files passes (docstring-only change)
- [x] No code paths changed; existing recipe + infra unit tests stay green
- [x] Manual: V2 SFT job with `batch_size_samples=N` is observable on the trainer (covered by parent fireworks PR end-to-end)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docstring-only changes clarifying configuration semantics; no runtime logic or data-handling behavior is modified.
> 
> **Overview**
> Clarifies the meaning/source of `Config.batch_size` in the `sft_loop`, `dpo_loop`, and `orpo_loop` recipes.
> 
> The `batch_size` docstrings now explicitly note that for managed (V2) jobs this value is populated from `BaseTrainingConfig.batch_size_samples` by the cookbook orchestrator, so users running recipes directly understand when their local setting is the source of truth vs overridden.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c92e1be89e427f9d43ac779d92d489acc7624f8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->