### PR TITLE
Validate unused reference infra config

### DIFF
--- a/training/tests/unit/test_infra_setup.py
+++ b/training/tests/unit/test_infra_setup.py
@@ -178,6 +178,46 @@ def test_setup_infra_requires_deploy_mgr_when_inference_needed(patch_sdk):
         )
 
 
+def test_setup_infra_rejects_reference_job_when_reference_not_needed(patch_sdk):
+    rlor, deploy = _make_mgrs()
+    cfg = _make_cfg(reference_job_id="ref-job")
+    with pytest.raises(ValueError, match="reference_job_id requires needs_reference=True"):
+        setup_infra(
+            rlor_mgr=rlor, deploy_mgr=deploy,
+            base_model=cfg.base_model,
+            infra_cfg=cfg.infra,
+            deploy_cfg=cfg.deployment,
+            lora_rank=cfg.lora_rank,
+            max_seq_len=cfg.max_seq_len,
+            learning_rate=cfg.learning_rate,
+            step_timeout=cfg.step_timeout,
+            policy_job_id=cfg.policy_job_id,
+            reference_job_id=cfg.reference_job_id,
+            needs_reference=False, needs_inference=True,
+            role_prefix="grpo", api_key="key",
+        )
+
+
+def test_setup_infra_rejects_reference_shape_when_reference_not_needed(patch_sdk):
+    rlor, deploy = _make_mgrs()
+    cfg = _make_cfg(ref_training_shape_id="shape-ref")
+    with pytest.raises(ValueError, match="infra.ref_training_shape_id requires needs_reference=True"):
+        setup_infra(
+            rlor_mgr=rlor, deploy_mgr=deploy,
+            base_model=cfg.base_model,
+            infra_cfg=cfg.infra,
+            deploy_cfg=cfg.deployment,
+            lora_rank=cfg.lora_rank,
+            max_seq_len=cfg.max_seq_len,
+            learning_rate=cfg.learning_rate,
+            step_timeout=cfg.step_timeout,
+            policy_job_id=cfg.policy_job_id,
+            reference_job_id=cfg.reference_job_id,
+            needs_reference=False, needs_inference=True,
+            role_prefix="grpo", api_key="key",
+        )
+
+
 # ---------------------------------------------------------------------------
 # RL — full-param + KL: separate reference trainer
 # ---------------------------------------------------------------------------

--- a/training/utils/infra.py
+++ b/training/utils/infra.py
@@ -995,6 +995,10 @@ def setup_infra(
     """
     if needs_inference and deploy_mgr is None:
         raise ValueError("deploy_mgr is required when needs_inference=True")
+    if not needs_reference and reference_job_id:
+        raise ValueError("reference_job_id requires needs_reference=True")
+    if not needs_reference and infra_cfg.ref_training_shape_id:
+        raise ValueError("infra.ref_training_shape_id requires needs_reference=True")
 
     emit: StatusCallback = on_status or (lambda _: None)
     boot_start = time.time()
@@ -1532,5 +1536,4 @@ def _make_boot_metrics(boot_start: float, deploy_mgr: DeploymentManager | None) 
     if deploy_mgr is not None and deploy_mgr.boot_time_s is not None:
         metrics["infra/deploy_boot_time"] = deploy_mgr.boot_time_s
     return metrics
-
 


### PR DESCRIPTION
## Summary
- Fail fast when a reference job ID is supplied while `needs_reference=False`.
- Fail fast when a reference training shape is supplied while `needs_reference=False`.
- Add unit coverage for both validation paths.

## Test Plan
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest training/tests/unit/test_infra_setup.py -q`
- `python -m compileall -q training/utils/infra.py training/tests/unit/test_infra_setup.py`
- `git diff --check`