### PR TITLE
feat(rl): adapt eval-protocol evaluators to async rollouts

### DIFF
--- a/training/examples/rl/frozen_lake/train_frozen_lake.py
+++ b/training/examples/rl/frozen_lake/train_frozen_lake.py
@@ -686,6 +686,7 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
         )
         resume_info = ckpt.resume()
         step_offset = resume_info.step if resume_info else 0
+        prior_rows_consumed = resume_info.data_consumed if resume_info else 0
         if weight_sync_cfg.weight_sync_before_training and deploy_cfg.deployment_id:
             name = f"resume-{step_offset}-base" if step_offset > 0 else "step-0-base"
             weight_syncer.save_and_hotload(name, checkpoint_type="base")
@@ -752,7 +753,7 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
             completion_params={"model": inference_model},
             steps=cfg.max_steps,
         )
-        eval3_input_rows = load_eval_protocol_input_rows(frozen_lake_evaluator)
+        eval3_input_rows = load_eval_protocol_input_rows(frozen_lake_evaluator)[prior_rows_consumed:]
 
         adam_params = tinker.AdamParams(learning_rate=cfg.learning_rate, **DEFAULT_ADAM)
         # Client-side fallback: build the Python loss closure used by
@@ -962,7 +963,7 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
             _wandb_step = [step_offset]
 
             def make_row_requests():
-                for row_idx, eval_row in enumerate(eval3_input_rows):
+                for row_idx, eval_row in enumerate(eval3_input_rows, start=prior_rows_consumed):
                     dataset_info = eval_row.input_metadata.dataset_info or {}
                     env_context_dict = dict(dataset_info.get("environment_context") or {})
 
@@ -1000,7 +1001,7 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
                 max_concurrent=max_concurrent_samples,
                 dynamic_filter_fn=should_accept,
                 global_step=step_offset,
-                resolved_rows_offset=resume_info.data_consumed if resume_info else 0,
+                resolved_rows_offset=prior_rows_consumed,
                 return_final_stats=True,
             ))
 

--- a/training/examples/rl/frozen_lake/train_frozen_lake.py
+++ b/training/examples/rl/frozen_lake/train_frozen_lake.py
@@ -35,7 +35,7 @@ if _SRC not in sys.path:
     sys.path.insert(0, _SRC)
 
 from eval_protocol.models import EvaluationRow, InputMetadata
-from eval_protocol.pytest.types import RolloutProcessorConfig
+from eval_protocol.pytest import evaluation_test
 
 from training.examples.rl.frozen_lake.frozen_lake_rollout import (
     DEFAULT_SYSTEM_PROMPT_INSTRUCTIONS,
@@ -64,13 +64,18 @@ from training.utils import (
     log_metrics_json,
     setup_deployment,
     create_trainer_job,
-    compute_advantages,
     build_datum_from_token_mask,
     validate_config,
     auto_select_training_shape,
 )
 from training.utils.rl import PromptGroup
-from training.utils.rl.train import TrainStepFns, run_rl_loop
+from training.utils.rl.async_train import RowRequest, run_async_rl_loop
+from training.utils.rl.rollout import (
+    RolloutSample,
+    load_eval_protocol_input_rows,
+    make_eval_protocol_rollout_fn_factory,
+)
+from training.utils.rl.train import TrainStepFns
 from training.utils.rl.cispo import CISPOConfig
 from training.utils.rl.dapo import DAPOConfig
 from training.utils.rl.dro import DROConfig
@@ -323,6 +328,90 @@ def evaluation_row_to_training_data(
     episode_reward = 1.0 if step_rewards and float(step_rewards[-1]) > 0 else 0.0
 
     return [datum], first_prompt_len, [inf_logprobs], [episode_reward]
+
+
+def evaluation_row_to_rollout_sample(row: EvaluationRow) -> RolloutSample | None:
+    """Convert a completed FrozenLake EvaluationRow into one RolloutSample."""
+    extra = row.execution_metadata.extra or {}
+    token_turn_traces = extra.get("token_turn_traces") or []
+    step_rewards = extra.get("step_rewards") or []
+
+    if not token_turn_traces:
+        return None
+
+    last_trace = token_turn_traces[-1]
+    last_prompt_ids = [int(x) for x in (last_trace.get("prompt_ids") or [])]
+    last_completion_ids = [int(x) for x in (last_trace.get("completion_ids") or [])]
+    full_tokens = last_prompt_ids + last_completion_ids
+    if len(full_tokens) < 2:
+        return None
+
+    model_request_traces = extra.get("model_request_traces") or []
+    spans = compute_model_output_spans(token_turn_traces, model_request_traces)
+    ui_token_mask = build_ui_token_mask(spans, len(full_tokens))
+    loss_mask = [1 if int(m) > 0 else 0 for m in ui_token_mask]
+
+    # RolloutSample.logprobs are token-aligned. Non-generated tokens keep 0.0;
+    # generated token logprobs are copied from each turn's completion payload.
+    token_logprobs = [0.0] * len(full_tokens)
+    for trace in token_turn_traces:
+        turn_prompt_len = len(trace.get("prompt_ids") or [])
+        turn_completion_logprobs = trace.get("completion_logprobs") or []
+        for i, lp in enumerate(turn_completion_logprobs):
+            pos = turn_prompt_len + i
+            if pos < len(token_logprobs):
+                token_logprobs[pos] = float(lp)
+
+    episode_reward = 1.0 if step_rewards and float(step_rewards[-1]) > 0 else 0.0
+    return RolloutSample(
+        tokens=full_tokens,
+        logprobs=token_logprobs,
+        loss_mask=loss_mask,
+        reward=episode_reward,
+        finish_reason=str(row.execution_metadata.finish_reason or "stop"),
+    )
+
+
+def frozen_lake_eval_row_factory(row: Dict[str, Any]) -> EvaluationRow:
+    """Build one per-sample EvaluationRow from an eval3 input row."""
+    base_row = row.get("evaluation_row")
+    rollout_idx = int(row.get("rollout_idx", 0))
+    if not isinstance(base_row, EvaluationRow):
+        raise TypeError("FrozenLake row must include an 'evaluation_row' EvaluationRow.")
+
+    eval_row = base_row.model_copy(deep=True)
+    base_row_id = eval_row.input_metadata.row_id or "row"
+    eval_row.input_metadata.row_id = f"{base_row_id}_{rollout_idx}"
+    return eval_row
+
+
+def make_frozen_lake_eval3_evaluator(
+    *,
+    input_rows: List[EvaluationRow],
+    rollout_processor: FrozenLakeToolRolloutProcessor,
+    completion_params: Dict[str, Any],
+    steps: int,
+):
+    """Create the eval3 expression that managed RFT can adapt into rollout_fn.
+
+    FrozenLake's scalar reward and token trace are produced by the rollout
+    processor, so the pointwise evaluator body is intentionally identity.
+    """
+
+    def frozen_lake_eval(row):
+        return row
+
+    # eval-protocol validates annotations by object identity, while this module
+    # uses postponed annotations. Set the runtime annotations explicitly.
+    frozen_lake_eval.__annotations__ = {"row": EvaluationRow, "return": EvaluationRow}
+
+    return evaluation_test(
+        input_rows=[input_rows],
+        completion_params=[completion_params],
+        rollout_processor=rollout_processor,
+        mcp_config_path="",
+        steps=steps,
+    )(frozen_lake_eval)
 
 
 # ---------------------------------------------------------------------------
@@ -643,12 +732,27 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
             observation_mode=cfg.observation_mode,
             allow_plaintext_action_fallback=cfg.allow_plaintext_action_fallback,
         )
-        rollout_config = RolloutProcessorConfig(
+        all_prompts = seed_contexts * cfg.epochs
+        frozen_lake_input_rows = [
+            EvaluationRow(
+                input_metadata=InputMetadata(
+                    row_id=f"seed_{env_context.get('seed', row_idx)}_{row_idx}",
+                    dataset_info={
+                        "environment_context": dict(env_context),
+                        "user_prompt_template": cfg.user_prompt_template,
+                        "visual_prompt_template": cfg.visual_prompt_template,
+                    },
+                ),
+            )
+            for row_idx, env_context in enumerate(all_prompts)
+        ]
+        frozen_lake_evaluator = make_frozen_lake_eval3_evaluator(
+            input_rows=frozen_lake_input_rows,
+            rollout_processor=rollout_processor,
             completion_params={"model": inference_model},
-            mcp_config_path="",
             steps=cfg.max_steps,
-            semaphore=asyncio.Semaphore(cfg.max_concurrent),
         )
+        eval3_input_rows = load_eval_protocol_input_rows(frozen_lake_evaluator)
 
         adam_params = tinker.AdamParams(learning_rate=cfg.learning_rate, **DEFAULT_ADAM)
         # Client-side fallback: build the Python loss closure used by
@@ -661,93 +765,48 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
         trajectory_log = open(trajectory_path, "a")
         logger.info("Logging trajectories to %s", trajectory_path)
         try:
-            # -- Sample one prompt group ----------------------------------------
+            # -- Per-sample rollout function ------------------------------------
 
-            async def sample_one_prompt(env_context: Dict[str, Any]) -> PromptGroup | None:
-                """Run completions_per_prompt rollouts for one seed, return PromptGroup."""
-                rows: List[EvaluationRow] = []
-                for rollout_idx in range(completions_per_prompt):
-                    rows.append(EvaluationRow(
-                        input_metadata=InputMetadata(
-                            row_id=f"seed_{env_context.get('seed', 0)}_{rollout_idx}",
-                            dataset_info={
-                                "environment_context": dict(env_context),
-                                "user_prompt_template": cfg.user_prompt_template,
-                                "visual_prompt_template": cfg.visual_prompt_template,
-                            },
-                        ),
-                    ))
+            def convert_and_log_sample(result: EvaluationRow) -> RolloutSample | None:
+                extra = result.execution_metadata.extra or {}
+                dataset_info = result.input_metadata.dataset_info or {}
+                env_context = dict(dataset_info.get("environment_context") or {})
+                rollout_idx = str(result.input_metadata.row_id or "").rsplit("_", 1)[-1]
+                if extra.get("rollout_error"):
+                    logger.warning(
+                        "Rollout error for seed %s sample %s: %s",
+                        env_context.get("seed"),
+                        rollout_idx,
+                        extra["rollout_error"],
+                    )
+                    return None
 
-                tasks = rollout_processor(rows, rollout_config)
-                completed_rows: List[EvaluationRow] = []
-                for task in tasks:
-                    try:
-                        result = await task
-                        extra = result.execution_metadata.extra or {}
-                        if extra.get("rollout_error"):
-                            logger.warning(
-                                "Rollout error for seed %s: %s",
-                                env_context.get("seed"), extra["rollout_error"],
-                            )
-                            continue
-                        completed_rows.append(result)
-                    except Exception as e:
-                        logger.warning("Rollout task failed for seed %s: %s", env_context.get("seed"), e)
+                sample = evaluation_row_to_rollout_sample(result)
+                if sample is None:
+                    return None
 
                 if trajectory_log:
-                    for row in completed_rows:
-                        extra = row.execution_metadata.extra or {}
-                        entry = {
-                            "seed": env_context.get("seed"),
-                            "messages": [m.model_dump() if hasattr(m, "model_dump") else m for m in (row.messages or [])],
-                            "step_rewards": extra.get("step_rewards", []),
-                            "reward": 1.0 if extra.get("step_rewards") and float(extra["step_rewards"][-1]) > 0 else 0.0,
-                            "rollout_error": extra.get("rollout_error"),
-                        }
-                        trajectory_log.write(json.dumps(entry) + "\n")
-                        trajectory_log.flush()
+                    entry = {
+                        "seed": env_context.get("seed"),
+                        "rollout_idx": rollout_idx,
+                        "messages": [
+                            m.model_dump() if hasattr(m, "model_dump") else m
+                            for m in (result.messages or [])
+                        ],
+                        "step_rewards": extra.get("step_rewards", []),
+                        "reward": sample.reward,
+                        "rollout_error": extra.get("rollout_error"),
+                    }
+                    trajectory_log.write(json.dumps(entry) + "\n")
+                    trajectory_log.flush()
 
-                if len(completed_rows) < 2:
-                    return None
+                return sample
 
-                all_datums: List[tinker.Datum] = []
-                all_ref_datums: List[tinker.Datum] = []
-                all_rewards: List[float] = []
-                all_inf_logprobs: List[List[float]] = []
-                first_prompt_len = 0
-
-                for row in completed_rows:
-                    datums, prompt_len, inf_lps, rewards = evaluation_row_to_training_data(row)
-                    if not datums:
-                        continue
-                    all_datums.extend(datums)
-                    all_rewards.extend(rewards)
-                    all_inf_logprobs.extend(inf_lps)
-                    if first_prompt_len == 0:
-                        first_prompt_len = prompt_len
-
-                    if use_reference:
-                        for d in datums:
-                            ref_datum = tinker.Datum(
-                                model_input=d.model_input,
-                                loss_fn_inputs=d.loss_fn_inputs,
-                            )
-                            all_ref_datums.append(ref_datum)
-
-                if not all_datums or len(all_rewards) < 2:
-                    return None
-
-                advantages = compute_advantages(all_rewards)
-
-                return PromptGroup(
-                    data=all_datums,
-                    ref_data=all_ref_datums,
-                    advantages=advantages,
-                    ref_logprobs=[],
-                    prompt_len=first_prompt_len,
-                    rewards=all_rewards,
-                    inf_logprobs=all_inf_logprobs,
-                )
+            frozen_lake_rollout_fn = make_eval_protocol_rollout_fn_factory(
+                frozen_lake_evaluator,
+                row_factory=frozen_lake_eval_row_factory,
+                sample_converter=convert_and_log_sample,
+            )(None)
 
             # -- Training callbacks ---------------------------------------------
 
@@ -881,29 +940,68 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
             def should_accept(pg: PromptGroup) -> bool:
                 return len(set(pg.rewards)) > 1
 
-            all_prompts = seed_contexts * cfg.epochs
+            max_concurrent_samples = cfg.max_concurrent if cfg.max_concurrent > 0 else None
+            min_group_size = 2 if completions_per_prompt > 1 else 1
+            async_weight_sync_interval = (
+                max(1, weight_sync_cfg.weight_sync_interval)
+                if weight_sync_cfg.weight_sync_interval > 0
+                else 1
+            )
+            max_head_offpolicy_versions = (
+                max(0, async_weight_sync_interval - 1)
+                if weight_sync_cfg.weight_sync_interval > 0
+                else max(0, (len(eval3_input_rows) + prompt_groups_per_step - 1) // prompt_groups_per_step)
+            )
             logger.info(
                 "Training: %d seeds x %d epochs = %d prompt groups, "
-                "%d completions/prompt, %d groups/step",
-                len(seed_contexts), cfg.epochs, len(all_prompts),
-                completions_per_prompt, prompt_groups_per_step,
+                "%d completions/prompt, %d groups/step, max_concurrent_samples=%s",
+                len(seed_contexts), cfg.epochs, len(eval3_input_rows),
+                completions_per_prompt, prompt_groups_per_step, max_concurrent_samples,
             )
 
             _wandb_step = [step_offset]
 
-            def _filtered_step_callback(loop_metrics: dict) -> None:
-                _wandb_step[0] += 1
-                wandb_log(loop_metrics, step=_wandb_step[0])
+            def make_row_requests():
+                for row_idx, eval_row in enumerate(eval3_input_rows):
+                    dataset_info = eval_row.input_metadata.dataset_info or {}
+                    env_context_dict = dict(dataset_info.get("environment_context") or {})
 
-            global_step = asyncio.run(run_rl_loop(
-                sample_fns=(sample_one_prompt(ctx) for ctx in all_prompts),
+                    def factory(
+                        rollout_idx: int,
+                        *,
+                        row_idx: int = row_idx,
+                        eval_row: EvaluationRow = eval_row,
+                    ):
+                        return frozen_lake_rollout_fn({
+                            "row_id": row_idx,
+                            "rollout_idx": rollout_idx,
+                            "evaluation_row": eval_row,
+                        })
+
+                    yield RowRequest(
+                        row_id=row_idx,
+                        sample_factory=factory,
+                        row_meta={
+                            "seed": env_context_dict.get("seed"),
+                            "environment_context": env_context_dict,
+                        },
+                    )
+
+            global_step, final_stats = asyncio.run(run_async_rl_loop(
+                rows=make_row_requests(),
                 train_fns=train_fns,
+                completions_per_prompt=completions_per_prompt,
                 prompt_groups_per_step=prompt_groups_per_step,
+                max_head_offpolicy_versions=max_head_offpolicy_versions,
+                with_reference=use_reference,
+                min_group_size=min_group_size,
+                weight_sync_fn=_weight_sync if weight_sync_cfg.weight_sync_interval > 0 else None,
+                weight_sync_interval=async_weight_sync_interval,
+                max_concurrent=max_concurrent_samples,
                 dynamic_filter_fn=should_accept,
                 global_step=step_offset,
-                metrics_callback=_filtered_step_callback,
-                weight_sync_fn=_weight_sync if weight_sync_cfg.weight_sync_interval > 0 else None,
-                weight_sync_interval=weight_sync_cfg.weight_sync_interval,
+                resolved_rows_offset=resume_info.data_consumed if resume_info else 0,
+                return_final_stats=True,
             ))
 
             # -- Final checkpoint -----------------------------------------------
@@ -911,7 +1009,7 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
             if global_step > step_offset:
                 try:
                     cp_name = f"step-{global_step}"
-                    _data_consumed = (resume_info.data_consumed if resume_info else 0) + (global_step - step_offset) * prompt_groups_per_step
+                    _data_consumed = int(final_stats["resolved_rows"])
                     ckpt.save(
                         cp_name,
                         resumable=True,

--- a/training/tests/unit/test_eval_protocol_rollout_adapter.py
+++ b/training/tests/unit/test_eval_protocol_rollout_adapter.py
@@ -1,0 +1,135 @@
+import asyncio
+from types import SimpleNamespace
+
+from eval_protocol.models import EvaluationRow, InputMetadata
+from eval_protocol.pytest import evaluation_test
+
+from training.utils.rl.rollout import (
+    RolloutSample,
+    load_eval_protocol_input_rows,
+    make_eval_protocol_rollout_fn_factory,
+)
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _sample_from_row(row: EvaluationRow) -> RolloutSample:
+    reward = float((row.execution_metadata.extra or {}).get("reward", 0.0))
+    return RolloutSample(
+        tokens=[1, 2, 3],
+        logprobs=[0.0, -0.1, -0.2],
+        loss_mask=[0, 1, 1],
+        reward=reward,
+    )
+
+
+def test_load_eval_protocol_input_rows_from_decorated_evaluator():
+    rows = [
+        EvaluationRow(input_metadata=InputMetadata(row_id="keep")),
+        EvaluationRow(input_metadata=InputMetadata(row_id="drop")),
+    ]
+
+    @evaluation_test(input_rows=[rows], filtered_row_ids=["keep"])
+    def evaluator(row: EvaluationRow) -> EvaluationRow:
+        return row
+
+    loaded = load_eval_protocol_input_rows(evaluator)
+
+    assert [row.input_metadata.row_id for row in loaded] == ["keep"]
+    assert loaded[0] is not rows[0]
+
+
+def test_eval_protocol_adapter_invokes_processor_one_row_and_scores():
+    calls: list[dict] = []
+
+    class FakeProcessor:
+        def setup(self):
+            calls.append({"setup": True})
+
+        def __call__(self, rows, config):
+            calls.append({
+                "row_ids": [row.input_metadata.row_id for row in rows],
+                "completion_params": config.completion_params,
+                "steps": config.steps,
+                "semaphore_value": config.semaphore._value,
+                "kwargs": config.kwargs,
+            })
+
+            async def finish():
+                row = rows[0]
+                row.execution_metadata.extra = {"reward": 0.25}
+                return row
+
+            return [finish()]
+
+    input_row = EvaluationRow(input_metadata=InputMetadata(row_id="row-1"))
+
+    @evaluation_test(
+        input_rows=[[input_row]],
+        completion_params=[{"model": "decorator-model", "temperature": 0.7}],
+        rollout_processor=FakeProcessor(),
+        rollout_processor_kwargs={"custom": "value"},
+        steps=7,
+    )
+    def evaluator(row: EvaluationRow) -> EvaluationRow:
+        row.execution_metadata.extra["reward"] = 1.0
+        return row
+
+    rollout_fn = make_eval_protocol_rollout_fn_factory(
+        evaluator,
+        sample_converter=_sample_from_row,
+    )(SimpleNamespace(model="runtime-model", sample_kwargs={"top_p": 0.9}))
+
+    sample = _run(rollout_fn(input_row))
+
+    assert sample.reward == 1.0
+    assert calls == [
+        {"setup": True},
+        {
+            "row_ids": ["row-1"],
+            "completion_params": {
+                "model": "runtime-model",
+                "temperature": 0.7,
+                "top_p": 0.9,
+            },
+            "steps": 7,
+            "semaphore_value": 1,
+            "kwargs": {"custom": "value"},
+        },
+    ]
+
+
+def test_eval_protocol_adapter_accepts_custom_row_factory():
+    class FakeProcessor:
+        def setup(self):
+            pass
+
+        def __call__(self, rows, _config):
+            async def finish():
+                row = rows[0]
+                row.execution_metadata.extra = {"reward": 0.5}
+                return row
+
+            return [finish()]
+
+    @evaluation_test(
+        input_rows=[[EvaluationRow(input_metadata=InputMetadata(row_id="placeholder"))]],
+        rollout_processor=FakeProcessor(),
+    )
+    def evaluator(row: EvaluationRow) -> EvaluationRow:
+        return row
+
+    def row_factory(row: dict) -> EvaluationRow:
+        return EvaluationRow(input_metadata=InputMetadata(row_id=row["id"]))
+
+    rollout_fn = make_eval_protocol_rollout_fn_factory(
+        evaluator,
+        row_factory=row_factory,
+        sample_converter=_sample_from_row,
+    )(None)
+
+    sample = _run(rollout_fn({"id": "custom-row"}))
+
+    assert sample.reward == 0.5

--- a/training/tests/unit/test_train_frozen_lake.py
+++ b/training/tests/unit/test_train_frozen_lake.py
@@ -9,6 +9,7 @@ import httpx
 import pytest
 
 import training.examples.rl.frozen_lake.train_frozen_lake as train_module
+from training.utils.rl.rollout import Rollout, rollout_to_prompt_group
 from training.examples.rl.frozen_lake.masking import (
     build_training_loss_mask,
     build_ui_token_mask,
@@ -16,6 +17,7 @@ from training.examples.rl.frozen_lake.masking import (
 )
 from training.examples.rl.frozen_lake.train_frozen_lake import (
     FrozenLakeConfig,
+    evaluation_row_to_rollout_sample,
     evaluation_row_to_training_data,
     load_seed_contexts,
     parse_args,
@@ -142,6 +144,80 @@ def test_evaluation_row_to_training_data_builds_weighted_episode():
     assert datums[0].loss_fn_inputs["weights"].data == loss_mask
     assert datums[0].loss_fn_inputs["loss_mask"].data == loss_mask
     assert ui_mask == [0, 0, 0, 1, 1, 0, 0, 0, 2, 2, 2]
+
+
+def test_evaluation_row_to_rollout_sample_builds_token_native_sample():
+    row = EvaluationRow(input_metadata=InputMetadata(row_id="rollout"))
+    row.execution_metadata.extra = {
+        "token_turn_traces": [
+            {
+                "prompt_ids": [1, 2, 3],
+                "completion_ids": [10, 11],
+                "completion_logprobs": [-0.1, -0.2],
+            },
+            {
+                "prompt_ids": [1, 2, 3, 10, 11, 20, 21, 22],
+                "completion_ids": [30, 31, 32],
+                "completion_logprobs": [-0.3, -0.4, -0.5],
+            },
+        ],
+        "model_request_traces": [{"assistant_turn_len": 2}, {}],
+        "step_rewards": [0.0, 1.0],
+    }
+
+    sample = evaluation_row_to_rollout_sample(row)
+
+    assert sample is not None
+    assert sample.tokens == [1, 2, 3, 10, 11, 20, 21, 22, 30, 31, 32]
+    assert sample.loss_mask == [0, 0, 0, 1, 1, 0, 0, 0, 1, 1, 1]
+    assert sample.logprobs == [0.0, 0.0, 0.0, -0.1, -0.2, 0.0, 0.0, 0.0, -0.3, -0.4, -0.5]
+    assert sample.reward == 1.0
+
+
+def test_rollout_sample_adapter_matches_legacy_training_data():
+    row = EvaluationRow(input_metadata=InputMetadata(row_id="parity"))
+    row.execution_metadata.extra = {
+        "token_turn_traces": [
+            {
+                "prompt_ids": [1, 2, 3],
+                "completion_ids": [10, 11],
+                "completion_logprobs": [-0.1, -0.2],
+            },
+            {
+                "prompt_ids": [1, 2, 3, 10, 11, 20, 21, 22],
+                "completion_ids": [30, 31, 32],
+                "completion_logprobs": [-0.3, -0.4, -0.5],
+            },
+        ],
+        "model_request_traces": [{"assistant_turn_len": 2}, {}],
+        "step_rewards": [0.0, 1.0],
+    }
+
+    legacy_datums, _prompt_len, legacy_inf_logprobs, legacy_rewards = (
+        evaluation_row_to_training_data(row)
+    )
+    sample = evaluation_row_to_rollout_sample(row)
+    assert sample is not None
+    contrasting_sample = sample.__class__(
+        tokens=list(sample.tokens),
+        logprobs=list(sample.logprobs),
+        loss_mask=list(sample.loss_mask),
+        reward=0.0,
+    )
+
+    prompt_group = rollout_to_prompt_group(Rollout(samples=[sample, contrasting_sample]))
+
+    assert prompt_group is not None
+    assert (
+        prompt_group.data[0].loss_fn_inputs["target_tokens"].data
+        == legacy_datums[0].loss_fn_inputs["target_tokens"].data
+    )
+    assert (
+        prompt_group.data[0].loss_fn_inputs["weights"].data
+        == legacy_datums[0].loss_fn_inputs["weights"].data
+    )
+    assert prompt_group.inf_logprobs[0] == legacy_inf_logprobs[0]
+    assert prompt_group.rewards[0] == legacy_rewards[0]
 
 
 def test_evaluation_row_to_training_data_handles_multimodal_row_messages():
@@ -282,9 +358,9 @@ def test_main_bootstraps_without_reference_and_cleans_up(monkeypatch, tmp_path):
             events["rollout_processor_call"] = (rows, rollout_config)
             return []
 
-    async def fake_run_rl_loop(**kwargs):
-        events["run_rl_loop_kwargs"] = kwargs
-        return 0
+    async def fake_run_async_rl_loop(**kwargs):
+        events["run_async_rl_loop_kwargs"] = kwargs
+        return 0, {"resolved_rows": 0}
 
     def fake_create_trainer_job(*args, **kwargs):
         events["trainer_jobs"].append(kwargs)
@@ -312,7 +388,7 @@ def test_main_bootstraps_without_reference_and_cleans_up(monkeypatch, tmp_path):
     monkeypatch.setattr(train_module, "WeightSyncer", FakeWeightSyncer)
     monkeypatch.setattr(train_module, "FrozenLakeToolRolloutProcessor", FakeRolloutProcessor)
     monkeypatch.setattr(train_module, "build_loss_fn", lambda args: ("loss-builder", args))
-    monkeypatch.setattr(train_module, "run_rl_loop", fake_run_rl_loop)
+    monkeypatch.setattr(train_module, "run_async_rl_loop", fake_run_async_rl_loop)
     monkeypatch.setattr(httpx, "post", lambda *args, **kwargs: SimpleNamespace(status_code=200))
 
     train_module.main()
@@ -326,10 +402,12 @@ def test_main_bootstraps_without_reference_and_cleans_up(monkeypatch, tmp_path):
     assert events["weight_syncer_init"]["deployment_id"] == "dep-123"
     assert events["rollout_processor_init"]["observation_mode"] == "image"
     assert events["rollout_processor_init"]["allow_plaintext_action_fallback"] is True
-    assert events["run_rl_loop_kwargs"]["prompt_groups_per_step"] == 4
-    assert "train_fns" in events["run_rl_loop_kwargs"]
-    assert events["run_rl_loop_kwargs"]["weight_sync_interval"] == 1
-    assert events["run_rl_loop_kwargs"]["weight_sync_fn"] is not None
+    assert events["run_async_rl_loop_kwargs"]["prompt_groups_per_step"] == 4
+    assert events["run_async_rl_loop_kwargs"]["completions_per_prompt"] == 2
+    assert events["run_async_rl_loop_kwargs"]["max_concurrent"] == 8
+    assert "train_fns" in events["run_async_rl_loop_kwargs"]
+    assert events["run_async_rl_loop_kwargs"]["weight_sync_interval"] == 1
+    assert events["run_async_rl_loop_kwargs"]["weight_sync_fn"] is not None
     assert events["deleted_jobs"] == ["policy-job"]
     assert events["deleted_deployments"] == []
     assert events["wandb_finished"] == 1
@@ -360,6 +438,7 @@ def test_main_runs_sampling_and_training_with_reference(monkeypatch, tmp_path):
         max_concurrent=8,
         max_steps=5,
         max_seeds=1,
+        epochs=1,
         kl_beta=0.1,
         ratio_log_cap=9.0,
         training_shape="ts-qwen3-4b-smoke-v1",
@@ -523,7 +602,10 @@ def test_main_runs_sampling_and_training_with_reference(monkeypatch, tmp_path):
             events["rollout_processor_init"] = kwargs
 
         def __call__(self, rows, rollout_config):
-            events["rollout_processor_call"] = {"row_ids": [row.input_metadata.row_id for row in rows], "steps": rollout_config.steps}
+            row_id = rows[0].input_metadata.row_id
+            events.setdefault("rollout_processor_calls", []).append(
+                {"row_ids": [row.input_metadata.row_id for row in rows], "steps": rollout_config.steps}
+            )
 
             async def _finish(row, reward):
                 row.execution_metadata.extra = {
@@ -540,31 +622,8 @@ def test_main_runs_sampling_and_training_with_reference(monkeypatch, tmp_path):
                 row.messages = []
                 return row
 
-            return [_finish(rows[0], 1.0), _finish(rows[1], 0.0)]
-
-    async def fake_run_rl_loop(**kwargs):
-        events["run_rl_loop_kwargs"] = kwargs
-        sample_iter = iter(kwargs["sample_fns"])
-        pg = await next(sample_iter)
-        assert pg is not None
-        assert kwargs["dynamic_filter_fn"](pg) is True
-        step, metrics = kwargs["train_fns"].train_step(
-            0,
-            [pg],
-            {
-                "valid_prompt_groups": 1,
-                "total_sampled": 1,
-                "filter_drops": 0,
-                "sample_fails": 0,
-                "trainer_wait_for_sampler_time": 0.1,
-                "step_wall_time": 0.2,
-            },
-        )
-        if kwargs.get("weight_sync_fn") is not None:
-            kwargs["weight_sync_fn"](step)
-        kwargs["metrics_callback"]({"train/step": step, "rollout/sample_fail_count": 0})
-        events["finish_metrics"] = metrics
-        return step
+            reward = 1.0 if row_id.endswith("_0") else 0.0
+            return [_finish(rows[0], reward)]
 
     def fake_create_trainer_job(*args, **kwargs):
         events["trainer_jobs"].append(kwargs)
@@ -624,7 +683,6 @@ def test_main_runs_sampling_and_training_with_reference(monkeypatch, tmp_path):
     })
     monkeypatch.setattr(train_module, "flush_timing", lambda: {"perf/step_time": 1.0})
     monkeypatch.setattr(train_module, "compute_pp_recommendation", lambda *args, **kwargs: SimpleNamespace(recommended_prompts_per_step=3))
-    monkeypatch.setattr(train_module, "run_rl_loop", fake_run_rl_loop)
     _OrigInfraConfig = train_module.InfraConfig
     monkeypatch.setattr(
         train_module, "InfraConfig",
@@ -645,7 +703,10 @@ def test_main_runs_sampling_and_training_with_reference(monkeypatch, tmp_path):
         "frozen-lake-policy",
         "frozen-lake-reference",
     ]
-    assert events["rollout_processor_call"]["row_ids"] == ["seed_101_0", "seed_101_1"]
+    assert [call["row_ids"] for call in events["rollout_processor_calls"]] == [
+        ["seed_101_0_0"],
+        ["seed_101_0_1"],
+    ]
     assert events["weight_sync_saves"] == [("step-0-base", "base"), ("step-1", "base")]
     assert events["weight_sync_dcp"] == []
     assert events["final_save"] == ("step-1", None)

--- a/training/tests/unit/test_train_frozen_lake.py
+++ b/training/tests/unit/test_train_frozen_lake.py
@@ -413,6 +413,173 @@ def test_main_bootstraps_without_reference_and_cleans_up(monkeypatch, tmp_path):
     assert events["wandb_finished"] == 1
 
 
+def test_main_skips_consumed_eval3_rows_on_resume(monkeypatch, tmp_path):
+    monkeypatch.setenv("FIREWORKS_API_KEY", "test-key")
+    monkeypatch.setenv("FIREWORKS_BASE_URL", "https://unit.test")
+
+    events: dict[str, object] = {
+        "trainer_jobs": [],
+        "deleted_jobs": [],
+        "deleted_deployments": [],
+        "weight_sync_saves": [],
+        "wandb_finished": 0,
+    }
+
+    cfg = train_module.FrozenLakeConfig(
+        log_path=str(tmp_path / "frozen_lake_logs"),
+        base_model="accounts/test/models/qwen3-4b",
+        tokenizer_model="Qwen/Qwen3-4B",
+        completions_per_prompt=2,
+        prompt_groups_per_step=4,
+        max_concurrent=8,
+        max_steps=5,
+        max_seeds=3,
+        epochs=1,
+        kl_beta=0.0,
+        training_shape="ts-qwen3-4b-smoke-v1",
+        deployment_id="dep-123",
+    )
+
+    class FakeTrainerJobManager:
+        def __init__(self, *, api_key, base_url):
+            pass
+
+        def resolve_training_profile(self, shape_id):
+            return SimpleNamespace(
+                deployment_shape="shape/versions/7",
+                deployment_shape_version="shape/versions/7",
+                pipeline_parallelism=1,
+                max_supported_context_length=256,
+            )
+
+        def cancel(self, job_id):
+            events["deleted_jobs"].append(job_id)
+
+        def delete(self, job_id):
+            self.cancel(job_id)
+
+        def get(self, _job_id):
+            return None
+
+    class FakeDeploymentManager:
+        inference_url = "https://deployments.unit.test"
+
+        def __init__(self, *, api_key, base_url, hotload_api_url, inference_url=None):
+            pass
+
+        def delete(self, deployment_id):
+            events["deleted_deployments"].append(deployment_id)
+
+        def get(self, _deployment_id):
+            return None
+
+    class FakeClient:
+        def __init__(self, _mgr, job_id, *_args, **_kwargs):
+            self.job_id = job_id
+            self.inner = object()
+
+    class FakeWeightSyncer:
+        def __init__(self, **kwargs):
+            pass
+
+        def save_and_hotload(self, name, checkpoint_type="base"):
+            events["weight_sync_saves"].append((name, checkpoint_type))
+
+    class FakeTrainingCheckpoints:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def resume(self):
+            return SimpleNamespace(step=7, data_consumed=1)
+
+        def save(self, *args, **kwargs):
+            events.setdefault("checkpoint_saves", []).append((args, kwargs))
+
+    class FakeRolloutProcessor:
+        def __init__(self, **kwargs):
+            pass
+
+        def __call__(self, rows, rollout_config):
+            return []
+
+    async def fake_run_async_rl_loop(**kwargs):
+        row_requests = list(kwargs["rows"])
+        events["row_request_ids"] = [request.row_id for request in row_requests]
+        events["row_request_seeds"] = [
+            request.row_meta["seed"] for request in row_requests
+        ]
+        events["run_async_rl_loop_kwargs"] = {
+            key: value for key, value in kwargs.items() if key != "rows"
+        }
+        return kwargs["global_step"], {"resolved_rows": kwargs["resolved_rows_offset"]}
+
+    def fake_create_trainer_job(*args, **kwargs):
+        events["trainer_jobs"].append(kwargs)
+        return SimpleNamespace(job_id="policy-job")
+
+    monkeypatch.setattr(train_module, "parse_args", lambda: cfg)
+    monkeypatch.setattr(train_module, "setup_wandb", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        train_module,
+        "wandb_finish",
+        lambda: events.__setitem__("wandb_finished", 1),
+    )
+    monkeypatch.setattr(train_module, "wandb_log", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        train_module,
+        "load_seed_contexts",
+        lambda *args, **kwargs: [
+            {"seed": 101, "map_name": "4x4", "use_random_map": True},
+            {"seed": 202, "map_name": "4x4", "use_random_map": True},
+            {"seed": 303, "map_name": "4x4", "use_random_map": True},
+        ],
+    )
+    monkeypatch.setattr(train_module, "TrainerJobManager", FakeTrainerJobManager)
+    monkeypatch.setattr(train_module, "DeploymentManager", FakeDeploymentManager)
+    monkeypatch.setattr(
+        train_module,
+        "setup_deployment",
+        lambda *args, **kwargs: SimpleNamespace(
+            inference_model="accounts/test/models/deployed",
+        ),
+    )
+    monkeypatch.setattr(train_module, "create_trainer_job", fake_create_trainer_job)
+    monkeypatch.setattr(train_module, "ReconnectableClient", FakeClient)
+    monkeypatch.setattr(train_module, "WeightSyncer", FakeWeightSyncer)
+    monkeypatch.setattr(
+        train_module,
+        "FrozenLakeToolRolloutProcessor",
+        FakeRolloutProcessor,
+    )
+    monkeypatch.setattr(
+        train_module,
+        "build_loss_fn",
+        lambda args: ("loss-builder", args),
+    )
+    monkeypatch.setattr(train_module, "run_async_rl_loop", fake_run_async_rl_loop)
+    monkeypatch.setattr(
+        "training.utils.checkpoints.TrainingCheckpoints",
+        FakeTrainingCheckpoints,
+    )
+    monkeypatch.setattr(
+        httpx,
+        "post",
+        lambda *args, **kwargs: SimpleNamespace(status_code=200),
+    )
+
+    train_module.main()
+
+    assert events["row_request_ids"] == [1, 2]
+    assert events["row_request_seeds"] == [202, 303]
+    assert events["run_async_rl_loop_kwargs"]["global_step"] == 7
+    assert events["run_async_rl_loop_kwargs"]["resolved_rows_offset"] == 1
+    assert events["weight_sync_saves"] == [("resume-7-base", "base")]
+    assert events.get("checkpoint_saves", []) == []
+    assert events["deleted_jobs"] == ["policy-job"]
+    assert events["deleted_deployments"] == []
+    assert events["wandb_finished"] == 1
+
+
 def test_main_runs_sampling_and_training_with_reference(monkeypatch, tmp_path):
     monkeypatch.setenv("FIREWORKS_API_KEY", "test-key")
     monkeypatch.setenv("FIREWORKS_BASE_URL", "https://unit.test")

--- a/training/utils/rl/rollout/__init__.py
+++ b/training/utils/rl/rollout/__init__.py
@@ -33,6 +33,8 @@ This package layers the supporting types and helpers:
   assistant tokens with TITO-style incremental tokenization.
 * :mod:`.trace` — native rollout trajectory analysis for visualization and
   diagnostics without a live verifier probe.
+* :mod:`.eval_protocol` — adapter from ``@evaluation_test`` metadata to the
+  per-sample rollout function contract.
 """
 
 from training.utils.rl.rollout.assembler import (
@@ -41,6 +43,13 @@ from training.utils.rl.rollout.assembler import (
     TrajectoryAssembler,
     extract_completion,
     precompute_chat_suffix,
+)
+from training.utils.rl.rollout.eval_protocol import (
+    default_completion_params_factory,
+    default_eval_row_factory,
+    get_eval_protocol_params,
+    load_eval_protocol_input_rows,
+    make_eval_protocol_rollout_fn_factory,
 )
 from training.utils.rl.rollout.group_assembler import (
     GroupAssembler,
@@ -106,8 +115,13 @@ __all__ = [
     "analyze_flat_sample",
     "analyze_token_turn_traces",
     "analyze_turns",
+    "default_completion_params_factory",
+    "default_eval_row_factory",
     "extract_completion",
+    "get_eval_protocol_params",
     "get_tito_tokenizer",
+    "load_eval_protocol_input_rows",
+    "make_eval_protocol_rollout_fn_factory",
     "make_remote_rollout_fn",
     "model_input_to_token_ids",
     "pack_payload_to_sample",

--- a/training/utils/rl/rollout/eval_protocol.py
+++ b/training/utils/rl/rollout/eval_protocol.py
@@ -1,0 +1,230 @@
+"""Adapter from eval-protocol/eval3 evaluators to per-sample rollout fns.
+
+The async RL loop only depends on ``rollout_fn(row) -> RolloutSample | None``.
+This module lets managed RFT accept the user-facing eval3 shape instead:
+``@evaluation_test(..., rollout_processor=..., completion_params=..., steps=...)``.
+The adapter extracts the decorator metadata, invokes the rollout processor for
+exactly one row per call, optionally runs the pointwise evaluator body, and
+converts the resulting ``EvaluationRow`` into a token-native ``RolloutSample``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import logging
+from collections.abc import Awaitable, Callable, Sequence
+from typing import Any
+
+from eval_protocol.models import EPParameters, EvaluationRow
+from eval_protocol.pytest.types import RolloutProcessorConfig
+
+from training.utils.rl.rollout.types import RolloutSample
+
+RolloutFn = Callable[[Any], Awaitable[RolloutSample | None]]
+RolloutFnFactory = Callable[[Any], RolloutFn]
+EvalRowFactory = Callable[[Any], EvaluationRow]
+SampleConverter = Callable[[EvaluationRow], RolloutSample | None]
+CompletionParamsFactory = Callable[[Any, EPParameters], dict[str, Any]]
+ProcessorFactory = Callable[[Any, EPParameters], Any]
+
+logger = logging.getLogger(__name__)
+
+
+def get_eval_protocol_params(evaluator: Any) -> EPParameters:
+    """Return ``EPParameters`` attached by ``@evaluation_test``.
+
+    Tests and internal callers may pass an ``EPParameters`` object directly,
+    but the normal path is a decorated evaluator function with ``__ep_params__``.
+    """
+    if isinstance(evaluator, EPParameters):
+        return evaluator
+    params = getattr(evaluator, "__ep_params__", None)
+    if isinstance(params, EPParameters):
+        return params
+    raise TypeError(
+        "Expected an eval-protocol @evaluation_test function or EPParameters "
+        f"object, got {type(evaluator).__name__}."
+    )
+
+
+def load_eval_protocol_input_rows(evaluator: Any) -> list[EvaluationRow]:
+    """Load static input rows from a decorated eval-protocol evaluator.
+
+    This intentionally supports the RFT-compatible subset used for async RL:
+    preconstructed ``input_rows``. Dataset paths and data loaders are still
+    valid eval3 features, but managed RFT should materialize them before it
+    constructs row requests so resume cursors and sharding are explicit.
+    """
+    params = get_eval_protocol_params(evaluator)
+    input_rows = params.input_rows or []
+    rows: list[EvaluationRow] = []
+    for dataset_rows in input_rows:
+        for row in dataset_rows or []:
+            rows.append(_copy_row(row))
+    if params.filtered_row_ids is not None:
+        allowed = set(params.filtered_row_ids)
+        rows = [row for row in rows if row.input_metadata.row_id in allowed]
+    if params.max_dataset_rows is not None:
+        rows = rows[: params.max_dataset_rows]
+    if params.preprocess_fn is not None:
+        rows = params.preprocess_fn(rows)
+    return rows
+
+
+def make_eval_protocol_rollout_fn_factory(
+    evaluator: Any,
+    *,
+    row_factory: EvalRowFactory | None = None,
+    sample_converter: SampleConverter,
+    completion_params_factory: CompletionParamsFactory | None = None,
+    processor_factory: ProcessorFactory | None = None,
+    apply_evaluator: bool = True,
+    setup_processor: bool = True,
+    swallow_exceptions: bool = True,
+) -> RolloutFnFactory:
+    """Build a per-sample rollout factory from an eval3 evaluator.
+
+    ``evaluator`` is expected to be a function decorated with
+    ``@evaluation_test``. The decorator remains the user-facing place to
+    consolidate rollout processor and config. The returned factory is the
+    internal async-RL boundary.
+    """
+    params = get_eval_protocol_params(evaluator)
+    if params.mode != "pointwise":
+        raise ValueError(
+            "eval-protocol rollout adapter currently supports only "
+            f"pointwise evaluators, got mode={params.mode!r}."
+        )
+
+    eval_fn = _origin_eval_fn(evaluator) if apply_evaluator else None
+    build_row = row_factory or default_eval_row_factory
+    build_completion_params = completion_params_factory or default_completion_params_factory
+
+    def factory(setup: Any) -> RolloutFn:
+        processor = (
+            processor_factory(setup, params)
+            if processor_factory is not None
+            else params.rollout_processor
+        )
+        if processor is None:
+            raise ValueError(
+                "eval-protocol evaluator has no rollout_processor. "
+                "Pass rollout_processor=... to @evaluation_test or provide "
+                "processor_factory=...."
+            )
+        if setup_processor and hasattr(processor, "setup"):
+            processor.setup()
+
+        async def rollout_fn(row: Any) -> RolloutSample | None:
+            try:
+                eval_row = build_row(row)
+                config = RolloutProcessorConfig(
+                    completion_params=build_completion_params(setup, params),
+                    mcp_config_path=params.mcp_config_path or "",
+                    server_script_path=params.server_script_path,
+                    steps=int(params.steps),
+                    logger=params.logger,
+                    semaphore=asyncio.Semaphore(1),
+                    kwargs=dict(params.rollout_processor_kwargs or {}),
+                    exception_handler_config=params.exception_handler_config,
+                )
+                result = await _run_single_row_rollout(processor, eval_row, config)
+                if eval_fn is not None:
+                    evaluated = await _maybe_await(eval_fn(result))
+                    if evaluated is not None:
+                        result = evaluated
+                    if not isinstance(result, EvaluationRow):
+                        raise TypeError(
+                            "eval-protocol evaluator must return EvaluationRow "
+                            f"or None, got {type(result).__name__}."
+                        )
+                return sample_converter(result)
+            except Exception:
+                if not swallow_exceptions:
+                    raise
+                logger.exception("eval-protocol rollout_fn failed; dropping sample")
+                return None
+
+        return rollout_fn
+
+    return factory
+
+
+def default_eval_row_factory(row: Any) -> EvaluationRow:
+    """Default row adapter for callers that already traffic in EvaluationRows."""
+    if isinstance(row, EvaluationRow):
+        return _copy_row(row)
+    if isinstance(row, dict) and isinstance(row.get("evaluation_row"), EvaluationRow):
+        return _copy_row(row["evaluation_row"])
+    raise TypeError(
+        "Default eval-protocol row factory expects an EvaluationRow or a dict "
+        "with an 'evaluation_row' EvaluationRow. Provide row_factory=... for "
+        f"{type(row).__name__} inputs."
+    )
+
+
+def default_completion_params_factory(setup: Any, params: EPParameters) -> dict[str, Any]:
+    """Merge evaluator completion params with runtime setup sampling defaults."""
+    completion_params = _first_completion_params(params.completion_params)
+    setup_sample_kwargs = getattr(setup, "sample_kwargs", None) if setup is not None else None
+    if isinstance(setup_sample_kwargs, dict):
+        completion_params.update(setup_sample_kwargs)
+    setup_model = getattr(setup, "model", None) if setup is not None else None
+    if setup_model:
+        completion_params["model"] = setup_model
+    return completion_params
+
+
+async def _run_single_row_rollout(
+    processor: Any,
+    row: EvaluationRow,
+    config: RolloutProcessorConfig,
+) -> EvaluationRow:
+    tasks = processor([row], config)
+    if not isinstance(tasks, Sequence) or len(tasks) != 1:
+        raise ValueError(
+            "eval-protocol rollout adapter expects processor([row], config) "
+            f"to return exactly one task/result, got {type(tasks).__name__} "
+            f"with length {len(tasks) if isinstance(tasks, Sequence) else 'unknown'}."
+        )
+    result = await _maybe_await(tasks[0])
+    if not isinstance(result, EvaluationRow):
+        raise TypeError(
+            "eval-protocol rollout processor must return EvaluationRow, "
+            f"got {type(result).__name__}."
+        )
+    return result
+
+
+def _first_completion_params(value: Any) -> dict[str, Any]:
+    if value is None:
+        return {}
+    if isinstance(value, dict):
+        return dict(value)
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        if not value:
+            return {}
+        first = value[0]
+        return dict(first or {})
+    return {}
+
+
+def _copy_row(row: EvaluationRow) -> EvaluationRow:
+    if hasattr(row, "model_copy"):
+        return row.model_copy(deep=True)
+    return row.copy(deep=True)
+
+
+def _origin_eval_fn(evaluator: Any) -> Callable[[EvaluationRow], Any]:
+    return (
+        getattr(evaluator, "_origin_func", None)
+        or getattr(evaluator, "__wrapped__", None)
+        or evaluator
+    )
+
+
+async def _maybe_await(value: Any) -> Any:
+    if inspect.isawaitable(value):
+        return await value
+    return value


### PR DESCRIPTION
## Summary

Adapt eval-protocol's `@evaluation_test` evaluators to the per-sample async RL rollout contract, and migrate the FrozenLake recipe to drive training through `run_async_rl_loop` via that adapter.

- `training/utils/rl/rollout/eval_protocol.py`: new adapter that extracts `EPParameters`, runs the configured `rollout_processor` for exactly one row per call with `asyncio.Semaphore(1)`, optionally applies the pointwise evaluator body, and converts the resulting `EvaluationRow` into a token-native `RolloutSample`.
- `training/examples/rl/frozen_lake/train_frozen_lake.py`: defines FrozenLake as an eval3 `@evaluation_test`, materializes per-sample `EvaluationRow`s, plugs them into `run_async_rl_loop`, and converts token traces into `RolloutSample`s.
- Resume handling now skips `resume_info.data_consumed` eval3 input rows before building async row requests, while keeping the async loop's resolved-row offset aligned.
- Tests cover the eval-protocol adapter, the FrozenLake async/token-native rollout path, and the resume skip regression.

## Code Overview

```mermaid
flowchart TD
    A["@evaluation_test evaluator"] --> B[get_eval_protocol_params -> EPParameters]
    B --> C[make_eval_protocol_rollout_fn_factory]
    C --> D["per-sample rollout_fn(row)"]
    D --> E["row_factory -> EvaluationRow"]
    E --> F["rollout_processor([row], RolloutProcessorConfig(semaphore=1))"]
    F --> G[optional pointwise evaluator body]
    G --> H["sample_converter -> RolloutSample"]
    H --> I[run_async_rl_loop]
    I --> J[GroupAssembler -> PromptGroup -> trainer step]
```

## Test Plan

- [x] `python -m pytest training/tests/unit/test_train_frozen_lake.py training/tests/unit/test_eval_protocol_rollout_adapter.py`
- [x] `python -m compileall -q training/examples/rl/frozen_lake/train_frozen_lake.py training/tests/unit/test_train_frozen_lake.py`

## Notes

- Adapter is currently restricted to `mode="pointwise"` evaluators; non-pointwise modes raise `ValueError`.
- Dataset paths / loaders are intentionally unsupported on the adapter input-rows path. Managed RFT should materialize rows before issuing row requests so resume cursors and sharding stay explicit.
- `swallow_exceptions=True` by default so a single failed sample is logged and dropped rather than killing the loop; flip it off in tests/debug to surface tracebacks.