### PR TITLE
fix(glm5): default strip_thinking_from_history=True to match HF apply_chat_template

### DIFF
--- a/training/renderer/glm5.py
+++ b/training/renderer/glm5.py
@@ -7,10 +7,12 @@ tokenizer and chat template).
 Token-level layout follows ``tokenizer.apply_chat_template`` byte-for-byte
 (verified by the unit tests in ``test_glm5_renderer.py``), modulo a synthetic
 terminal role sentinel used only for supervised examples that end on an
-assistant message. The registered renderer uses GLM preserved-thinking
-semantics by default; opt-in
-``strip_thinking_from_history=True`` matches the template's standard
-``clear_thinking`` behavior.
+assistant message. The registered renderer defaults to
+``strip_thinking_from_history=True``, matching the shipped chat template's
+default behavior (``clear_thinking`` is unset, which the Jinja treats as
+"strip historical reasoning"); opt-in ``strip_thinking_from_history=False``
+preserves historical reasoning and is intended for callers who also pass
+``clear_thinking=False`` to ``apply_chat_template`` at inference time.
 
 Role tag layout (as the shipped Jinja template emits them):
 
@@ -35,18 +37,20 @@ Assistant turn layout:
 
       <|assistant|></think>{content}
 
-- **Historical assistant turn** (any turn before the last user message) when
-  ``strip_thinking_from_history=False`` (the default) and reasoning content is
-  provided::
-
-      <|assistant|><think>{reasoning}</think>{content}
-
-- **Historical assistant turn** when ``strip_thinking_from_history=True``::
+- **Historical assistant turn** when ``strip_thinking_from_history=True``
+  (the default — matches the shipped template's ``clear_thinking`` behavior
+  when no kwarg is passed to ``apply_chat_template``)::
 
       <|assistant|></think>{content}
 
-  This opt-in strip-history mode matches the shipped template's default
-  ``clear_thinking`` behavior.
+- **Historical assistant turn** when ``strip_thinking_from_history=False``
+  (opt-in) and reasoning content is provided::
+
+      <|assistant|><think>{reasoning}</think>{content}
+
+  Use this only if your inference path also passes ``clear_thinking=False``
+  to ``apply_chat_template``; otherwise training tokens diverge from
+  inference rendering.
 
 Other invariants:
 
@@ -244,7 +248,7 @@ class GLM5Renderer(Renderer):
     def __init__(
         self,
         tokenizer: Tokenizer,
-        strip_thinking_from_history: bool = False,
+        strip_thinking_from_history: bool = True,
     ) -> None:
         super().__init__(tokenizer)
         self.strip_thinking_from_history = strip_thinking_from_history

--- a/training/tests/smoke_test/test_glm5_serverless_prompt_tokens.py
+++ b/training/tests/smoke_test/test_glm5_serverless_prompt_tokens.py
@@ -107,7 +107,17 @@ def test_glm5_renderer_matches_fireworks_serverless_prompt_token_ids(
         tokenizer_model,
         trust_remote_code=True,
     )
-    renderer = GLM5Renderer(tokenizer)
+    # Mirror the serverless render mode: when the case asks for
+    # ``reasoning_history=preserved``, build a non-stripping renderer so
+    # token sequences line up (registered default strips history thinking
+    # to match HF ``apply_chat_template`` with ``clear_thinking`` unset).
+    preserves_history = (
+        case.get("request_kwargs", {}).get("reasoning_history") == "preserved"
+    )
+    renderer = GLM5Renderer(
+        tokenizer,
+        strip_thinking_from_history=not preserves_history,
+    )
 
     server_ids = _serverless_prompt_token_ids(
         client,

--- a/training/tests/unit/test_glm5_renderer.py
+++ b/training/tests/unit/test_glm5_renderer.py
@@ -84,22 +84,24 @@ def tokenizer():
 
 @pytest.fixture(scope="module")
 def renderer(tokenizer):
-    """Strip-history renderer used for HF default ``clear_thinking`` parity."""
-    return GLM5Renderer(tokenizer, strip_thinking_from_history=True)
+    """Registered-default strip-history renderer (matches HF
+    ``apply_chat_template`` with ``clear_thinking`` unset)."""
+    return GLM5Renderer(tokenizer)
 
 
 @pytest.fixture(scope="module")
 def renderer_keep_thinking(tokenizer):
-    """Registered-default preserve-thinking renderer."""
-    return GLM5Renderer(tokenizer)
+    """Opt-in preserve-thinking renderer (caller must also pass
+    ``clear_thinking=False`` at inference for parity)."""
+    return GLM5Renderer(tokenizer, strip_thinking_from_history=False)
 
 
-def test_registered_glm5_default_preserves_thinking(tokenizer):
+def test_registered_glm5_default_strips_thinking_from_history(tokenizer):
     default_renderer = get_renderer("glm5", tokenizer)
 
     assert isinstance(default_renderer, GLM5Renderer)
-    assert default_renderer.strip_thinking_from_history is False
-    assert default_renderer.has_extension_property is True
+    assert default_renderer.strip_thinking_from_history is True
+    assert default_renderer.has_extension_property is False
 
 
 def _hf_tokens(tokenizer, messages, add_generation_prompt: bool, **kwargs) -> list[int]:
@@ -913,6 +915,89 @@ def test_build_supervised_examples_all_assistant_splits_by_user_turn(
     assert "A3" in trained_examples[2]
     assert "A1" not in trained_examples[2]
     assert "A2" not in trained_examples[2]
+
+
+def test_build_supervised_examples_disaggregate_matches_hf_default(tokenizer, renderer):
+    """Each per-turn split must match HF ``apply_chat_template`` rendering of
+    the matching prefix with ``clear_thinking`` left unset (the HF default,
+    i.e. strip historical reasoning). This guards against training-inference
+    OOD: if a customer fine-tunes via cookbook then deploys behind any
+    standard HF inference stack, the model must see prompt contexts shaped
+    exactly like the per-turn datums it was trained on.
+    """
+    messages_with_reasoning = [
+        {"role": "user", "content": "Q1"},
+        {
+            "role": "assistant",
+            "reasoning_content": "THINK_A",
+            "content": "A1",
+        },
+        {"role": "user", "content": "Q2"},
+        {
+            "role": "assistant",
+            "reasoning_content": "THINK_B",
+            "content": "A2",
+        },
+        {"role": "user", "content": "Q3"},
+        {
+            "role": "assistant",
+            "reasoning_content": "THINK_C",
+            "content": "A3",
+        },
+    ]
+    # Renderer messages keep the structured ``thinking`` part on each turn so
+    # the disaggregate path has reasoning to either preserve (current turn) or
+    # strip (history); supervised examples drop the trailing role sentinel.
+    renderer_messages = [
+        {"role": "user", "content": "Q1"},
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "thinking", "thinking": "THINK_A"},
+                {"type": "text", "text": "A1"},
+            ],
+        },
+        {"role": "user", "content": "Q2"},
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "thinking", "thinking": "THINK_B"},
+                {"type": "text", "text": "A2"},
+            ],
+        },
+        {"role": "user", "content": "Q3"},
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "thinking", "thinking": "THINK_C"},
+                {"type": "text", "text": "A3"},
+            ],
+        },
+    ]
+
+    examples = renderer.build_supervised_examples(
+        renderer_messages,
+        train_on_what=TrainOnWhat.ALL_ASSISTANT_MESSAGES,
+    )
+
+    user_idxs = [i for i, m in enumerate(messages_with_reasoning) if m["role"] == "user"]
+    assert len(examples) == len(user_idxs), (
+        f"Expected {len(user_idxs)} per-turn datums, got {len(examples)}"
+    )
+
+    # Each datum corresponds to messages[: next_user_idx]; the last datum
+    # consumes everything through the final assistant turn.
+    prefix_ends = user_idxs[1:] + [len(messages_with_reasoning)]
+    for i, (example, end) in enumerate(zip(examples, prefix_ends)):
+        ours = list(example[0].to_ints())
+        prefix = messages_with_reasoning[:end]
+        # HF default rendering with no clear_thinking kwarg: strip historical
+        # reasoning, preserve last-turn reasoning (this is what every standard
+        # inference stack feeds the model). Compare without
+        # add_generation_prompt because the example renders the full assistant
+        # turn rather than a generation-only prompt.
+        hf = _hf_tokens(tokenizer, prefix, add_generation_prompt=False)
+        _assert_supervised_parity_with_role_stop(ours, hf, tokenizer, prefix)
 
 
 def test_build_supervised_examples_warns_on_non_assistant_mode(tokenizer, renderer):


### PR DESCRIPTION
## Summary

PR #397 shipped GLM5Renderer with **`strip_thinking_from_history=False` as the registered default**, with the stated intent of *"matching HF default \`clear_thinking\` behavior"*. The intent was right; the default value was inverted by accident.

The shipped GLM-5.1 [chat_template.jinja line 75-76](https://huggingface.co/zai-org/GLM-5.1/blob/main/chat_template.jinja#L75-L76) treats **unset `clear_thinking` as strip**:

\`\`\`jinja
{%- if ((clear_thinking is defined and not clear_thinking) or loop.index0 > ns.last_user_index) and reasoning_content is defined -%}
\`\`\`

When \`clear_thinking\` is not passed, \`is defined\` short-circuits to False → \`keep_reasoning\` is False for historical turns → strip. Empirical:

| call | history rendering |
|---|---|
| \`apply_chat_template(msgs)\` (default, no kwarg) | \`<\|assistant\|></think>A1\` |
| \`apply_chat_template(msgs, clear_thinking=True)\` | \`<\|assistant\|></think>A1\` |
| \`apply_chat_template(msgs, clear_thinking=False)\` | \`<\|assistant\|><think>{reasoning}</think>A1\` |

So the registered cookbook default (preserve) produced **training tokens that diverge from every standard inference stack** (vLLM, transformers, Fireworks serverless without explicit \`reasoning_history=preserved\` kwarg) — a silent training/inference OOD.

A second consequence: with \`has_extension_property=True\`, the dispatcher in \`utils/supervised.py:781\` fast-paths to the singular render path on entry, so the per-user-turn disaggregate logic added at \`glm5.py:483-546\` was **unreachable in production** (only the strip-mode unit-test fixture exercised it).

## Fix

Flip the default. Now:

- \`has_extension_property=False\`
- dispatcher routes multi-turn \`ALL_ASSISTANT_MESSAGES\` to the plural path
- the disaggregate code at \`glm5.py:483-546\` is the production path
- per-turn rendered tokens equal HF \`apply_chat_template\` with default args

Reproducer (post-fix):

\`\`\`
strip_thinking_from_history: True
has_extension_property: False
dispatcher needs_plural: True
\`\`\`

## Test changes

- \`test_glm5_renderer.py\`: swap fixture semantics — \`renderer\` is now the registered default (strip), \`renderer_keep_thinking\` explicitly opts into preserve. All existing assertions still hold (they covered the same renderer modes; only the fixture-name → mode mapping flipped).
- **Add \`test_build_supervised_examples_disaggregate_matches_hf_default\`** — asserts each per-turn datum byte-equals HF \`apply_chat_template\` with no kwargs for the matching prefix. This is the parity guard the disaggregate path was missing.
- \`test_glm5_serverless_prompt_tokens.py\`: select renderer mode based on the test case's \`request_kwargs\` (\`reasoning_history=preserved\` → use \`strip=False\`; otherwise default \`strip=True\`).

## Architecture / Code Overview

\`\`\`mermaid
flowchart TB
  subgraph Before["Before (PR #397 default preserve)"]
    A1[register_renderer 'glm5'] --> B1[GLM5Renderer default strip=False]
    B1 --> C1[has_extension_property=True]
    C1 --> D1[dispatcher fast-path: singular]
    D1 --> E1[singular render: history KEEPS think]
    E1 --> F1[Training tokens != HF default rendering]
    F1 --> G1[OOD at inference]
    H1[disaggregate code 483-546] -.->|never reached| X1[dead code]
  end

  subgraph After["After (this PR)"]
    A2[register_renderer 'glm5'] --> B2[GLM5Renderer default strip=True]
    B2 --> C2[has_extension_property=False]
    C2 --> D2[dispatcher: plural]
    D2 --> E2[disaggregate per-user-turn]
    E2 --> F2[Per-turn tokens == HF default rendering]
    F2 --> G2[Inference parity ✓]
  end
\`\`\`

## Test plan

- [x] \`pytest training/tests/unit/test_glm5_renderer.py\` — 93 passed
- [x] \`pytest training/tests/unit/test_supervised_rendering.py training/tests/unit/test_sft_loop.py\` — 65 passed
- [ ] \`FIREWORKS_API_KEY=… pytest training/tests/smoke_test/test_glm5_serverless_prompt_tokens.py\` — verify against live serverless (skipped locally; runs in CI smoke matrix)
- [ ] Re-train a GLM5 multi-turn SFT job to confirm the new per-turn datum count and check resource budget (disaggregate produces N datums/conversation; expected token-volume increase for long multi-turn datasets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)