### PR TITLE
renderer: drop incorrect minimax_m2 xfail; add renderer README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,21 +28,10 @@ training/           Training SDK recipes, utilities, and examples
   recipes/          Fork-and-customize training loop scripts
   utils/            Shared config, data loading, losses, metrics
   examples/         Worked examples (RL, SFT, DPO, ORPO)
-  verifier/         Renderer correctness validator + live React viewer
+  renderer/         Cookbook-local renderers + verifier (see training/renderer/README.md)
   tests/            Unit and end-to-end tests
 skills/             Agent skills and reference docs
 ```
-
-## Renderer skills
-
-- [`skills/renderer/SKILL.md`](skills/renderer/SKILL.md) — implementing
-  a new renderer (chat template, stop semantics, weight-mask
-  invariants, registration, dev loop).
-- [`skills/verifier/SKILL.md`](skills/verifier/SKILL.md) — validating
-  a renderer against the live Fireworks gateway and the upstream
-  HuggingFace chat template. The verifier ships a probe CLI, a batch
-  triage runner, and a single-file React viewer that highlights every
-  audit-table row by provenance, weight, and inspection-rule match.
 
 ## Contributing
 

--- a/training/renderer/README.md
+++ b/training/renderer/README.md
@@ -1,0 +1,33 @@
+# Renderers
+
+Cookbook-local renderer implementations (`gemma4`, `glm5`, `minimax_m2`,
+`nemotron`). Each module subclasses
+`tinker_cookbook.renderers.base.Renderer` and registers itself via
+`register_renderer(...)`, so it's reachable through
+`get_renderer(name, tokenizer)`.
+
+This folder also hosts the **verifier** under
+[`verifier/`](./verifier/) — the validation half of any renderer
+change. Always pair adding/editing a renderer with a verifier run.
+
+## Adding a new renderer
+
+→ [`cookbook/skills/renderer/SKILL.md`](../../skills/renderer/SKILL.md)
+covers the contract (4 methods), the training-mechanics invariants,
+common shape decisions (stop signal, thinking modes, tool calls), the
+implementation flow, and the gotchas.
+
+## Verifying a renderer
+
+→ [`cookbook/skills/verifier/SKILL.md`](../../skills/verifier/SKILL.md)
+covers the workflow: pick renderer / tokenizer / model, edit the
+inspection rules, run interactively or batch, inspect the audit table.
+The verifier highlights every token by provenance and flags
+attribute combinations the rule file marks as worth a closer look:
+
+![Verifier — token stream](./verifier/images/token_stream.png)
+
+For agents triaging a renderer-shaped problem, the dev skill router
+([`cookbook/skills/dev/SKILL.md`](../../skills/dev/SKILL.md)) routes
+both questions ("how do I add a renderer?" / "why does my model emit
+unexpected tokens?") to those two skills.

--- a/training/tests/unit/test_renderer_hf_parity.py
+++ b/training/tests/unit/test_renderer_hf_parity.py
@@ -102,12 +102,6 @@ _CASES: list[_Case] = [
         renderer="minimax_m2",
         tokenizer_model="MiniMaxAI/MiniMax-M2",
         messages=_SHORT_MSGS,
-        xfail_reason=(
-            "renderer emits an extra '\\n' after <think> in the generation "
-            "suffix — surfaced by the empirical sweep against "
-            "accounts/fireworks/models/minimax-m2p7. "
-            "See workspace_batching/renderer-verifier-findings.md."
-        ),
     ),
 ]
 


### PR DESCRIPTION
## Summary

- Drop the incorrect xfail marker on the \`minimax_m2-single-turn\` HF parity case. \`pytest.xfail()\` short-circuits before running the comparison, so the previous marker was applied based on the live-gateway divergence without ever verifying CPU divergence. Running the parity check directly shows the renderer matches HF byte-for-byte; the gateway is the odd one out (`<think>` vs HF/renderer's `<think>\n`). The right action is to keep the renderer as-is and let the test enforce parity going forward.
- Add a compact \`training/renderer/README.md\` that routes agents to \`skills/renderer/SKILL.md\` (implement) and \`skills/verifier/SKILL.md\` (validate) and embeds the verifier token-stream screenshot.
- Drop the now-redundant "Renderer skills" section from the top-level cookbook README; the renderer README owns that entry point.

## Test plan

- [x] \`pytest -q training/tests/unit/test_renderer_hf_parity.py\` → 7/7 pass
- [ ] CI \`Training CI / Unit And Import Tests\` job goes green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)