### PR TITLE
fix(multihop_qa): correct frozen_lake.masking import path

### DIFF
--- a/training/examples/multihop_qa/train_multihop_qa_igpo.py
+++ b/training/examples/multihop_qa/train_multihop_qa_igpo.py
@@ -35,7 +35,7 @@ if _SRC not in sys.path:
 from eval_protocol.models import EvaluationRow, InputMetadata, Message
 from eval_protocol.pytest.types import RolloutProcessorConfig
 
-from training.examples.frozen_lake.masking import (
+from training.examples.rl.frozen_lake.masking import (
     compute_model_output_spans,
     build_ui_token_mask,
 )


### PR DESCRIPTION
## Summary
- `train_multihop_qa_igpo.py` imported `training.examples.frozen_lake.masking`, but the actual path is `training.examples.rl.frozen_lake.masking` — so the example was unimportable on `main` (ModuleNotFoundError at line 38) and broke `training/tests/test_smoke_imports.py`.
- Single-line fix: prepend the missing `rl.` segment to the import.

## Test plan
- [x] `FIREWORKS_API_KEY=dummy python -c "import training.examples.multihop_qa.train_multihop_qa_igpo"` → OK
- [x] `FIREWORKS_API_KEY=dummy pytest training/tests/test_smoke_imports.py` → 63 passed (was 62 passed + 1 fail before fix)
- [x] `pytest training/tests/unit/ --ignore=training/tests/unit/test_sft_loop.py` → 497 passed, 32 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)