### PR TITLE
fix(sft): per-user-turn fallback for non-extension renderers

### DIFF
--- a/training/tests/smoke_test/test_sft_smoke.py
+++ b/training/tests/smoke_test/test_sft_smoke.py
@@ -10,15 +10,33 @@ import pytest
 
 
 def _make_chat_dataset(path: str, num_examples: int = 4) -> None:
+    """Write a tiny SFT dataset that exercises both single-turn and multi-turn rows.
+
+    The first row is single-turn (1 user message). All subsequent rows are
+    multi-turn (>=2 user messages) so the smoke test runs the
+    ``build_supervised_examples`` dispatcher path used by non-extension
+    renderers (Qwen3-family, Kimi K2.5/K2.6, DeepSeek-thinking) on
+    multi-turn data. Without a multi-turn row, the dispatcher's
+    ``users > 1`` guard short-circuits and the smoke test never validates
+    that the active renderer can split a conversation into multiple
+    supervised examples — see the qwen3p5-27b SFT failure that this guard
+    would have caught.
+    """
     with open(path, "w") as f:
         for i in range(num_examples):
-            row = {
-                "messages": [
+            if i == 0:
+                messages = [
                     {"role": "user", "content": f"What is {i} plus {i}?"},
                     {"role": "assistant", "content": f"The answer is {i + i}."},
                 ]
-            }
-            f.write(json.dumps(row) + "\n")
+            else:
+                messages = [
+                    {"role": "user", "content": f"What is {i} plus {i}?"},
+                    {"role": "assistant", "content": f"The answer is {i + i}."},
+                    {"role": "user", "content": f"And what about {i} plus {i + 1}?"},
+                    {"role": "assistant", "content": f"The answer is {i + i + 1}."},
+                ]
+            f.write(json.dumps({"messages": messages}) + "\n")
 
 
 @pytest.mark.e2e

--- a/training/tests/unit/test_supervised_rendering.py
+++ b/training/tests/unit/test_supervised_rendering.py
@@ -261,6 +261,11 @@ def test_render_messages_to_datums_uses_renderer_split_for_weighted_rows():
 
 
 def test_render_messages_to_datums_fails_fast_without_split_implementation():
+    """A renderer that explicitly overrides build_supervised_examples to raise
+    must not be silently rescued by the per-user-turn fallback — its own
+    NotImplementedError surfaces so authors see exactly which renderer needs
+    work."""
+
     class UnimplementedSplitRenderer:
         has_extension_property = False
 
@@ -281,6 +286,99 @@ def test_render_messages_to_datums_fails_fast_without_split_implementation():
             renderer=UnimplementedSplitRenderer(),
             train_on_what="all_assistant_messages",
         )
+
+
+def test_render_messages_to_datums_falls_back_per_user_turn_when_no_override():
+    """Multi-turn SFT on a non-extension renderer that does NOT override the
+    plural ``build_supervised_examples`` method (the upstream
+    ``tinker_cookbook`` default) must fall back to one
+    ``build_supervised_example`` call per user-turn prefix instead of raising
+    ``NotImplementedError``.
+
+    Regression test: Qwen3 / Qwen3.5 / Qwen3-VL / Kimi K2.5 / Kimi K2.6 /
+    DeepSeek-V3-thinking renderers have ``has_extension_property=False`` and
+    inherit the base ``build_supervised_examples`` that raises
+    NotImplementedError. Multi-turn SFT rows used to fail at runtime with
+    ``NotImplementedError: build_supervised_examples has not been implemented
+    for this renderer.`` even though each assistant turn is trivially
+    renderable as its own example.
+    """
+    from tinker_cookbook.renderers.base import Renderer as _BaseRenderer
+
+    calls: list[tuple[list[dict], TrainOnWhat]] = []
+
+    class NonExtensionRenderer:
+        """Stand-in for a tinker_cookbook renderer with strip_thinking_from_history=True."""
+
+        has_extension_property = False
+        build_supervised_examples = _BaseRenderer.build_supervised_examples
+
+        def build_supervised_example(self, messages, train_on_what):
+            calls.append(([dict(m) for m in messages], train_on_what))
+            n = len(messages)
+            tokens = list(range(10, 10 + n + 1))
+            weights = [1.0] * len(tokens)
+            return (
+                torch.tensor(tokens, dtype=torch.int64),
+                torch.tensor(weights, dtype=torch.float32),
+            )
+
+    rendered = render_messages_to_datums(
+        [
+            {"role": "user", "content": "u1"},
+            {"role": "assistant", "content": "a1"},
+            {"role": "user", "content": "u2"},
+            {"role": "assistant", "content": "a2"},
+            {"role": "user", "content": "u3"},
+            {"role": "assistant", "content": "a3"},
+        ],
+        renderer=NonExtensionRenderer(),
+        train_on_what="all_assistant_messages",
+    )
+
+    assert len(rendered) == 3
+    prefixes = [[m["role"] for m in messages] for messages, _ in calls]
+    assert prefixes == [
+        ["user", "assistant"],
+        ["user", "assistant", "user", "assistant"],
+        ["user", "assistant", "user", "assistant", "user", "assistant"],
+    ]
+    train_on_what_modes = [tow for _, tow in calls]
+    assert train_on_what_modes == [TrainOnWhat.LAST_ASSISTANT_TURN] * 3
+
+
+def test_render_messages_to_datums_per_turn_fallback_passes_through_other_modes():
+    """Non-ALL_ASSISTANT_MESSAGES modes (e.g. CUSTOMIZED weighted rows) must
+    pass through unchanged so the renderer honors the caller's train_on_what
+    on each user-turn prefix instead of being silently coerced to
+    LAST_ASSISTANT_TURN."""
+    from tinker_cookbook.renderers.base import Renderer as _BaseRenderer
+
+    calls: list[TrainOnWhat] = []
+
+    class NonExtensionRenderer:
+        has_extension_property = False
+        build_supervised_examples = _BaseRenderer.build_supervised_examples
+
+        def build_supervised_example(self, messages, train_on_what):
+            calls.append(train_on_what)
+            return (
+                torch.tensor([10, 11], dtype=torch.int64),
+                torch.tensor([0.0, 1.0], dtype=torch.float32),
+            )
+
+    render_messages_to_datums(
+        [
+            {"role": "user", "content": "u1"},
+            {"role": "assistant", "content": "a1", "weight": 0},
+            {"role": "user", "content": "u2"},
+            {"role": "assistant", "content": "a2"},
+        ],
+        renderer=NonExtensionRenderer(),
+        train_on_what="all_assistant_messages",
+    )
+
+    assert calls == [TrainOnWhat.CUSTOMIZED, TrainOnWhat.CUSTOMIZED]
 
 
 def test_normalize_messages_supports_openai_tool_call_shape():

--- a/training/utils/supervised.py
+++ b/training/utils/supervised.py
@@ -30,6 +30,7 @@ from tinker_cookbook.renderers import (
     TrainOnWhat,
     get_renderer,
 )
+from tinker_cookbook.renderers.base import Renderer as _BaseRenderer
 
 from tinker_cookbook.image_processing_utils import get_image_processor
 from tinker_cookbook.supervised.common import datum_from_model_input_weights
@@ -797,25 +798,73 @@ def _requires_renderer_supervised_examples(
     return sum(1 for message in messages if message["role"] == "user") > 1
 
 
+def _renderer_has_own_split(renderer: Renderer) -> bool:
+    """Renderer overrides ``build_supervised_examples`` from the upstream base.
+
+    Used to decide between calling the renderer's plural method and the
+    per-user-turn fallback. We treat both ``None`` (no method at all) and the
+    upstream base-class method (which raises ``NotImplementedError`` for
+    non-extension renderers) as "no override".
+    """
+    method = getattr(type(renderer), "build_supervised_examples", None)
+    if method is None:
+        return False
+    base_method = getattr(_BaseRenderer, "build_supervised_examples", None)
+    return method is not base_method
+
+
+def _split_messages_at_user_turns(messages: list[Message]) -> list[list[Message]]:
+    """Yield message prefixes ending after each non-final user turn's responses."""
+    user_idxs = [idx for idx, message in enumerate(messages) if message["role"] == "user"]
+    if not user_idxs:
+        return [list(messages)]
+    cut_points = [*user_idxs[1:], len(messages)]
+    return [list(messages[:cut]) for cut in cut_points]
+
+
+def _build_examples_per_user_turn(
+    renderer: Renderer,
+    messages: list[Message],
+    train_on_what: TrainOnWhat,
+) -> list[tuple[Any, Any]]:
+    """Per-user-turn fallback for renderers without ``build_supervised_examples``.
+
+    Splits the conversation at user boundaries and renders each prefix as its
+    own ``build_supervised_example``. For ``ALL_ASSISTANT_MESSAGES`` this
+    matches the GLM-5.1 dispatcher's semantics (each assistant suffix is
+    trained at the same position the renderer would produce at generation
+    time), which is the safe default for thinking-history-stripped renderers
+    (Qwen3, Qwen3.5, Qwen3-VL, Kimi K2.5/K2.6, DeepSeek V3-thinking) when
+    ``has_extension_property=False``.
+    """
+    per_turn_train_on_what = (
+        TrainOnWhat.LAST_ASSISTANT_TURN
+        if train_on_what == TrainOnWhat.ALL_ASSISTANT_MESSAGES
+        else train_on_what
+    )
+    return [
+        renderer.build_supervised_example(
+            prefix,
+            train_on_what=per_turn_train_on_what,
+        )
+        for prefix in _split_messages_at_user_turns(messages)
+    ]
+
+
 def _build_renderer_supervised_examples(
     renderer: Renderer,
     messages: list[Message],
     train_on_what: TrainOnWhat,
 ) -> list[tuple[Any, Any]]:
     if _requires_renderer_supervised_examples(renderer, messages, train_on_what):
-        build_supervised_examples = getattr(renderer, "build_supervised_examples", None)
-        if build_supervised_examples is None:
-            raise TypeError(
-                f"{type(renderer).__name__} has has_extension_property=False and "
-                f"cannot safely render train_on_what={train_on_what.value!r} without "
-                "build_supervised_examples."
+        if _renderer_has_own_split(renderer):
+            return list(
+                renderer.build_supervised_examples(
+                    messages,
+                    train_on_what=train_on_what,
+                )
             )
-        return list(
-            build_supervised_examples(
-                messages,
-                train_on_what=train_on_what,
-            )
-        )
+        return _build_examples_per_user_turn(renderer, messages, train_on_what)
 
     return [
         renderer.build_supervised_example(


### PR DESCRIPTION
## Description

Multi-turn SFT on a non-extension renderer (Qwen3 / Qwen3.5 / Qwen3-VL / Kimi K2.5 / Kimi K2.6 / DeepSeek-V3-thinking) used to fail at runtime with:

```
NotImplementedError: build_supervised_examples has not been implemented for this renderer.
```

The dispatcher introduced in #397 routes non-extension renderers (`has_extension_property=False`) through the renderer's plural `build_supervised_examples` whenever the row has `>1` user messages and `train_on_what` is one of `ALL_ASSISTANT_MESSAGES / ALL_MESSAGES / ALL_TOKENS / ALL_USER_AND_SYSTEM_MESSAGES / CUSTOMIZED`. Today only `GLM5Renderer` overrides `build_supervised_examples`. Every Qwen3-family / Kimi / DeepSeek-thinking renderer in `tinker_cookbook` inherits the upstream base implementation, which raises `NotImplementedError`. Multi-turn customer SFT crashed in the DataLoader worker before any training step.

This PR adds a per-user-turn fallback when the renderer does not override `build_supervised_examples`. The fallback splits the conversation at user-turn boundaries and renders each prefix as its own `build_supervised_example` — matching the GLM-5.1 dispatcher's semantics for `ALL_ASSISTANT_MESSAGES` (each assistant suffix is trained at the same position the renderer would emit at generation time).

## Why the smoke test missed it

`training/tests/smoke_test/test_sft_smoke.py::_make_chat_dataset` writes single-turn rows only (1 user message per row). The dispatcher's `users > 1` guard short-circuits and the renderer never has to implement `build_supervised_examples`. Multi-turn SFT — the customer's case — fires the code path that is unimplemented for Qwen3-family. This PR also extends the smoke dataset so subsequent rows are multi-turn (`user/assistant/user/assistant`), which exercises the dispatcher path on the smoke base model.

## Architecture / Code Overview Diagram

```mermaid
flowchart TD
    A[render_messages_to_datums] --> B{has_extension_property?}
    B -- True --> C[build_supervised_example single example]
    B -- False --> D{users > 1 and train_on_what requires split?}
    D -- No --> C
    D -- Yes --> E{Renderer overrides build_supervised_examples?}
    E -- Yes --> F[renderer.build_supervised_examples e.g. GLM5]
    E -- No --> G[Per-user-turn fallback: build_supervised_example for each user-turn prefix]
    G --> H[Qwen3 / Qwen3.5 / Qwen3-VL / Kimi K2.5 / Kimi K2.6 / DeepSeek-V3-thinking]
```

## Behavior summary

| Renderer kind | `has_extension_property` | Override `build_supervised_examples`? | Path before | Path after |
|---|---|---|---|---|
| Llama-3 / Qwen3-Instruct / DeepSeek-V3-non-thinking | `True` | — | single-example | single-example (unchanged) |
| GLM-5.1 | `False` | yes | renderer split | renderer split (unchanged) |
| **Qwen3 / Qwen3.5 / Qwen3-VL / Kimi K2.5 / Kimi K2.6 / DeepSeek-V3-thinking** | `False` | no (inherits base) | **NotImplementedError** | **per-user-turn fallback** |
| Test renderer that intentionally raises | `False` | yes (raises) | NotImplementedError surfaced | NotImplementedError surfaced (unchanged) |

## Testing

- Added two unit tests in `training/tests/unit/test_supervised_rendering.py`:
  - `test_render_messages_to_datums_falls_back_per_user_turn_when_no_override` — verifies the fallback splits at user turns and uses `LAST_ASSISTANT_TURN` per prefix for `ALL_ASSISTANT_MESSAGES`.
  - `test_render_messages_to_datums_per_turn_fallback_passes_through_other_modes` — verifies `CUSTOMIZED` (and other non-`ALL_ASSISTANT_MESSAGES` modes) are passed through unchanged on each prefix.
- Verified end-to-end against the real `tinker_cookbook.renderers.qwen3.Qwen3Renderer` (same lineage as Qwen3.5: 3 datums returned for a 3-user-turn conversation, weights non-zero only on the last assistant turn of each prefix).
- `pytest training/tests/unit/test_supervised_rendering.py training/tests/unit/test_sft_loop.py training/tests/unit/test_glm5_renderer.py training/tests/unit/test_streaming.py` → 142 passed.
