### PR TITLE
fix(sft): run eval via forward() instead of forward_backward_custom

### DIFF
--- a/training/recipes/sft_loop.py
+++ b/training/recipes/sft_loop.py
@@ -340,10 +340,10 @@ def run_eval(
 ) -> float | None:
     """Run evaluation without affecting model weights or optimizer state.
 
-    Uses forward_backward_custom with a zero-gradient loss function: the
-    training loss computes correct metrics, but the returned loss is
-    multiplied by zero so backward produces zero gradients.  This avoids
-    corrupting Adam's momentum/variance estimates.
+    Uses forward (no backward) so weights, gradient state, and Adam moments
+    are untouched. Logprobs come back from the server; the training loss
+    function is invoked client-side purely to compute metrics, and the
+    returned loss tensor is discarded.
     """
     if not eval_data:
         return None
@@ -353,31 +353,27 @@ def run_eval(
     eval_loss_sum = 0.0
     eval_resp_tokens = 0
 
-    def _make_eval_loss_fn():
-        train_loss_fn = make_batch_weighted_sft_loss_fn()
+    train_loss_fn = make_batch_weighted_sft_loss_fn()
 
-        def eval_loss_fn(
-            data: List[tinker.Datum],
-            logprobs_list: List[torch.Tensor],
-        ) -> tuple[torch.Tensor, Dict[str, float]]:
-            real_loss, metrics = train_loss_fn(data, logprobs_list)
-            return real_loss * 0.0, metrics
-
-        return eval_loss_fn
+    def _eval_batch(b: List[tinker.Datum]) -> Dict[str, float]:
+        fwd = client.forward(b, "cross_entropy")
+        logprobs_list = [
+            fwd.loss_fn_outputs[i]["logprobs"].to_torch() for i in range(len(b))
+        ]
+        _, metrics = train_loss_fn(b, logprobs_list)
+        return metrics
 
     batch: List[tinker.Datum] = []
     for item in eval_data:
         batch.append(item)
         if len(batch) >= batch_size:
-            result = client.forward_backward_custom(batch, _make_eval_loss_fn())
-            m = result.metrics
+            m = _eval_batch(batch)
             eval_loss_sum += m.get("ce_loss_sum", 0.0)
             eval_resp_tokens += int(m.get("response_tokens", 0))
             batch = []
 
     if batch:
-        result = client.forward_backward_custom(batch, _make_eval_loss_fn())
-        m = result.metrics
+        m = _eval_batch(batch)
         eval_loss_sum += m.get("ce_loss_sum", 0.0)
         eval_resp_tokens += int(m.get("response_tokens", 0))
 

--- a/training/tests/unit/test_sft_loop.py
+++ b/training/tests/unit/test_sft_loop.py
@@ -1002,9 +1002,13 @@ def test_eval_auto_carveout_splits_data_and_runs_eval(tmp_path, monkeypatch):
             events["train_batches"].append(list(batch))
             return SimpleNamespace(metrics={"loss:sum": 1.0, "ce_loss_sum": 1.0, "response_tokens": 2})
 
-        def forward_backward_custom(self, batch, loss_fn):
+        def forward(self, batch, loss_fn):
             events["eval_batches"].append(list(batch))
-            return SimpleNamespace(metrics={"ce_loss_sum": 0.5, "response_tokens": 2})
+            return SimpleNamespace(
+                loss_fn_outputs=[
+                    {"logprobs": SimpleNamespace(to_torch=lambda: None)} for _ in batch
+                ],
+            )
 
         def optim_step(self, _params, **kwargs):
             return SimpleNamespace(metrics={})
@@ -1033,6 +1037,11 @@ def test_eval_auto_carveout_splits_data_and_runs_eval(tmp_path, monkeypatch):
         lambda *args, **kwargs: "accounts/test/trainingShapes/sft",
     )
     monkeypatch.setattr(module, "ReconnectableClient", FakeClient)
+    monkeypatch.setattr(
+        module,
+        "make_batch_weighted_sft_loss_fn",
+        lambda: lambda data, logprobs_list: (None, {"ce_loss_sum": 0.5, "response_tokens": 2}),
+    )
 
     def _fake_render(messages, **kwargs):
         row_idx = int(messages[0]["content"][1:])
@@ -1126,9 +1135,13 @@ def test_eval_auto_carveout_eval_set_is_stable_across_epochs(tmp_path, monkeypat
             events["train_batches"].append(list(batch))
             return SimpleNamespace(metrics={"loss:sum": 1.0, "ce_loss_sum": 1.0, "response_tokens": 2})
 
-        def forward_backward_custom(self, batch, loss_fn):
+        def forward(self, batch, loss_fn):
             events["eval_batches"].append(list(batch))
-            return SimpleNamespace(metrics={"ce_loss_sum": 0.5, "response_tokens": 2})
+            return SimpleNamespace(
+                loss_fn_outputs=[
+                    {"logprobs": SimpleNamespace(to_torch=lambda: None)} for _ in batch
+                ],
+            )
 
         def optim_step(self, _params, **kwargs):
             return SimpleNamespace(metrics={})
@@ -1157,6 +1170,11 @@ def test_eval_auto_carveout_eval_set_is_stable_across_epochs(tmp_path, monkeypat
         lambda *args, **kwargs: "accounts/test/trainingShapes/sft",
     )
     monkeypatch.setattr(module, "ReconnectableClient", FakeClient)
+    monkeypatch.setattr(
+        module,
+        "make_batch_weighted_sft_loss_fn",
+        lambda: lambda data, logprobs_list: (None, {"ce_loss_sum": 0.5, "response_tokens": 2}),
+    )
 
     def _fake_render(messages, **kwargs):
         row_idx = int(messages[0]["content"][1:])


### PR DESCRIPTION
## Summary

`run_eval` in `training/recipes/sft_loop.py` previously called
`client.forward_backward_custom(batch, eval_loss_fn)` where `eval_loss_fn`
returned `real_loss * 0.0` to "do an eval pass with zero gradients."
Tinker's sanity check `No gradient computed for logprob tensor` rejects
that input — the exception is then swallowed by the surrounding
`try/except`, the eval batch silently produces no metrics, and
`metrics.jsonl` ends up with zero `eval/loss` entries.

This was caught by the SFT nightly canary
(`control_plane/e2e_tests/fireoptimizer/canary_sft`), whose Phase 4
asserts that at least one `eval/loss` row is written. The phase failed
on every run despite training itself succeeding.

Fix: replace the zero-gradient trick with a real `forward()` call.

- `client.forward(batch, "cross_entropy")` — pure forward, no backward,
  so weights / gradients / Adam state are untouched by construction.
- Pull logprobs out of `fwd.loss_fn_outputs[i]["logprobs"].to_torch()`.
- Call `make_batch_weighted_sft_loss_fn()` purely to compute metrics
  client-side; the loss tensor it returns is discarded.

Same metric keys (`ce_loss_sum`, `response_tokens`) are produced, so
downstream aggregation (`eval_loss_sum / eval_resp_tokens`) is
unchanged.

## Architecture / Code Overview

```mermaid
flowchart LR
  subgraph BEFORE["Before (broken)"]
    A1[forward_backward_custom\nbatch, loss*0.0] --> B1[tinker sanity check]
    B1 --> C1[Exception:\nNo gradient computed]
    C1 --> D1[swallowed by try/except]
    D1 --> E1[metrics.jsonl missing\neval/loss rows]
  end

  subgraph AFTER["After (fix)"]
    A2[forward batch, cross_entropy] --> B2[loss_fn_outputs i logprobs]
    B2 --> C2[make_batch_weighted_sft_loss_fn\ncomputes ce_loss_sum, response_tokens]
    C2 --> D2[metrics.jsonl includes\neval/loss + eval/ppl]
  end
```

## Test plan

- [ ] Re-trigger SFT nightly canary against this cookbook commit;
  verify Phase 4 (eval/loss presence) passes.
- [ ] Confirm `eval/loss` and `eval/ppl` numbers match what
  `forward_backward_custom` was producing internally before the
  zero-gradient guard rejected the call. (Locally, run a small SFT job
  and inspect `metrics.jsonl` for non-empty `eval/loss` rows.)