### PR TITLE
feat(deepseek_v4): add DeepseekV4Renderer with parity oracle and weight tests

### DIFF
--- a/training/renderer/__init__.py
+++ b/training/renderer/__init__.py
@@ -10,6 +10,7 @@ Importing this package eagerly imports every contained renderer module so
 the registrations take effect.
 """
 
+from training.renderer import deepseek_v4 as _deepseek_v4  # noqa: F401  (registers "deepseek_v4")
 from training.renderer import gemma4 as _gemma4  # noqa: F401  (registers "gemma4")
 from training.renderer import glm5 as _glm5  # noqa: F401  (registers "glm5")
 from training.renderer import minimax_m2 as _minimax_m2  # noqa: F401  (registers "minimax_m2")

--- a/training/renderer/deepseek_v4.py
+++ b/training/renderer/deepseek_v4.py
@@ -1,0 +1,704 @@
+"""Renderer for DeepSeek-V4-Flash chat templates.
+
+This is a port of the upstream Python encoder shipped at
+``deepseek-ai/DeepSeek-V4-Flash/encoding/encoding_dsv4.py`` (license: MIT)
+into the ``tinker_cookbook`` renderer abstraction.
+
+DeepSeek-V4 uses a hand-rolled DSML-flavored format rather than a Jinja
+chat template:
+
+- ``<｜begin▁of▁sentence｜>`` once at the very start of the conversation.
+- System messages emit their content with no role tag.
+- User messages emit ``<｜User｜>{content}`` (or, after merging, a
+  ``\\n\\n``-joined sequence of text blocks and
+  ``<tool_result>...</tool_result>`` blocks for prior tool responses).
+- Assistant messages emit ``{thinking_block}{content}{tool_calls}<EOS>``.
+  Thinking is a literal ``<think>{reasoning}</think>`` and is always
+  preceded by a ``<｜Assistant｜>`` role tag emitted by the *boundary*
+  between the previous user-or-developer message and this assistant turn.
+
+The boundary suffix has three forms:
+
+* ``<｜Assistant｜><think>``  — thinking-mode terminal turn, OR thinking
+  mode without history-stripping.
+* ``<｜Assistant｜></think>`` — thinking-mode historical turn under
+  ``strip_thinking_from_history=True`` (matches the encoder's
+  ``drop_thinking=True`` default), OR any chat-mode turn.
+
+The encoder also auto-disables history thinking-stripping whenever any
+message in the conversation carries a ``tools`` field. We mirror that
+behaviour so renderer output matches the encoder byte-for-byte.
+
+Tool calls serialize as a DSML block::
+
+    \\n\\n<｜DSML｜tool_calls>
+    <｜DSML｜invoke name="{name}">
+    <｜DSML｜parameter name="{k}" string="true|false">{v}</｜DSML｜parameter>
+    ...
+    </｜DSML｜invoke>
+    ...
+    </｜DSML｜tool_calls>
+
+with ``string="true"`` for raw string parameters (emitted verbatim) and
+``string="false"`` for everything else (JSON-encoded with
+``ensure_ascii=False``).
+
+Tool messages are merged into the *preceding* user message as
+``<tool_result>...</tool_result>`` blocks and reordered to match the
+order of the preceding assistant's ``tool_calls`` (matching the encoder's
+``merge_tool_messages`` + ``sort_tool_results_by_call_order`` pipeline).
+
+Out of scope for this renderer (call sites that use these features should
+keep using the upstream encoder directly):
+
+- ``developer`` role
+- ``latest_reminder`` role
+- Internal task tokens (``action`` / ``query`` / ``authority`` / ``domain``
+  / ``title`` / ``read_url``)
+- ``wo_eos`` flag
+- ``reasoning_effort`` preamble
+- ``context`` (encoded prefix) parameter
+
+Verified against ``encoding_dsv4.encode_messages`` byte-for-byte by the
+unit tests in ``test_deepseek_v4_renderer.py``.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import re
+from collections.abc import Mapping
+from typing import Any, Literal
+
+import tinker
+import torch
+from tinker_cookbook.renderers import register_renderer
+from tinker_cookbook.renderers.base import (
+    Message,
+    RenderContext,
+    RenderedMessage,
+    Renderer,
+    Role,
+    ToolCall,
+    TrainOnWhat,
+    UnparsedToolCall,
+)
+from tinker_cookbook.tokenizer_utils import Tokenizer
+
+# ── Special tokens (must match encoding_dsv4.py exactly) ────────────────────
+# NOTE: ``｜`` is U+FF5C FULLWIDTH VERTICAL LINE (not ASCII ``|``).
+#       ``▁`` is U+2581 LOWER ONE EIGHTH BLOCK (not ASCII ``_``).
+_BOS_TEXT = "<｜begin▁of▁sentence｜>"
+_EOS_TEXT = "<｜end▁of▁sentence｜>"
+_USER_SP = "<｜User｜>"
+_ASSISTANT_SP = "<｜Assistant｜>"
+_THINK_OPEN = "<think>"
+_THINK_CLOSE = "</think>"
+_DSML = "｜DSML｜"
+
+_TOOL_CALLS_OPEN = f"<{_DSML}tool_calls>"
+_TOOL_CALLS_CLOSE = f"</{_DSML}tool_calls>"
+_TOOL_CALLS_BOUNDARY = f"\n\n<{_DSML}tool_calls"
+
+# ── Tools / response_format prompt sections ─────────────────────────────────
+
+_TOOLS_TEMPLATE = """## Tools
+
+You have access to a set of tools to help answer the user's question. You can invoke tools by writing a "<{dsml}tool_calls>" block like the following:
+
+<{dsml}tool_calls>
+<{dsml}invoke name="$TOOL_NAME">
+<{dsml}parameter name="$PARAMETER_NAME" string="true|false">$PARAMETER_VALUE</{dsml}parameter>
+...
+</{dsml}invoke>
+<{dsml}invoke name="$TOOL_NAME2">
+...
+</{dsml}invoke>
+</{dsml}tool_calls>
+
+String parameters should be specified as is and set `string="true"`. For all other types (numbers, booleans, arrays, objects), pass the value in JSON format and set `string="false"`.
+
+If thinking_mode is enabled (triggered by {think_open}), you MUST output your complete reasoning inside {think_open}...{think_close} BEFORE any tool calls or final response.
+
+Otherwise, output directly after {think_close} with tool calls or final response.
+
+### Available Tool Schemas
+
+{tool_schemas}
+
+You MUST strictly follow the above defined tool name and parameter schemas to invoke tool calls.
+"""
+
+_RESPONSE_FORMAT_TEMPLATE = (
+    "## Response Format:\n\n"
+    "You MUST strictly adhere to the following schema to reply:\n{schema}"
+)
+
+# ── Parsing regexes (mirror encoding_dsv4.parse_tool_calls) ─────────────────
+
+_TOOL_CALLS_BLOCK_RE = re.compile(
+    rf"\n\n<{re.escape(_DSML)}tool_calls>\n(.*?)\n</{re.escape(_DSML)}tool_calls>",
+    re.DOTALL,
+)
+_INVOKE_RE = re.compile(
+    rf'<{re.escape(_DSML)}invoke name="([^"]+)">\n(.*?)\n</{re.escape(_DSML)}invoke>',
+    re.DOTALL,
+)
+_PARAMETER_RE = re.compile(
+    rf'<{re.escape(_DSML)}parameter name="([^"]+)" string="(true|false)">'
+    rf"(.*?)"
+    rf"</{re.escape(_DSML)}parameter>",
+    re.DOTALL,
+)
+
+
+# ── Helpers ─────────────────────────────────────────────────────────────────
+
+
+def _to_json(value: Any) -> str:
+    """Match ``encoding_dsv4.to_json`` (ensure_ascii=False, ASCII fallback)."""
+    try:
+        return json.dumps(value, ensure_ascii=False)
+    except Exception:  # noqa: BLE001
+        return json.dumps(value, ensure_ascii=True)
+
+
+def _visible_text(content: Any) -> str:
+    """Flatten string-or-structured content to a plain string."""
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        out: list[str] = []
+        for item in content:
+            if isinstance(item, str):
+                out.append(item)
+            elif (
+                isinstance(item, Mapping)
+                and item.get("type") == "text"
+                and isinstance(item.get("text"), str)
+            ):
+                out.append(item["text"])
+        return "".join(out)
+    return str(content)
+
+
+def _extract_reasoning_and_text(content: Any) -> tuple[str, str]:
+    """Split assistant ``content`` into ``(reasoning, visible_text)``."""
+    if isinstance(content, str):
+        if "</think>" not in content:
+            return "", content
+        head, _, tail = content.partition("</think>")
+        reasoning = head.split("<think>", 1)[-1].strip("\n")
+        visible = tail.lstrip("\n")
+        return reasoning, visible
+    if isinstance(content, list):
+        reasoning_parts: list[str] = []
+        text_parts: list[str] = []
+        for part in content:
+            if not isinstance(part, Mapping):
+                continue
+            if part.get("type") == "thinking" and isinstance(part.get("thinking"), str):
+                reasoning_parts.append(part["thinking"])
+            elif part.get("type") == "text" and isinstance(part.get("text"), str):
+                text_parts.append(part["text"])
+        return "".join(reasoning_parts), "".join(text_parts)
+    return "", str(content)
+
+
+def _normalize_tool_arguments(raw: str) -> dict[str, Any]:
+    """Tinker stores tool args as a JSON string; decode it once for rendering.
+
+    Mirrors the encoder's defensive fallback: if ``raw`` doesn't parse as
+    a JSON object, wrap it as ``{"arguments": raw}`` so we never crash on
+    malformed model output.
+    """
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return {"arguments": raw}
+    if not isinstance(parsed, Mapping):
+        return {"arguments": raw}
+    return dict(parsed)
+
+
+def _format_tool_calls(tool_calls: list[ToolCall]) -> str:
+    """Render a list of tool calls as a single DSML ``<…tool_calls>`` block."""
+    invokes: list[str] = []
+    for tc in tool_calls:
+        args = _normalize_tool_arguments(tc.function.arguments)
+        param_lines = [
+            f'<{_DSML}parameter name="{k}" string="'
+            f'{"true" if isinstance(v, str) else "false"}">'
+            f"{v if isinstance(v, str) else _to_json(v)}"
+            f"</{_DSML}parameter>"
+            for k, v in args.items()
+        ]
+        invokes.append(
+            f'<{_DSML}invoke name="{tc.function.name}">\n'
+            + "\n".join(param_lines)
+            + f"\n</{_DSML}invoke>"
+        )
+    body = "\n".join(invokes)
+    return f"\n\n{_TOOL_CALLS_OPEN}\n{body}\n{_TOOL_CALLS_CLOSE}"
+
+
+def _render_tools_section(tools: list[Mapping[str, Any]]) -> str:
+    """Render OpenAI-format tool schemas into the ``## Tools`` block.
+
+    Mirrors ``encoding_dsv4.render_tools`` exactly: each ``tool`` is
+    expected to be ``{"type": "function", "function": {...}}``; we extract
+    the inner function dict, JSON-dump one per line, and substitute into
+    ``TOOLS_TEMPLATE``.
+    """
+    function_dicts = [tool["function"] for tool in tools]
+    return _TOOLS_TEMPLATE.format(
+        dsml=_DSML,
+        think_open=_THINK_OPEN,
+        think_close=_THINK_CLOSE,
+        tool_schemas="\n".join(_to_json(t) for t in function_dicts),
+    )
+
+
+def _has_any_tools(messages: list[Message]) -> bool:
+    return any(m.get("tools") for m in messages)
+
+
+# ── Preprocessing (mirror encoder's merge + sort + drop pipeline) ───────────
+
+
+def _merge_tool_messages(messages: list[Message]) -> list[Message]:
+    """Fold ``role=tool`` messages into the previous user's ``content_blocks``.
+
+    Mirrors ``encoding_dsv4.merge_tool_messages``. User messages always get
+    a ``content_blocks`` field added (even when there's no tool to merge
+    in) so subsequent passes can rely on the field's presence.
+    """
+    merged: list[Message] = []
+    for msg in messages:
+        msg = copy.deepcopy(dict(msg))
+        role = msg.get("role")
+
+        if role == "tool":
+            tool_block = {
+                "type": "tool_result",
+                "tool_use_id": msg.get("tool_call_id", ""),
+                "content": msg.get("content", ""),
+            }
+            if (
+                merged
+                and merged[-1].get("role") == "user"
+                and "content_blocks" in merged[-1]
+            ):
+                merged[-1]["content_blocks"].append(tool_block)
+            else:
+                merged.append({"role": "user", "content_blocks": [tool_block]})
+            continue
+
+        if role == "user":
+            text_block = {"type": "text", "text": msg.get("content", "")}
+            if (
+                merged
+                and merged[-1].get("role") == "user"
+                and "content_blocks" in merged[-1]
+                and merged[-1].get("task") is None
+            ):
+                merged[-1]["content_blocks"].append(text_block)
+            else:
+                new_msg: dict[str, Any] = {
+                    "role": "user",
+                    "content": msg.get("content", ""),
+                    "content_blocks": [text_block],
+                }
+                for key in ("task", "wo_eos", "mask"):
+                    if key in msg:
+                        new_msg[key] = msg[key]
+                merged.append(new_msg)
+            continue
+
+        merged.append(msg)
+    return merged
+
+
+def _sort_tool_results_by_call_order(messages: list[Message]) -> list[Message]:
+    """Reorder ``tool_result`` blocks to match the preceding tool-call order.
+
+    Mirrors ``encoding_dsv4.sort_tool_results_by_call_order``. Mutates
+    ``messages`` in place (consistent with the encoder); callers should
+    ``deepcopy`` first if they need the originals untouched.
+    """
+    last_order: dict[str, int] = {}
+    for msg in messages:
+        role = msg.get("role")
+        if role == "assistant" and msg.get("tool_calls"):
+            last_order = {}
+            for idx, tc in enumerate(msg["tool_calls"]):
+                # Tinker ToolCall objects expose ``.id``; OpenAI dict shape
+                # nests it under ``id``/``function.id``.
+                tc_id = ""
+                if isinstance(tc, Mapping):
+                    tc_id = tc.get("id") or tc.get("function", {}).get("id", "")
+                else:
+                    tc_id = getattr(tc, "id", "") or ""
+                if tc_id:
+                    last_order[tc_id] = idx
+            continue
+
+        if role == "user" and msg.get("content_blocks"):
+            tool_blocks = [
+                b for b in msg["content_blocks"] if b.get("type") == "tool_result"
+            ]
+            if len(tool_blocks) > 1 and last_order:
+                sorted_blocks = sorted(
+                    tool_blocks,
+                    key=lambda b: last_order.get(b.get("tool_use_id", ""), 0),
+                )
+                cursor = 0
+                new_blocks: list[Any] = []
+                for block in msg["content_blocks"]:
+                    if block.get("type") == "tool_result":
+                        new_blocks.append(sorted_blocks[cursor])
+                        cursor += 1
+                    else:
+                        new_blocks.append(block)
+                msg["content_blocks"] = new_blocks
+    return messages
+
+
+def _drop_thinking_from_history(messages: list[Message]) -> list[Message]:
+    """Strip ``reasoning_content`` and structured ``thinking`` parts from
+    historical assistant turns (mirrors ``_drop_thinking_messages``).
+
+    A "historical" assistant is one whose index is strictly less than the
+    last user index. Assistant turns at or after the last user index keep
+    their reasoning intact.
+    """
+    last_user_idx = -1
+    for idx in range(len(messages) - 1, -1, -1):
+        if messages[idx].get("role") in ("user", "developer"):
+            last_user_idx = idx
+            break
+
+    result: list[Message] = []
+    for idx, msg in enumerate(messages):
+        if msg.get("role") == "assistant" and idx < last_user_idx:
+            stripped = copy.copy(dict(msg))
+            stripped.pop("reasoning_content", None)
+            content = stripped.get("content")
+            if isinstance(content, list):
+                stripped["content"] = [
+                    p
+                    for p in content
+                    if not (isinstance(p, Mapping) and p.get("type") == "thinking")
+                ]
+            elif isinstance(content, str) and "</think>" in content:
+                stripped["content"] = content.split("</think>", 1)[-1].lstrip("\n")
+            result.append(stripped)
+        else:
+            result.append(msg)
+    return result
+
+
+# ── Renderer ────────────────────────────────────────────────────────────────
+
+
+ThinkingMode = Literal["chat", "thinking"]
+
+
+class DeepseekV4Renderer(Renderer):
+    """Renderer for ``deepseek-ai/DeepSeek-V4-Flash`` instruct models."""
+
+    def __init__(
+        self,
+        tokenizer: Tokenizer,
+        *,
+        thinking_mode: ThinkingMode = "thinking",
+        strip_thinking_from_history: bool = True,
+    ) -> None:
+        super().__init__(tokenizer)
+        if thinking_mode not in ("chat", "thinking"):
+            raise ValueError(f"Invalid thinking_mode: {thinking_mode!r}")
+        self.thinking_mode: ThinkingMode = thinking_mode
+        self.strip_thinking_from_history = strip_thinking_from_history
+        # Set per-call by ``_preprocess`` so ``render_message`` can pick the
+        # right assistant header without re-checking the message list.
+        self._effective_strip = strip_thinking_from_history
+
+    # ---- public Renderer API --------------------------------------------------
+
+    @property
+    def has_extension_property(self) -> bool:
+        """True when historical and terminal assistant turns render identically.
+
+        Chat mode never emits a thinking block, so it always satisfies the
+        extension property. Thinking mode only satisfies it when we keep
+        history reasoning intact.
+        """
+        return self.thinking_mode == "chat" or not self.strip_thinking_from_history
+
+    def get_stop_sequences(self) -> list[int]:
+        return [self._eos_token]
+
+    def build_generation_prompt(
+        self,
+        messages: list[Message],
+        role: Role = "assistant",
+        prefill: str | None = None,
+    ) -> tinker.ModelInput:
+        return super().build_generation_prompt(
+            self._preprocess(messages),
+            role=role,
+            prefill=prefill,
+        )
+
+    def build_supervised_example(
+        self,
+        messages: list[Message],
+        train_on_what: TrainOnWhat = TrainOnWhat.LAST_ASSISTANT_MESSAGE,
+    ) -> tuple[tinker.ModelInput, torch.Tensor]:
+        return super().build_supervised_example(
+            self._preprocess(messages),
+            train_on_what=train_on_what,
+        )
+
+    def render_message(self, message: Message, ctx: RenderContext) -> RenderedMessage:
+        role = message["role"]
+        if role == "system":
+            return self._render_system(message)
+        if role == "user":
+            return self._render_user(message)
+        if role == "assistant":
+            return self._render_assistant(message, ctx)
+        raise ValueError(
+            f"DeepseekV4Renderer: unsupported role {role!r}. "
+            f"`developer`, `latest_reminder`, `tool` (un-merged), and task roles "
+            f"are intentionally out of scope; preprocess them upstream."
+        )
+
+    def parse_response(self, response: list[int]) -> tuple[Message, bool]:
+        """Decode ``response`` and split into reasoning / content / tool_calls.
+
+        Mirrors ``encoding_dsv4.parse_message_from_completion_text`` enough
+        to roundtrip the rendered output, but stays forgiving for partial
+        completions: returns ``ok=False`` when the EOS hasn't shown up yet.
+        """
+        text = self.tokenizer.decode(response)
+        eos_idx = text.find(_EOS_TEXT)
+        ok = eos_idx >= 0
+        if ok:
+            text = text[:eos_idx]
+
+        reasoning = ""
+        if self.thinking_mode == "thinking" and _THINK_CLOSE in text:
+            head, _, text = text.partition(_THINK_CLOSE)
+            reasoning = head.removeprefix(_THINK_OPEN).strip("\n")
+
+        tool_calls: list[ToolCall] = []
+        unparsed: list[UnparsedToolCall] = []
+        block_match = _TOOL_CALLS_BLOCK_RE.search(text)
+        if block_match:
+            content = text[: block_match.start()]
+            for invoke in _INVOKE_RE.finditer(block_match.group(1)):
+                name = invoke.group(1)
+                args: dict[str, Any] = {}
+                for param in _PARAMETER_RE.finditer(invoke.group(2)):
+                    key, is_str, value = param.group(1), param.group(2), param.group(3)
+                    args[key] = value if is_str == "true" else _parse_value(value)
+                tool_calls.append(
+                    ToolCall(
+                        function=ToolCall.FunctionBody(
+                            name=name,
+                            arguments=_to_json(args),
+                        )
+                    )
+                )
+            trailing = text[block_match.end() :]
+            if trailing.strip():
+                unparsed.append(
+                    UnparsedToolCall(
+                        raw_text=trailing,
+                        error="Unexpected content after tool_calls block",
+                    )
+                )
+        else:
+            content = text
+
+        message = Message(role="assistant", content=content)
+        if reasoning:
+            message["reasoning_content"] = reasoning
+        if tool_calls:
+            message["tool_calls"] = tool_calls
+        if unparsed:
+            message["unparsed_tool_calls"] = unparsed
+        return message, ok
+
+    # ---- internal helpers -----------------------------------------------------
+
+    def _preprocess(self, messages: list[Message]) -> list[Message]:
+        merged = _merge_tool_messages(messages)
+        merged = _sort_tool_results_by_call_order(merged)
+        # Encoder rule: any message with `tools` defined disables drop_thinking.
+        self._effective_strip = self.strip_thinking_from_history and not _has_any_tools(
+            merged
+        )
+        if self.thinking_mode == "thinking" and self._effective_strip:
+            merged = _drop_thinking_from_history(merged)
+        return merged
+
+    @property
+    def _bos_tokens(self) -> list[int]:
+        return self.tokenizer.encode(_BOS_TEXT, add_special_tokens=False)
+
+    def _encode_single_special(self, token_str: str) -> int:
+        token_ids = self.tokenizer.encode(token_str, add_special_tokens=False)
+        if len(token_ids) != 1:
+            raise RuntimeError(
+                f"DeepseekV4Renderer expected {token_str!r} to encode as one "
+                f"token, got {token_ids}."
+            )
+        return int(token_ids[0])
+
+    @property
+    def _eos_token(self) -> int:
+        return self._encode_single_special(_EOS_TEXT)
+
+    def _encode(self, text: str) -> list[int]:
+        return self.tokenizer.encode(text, add_special_tokens=False)
+
+    # ---- render_message branches ---------------------------------------------
+
+    def _render_system(self, message: Message) -> RenderedMessage:
+        # System has no role tag — content goes directly into the prompt.
+        body = _visible_text(message.get("content"))
+        tools = message.get("tools")
+        response_format = message.get("response_format")
+        if tools:
+            body += "\n\n" + _render_tools_section(list(tools))
+        if response_format:
+            body += "\n\n" + _RESPONSE_FORMAT_TEMPLATE.format(
+                schema=_to_json(response_format)
+            )
+        header = tinker.types.EncodedTextChunk(tokens=[])
+        output = [tinker.types.EncodedTextChunk(tokens=self._encode(body))]
+        return RenderedMessage(header=header, output=output)
+
+    def _render_user(self, message: Message) -> RenderedMessage:
+        # Header is the role tag; output is the content blocks (or raw content).
+        header = tinker.types.EncodedTextChunk(tokens=self._encode(_USER_SP))
+        body = self._render_user_body(message)
+        output = [tinker.types.EncodedTextChunk(tokens=self._encode(body))]
+        return RenderedMessage(header=header, output=output)
+
+    def _render_user_body(self, message: Message) -> str:
+        content_blocks = message.get("content_blocks")
+        if not content_blocks:
+            return _visible_text(message.get("content"))
+
+        parts: list[str] = []
+        for block in content_blocks:
+            block_type = block.get("type")
+            if block_type == "text":
+                parts.append(block.get("text", "") or "")
+            elif block_type == "tool_result":
+                tool_content = block.get("content", "")
+                if isinstance(tool_content, list):
+                    inner: list[str] = []
+                    for sub in tool_content:
+                        if isinstance(sub, Mapping) and sub.get("type") == "text":
+                            inner.append(sub.get("text", "") or "")
+                        else:
+                            kind = (
+                                sub.get("type")
+                                if isinstance(sub, Mapping)
+                                else type(sub).__name__
+                            )
+                            inner.append(f"[Unsupported {kind}]")
+                    tool_content = "\n\n".join(inner)
+                parts.append(f"<tool_result>{tool_content}</tool_result>")
+            else:
+                parts.append(f"[Unsupported {block_type}]")
+        return "\n\n".join(parts)
+
+    def _assistant_header_str(self, ctx: RenderContext) -> str:
+        # Boundary suffix from the *previous* user/developer message, attributed
+        # here as the assistant's own header so masking lines up.
+        is_terminal = ctx.last_user_index < 0 or ctx.idx > ctx.last_user_index
+        thinking_branch = self.thinking_mode == "thinking" and (
+            not self._effective_strip or is_terminal
+        )
+        return _ASSISTANT_SP + (_THINK_OPEN if thinking_branch else _THINK_CLOSE)
+
+    def _render_assistant(
+        self,
+        message: Message,
+        ctx: RenderContext,
+    ) -> RenderedMessage:
+        header_str = self._assistant_header_str(ctx)
+        emit_thinking_body = header_str.endswith(_THINK_OPEN)
+
+        # The encoder reads ``reasoning_content`` directly from the message;
+        # we mirror that, but also accept the cookbook conventions of
+        # ``<think>...</think>`` embedded in ``content`` and structured
+        # ``[{"type": "thinking", ...}]`` blocks for backwards compat.
+        explicit_reasoning = message.get("reasoning_content")
+        if explicit_reasoning is not None:
+            reasoning = explicit_reasoning
+            visible = _visible_text(message.get("content"))
+        else:
+            reasoning, visible = _extract_reasoning_and_text(message.get("content"))
+        body = ""
+        if emit_thinking_body:
+            # Header already injects ``<think>``; output starts with the
+            # reasoning text + the closing ``</think>`` so the model trains
+            # to produce that closing tag itself.
+            body += reasoning + _THINK_CLOSE
+        body += visible
+
+        tool_calls = message.get("tool_calls") or []
+        if tool_calls:
+            body += _format_tool_calls(list(tool_calls))
+
+        body += _EOS_TEXT
+
+        header = tinker.types.EncodedTextChunk(tokens=self._encode(header_str))
+        output = [tinker.types.EncodedTextChunk(tokens=self._encode(body))]
+        return RenderedMessage(header=header, output=output)
+
+    def _get_generation_suffix(self, role: Role, ctx: RenderContext) -> list[int]:
+        del ctx
+        if role == "assistant":
+            # A generation prompt always targets the *terminal* assistant slot,
+            # so the boundary always uses the thinking-start branch in
+            # thinking mode and the thinking-end branch in chat mode.
+            suffix = _ASSISTANT_SP + (
+                _THINK_OPEN if self.thinking_mode == "thinking" else _THINK_CLOSE
+            )
+            return self._encode(suffix)
+        if role == "user":
+            return self._encode(_USER_SP)
+        # System has no role tag in DSv4; emit nothing.
+        if role == "system":
+            return []
+        raise ValueError(f"DeepseekV4Renderer: cannot generate role {role!r}")
+
+
+def _parse_value(raw: str) -> Any:
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return raw
+
+
+def _deepseek_v4_factory(
+    tokenizer: Tokenizer,
+    image_processor: Any = None,
+) -> DeepseekV4Renderer:
+    del image_processor
+    return DeepseekV4Renderer(tokenizer)
+
+
+register_renderer("deepseek_v4", _deepseek_v4_factory)

--- a/training/tests/_encoding_dsv4_oracle.py
+++ b/training/tests/_encoding_dsv4_oracle.py
@@ -1,0 +1,762 @@
+# ruff: noqa
+# fmt: off
+# pylint: skip-file
+#
+# VENDORED — DO NOT EDIT
+#
+# Verbatim copy of:
+#   https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash/raw/main/encoding/encoding_dsv4.py
+#   commit a7aaed8 ("Release DeepSeek-V4")
+#   License: MIT (see model repo LICENSE)
+#
+# This file is the **source of truth** for DeepseekV4Renderer parity tests.
+# Any edits here will mask drift between our renderer and the upstream encoder.
+# To refresh:
+#     curl -sL https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash/raw/main/encoding/encoding_dsv4.py \
+#         -o train-firetitan-py/cookbook/training/tests/_encoding_dsv4_oracle.py
+# and re-prepend this header.
+
+"""
+DeepSeek-V4 Encoding
+
+A self-contained implementation for encoding/decoding DeepSeek-V4 chat messages
+with tool calling, thinking mode, and quick instruction task support.
+"""
+
+from typing import Any, Dict, List, Union, Optional, Tuple
+import copy
+import json
+import re
+
+# ============================================================
+# Special Tokens
+# ============================================================
+
+bos_token: str = "<｜begin▁of▁sentence｜>"
+eos_token: str = "<｜end▁of▁sentence｜>"
+thinking_start_token: str = "<think>"
+thinking_end_token: str = "</think>"
+dsml_token: str = "｜DSML｜"
+
+USER_SP_TOKEN = "<｜User｜>"
+ASSISTANT_SP_TOKEN = "<｜Assistant｜>"
+LATEST_REMINDER_SP_TOKEN = "<｜latest_reminder｜>"
+
+# Task special tokens for internal classification tasks
+DS_TASK_SP_TOKENS = {
+    "action": "<｜action｜>",
+    "query": "<｜query｜>",
+    "authority": "<｜authority｜>",
+    "domain": "<｜domain｜>",
+    "title": "<｜title｜>",
+    "read_url": "<｜read_url｜>",
+}
+VALID_TASKS = set(DS_TASK_SP_TOKENS.keys())
+
+# ============================================================
+# Templates
+# ============================================================
+
+system_msg_template: str = "{content}"
+user_msg_template: str = "{content}"
+latest_reminder_msg_template: str = "{content}"
+assistant_msg_template: str = "{reasoning}{content}{tool_calls}" + eos_token
+assistant_msg_wo_eos_template: str = "{reasoning}{content}{tool_calls}"
+thinking_template: str = "{reasoning_content}"
+
+response_format_template: str = (
+    "## Response Format:\n\nYou MUST strictly adhere to the following schema to reply:\n{schema}"
+)
+tool_call_template: str = (
+    "<{dsml_token}invoke name=\"{name}\">\n{arguments}\n</{dsml_token}invoke>"
+)
+tool_calls_template = (
+    "<{dsml_token}{tc_block_name}>\n{tool_calls}\n</{dsml_token}{tc_block_name}>"
+)
+tool_calls_block_name: str = "tool_calls"
+
+tool_output_template: str = (
+    "<tool_result>{content}</tool_result>"
+)
+
+REASONING_EFFORT_MAX = (
+    "Reasoning Effort: Absolute maximum with no shortcuts permitted.\n"
+    "You MUST be very thorough in your thinking and comprehensively decompose the problem to resolve the root cause, rigorously stress-testing your logic against all potential paths, edge cases, and adversarial scenarios.\n"
+    "Explicitly write out your entire deliberation process, documenting every intermediate step, considered alternative, and rejected hypothesis to ensure absolutely no assumption is left unchecked.\n\n"
+)
+
+TOOLS_TEMPLATE = """## Tools
+
+You have access to a set of tools to help answer the user's question. You can invoke tools by writing a "<{dsml_token}tool_calls>" block like the following:
+
+<{dsml_token}tool_calls>
+<{dsml_token}invoke name="$TOOL_NAME">
+<{dsml_token}parameter name="$PARAMETER_NAME" string="true|false">$PARAMETER_VALUE</{dsml_token}parameter>
+...
+</{dsml_token}invoke>
+<{dsml_token}invoke name="$TOOL_NAME2">
+...
+</{dsml_token}invoke>
+</{dsml_token}tool_calls>
+
+String parameters should be specified as is and set `string="true"`. For all other types (numbers, booleans, arrays, objects), pass the value in JSON format and set `string="false"`.
+
+If thinking_mode is enabled (triggered by {thinking_start_token}), you MUST output your complete reasoning inside {thinking_start_token}...{thinking_end_token} BEFORE any tool calls or final response.
+
+Otherwise, output directly after {thinking_end_token} with tool calls or final response.
+
+### Available Tool Schemas
+
+{tool_schemas}
+
+You MUST strictly follow the above defined tool name and parameter schemas to invoke tool calls.
+"""
+
+# ============================================================
+# Utility Functions
+# ============================================================
+
+def to_json(value: Any) -> str:
+    """Serialize a value to JSON string."""
+    try:
+        return json.dumps(value, ensure_ascii=False)
+    except:
+        return json.dumps(value, ensure_ascii=True)
+
+
+def tools_from_openai_format(tools):
+    """Extract function definitions from OpenAI-format tool list."""
+    return [tool["function"] for tool in tools]
+
+
+def tool_calls_from_openai_format(tool_calls):
+    """Convert OpenAI-format tool calls to internal format."""
+    return [
+        {
+            "name": tool_call["function"]["name"],
+            "arguments": tool_call["function"]["arguments"],
+        }
+        for tool_call in tool_calls
+    ]
+
+
+def tool_calls_to_openai_format(tool_calls):
+    """Convert internal tool calls to OpenAI format."""
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": tool_call["name"],
+                "arguments": tool_call["arguments"],
+            }
+        }
+        for tool_call in tool_calls
+    ]
+
+
+def encode_arguments_to_dsml(tool_call: Dict[str, str]) -> str:
+    """
+    Encode tool call arguments into DSML parameter format.
+
+    Args:
+        tool_call: Dict with "name" and "arguments" (JSON string) keys.
+
+    Returns:
+        DSML-formatted parameter string.
+    """
+    p_dsml_template = '<{dsml_token}parameter name="{key}" string="{is_str}">{value}</{dsml_token}parameter>'
+    P_dsml_strs = []
+
+    try:
+        arguments = json.loads(tool_call["arguments"])
+    except Exception as err:
+        arguments = {"arguments": tool_call["arguments"]}
+
+    for k, v in arguments.items():
+        p_dsml_str = p_dsml_template.format(
+            dsml_token=dsml_token,
+            key=k,
+            is_str="true" if isinstance(v, str) else "false",
+            value=v if isinstance(v, str) else to_json(v),
+        )
+        P_dsml_strs.append(p_dsml_str)
+
+    return "\n".join(P_dsml_strs)
+
+
+def decode_dsml_to_arguments(tool_name: str, tool_args: Dict[str, Tuple[str, str]]) -> Dict[str, str]:
+    """
+    Decode DSML parameters back to a tool call dict.
+
+    Args:
+        tool_name: Name of the tool.
+        tool_args: Dict mapping param_name -> (value, is_string_flag).
+
+    Returns:
+        Dict with "name" and "arguments" (JSON string) keys.
+    """
+    def _decode_value(key: str, value: str, string: str):
+        if string == "true":
+            value = to_json(value)
+        return f"{to_json(key)}: {value}"
+
+    tool_args_json = "{" + ", ".join([_decode_value(k, v, string=is_str) for k, (v, is_str) in tool_args.items()]) + "}"
+    return dict(name=tool_name, arguments=tool_args_json)
+
+
+def render_tools(tools: List[Dict[str, Union[str, Dict[str, Any]]]]) -> str:
+    """
+    Render tool schemas into the system prompt format.
+
+    Args:
+        tools: List of tool schema dicts (each with name, description, parameters).
+
+    Returns:
+        Formatted tools section string.
+    """
+    tools_json = [to_json(t) for t in tools]
+
+    return TOOLS_TEMPLATE.format(
+        tool_schemas="\n".join(tools_json),
+        dsml_token=dsml_token,
+        thinking_start_token=thinking_start_token,
+        thinking_end_token=thinking_end_token,
+    )
+
+
+def find_last_user_index(messages: List[Dict[str, Any]]) -> int:
+    """Find the index of the last user/developer message."""
+    last_user_index = -1
+    for idx in range(len(messages) - 1, -1, -1):
+        if messages[idx].get("role") in ["user", "developer"]:
+            last_user_index = idx
+            break
+    return last_user_index
+
+
+# ============================================================
+# Message Rendering
+# ============================================================
+
+def render_message(index: int, messages: List[Dict[str, Any]], thinking_mode: str, drop_thinking: bool = True, reasoning_effort: Optional[str] = None) -> str:
+    """
+    Render a single message at the given index into its encoded string form.
+
+    This is the core function that converts each message in the conversation
+    into the DeepSeek-V4 format.
+
+    Args:
+        index: Index of the message to render.
+        messages: Full list of messages in the conversation.
+        thinking_mode: Either "chat" or "thinking".
+        drop_thinking: Whether to drop reasoning content from earlier turns.
+        reasoning_effort: Optional reasoning effort level ("max", "high", or None).
+
+    Returns:
+        Encoded string for this message.
+    """
+    assert 0 <= index < len(messages)
+    assert thinking_mode in ["chat", "thinking"], f"Invalid thinking_mode `{thinking_mode}`"
+
+    prompt = ""
+    msg = messages[index]
+    last_user_idx = find_last_user_index(messages)
+
+    role = msg.get("role")
+    content = msg.get("content")
+    tools = msg.get("tools")
+    response_format = msg.get("response_format")
+    tool_calls = msg.get("tool_calls")
+    reasoning_content = msg.get("reasoning_content")
+    wo_eos = msg.get("wo_eos", False)
+
+    if tools:
+        tools = tools_from_openai_format(tools)
+    if tool_calls:
+        tool_calls = tool_calls_from_openai_format(tool_calls)
+
+    # Reasoning effort prefix (only at index 0 in thinking mode with max effort)
+    assert reasoning_effort in ['max', None, 'high'], f"Invalid reasoning effort: {reasoning_effort}"
+    if index == 0 and thinking_mode == "thinking" and reasoning_effort == 'max':
+        prompt += REASONING_EFFORT_MAX
+
+    if role == "system":
+        prompt += system_msg_template.format(content=content or "")
+        if tools:
+            prompt += "\n\n" + render_tools(tools)
+        if response_format:
+            prompt += "\n\n" + response_format_template.format(schema=to_json(response_format))
+
+    elif role == "developer":
+        assert content, f"Invalid message for role `{role}`: {msg}"
+
+        content_developer = USER_SP_TOKEN
+        content_developer += content
+
+        if tools:
+            content_developer += "\n\n" + render_tools(tools)
+        if response_format:
+            content_developer += "\n\n" + response_format_template.format(schema=to_json(response_format))
+
+        prompt += user_msg_template.format(content=content_developer)
+
+    elif role == "user":
+        prompt += USER_SP_TOKEN
+
+        # Handle content blocks (tool results mixed with text)
+        content_blocks = msg.get("content_blocks")
+        if content_blocks:
+            parts = []
+            for block in content_blocks:
+                block_type = block.get("type")
+                if block_type == "text":
+                    parts.append(block.get("text", ""))
+                elif block_type == "tool_result":
+                    tool_content = block.get("content", "")
+                    if isinstance(tool_content, list):
+                        text_parts = []
+                        for b in tool_content:
+                            if b.get("type") == "text":
+                                text_parts.append(b.get("text", ""))
+                            else:
+                                text_parts.append(f"[Unsupported {b.get('type')}]")
+                        tool_content = "\n\n".join(text_parts)
+                    parts.append(tool_output_template.format(content=tool_content))
+                else:
+                    parts.append(f"[Unsupported {block_type}]")
+            prompt += "\n\n".join(parts)
+        else:
+            prompt += content or ""
+
+    elif role == "latest_reminder":
+        prompt += LATEST_REMINDER_SP_TOKEN + latest_reminder_msg_template.format(content=content)
+
+    elif role == "tool":
+        raise NotImplementedError("deepseek_v4 merges tool messages into user; please preprocess with merge_tool_messages()")
+
+    elif role == "assistant":
+        thinking_part = ""
+        tc_content = ""
+
+        if tool_calls:
+            tc_list = [
+                tool_call_template.format(
+                    dsml_token=dsml_token,
+                    name=tc.get("name"),
+                    arguments=encode_arguments_to_dsml(tc)
+                )
+                for tc in tool_calls
+            ]
+            tc_content += '\n\n' + tool_calls_template.format(
+                dsml_token=dsml_token,
+                tool_calls="\n".join(tc_list),
+                tc_block_name=tool_calls_block_name,
+            )
+
+        summary_content = content or ""
+        rc = reasoning_content or ""
+
+        # Check if previous message has a task - if so, this is a task output (no thinking)
+        prev_has_task = index - 1 >= 0 and messages[index - 1].get("task") is not None
+
+        if thinking_mode == "thinking" and not prev_has_task:
+            if not drop_thinking or index > last_user_idx:
+                thinking_part = thinking_template.format(reasoning_content=rc) + thinking_end_token
+            else:
+                thinking_part = ""
+
+        if wo_eos:
+            prompt += assistant_msg_wo_eos_template.format(
+                reasoning=thinking_part,
+                content=summary_content,
+                tool_calls=tc_content,
+            )
+        else:
+            prompt += assistant_msg_template.format(
+                reasoning=thinking_part,
+                content=summary_content,
+                tool_calls=tc_content,
+            )
+    else:
+        raise NotImplementedError(f"Unknown role: {role}")
+
+    # Append transition tokens based on what follows
+    if index + 1 < len(messages) and messages[index + 1].get("role") not in ["assistant", "latest_reminder"]:
+        return prompt
+
+    task = messages[index].get("task")
+    if task is not None:
+        # Task special token for internal classification tasks
+        assert task in VALID_TASKS, f"Invalid task: '{task}'. Valid tasks are: {list(VALID_TASKS)}"
+        task_sp_token = DS_TASK_SP_TOKENS[task]
+
+        if task != "action":
+            # Non-action tasks: append task sp token directly after the message
+            prompt += task_sp_token
+        else:
+            # Action task: append Assistant + thinking token + action sp token
+            prompt += ASSISTANT_SP_TOKEN
+            prompt += thinking_end_token if thinking_mode != "thinking" else thinking_start_token
+            prompt += task_sp_token
+
+    elif messages[index].get("role") in ["user", "developer"]:
+        # Normal generation: append Assistant + thinking token
+        prompt += ASSISTANT_SP_TOKEN
+        if not drop_thinking and thinking_mode == "thinking":
+            prompt += thinking_start_token
+        elif drop_thinking and thinking_mode == "thinking" and index >= last_user_idx:
+            prompt += thinking_start_token
+        else:
+            prompt += thinking_end_token
+
+    return prompt
+
+
+# ============================================================
+# Preprocessing
+# ============================================================
+
+def merge_tool_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """
+    Merge tool messages into the preceding user message using content_blocks format.
+
+    DeepSeek-V4 does not have a standalone "tool" role; instead, tool results
+    are encoded as <tool_result> blocks within user messages.
+
+    This function converts a standard OpenAI-format conversation (with separate
+    "tool" role messages) into V4 format where tool results are merged into
+    user messages.
+
+    Args:
+        messages: List of message dicts in OpenAI format.
+
+    Returns:
+        Processed message list with tool messages merged into user messages.
+    """
+    merged: List[Dict[str, Any]] = []
+
+    for msg in messages:
+        msg = copy.deepcopy(msg)
+        role = msg.get("role")
+
+        if role == "tool":
+            # Convert tool message to a user message with tool_result block
+            tool_block = {
+                "type": "tool_result",
+                "tool_use_id": msg.get("tool_call_id", ""),
+                "content": msg.get("content", ""),
+            }
+            # Merge into previous message if it's already a user (merged tool)
+            if merged and merged[-1].get("role") == "user" and "content_blocks" in merged[-1]:
+                merged[-1]["content_blocks"].append(tool_block)
+            else:
+                merged.append({
+                    "role": "user",
+                    "content_blocks": [tool_block],
+                })
+        elif role == "user":
+            text_block = {"type": "text", "text": msg.get("content", "")}
+            if merged and merged[-1].get("role") == "user" and "content_blocks" in merged[-1] and merged[-1].get("task") is None:
+                merged[-1]["content_blocks"].append(text_block)
+            else:
+                new_msg = {
+                    "role": "user",
+                    "content": msg.get("content", ""),
+                    "content_blocks": [text_block],
+                }
+                # Preserve extra fields (task, wo_eos, mask, etc.)
+                for key in ("task", "wo_eos", "mask"):
+                    if key in msg:
+                        new_msg[key] = msg[key]
+                merged.append(new_msg)
+        else:
+            merged.append(msg)
+
+    return merged
+
+
+def sort_tool_results_by_call_order(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """
+    Sort tool_result blocks within user messages by the order of tool_calls
+    in the preceding assistant message.
+
+    Args:
+        messages: Preprocessed message list (after merge_tool_messages).
+
+    Returns:
+        Message list with sorted tool result blocks.
+    """
+    last_tool_call_order: Dict[str, int] = {}
+
+    for msg in messages:
+        role = msg.get("role")
+        if role == "assistant" and msg.get("tool_calls"):
+            last_tool_call_order = {}
+            for idx, tc in enumerate(msg["tool_calls"]):
+                tc_id = tc.get("id") or tc.get("function", {}).get("id", "")
+                if tc_id:
+                    last_tool_call_order[tc_id] = idx
+
+        elif role == "user" and msg.get("content_blocks"):
+            tool_blocks = [b for b in msg["content_blocks"] if b.get("type") == "tool_result"]
+            if len(tool_blocks) > 1 and last_tool_call_order:
+                sorted_blocks = sorted(
+                    tool_blocks,
+                    key=lambda b: last_tool_call_order.get(b.get("tool_use_id", ""), 0)
+                )
+                sorted_idx = 0
+                new_blocks = []
+                for block in msg["content_blocks"]:
+                    if block.get("type") == "tool_result":
+                        new_blocks.append(sorted_blocks[sorted_idx])
+                        sorted_idx += 1
+                    else:
+                        new_blocks.append(block)
+                msg["content_blocks"] = new_blocks
+
+    return messages
+
+
+# ============================================================
+# Main Encoding Function
+# ============================================================
+
+def encode_messages(
+    messages: List[Dict[str, Any]],
+    thinking_mode: str,
+    context: Optional[List[Dict[str, Any]]] = None,
+    drop_thinking: bool = True,
+    add_default_bos_token: bool = True,
+    reasoning_effort: Optional[str] = None,
+) -> str:
+    """
+    Encode a list of messages into the DeepSeek-V4 prompt format.
+
+    This is the main entry point for encoding conversations. It handles:
+    - BOS token insertion
+    - Thinking mode with optional reasoning content dropping
+    - Tool message merging into user messages
+    - Multi-turn conversation context
+
+    Args:
+        messages: List of message dicts to encode.
+        thinking_mode: Either "chat" or "thinking".
+        context: Optional preceding context messages (already encoded prefix).
+        drop_thinking: If True, drop reasoning_content from earlier assistant turns
+                      (only keep reasoning for messages after the last user message).
+        add_default_bos_token: Whether to prepend BOS token at conversation start.
+        reasoning_effort: Optional reasoning effort level ("max", "high", or None).
+
+    Returns:
+        The encoded prompt string.
+    """
+    context = context if context else []
+
+    # Preprocess: merge tool messages and sort tool results
+    messages = merge_tool_messages(messages)
+    messages = sort_tool_results_by_call_order(context + messages)[len(context):]
+    if context:
+        context = merge_tool_messages(context)
+        context = sort_tool_results_by_call_order(context)
+
+    full_messages = context + messages
+
+    prompt = bos_token if add_default_bos_token and len(context) == 0 else ""
+
+    # Resolve drop_thinking: if any message has tools defined, don't drop thinking
+    effective_drop_thinking = drop_thinking
+    if any(m.get("tools") for m in full_messages):
+        effective_drop_thinking = False
+
+    if thinking_mode == "thinking" and effective_drop_thinking:
+        full_messages = _drop_thinking_messages(full_messages)
+        # After dropping, recalculate how many messages to render
+        # (context may have shrunk too)
+        num_to_render = len(full_messages) - len(_drop_thinking_messages(context))
+        context_len = len(full_messages) - num_to_render
+    else:
+        num_to_render = len(messages)
+        context_len = len(context)
+
+    for idx in range(num_to_render):
+        prompt += render_message(
+            idx + context_len,
+            full_messages,
+            thinking_mode=thinking_mode,
+            drop_thinking=effective_drop_thinking,
+            reasoning_effort=reasoning_effort,
+        )
+
+    return prompt
+
+
+def _drop_thinking_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """
+    Drop reasoning_content and non-essential messages before the last user message.
+
+    Behavior:
+    - Messages with role in ["user", "system", "tool", "latest_reminder"] are always kept.
+    - Messages at or after the last user index are always kept.
+    - Assistant messages before the last user get reasoning_content removed.
+    - Developer messages before the last user are dropped entirely.
+    """
+    last_user_idx = find_last_user_index(messages)
+    result = []
+    keep_roles = {"user", "system", "tool", "latest_reminder", "direct_search_results"}
+
+    for idx, msg in enumerate(messages):
+        role = msg.get("role")
+        if role in keep_roles or idx >= last_user_idx:
+            result.append(msg)
+        elif role == "assistant":
+            msg = copy.copy(msg)
+            msg.pop("reasoning_content", None)
+            result.append(msg)
+        # developer and other roles before last_user_idx are dropped
+
+    return result
+
+
+# ============================================================
+# Parsing (Decoding model output)
+# ============================================================
+
+def _read_until_stop(index: int, text: str, stop: List[str]) -> Tuple[int, str, Optional[str]]:
+    """
+    Read text from index until one of the stop strings is found.
+
+    Returns:
+        Tuple of (new_index, content_before_stop, matched_stop_string_or_None).
+    """
+    min_pos = len(text)
+    matched_stop = None
+
+    for s in stop:
+        pos = text.find(s, index)
+        if pos != -1 and pos < min_pos:
+            min_pos = pos
+            matched_stop = s
+
+    if matched_stop:
+        content = text[index:min_pos]
+        return min_pos + len(matched_stop), content, matched_stop
+    else:
+        content = text[index:]
+        return len(text), content, None
+
+
+def parse_tool_calls(index: int, text: str) -> Tuple[int, Optional[str], List[Dict[str, str]]]:
+    """
+    Parse DSML tool calls from text starting at the given index.
+
+    Args:
+        index: Starting position in text.
+        text: The full text to parse.
+
+    Returns:
+        Tuple of (new_index, last_stop_token, list_of_tool_call_dicts).
+        Each tool call dict has "name" and "arguments" keys.
+    """
+    tool_calls: List[Dict[str, Any]] = []
+    stop_token = None
+    tool_calls_end_token = f"</{dsml_token}{tool_calls_block_name}>"
+
+    while index < len(text):
+        index, _, stop_token = _read_until_stop(index, text, [f"<{dsml_token}invoke", tool_calls_end_token])
+        if _ != ">\n":
+            raise ValueError(f"Tool call format error: expected '>\\n' but got '{_}'")
+
+        if stop_token == tool_calls_end_token:
+            break
+
+        if stop_token is None:
+            raise ValueError("Missing special token in tool calls")
+
+        index, tool_name_content, stop_token = _read_until_stop(index, text, [f"<{dsml_token}parameter", f"</{dsml_token}invoke"])
+
+        p_tool_name = re.findall(r'^\s*name="(.*?)">\n$', tool_name_content, flags=re.DOTALL)
+        if len(p_tool_name) != 1:
+            raise ValueError(f"Tool name format error: '{tool_name_content}'")
+        tool_name = p_tool_name[0]
+
+        tool_args: Dict[str, Tuple[str, str]] = {}
+        while stop_token == f"<{dsml_token}parameter":
+            index, param_content, stop_token = _read_until_stop(index, text, [f"/{dsml_token}parameter"])
+
+            param_kv = re.findall(r'^ name="(.*?)" string="(true|false)">(.*?)<$', param_content, flags=re.DOTALL)
+            if len(param_kv) != 1:
+                raise ValueError(f"Parameter format error: '{param_content}'")
+            param_name, string, param_value = param_kv[0]
+
+            if param_name in tool_args:
+                raise ValueError(f"Duplicate parameter name: '{param_name}'")
+            tool_args[param_name] = (param_value, string)
+
+            index, content, stop_token = _read_until_stop(index, text, [f"<{dsml_token}parameter", f"</{dsml_token}invoke"])
+            if content != ">\n":
+                raise ValueError(f"Parameter format error: expected '>\\n' but got '{content}'")
+
+        tool_call = decode_dsml_to_arguments(tool_name=tool_name, tool_args=tool_args)
+        tool_calls.append(tool_call)
+
+    return index, stop_token, tool_calls
+
+
+def parse_message_from_completion_text(text: str, thinking_mode: str) -> Dict[str, Any]:
+    """
+    Parse a model completion text into a structured assistant message.
+
+    This function takes the raw text output from the model (a single assistant turn)
+    and extracts:
+    - reasoning_content (thinking block)
+    - content (summary/response)
+    - tool_calls (if any)
+
+    NOTE: This function is designed to parse only correctly formatted strings and
+    will raise ValueError for malformed output.
+
+    Args:
+        text: The raw completion text (including EOS token).
+        thinking_mode: Either "chat" or "thinking".
+
+    Returns:
+        Dict with keys: "role", "content", "reasoning_content", "tool_calls".
+        tool_calls are in OpenAI format.
+    """
+    summary_content, reasoning_content, tool_calls = "", "", []
+    index, stop_token = 0, None
+    tool_calls_start_token = f"\n\n<{dsml_token}{tool_calls_block_name}"
+
+    is_thinking = thinking_mode == "thinking"
+    is_tool_calling = False
+
+    if is_thinking:
+        index, content_delta, stop_token = _read_until_stop(index, text, [thinking_end_token, tool_calls_start_token])
+        reasoning_content = content_delta
+        assert stop_token == thinking_end_token, "Invalid thinking format: missing </think>"
+
+    index, content_delta, stop_token = _read_until_stop(index, text, [eos_token, tool_calls_start_token])
+    summary_content = content_delta
+    if stop_token == tool_calls_start_token:
+        is_tool_calling = True
+    else:
+        assert stop_token == eos_token, "Invalid format: missing EOS token"
+
+    if is_tool_calling:
+        index, stop_token, tool_calls = parse_tool_calls(index, text)
+
+        index, tool_ends_text, stop_token = _read_until_stop(index, text, [eos_token])
+        assert not tool_ends_text, "Unexpected content after tool calls"
+
+    assert len(text) == index and stop_token in [eos_token, None], "Unexpected content at end"
+
+    for sp_token in [bos_token, eos_token, thinking_start_token, thinking_end_token, dsml_token]:
+        assert sp_token not in summary_content and sp_token not in reasoning_content, \
+            f"Unexpected special token '{sp_token}' in content"
+
+    return {
+        "role": "assistant",
+        "content": summary_content,
+        "reasoning_content": reasoning_content,
+        "tool_calls": tool_calls_to_openai_format(tool_calls)
+    }

--- a/training/tests/unit/test_deepseek_v4_renderer.py
+++ b/training/tests/unit/test_deepseek_v4_renderer.py
@@ -1,0 +1,1127 @@
+"""Verify DeepseekV4Renderer matches the upstream encoder byte-for-byte.
+
+The source-of-truth is ``deepseek-ai/DeepSeek-V4-Flash/encoding/encoding_dsv4.py``,
+vendored verbatim under ``training/tests/_encoding_dsv4_oracle.py``. This
+suite hits both layers:
+
+1. **String parity** — ``renderer.decode(...)`` matches
+   ``encoding_dsv4.encode_messages(...)`` character-for-character.
+2. **Token parity** — ``renderer.build_*(...)`` matches
+   ``tokenizer.encode(oracle_string, add_special_tokens=False)`` ID-for-ID.
+3. **Weight correctness** — supervised weight masks satisfy the
+   train-inference prefix invariant and the trained span roundtrips
+   through ``encoding_dsv4.parse_message_from_completion_text``.
+
+Run from cookbook/training with::
+
+    PYTHONPATH=../.. python -m pytest training/tests/unit/test_deepseek_v4_renderer.py -v -s
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+import transformers
+
+from training.renderer.deepseek_v4 import (
+    DeepseekV4Renderer,
+    _BOS_TEXT,
+    _EOS_TEXT,
+    _THINK_OPEN,
+    _THINK_CLOSE,
+    _USER_SP,
+    _ASSISTANT_SP,
+    _DSML,
+)
+from training.tests import _encoding_dsv4_oracle as oracle
+from tinker_cookbook.renderers import get_renderer
+from tinker_cookbook.renderers.base import ToolCall, TrainOnWhat
+
+# Public HF tokenizer. Local mirror probed first so internal CI works without
+# the Hub; falls through to public if absent.
+_LOCAL_TOKENIZER = "/shared/text-models/deepseek-v4-flash"
+_PUBLIC_TOKENIZER = "deepseek-ai/DeepSeek-V4-Flash"
+
+
+def _load_tokenizer() -> transformers.PreTrainedTokenizerBase | None:
+    if Path(_LOCAL_TOKENIZER).exists():
+        try:
+            return transformers.AutoTokenizer.from_pretrained(
+                _LOCAL_TOKENIZER,
+                trust_remote_code=True,
+            )
+        except Exception:  # noqa: BLE001
+            pass
+    try:
+        return transformers.AutoTokenizer.from_pretrained(
+            _PUBLIC_TOKENIZER,
+            trust_remote_code=True,
+        )
+    except Exception:  # noqa: BLE001
+        return None
+
+
+@pytest.fixture(scope="module")
+def tokenizer():
+    tok = _load_tokenizer()
+    if tok is None:
+        pytest.skip(
+            f"DeepSeek-V4 tokenizer not available "
+            f"(tried {_LOCAL_TOKENIZER!r} then {_PUBLIC_TOKENIZER!r})"
+        )
+    return tok
+
+
+@pytest.fixture(scope="module")
+def renderer_thinking_strip(tokenizer):
+    """Default registered renderer: thinking mode, strip-history."""
+    return DeepseekV4Renderer(
+        tokenizer,
+        thinking_mode="thinking",
+        strip_thinking_from_history=True,
+    )
+
+
+@pytest.fixture(scope="module")
+def renderer_thinking_keep(tokenizer):
+    """Thinking mode that keeps history reasoning (extension property)."""
+    return DeepseekV4Renderer(
+        tokenizer,
+        thinking_mode="thinking",
+        strip_thinking_from_history=False,
+    )
+
+
+@pytest.fixture(scope="module")
+def renderer_chat(tokenizer):
+    """Chat mode (no thinking ever)."""
+    return DeepseekV4Renderer(
+        tokenizer,
+        thinking_mode="chat",
+        strip_thinking_from_history=True,
+    )
+
+
+# ── Helpers ─────────────────────────────────────────────────────────────────
+
+
+def _make_tool_call(
+    name: str, arguments: dict[str, Any], call_id: str = ""
+) -> ToolCall:
+    """Build a Tinker ``ToolCall`` from (name, dict-args)."""
+    return ToolCall(
+        function=ToolCall.FunctionBody(
+            name=name,
+            arguments=json.dumps(arguments, ensure_ascii=False),
+        ),
+        id=call_id,
+    )
+
+
+def _oracle_tool_calls(
+    specs: list[tuple[str, dict[str, Any], str]],
+) -> list[dict[str, Any]]:
+    """Build OpenAI-format tool_calls for the oracle from (name, args, id) specs."""
+    return [
+        {
+            "type": "function",
+            "id": call_id,
+            "function": {
+                "name": name,
+                "arguments": json.dumps(args, ensure_ascii=False),
+            },
+        }
+        for name, args, call_id in specs
+    ]
+
+
+def _oracle_text(
+    messages: list[dict[str, Any]], thinking_mode: str, **kwargs: Any
+) -> str:
+    """Run the upstream encoder; never let test fixtures share mutable state."""
+    return oracle.encode_messages(
+        [json.loads(json.dumps(m)) for m in messages],
+        thinking_mode=thinking_mode,
+        **kwargs,
+    )
+
+
+def _oracle_ids(
+    tokenizer,
+    messages: list[dict[str, Any]],
+    thinking_mode: str,
+    **kwargs: Any,
+) -> list[int]:
+    return tokenizer.encode(
+        _oracle_text(messages, thinking_mode, **kwargs),
+        add_special_tokens=False,
+    )
+
+
+def _renderer_supervised(renderer, messages, **kwargs):
+    model_input, weights = renderer.build_supervised_example(messages, **kwargs)
+    return list(model_input.to_ints()), [int(w) for w in weights.tolist()]
+
+
+def _renderer_generation(renderer, messages, role: str = "assistant") -> list[int]:
+    return list(renderer.build_generation_prompt(messages, role=role).to_ints())
+
+
+def _trained_text(tokenizer, tokens: list[int], weights: list[int]) -> str:
+    return tokenizer.decode([t for t, w in zip(tokens, weights) if w > 0])
+
+
+# ── Registered renderer + special-token sanity ──────────────────────────────
+
+
+def test_registered_factory_returns_thinking_strip(tokenizer):
+    """``get_renderer("deepseek_v4", tok)`` matches our default constructor."""
+    r = get_renderer("deepseek_v4", tokenizer)
+    assert isinstance(r, DeepseekV4Renderer)
+    assert r.thinking_mode == "thinking"
+    assert r.strip_thinking_from_history is True
+    assert r.has_extension_property is False
+
+
+def test_keep_thinking_renderer_has_extension_property(renderer_thinking_keep):
+    assert renderer_thinking_keep.has_extension_property is True
+
+
+def test_chat_renderer_has_extension_property(renderer_chat):
+    assert renderer_chat.has_extension_property is True
+
+
+def test_special_tokens_each_encode_to_single_token(tokenizer):
+    """All hand-coded special token strings tokenize as one ID each."""
+    for tok_str in (_BOS_TEXT, _EOS_TEXT, _USER_SP, _ASSISTANT_SP):
+        ids = tokenizer.encode(tok_str, add_special_tokens=False)
+        assert len(ids) == 1, f"{tok_str!r} encoded to {ids}"
+    # ``<think>`` / ``</think>`` are also single tokens for DSv4.
+    for tok_str in (_THINK_OPEN, _THINK_CLOSE):
+        ids = tokenizer.encode(tok_str, add_special_tokens=False)
+        assert len(ids) == 1, f"{tok_str!r} encoded to {ids}"
+
+
+def test_dsml_token_round_trips(tokenizer):
+    """The DSML interior token survives decode→encode cleanly."""
+    sample = f'<{_DSML}invoke name="foo">'
+    ids = tokenizer.encode(sample, add_special_tokens=False)
+    assert tokenizer.decode(ids) == sample
+
+
+def test_get_stop_sequences_returns_eos(tokenizer, renderer_thinking_strip):
+    eos_id = tokenizer.encode(_EOS_TEXT, add_special_tokens=False)[0]
+    assert renderer_thinking_strip.get_stop_sequences() == [eos_id]
+
+
+def test_generation_suffix_thinking_is_assistant_plus_think(
+    tokenizer,
+    renderer_thinking_strip,
+):
+    from tinker_cookbook.renderers.base import RenderContext
+
+    ctx = RenderContext(idx=0, is_last=False, prev_message=None, last_user_index=-1)
+    suffix = renderer_thinking_strip._get_generation_suffix("assistant", ctx)
+    assert tokenizer.decode(suffix) == _ASSISTANT_SP + _THINK_OPEN
+
+
+def test_generation_suffix_chat_is_assistant_plus_close_think(
+    tokenizer,
+    renderer_chat,
+):
+    from tinker_cookbook.renderers.base import RenderContext
+
+    ctx = RenderContext(idx=0, is_last=False, prev_message=None, last_user_index=-1)
+    suffix = renderer_chat._get_generation_suffix("assistant", ctx)
+    assert tokenizer.decode(suffix) == _ASSISTANT_SP + _THINK_CLOSE
+
+
+# ── Layer 1: string + token parity vs the oracle ────────────────────────────
+
+
+_GENERATION_FIXTURES: list[list[dict[str, Any]]] = [
+    # User-only, expecting an assistant generation prompt.
+    [{"role": "user", "content": "Hello"}],
+    # System + user.
+    [
+        {"role": "system", "content": "You are helpful."},
+        {"role": "user", "content": "Hello"},
+    ],
+    # Multi-turn history with reasoning.
+    [
+        {"role": "user", "content": "What is 2+2?"},
+        {"role": "assistant", "reasoning_content": "2+2=4", "content": "4"},
+        {"role": "user", "content": "And 3+3?"},
+    ],
+    # Five-turn conversation, no reasoning.
+    [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "hello"},
+        {"role": "user", "content": "bye"},
+        {"role": "assistant", "content": "goodbye"},
+        {"role": "user", "content": "one more"},
+    ],
+    # Multi-line + unicode.
+    [{"role": "user", "content": "line one\nline two\nline three\n你好 🚀"}],
+    # System + user with a tool response already stitched in (covers
+    # encoder's ``user→tool`` merge path).
+    [
+        {"role": "user", "content": "weather?"},
+        {"role": "tool", "content": "sunny", "tool_call_id": "call_1"},
+    ],
+    # System with empty content.
+    [
+        {"role": "system", "content": ""},
+        {"role": "user", "content": "hello"},
+    ],
+]
+
+
+@pytest.mark.parametrize(
+    "messages",
+    _GENERATION_FIXTURES,
+    ids=[f"gen{i}" for i in range(len(_GENERATION_FIXTURES))],
+)
+def test_generation_prompt_thinking_strip_matches_oracle(
+    tokenizer,
+    renderer_thinking_strip,
+    messages,
+):
+    expected_text = _oracle_text(messages, thinking_mode="thinking")
+    expected_ids = tokenizer.encode(expected_text, add_special_tokens=False)
+    ours = _renderer_generation(renderer_thinking_strip, messages)
+    assert ours == expected_ids, (
+        f"thinking-strip generation mismatch:\n"
+        f"  oracle text: {expected_text!r}\n"
+        f"  ours text:   {tokenizer.decode(ours)!r}"
+    )
+
+
+@pytest.mark.parametrize(
+    "messages",
+    _GENERATION_FIXTURES,
+    ids=[f"gen{i}" for i in range(len(_GENERATION_FIXTURES))],
+)
+def test_generation_prompt_thinking_keep_matches_oracle(
+    tokenizer,
+    renderer_thinking_keep,
+    messages,
+):
+    expected_text = _oracle_text(
+        messages,
+        thinking_mode="thinking",
+        drop_thinking=False,
+    )
+    expected_ids = tokenizer.encode(expected_text, add_special_tokens=False)
+    ours = _renderer_generation(renderer_thinking_keep, messages)
+    assert ours == expected_ids
+
+
+@pytest.mark.parametrize(
+    "messages",
+    _GENERATION_FIXTURES,
+    ids=[f"gen{i}" for i in range(len(_GENERATION_FIXTURES))],
+)
+def test_generation_prompt_chat_matches_oracle(
+    tokenizer,
+    renderer_chat,
+    messages,
+):
+    expected_text = _oracle_text(messages, thinking_mode="chat")
+    expected_ids = tokenizer.encode(expected_text, add_special_tokens=False)
+    ours = _renderer_generation(renderer_chat, messages)
+    assert ours == expected_ids
+
+
+_SUPERVISED_FIXTURES: list[list[dict[str, Any]]] = [
+    # Single-turn no thinking.
+    [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "bye"},
+    ],
+    # Single-turn with reasoning.
+    [
+        {"role": "user", "content": "hi"},
+        {
+            "role": "assistant",
+            "reasoning_content": "the user said hi",
+            "content": "bye",
+        },
+    ],
+    # System + user + assistant.
+    [
+        {"role": "system", "content": "Be helpful."},
+        {"role": "user", "content": "Q"},
+        {"role": "assistant", "reasoning_content": "trivial", "content": "A"},
+    ],
+    # Multi-turn with reasoning history.
+    [
+        {"role": "user", "content": "q1"},
+        {"role": "assistant", "reasoning_content": "r1", "content": "a1"},
+        {"role": "user", "content": "q2"},
+        {"role": "assistant", "reasoning_content": "r2", "content": "a2"},
+    ],
+    # Three-turn no thinking.
+    [
+        {"role": "user", "content": "q1"},
+        {"role": "assistant", "content": "a1"},
+        {"role": "user", "content": "q2"},
+        {"role": "assistant", "content": "a2"},
+        {"role": "user", "content": "q3"},
+        {"role": "assistant", "content": "a3"},
+    ],
+    # Empty assistant content.
+    [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": ""},
+    ],
+    # Tool round-trip: assistant calls tool, tool responds, assistant answers.
+    [
+        {"role": "user", "content": "weather in SF?"},
+        {
+            "role": "assistant",
+            "reasoning_content": "need lookup",
+            "content": "",
+            "tool_calls": [
+                {
+                    "type": "function",
+                    "id": "call_1",
+                    "function": {
+                        "name": "get_weather",
+                        "arguments": json.dumps({"city": "SF"}),
+                    },
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "content": "sunny, 72F"},
+        {
+            "role": "assistant",
+            "reasoning_content": "got it",
+            "content": "It's sunny and 72F.",
+        },
+    ],
+]
+
+
+def _renderer_messages_from(
+    oracle_messages: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Convert oracle-shape tool_calls (dict) into Tinker-shape (ToolCall)."""
+    out: list[dict[str, Any]] = []
+    for msg in oracle_messages:
+        msg = json.loads(json.dumps(msg))
+        if msg.get("tool_calls"):
+            msg["tool_calls"] = [
+                _make_tool_call(
+                    tc["function"]["name"],
+                    json.loads(tc["function"]["arguments"]),
+                    call_id=tc.get("id", ""),
+                )
+                for tc in msg["tool_calls"]
+            ]
+        out.append(msg)
+    return out
+
+
+@pytest.mark.parametrize(
+    "messages",
+    _SUPERVISED_FIXTURES,
+    ids=[f"sft{i}" for i in range(len(_SUPERVISED_FIXTURES))],
+)
+def test_supervised_thinking_strip_matches_oracle(
+    tokenizer,
+    renderer_thinking_strip,
+    messages,
+):
+    expected_ids = _oracle_ids(tokenizer, messages, thinking_mode="thinking")
+    ours, _ = _renderer_supervised(
+        renderer_thinking_strip,
+        _renderer_messages_from(messages),
+        train_on_what=TrainOnWhat.LAST_ASSISTANT_TURN,
+    )
+    assert ours == expected_ids, (
+        f"thinking-strip SFT token mismatch:\n"
+        f"  oracle: {tokenizer.decode(expected_ids)!r}\n"
+        f"  ours:   {tokenizer.decode(ours)!r}"
+    )
+
+
+@pytest.mark.parametrize(
+    "messages",
+    _SUPERVISED_FIXTURES,
+    ids=[f"sft{i}" for i in range(len(_SUPERVISED_FIXTURES))],
+)
+def test_supervised_thinking_keep_matches_oracle(
+    tokenizer,
+    renderer_thinking_keep,
+    messages,
+):
+    expected_ids = _oracle_ids(
+        tokenizer,
+        messages,
+        thinking_mode="thinking",
+        drop_thinking=False,
+    )
+    ours, _ = _renderer_supervised(
+        renderer_thinking_keep,
+        _renderer_messages_from(messages),
+        train_on_what=TrainOnWhat.LAST_ASSISTANT_TURN,
+    )
+    assert ours == expected_ids
+
+
+@pytest.mark.parametrize(
+    "messages",
+    _SUPERVISED_FIXTURES,
+    ids=[f"sft{i}" for i in range(len(_SUPERVISED_FIXTURES))],
+)
+def test_supervised_chat_matches_oracle(tokenizer, renderer_chat, messages):
+    # Strip reasoning_content from chat-mode fixtures: the encoder ignores
+    # it in chat mode, but our oracle invocation should reflect that the
+    # model wouldn't have generated it.
+    chat_msgs = [
+        {k: v for k, v in m.items() if k != "reasoning_content"} for m in messages
+    ]
+    expected_ids = _oracle_ids(tokenizer, chat_msgs, thinking_mode="chat")
+    ours, _ = _renderer_supervised(
+        renderer_chat,
+        _renderer_messages_from(chat_msgs),
+        train_on_what=TrainOnWhat.LAST_ASSISTANT_TURN,
+    )
+    assert ours == expected_ids
+
+
+# ── Tools / response_format on system message ───────────────────────────────
+
+
+def test_system_with_tools_matches_oracle(tokenizer, renderer_thinking_keep):
+    """System message carrying ``tools`` renders the ``## Tools`` section.
+
+    The encoder also force-disables ``drop_thinking`` whenever any message
+    has ``tools``; we use ``renderer_thinking_keep`` to mirror that.
+    """
+    messages = [
+        {
+            "role": "system",
+            "content": "You are an assistant.",
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "description": "Look up weather",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"city": {"type": "string"}},
+                            "required": ["city"],
+                        },
+                    },
+                }
+            ],
+        },
+        {"role": "user", "content": "weather in SF?"},
+    ]
+    expected_ids = _oracle_ids(tokenizer, messages, thinking_mode="thinking")
+    ours = _renderer_generation(renderer_thinking_keep, messages)
+    assert ours == expected_ids, tokenizer.decode(ours)
+
+
+def test_drop_thinking_auto_disable_when_tools_present(
+    tokenizer,
+    renderer_thinking_strip,
+):
+    """The encoder auto-flips drop_thinking=False when any message has tools.
+
+    Same conversation rendered with and without a tools-bearing system
+    must satisfy: history reasoning is dropped without tools, preserved
+    with tools — matching the encoder's behavior even though our
+    renderer was constructed with strip_thinking_from_history=True.
+    """
+    base_messages = [
+        {"role": "user", "content": "q1"},
+        {
+            "role": "assistant",
+            "reasoning_content": "HISTORY_REASONING",
+            "content": "a1",
+        },
+        {"role": "user", "content": "q2"},
+    ]
+    with_tools = [
+        {
+            "role": "system",
+            "content": "be helpful",
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "noop",
+                        "description": "x",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                }
+            ],
+        },
+        *base_messages,
+    ]
+
+    # Without tools: HISTORY_REASONING must be dropped.
+    no_tools_text = _oracle_text(base_messages, thinking_mode="thinking")
+    no_tools_ours = tokenizer.decode(
+        _renderer_generation(renderer_thinking_strip, base_messages)
+    )
+    assert no_tools_ours == no_tools_text
+    assert "HISTORY_REASONING" not in no_tools_ours
+
+    # With tools: HISTORY_REASONING must be preserved (auto-flip).
+    with_tools_text = _oracle_text(with_tools, thinking_mode="thinking")
+    with_tools_ours = tokenizer.decode(
+        _renderer_generation(renderer_thinking_strip, with_tools)
+    )
+    assert with_tools_ours == with_tools_text
+    assert "HISTORY_REASONING" in with_tools_ours
+
+
+# ── Tool-call argument formatting (mixed types) ─────────────────────────────
+
+
+def test_tool_call_mixed_argument_types_matches_oracle(
+    tokenizer,
+    renderer_thinking_keep,
+):
+    """``string="true"`` for str args, ``string="false"`` (JSON) for the rest."""
+    oracle_messages = [
+        {"role": "user", "content": "do work"},
+        {
+            "role": "assistant",
+            "reasoning_content": "go",
+            "content": "",
+            "tool_calls": [
+                {
+                    "type": "function",
+                    "id": "call_1",
+                    "function": {
+                        "name": "f",
+                        "arguments": json.dumps(
+                            {
+                                "name": "alice",  # str → string="true"
+                                "count": 7,  # int → string="false"
+                                "active": True,  # bool → string="false"
+                                "tags": ["a", "b"],  # list → string="false"
+                                "meta": {"k": 1},  # dict → string="false"
+                            }
+                        ),
+                    },
+                }
+            ],
+        },
+    ]
+    expected_ids = _oracle_ids(
+        tokenizer,
+        oracle_messages,
+        thinking_mode="thinking",
+        drop_thinking=False,
+    )
+    ours, _ = _renderer_supervised(
+        renderer_thinking_keep,
+        _renderer_messages_from(oracle_messages),
+        train_on_what=TrainOnWhat.LAST_ASSISTANT_TURN,
+    )
+    assert ours == expected_ids
+
+
+def test_parallel_tool_results_reorder_to_call_order(
+    tokenizer,
+    renderer_thinking_keep,
+):
+    """tool_results in user are reordered to match preceding tool_calls."""
+    oracle_messages = [
+        {"role": "user", "content": "two tools"},
+        {
+            "role": "assistant",
+            "reasoning_content": "",
+            "content": "",
+            "tool_calls": [
+                {
+                    "type": "function",
+                    "id": "weather",
+                    "function": {
+                        "name": "weather",
+                        "arguments": json.dumps({"c": "SF"}),
+                    },
+                },
+                {
+                    "type": "function",
+                    "id": "convert",
+                    "function": {"name": "convert", "arguments": json.dumps({"v": 1})},
+                },
+            ],
+        },
+        # Out-of-order tool responses: convert before weather.
+        {"role": "tool", "tool_call_id": "convert", "content": "CONVERT_RESULT"},
+        {"role": "tool", "tool_call_id": "weather", "content": "WEATHER_RESULT"},
+        {"role": "assistant", "reasoning_content": "done", "content": "ok"},
+    ]
+    expected_ids = _oracle_ids(
+        tokenizer,
+        oracle_messages,
+        thinking_mode="thinking",
+        drop_thinking=False,
+    )
+    ours, _ = _renderer_supervised(
+        renderer_thinking_keep,
+        _renderer_messages_from(oracle_messages),
+        train_on_what=TrainOnWhat.LAST_ASSISTANT_TURN,
+    )
+    assert ours == expected_ids
+    decoded = tokenizer.decode(ours)
+    # Sorting must put weather before convert (call order).
+    assert decoded.index("WEATHER_RESULT") < decoded.index("CONVERT_RESULT")
+
+
+# ── Layer 2: train-inference prefix invariant (the bedrock check) ───────────
+
+
+@pytest.mark.parametrize(
+    "messages",
+    _SUPERVISED_FIXTURES,
+    ids=[f"inv{i}" for i in range(len(_SUPERVISED_FIXTURES))],
+)
+def test_supervised_extends_generation_prompt_thinking_keep(
+    tokenizer,
+    renderer_thinking_keep,
+    messages,
+):
+    """gen_prompt(messages[:-1]) must be a strict 0-weight prefix of supervised(messages).
+
+    The remaining tokens are exactly what the model would have produced
+    at inference time, and must all carry weight=1.
+    """
+    rmsgs = _renderer_messages_from(messages)
+    gen = _renderer_generation(renderer_thinking_keep, rmsgs[:-1])
+    sup, weights = _renderer_supervised(
+        renderer_thinking_keep,
+        rmsgs,
+        train_on_what=TrainOnWhat.LAST_ASSISTANT_TURN,
+    )
+    assert sup[: len(gen)] == gen, (
+        f"prefix mismatch:\n  gen:  {tokenizer.decode(gen)!r}\n  "
+        f"sup[:len(gen)]: {tokenizer.decode(sup[: len(gen)])!r}"
+    )
+    assert all(w == 0 for w in weights[: len(gen)]), (
+        "generation-prompt prefix tokens must have weight 0; got "
+        f"{weights[: len(gen)]}"
+    )
+    assert all(w == 1 for w in weights[len(gen) :]), (
+        f"model-output suffix must have weight 1; trained text was "
+        f"{tokenizer.decode([t for t, w in zip(sup, weights) if w > 0])!r}"
+    )
+
+
+@pytest.mark.parametrize(
+    "messages",
+    _SUPERVISED_FIXTURES,
+    ids=[f"inv-strip{i}" for i in range(len(_SUPERVISED_FIXTURES))],
+)
+def test_supervised_extends_generation_prompt_thinking_strip(
+    tokenizer,
+    renderer_thinking_strip,
+    messages,
+):
+    rmsgs = _renderer_messages_from(messages)
+    gen = _renderer_generation(renderer_thinking_strip, rmsgs[:-1])
+    sup, weights = _renderer_supervised(
+        renderer_thinking_strip,
+        rmsgs,
+        train_on_what=TrainOnWhat.LAST_ASSISTANT_TURN,
+    )
+    assert sup[: len(gen)] == gen
+    assert all(w == 0 for w in weights[: len(gen)])
+    assert all(w == 1 for w in weights[len(gen) :])
+
+
+@pytest.mark.parametrize(
+    "messages",
+    _SUPERVISED_FIXTURES,
+    ids=[f"inv-chat{i}" for i in range(len(_SUPERVISED_FIXTURES))],
+)
+def test_supervised_extends_generation_prompt_chat(
+    tokenizer,
+    renderer_chat,
+    messages,
+):
+    chat_msgs = [
+        {k: v for k, v in m.items() if k != "reasoning_content"} for m in messages
+    ]
+    rmsgs = _renderer_messages_from(chat_msgs)
+    gen = _renderer_generation(renderer_chat, rmsgs[:-1])
+    sup, weights = _renderer_supervised(
+        renderer_chat,
+        rmsgs,
+        train_on_what=TrainOnWhat.LAST_ASSISTANT_TURN,
+    )
+    assert sup[: len(gen)] == gen
+    assert all(w == 0 for w in weights[: len(gen)])
+    assert all(w == 1 for w in weights[len(gen) :])
+
+
+# ── Layer 3: trained-span roundtrips through the oracle parser ─────────────
+
+
+def _roundtrip_oracle_parse(
+    tokenizer,
+    renderer,
+    messages: list[dict[str, Any]],
+    thinking_mode: str,
+) -> dict[str, Any]:
+    """Decode the trained span and parse it via the oracle's own parser."""
+    rmsgs = _renderer_messages_from(messages)
+    sup, weights = _renderer_supervised(
+        renderer,
+        rmsgs,
+        train_on_what=TrainOnWhat.LAST_ASSISTANT_TURN,
+    )
+    trained_ids = [t for t, w in zip(sup, weights) if w > 0]
+    trained_text = tokenizer.decode(trained_ids)
+
+    if thinking_mode == "thinking":
+        # The oracle parser expects the closing </think> but NOT the
+        # opening <think> (which is part of the generation prefix).
+        # Our trained span already has that shape.
+        pass
+    return oracle.parse_message_from_completion_text(trained_text, thinking_mode)
+
+
+def test_trained_span_roundtrips_simple_chat(tokenizer, renderer_chat):
+    msgs = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "bye"},
+    ]
+    parsed = _roundtrip_oracle_parse(tokenizer, renderer_chat, msgs, "chat")
+    assert parsed["content"] == "bye"
+    assert parsed["reasoning_content"] == ""
+    assert parsed["tool_calls"] == []
+
+
+def test_trained_span_roundtrips_thinking(tokenizer, renderer_thinking_keep):
+    msgs = [
+        {"role": "user", "content": "What's 2+2?"},
+        {"role": "assistant", "reasoning_content": "compute 2+2", "content": "4"},
+    ]
+    parsed = _roundtrip_oracle_parse(
+        tokenizer,
+        renderer_thinking_keep,
+        msgs,
+        "thinking",
+    )
+    assert parsed["content"] == "4"
+    assert parsed["reasoning_content"] == "compute 2+2"
+    assert parsed["tool_calls"] == []
+
+
+def test_trained_span_roundtrips_with_tool_call(tokenizer, renderer_thinking_keep):
+    msgs = [
+        {"role": "user", "content": "weather"},
+        {
+            "role": "assistant",
+            "reasoning_content": "need lookup",
+            "content": "",
+            "tool_calls": [
+                {
+                    "type": "function",
+                    "id": "call_1",
+                    "function": {
+                        "name": "get_weather",
+                        "arguments": json.dumps({"city": "SF", "n": 1}),
+                    },
+                }
+            ],
+        },
+    ]
+    parsed = _roundtrip_oracle_parse(
+        tokenizer,
+        renderer_thinking_keep,
+        msgs,
+        "thinking",
+    )
+    assert parsed["content"] == ""
+    assert parsed["reasoning_content"] == "need lookup"
+    assert len(parsed["tool_calls"]) == 1
+    tc = parsed["tool_calls"][0]
+    assert tc["function"]["name"] == "get_weather"
+    # Oracle decoder produces a hand-built JSON string with raw values for
+    # non-string params; load it back to assert the semantic shape.
+    assert json.loads(tc["function"]["arguments"]) == {"city": "SF", "n": 1}
+
+
+# ── Layer 4: targeted weight-mask invariants ────────────────────────────────
+
+
+def test_weight_mask_eos_is_trained(tokenizer, renderer_thinking_keep):
+    """The EOS at the end of a trainable assistant carries weight=1.
+
+    DSv4 uses EOS as the assistant stop marker, so the model must learn
+    to produce it.
+    """
+    msgs = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "reasoning_content": "r", "content": "bye"},
+    ]
+    eos_id = tokenizer.encode(_EOS_TEXT, add_special_tokens=False)[0]
+    sup, weights = _renderer_supervised(
+        renderer_thinking_keep,
+        _renderer_messages_from(msgs),
+        train_on_what=TrainOnWhat.LAST_ASSISTANT_TURN,
+    )
+    assert sup[-1] == eos_id
+    assert weights[-1] == 1
+
+
+def test_weight_mask_assistant_header_is_masked(tokenizer, renderer_thinking_keep):
+    """``<|Assistant|><think>`` is the boundary — must be weight 0."""
+    msgs = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "reasoning_content": "r", "content": "bye"},
+    ]
+    asst_id = tokenizer.encode(_ASSISTANT_SP, add_special_tokens=False)[0]
+    think_open_id = tokenizer.encode(_THINK_OPEN, add_special_tokens=False)[0]
+    sup, weights = _renderer_supervised(
+        renderer_thinking_keep,
+        _renderer_messages_from(msgs),
+        train_on_what=TrainOnWhat.LAST_ASSISTANT_TURN,
+    )
+    asst_pos = sup.index(asst_id)
+    assert weights[asst_pos] == 0, "<|Assistant|> tag must be masked"
+    assert sup[asst_pos + 1] == think_open_id
+    assert weights[asst_pos + 1] == 0, "boundary <think> must be masked"
+    # The token immediately after the boundary <think> is part of the
+    # model's reasoning and MUST train.
+    assert (
+        weights[asst_pos + 2] == 1
+    ), "first reasoning token after <think> must be trained"
+
+
+def test_weight_mask_chat_mode_close_think_is_masked(tokenizer, renderer_chat):
+    """In chat mode, the boundary ``</think>`` is also masked."""
+    msgs = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "bye"},
+    ]
+    asst_id = tokenizer.encode(_ASSISTANT_SP, add_special_tokens=False)[0]
+    think_close_id = tokenizer.encode(_THINK_CLOSE, add_special_tokens=False)[0]
+    sup, weights = _renderer_supervised(
+        renderer_chat,
+        _renderer_messages_from(msgs),
+        train_on_what=TrainOnWhat.LAST_ASSISTANT_TURN,
+    )
+    asst_pos = sup.index(asst_id)
+    assert weights[asst_pos] == 0
+    assert sup[asst_pos + 1] == think_close_id
+    assert weights[asst_pos + 1] == 0
+    # The first content token (`bye`) must train.
+    assert weights[asst_pos + 2] == 1
+
+
+def test_weight_mask_user_and_system_are_masked(tokenizer, renderer_thinking_keep):
+    msgs = [
+        {"role": "system", "content": "SYSTEM_PROMPT"},
+        {"role": "user", "content": "USER_QUERY"},
+        {"role": "assistant", "reasoning_content": "REASON", "content": "ANSWER"},
+    ]
+    sup, weights = _renderer_supervised(
+        renderer_thinking_keep,
+        _renderer_messages_from(msgs),
+        train_on_what=TrainOnWhat.LAST_ASSISTANT_TURN,
+    )
+    decoded_full = tokenizer.decode(sup)
+    trained = _trained_text(tokenizer, sup, weights)
+
+    # Sanity: rendered output contains everything.
+    assert "SYSTEM_PROMPT" in decoded_full
+    assert "USER_QUERY" in decoded_full
+    assert "REASON" in decoded_full
+    assert "ANSWER" in decoded_full
+
+    # Trained span contains only model output.
+    assert "SYSTEM_PROMPT" not in trained
+    assert "USER_QUERY" not in trained
+    assert "REASON" in trained
+    assert "ANSWER" in trained
+    assert _USER_SP not in trained
+    assert _ASSISTANT_SP not in trained
+    assert trained.endswith(_EOS_TEXT)
+
+
+def test_weight_mask_tool_result_is_masked(tokenizer, renderer_thinking_keep):
+    """``<tool_result>...</tool_result>`` is environment-supplied → weight 0."""
+    msgs = [
+        {"role": "user", "content": "weather"},
+        {
+            "role": "assistant",
+            "reasoning_content": "r",
+            "content": "",
+            "tool_calls": [
+                {
+                    "type": "function",
+                    "id": "call_1",
+                    "function": {
+                        "name": "get_weather",
+                        "arguments": json.dumps({"city": "SF"}),
+                    },
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "content": "TOOL_RESULT_PAYLOAD"},
+        {"role": "assistant", "reasoning_content": "got it", "content": "FINAL_ANSWER"},
+    ]
+    sup, weights = _renderer_supervised(
+        renderer_thinking_keep,
+        _renderer_messages_from(msgs),
+        train_on_what=TrainOnWhat.LAST_ASSISTANT_TURN,
+    )
+    trained = _trained_text(tokenizer, sup, weights)
+    assert "TOOL_RESULT_PAYLOAD" not in trained
+    assert "FINAL_ANSWER" in trained
+    assert "got it" in trained
+
+
+def test_weight_mask_tool_call_body_is_trained(tokenizer, renderer_thinking_keep):
+    """The model produces the DSML tool-call body, so it must train."""
+    msgs = [
+        {"role": "user", "content": "weather"},
+        {
+            "role": "assistant",
+            "reasoning_content": "r",
+            "content": "",
+            "tool_calls": [
+                {
+                    "type": "function",
+                    "id": "call_1",
+                    "function": {
+                        "name": "get_weather",
+                        "arguments": json.dumps({"city": "PARAM_VALUE_SF"}),
+                    },
+                }
+            ],
+        },
+    ]
+    sup, weights = _renderer_supervised(
+        renderer_thinking_keep,
+        _renderer_messages_from(msgs),
+        train_on_what=TrainOnWhat.LAST_ASSISTANT_TURN,
+    )
+    trained = _trained_text(tokenizer, sup, weights)
+    assert "PARAM_VALUE_SF" in trained
+    assert "get_weather" in trained
+    assert _DSML in trained
+
+
+# ── Multi-turn weight check (extension property) ────────────────────────────
+
+
+def test_multi_turn_keeps_history_reasoning_in_keep_mode(
+    tokenizer,
+    renderer_thinking_keep,
+):
+    """When extension property holds, ALL_ASSISTANT_MESSAGES trains every turn."""
+    msgs = [
+        {"role": "user", "content": "q1"},
+        {"role": "assistant", "reasoning_content": "R1", "content": "A1"},
+        {"role": "user", "content": "q2"},
+        {"role": "assistant", "reasoning_content": "R2", "content": "A2"},
+    ]
+    sup, weights = _renderer_supervised(
+        renderer_thinking_keep,
+        _renderer_messages_from(msgs),
+        train_on_what=TrainOnWhat.ALL_ASSISTANT_MESSAGES,
+    )
+    trained = _trained_text(tokenizer, sup, weights)
+    # Both turns' reasoning + content trained; user content not trained.
+    assert "R1" in trained
+    assert "A1" in trained
+    assert "R2" in trained
+    assert "A2" in trained
+    assert "q1" not in trained
+    assert "q2" not in trained
+
+
+def test_strip_history_drops_first_turn_reasoning(
+    tokenizer,
+    renderer_thinking_strip,
+):
+    """In strip mode, the first turn's reasoning is dropped from the rendering.
+
+    LAST_ASSISTANT_MESSAGE only trains the terminal turn anyway, so this
+    asserts the *rendering* of historical assistants doesn't contain
+    their reasoning at all (let alone get it trained).
+    """
+    msgs = [
+        {"role": "user", "content": "q1"},
+        {
+            "role": "assistant",
+            "reasoning_content": "DROPPED_HISTORY_REASONING",
+            "content": "A1",
+        },
+        {"role": "user", "content": "q2"},
+        {"role": "assistant", "reasoning_content": "R2", "content": "A2"},
+    ]
+    sup, weights = _renderer_supervised(
+        renderer_thinking_strip,
+        _renderer_messages_from(msgs),
+        train_on_what=TrainOnWhat.LAST_ASSISTANT_MESSAGE,
+    )
+    decoded_full = tokenizer.decode(sup)
+    assert "DROPPED_HISTORY_REASONING" not in decoded_full
+    # Terminal reasoning still rendered + trained.
+    trained = _trained_text(tokenizer, sup, weights)
+    assert "R2" in trained
+    assert "A2" in trained
+
+
+# ── parse_response sanity ───────────────────────────────────────────────────
+
+
+def test_parse_response_recovers_thinking_and_content(
+    tokenizer,
+    renderer_thinking_keep,
+):
+    """``parse_response(ids)`` recovers reasoning + content from a model-emit."""
+    text = "the answer is 4"
+    full = "compute" + _THINK_CLOSE + text + _EOS_TEXT
+    ids = tokenizer.encode(full, add_special_tokens=False)
+    msg, ok = renderer_thinking_keep.parse_response(ids)
+    assert ok is True
+    assert msg.get("reasoning_content") == "compute"
+    assert msg["content"] == text
+
+
+def test_parse_response_returns_false_without_eos(tokenizer, renderer_thinking_keep):
+    text = "compute" + _THINK_CLOSE + "partial answer"
+    ids = tokenizer.encode(text, add_special_tokens=False)
+    msg, ok = renderer_thinking_keep.parse_response(ids)
+    assert ok is False
+    assert msg["content"] == "partial answer"
+
+
+def test_parse_response_extracts_tool_call(tokenizer, renderer_thinking_keep):
+    """``\\n\\n<|DSML|tool_calls>...`` block round-trips into a ``ToolCall``."""
+    body = (
+        f"reasoning{_THINK_CLOSE}"
+        f"\n\n<{_DSML}tool_calls>\n"
+        f'<{_DSML}invoke name="f">\n'
+        f'<{_DSML}parameter name="x" string="false">42</{_DSML}parameter>\n'
+        f"</{_DSML}invoke>\n"
+        f"</{_DSML}tool_calls>"
+        f"{_EOS_TEXT}"
+    )
+    ids = tokenizer.encode(body, add_special_tokens=False)
+    msg, ok = renderer_thinking_keep.parse_response(ids)
+    assert ok is True
+    assert msg.get("reasoning_content") == "reasoning"
+    assert msg["content"] == ""
+    assert len(msg["tool_calls"]) == 1
+    tc = msg["tool_calls"][0]
+    assert tc.function.name == "f"
+    assert json.loads(tc.function.arguments) == {"x": 42}

--- a/training/tests/unit/test_supervised_rendering.py
+++ b/training/tests/unit/test_supervised_rendering.py
@@ -692,6 +692,13 @@ def test_resolve_renderer_name_prefers_gemma4() -> None:
     assert resolve_renderer_name("google/gemma-4-27b-it") == "gemma4"
 
 
+def test_resolve_renderer_name_prefers_deepseek_v4() -> None:
+    """DeepSeek-V4 tokenizers should resolve to the custom deepseek_v4 renderer."""
+    assert resolve_renderer_name("deepseek-ai/DeepSeek-V4-Flash") == "deepseek_v4"
+    assert resolve_renderer_name("deepseek-ai/deepseek_v4") == "deepseek_v4"
+    assert resolve_renderer_name("custom/DeepSeekV4-finetune") == "deepseek_v4"
+
+
 def test_build_renderer_resolves_minimax_m2(monkeypatch) -> None:
     """build_renderer should resolve minimax_m2 and dispatch to get_renderer."""
     calls: list[tuple[str, object]] = []
@@ -846,7 +853,8 @@ def test_populate_render_worker_state_writes_canonical_keys(monkeypatch):
     fake_tokenizer = object()
     fake_renderer = object()
     monkeypatch.setattr(
-        sup.transformers.AutoTokenizer, "from_pretrained",
+        sup.transformers.AutoTokenizer,
+        "from_pretrained",
         lambda model, **kwargs: fake_tokenizer,
     )
     monkeypatch.setattr(sup, "build_renderer", lambda *a, **k: fake_renderer)
@@ -884,7 +892,10 @@ def test_populate_render_worker_state_uses_trust_remote_code(monkeypatch):
     monkeypatch.setattr(sup, "build_renderer", lambda *a, **k: object())
 
     populate_render_worker_state(
-        {}, tokenizer_model="m", renderer_name="r", max_seq_len=1,
+        {},
+        tokenizer_model="m",
+        renderer_name="r",
+        max_seq_len=1,
     )
     assert captured["model"] == "m"
     assert captured["kwargs"].get("trust_remote_code") is True

--- a/training/utils/supervised.py
+++ b/training/utils/supervised.py
@@ -36,6 +36,7 @@ from tinker_cookbook.supervised.common import datum_from_model_input_weights
 import training.renderer.nemotron as _nemotron_renderer  # noqa: F401 — triggers register_renderer
 import training.renderer.minimax_m2 as _minimax_m2_renderer  # noqa: F401 — triggers register_renderer
 import training.renderer.gemma4 as _gemma4_renderer  # noqa: F401 — triggers register_renderer
+import training.renderer.deepseek_v4 as _deepseek_v4_renderer  # noqa: F401 — triggers register_renderer
 
 
 @dataclass(frozen=True)
@@ -91,6 +92,16 @@ def resolve_renderer_name(
         return "qwen3_5"
     if "gemma-4" in normalized_model_name or "gemma4" in normalized_model_name:
         return "gemma4"
+    # DeepSeek-V4 ships a custom non-Jinja encoder (see encoding_dsv4.py upstream)
+    # with thinking blocks and DSML tool calls. Match the V4 family explicitly so
+    # we don't accidentally claim V3 (which routes through tinker_cookbook's
+    # built-in deepseekv3_thinking renderer via get_recommended_renderer_name).
+    if (
+        "deepseek-v4" in normalized_model_name
+        or "deepseek_v4" in normalized_model_name
+        or "deepseekv4" in normalized_model_name
+    ):
+        return "deepseek_v4"
     # ZhipuAI GLM-5.1 chat template (`[gMASK]<sop>`, `<|user|>`,
     # `<|assistant|>`, `<think>...</think>`, `<|endoftext|>`). Validated
     # end-to-end via SFT training. Other GLM versions are out of scope;
@@ -148,7 +159,8 @@ def populate_render_worker_state(
     for HF tokenizer load -- required by Kimi / Qwen image processors.
     """
     tokenizer = transformers.AutoTokenizer.from_pretrained(
-        tokenizer_model, trust_remote_code=True,
+        tokenizer_model,
+        trust_remote_code=True,
     )
     state.update(
         tokenizer=tokenizer,


### PR DESCRIPTION
## Summary

Port the upstream DSv4 encoder (`deepseek-ai/DeepSeek-V4-Flash/encoding/encoding_dsv4.py`) into the `tinker_cookbook` renderer abstraction so SFT/RLOR data renders byte-for-byte the same way DSv4 inference does.

DSv4 ships a hand-rolled Python encoder (no Jinja `chat_template`), so the encoder itself is the authoritative source of truth. We vendor it verbatim under `training/tests/_encoding_dsv4_oracle.py` (with a refresh recipe in the file header) and pin the renderer to it.

## What it covers

- `thinking` and `chat` modes
- `strip_thinking_from_history` flag, including the encoder's auto-disable when any message carries `tools`
- DSML-formatted parallel tool calls (`string="true"`/`"false"` arg branching)
- Tool-result reordering to match preceding `tool_calls` order (mirrors `sort_tool_results_by_call_order`)
- `tools` and `response_format` rendered into the system prompt
- Generation prompt: `<｜Assistant｜><think>` (thinking) / `<｜Assistant｜></think>` (chat)
- `parse_response` recovers `reasoning_content` + `content` + `tool_calls`

**Out of scope** (intentionally — call sites needing these should keep using the upstream encoder directly): `developer` role, `latest_reminder` role, internal task tokens (`action`/`query`/`authority`/`domain`/`title`/`read_url`), `wo_eos`, `reasoning_effort` preamble, `context` parameter.

## Code overview

```mermaid
flowchart LR
    subgraph caller["Caller (SFT loop / RL loop)"]
        msgs["List[Message]"]
    end

    subgraph renderer["DeepseekV4Renderer"]
        prep["_preprocess<br/>merge_tool→sort→drop_history"]
        rm["render_message<br/>system / user / assistant"]
        gs["_get_generation_suffix"]
        pr["parse_response"]
    end

    subgraph oracle["_encoding_dsv4_oracle (vendored, tests-only)"]
        enc["encode_messages"]
        parse["parse_message_from_completion_text"]
    end

    msgs -->|build_supervised_example| prep --> rm
    msgs -->|build_generation_prompt| prep --> gs
    rm -->|"(header, output, EOS)"| sup["ModelInput + weights"]
    gs -->|prompt prefix| gen["ModelInput"]

    sup -. "test parity" .-> enc
    gen -. "test parity" .-> enc
    sup -. "trained-span roundtrip" .-> parse
    pr -. "tool-call shape parity" .-> parse
```

## Testing strategy (89 tests, all passing)

Three layers of correctness checks:

1. **Format parity** — string and token IDs match `encoding_dsv4.encode_messages` across thinking-strip / thinking-keep / chat modes × 7 fixtures, plus tool-call argument formatting (string vs JSON-encoded mixed types) and parallel tool-result reordering.
2. **Train-inference prefix invariant** — the bedrock weight-mask check. For every supervised fixture, `build_generation_prompt(messages[:-1])` is a strict zero-weight prefix of `build_supervised_example(messages)`, and every token after the prefix has weight 1. Parametrized across all three modes × 7 fixtures.
3. **Trained-span roundtrip via the oracle parser** — decode the trained span and feed it to `encoding_dsv4.parse_message_from_completion_text`; it must reconstruct the original assistant message (reasoning + content + tool calls). Uniquely possible for DSv4 because the oracle ships a parser as well.

Plus targeted weight-mask tests:
- EOS trained as the assistant stop signal
- `<｜Assistant｜>` and the boundary `<think>` / `</think>` token masked (model never produces the framework-injected prefix)
- User / system / `<tool_result>` spans masked
- DSML tool-call body trained (`<｜DSML｜invoke>...<｜DSML｜parameter>` and arg values)

## Run locally

```bash
cd training
PYTHONPATH=../.. python -m pytest tests/unit/test_deepseek_v4_renderer.py -v
```

## Test plan

- [x] All 89 new tests pass against `deepseek-ai/DeepSeek-V4-Flash` from HF Hub
- [x] Existing renderer tests (GLM-5, MiniMax-M2, Nemotron, Gemma-4) still pass — 144 / 144 (32 skipped on tokenizer availability, unchanged from main)
- [x] `black` clean
- [x] No lint errors

Made with [Cursor](https://cursor.com)