### PR TITLE
chore(training): bump fireworks training sdk pin to >=1.2.0a67

### DIFF
--- a/training/pyproject.toml
+++ b/training/pyproject.toml
@@ -7,7 +7,7 @@ name = "fireworks-training-cookbook"
 version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [
-    "fireworks-ai[training]>=1.2.0a66,<2",
+    "fireworks-ai[training]>=1.2.0a67,<2",
     "tqdm",
     "torch",
     "datasets",


### PR DESCRIPTION
## Summary

Bump the cookbook's `fireworks-ai[training]` floor from `>=1.2.0a66` to `>=1.2.0a67` so cookbook + downstream installs (incl. fireworks-1's single-shape CI) pick up the FireTitan training SDK fixes from [stainless-sdks/fireworks-ai-python#133](https://github.com/stainless-sdks/fireworks-ai-python/pull/133):

- `DeploymentManager.hotload(path=...)` plumbs the resolved `gs://` URI to the gateway so vLLM-backed multi-LoRA hotload can fetch the adapter (FA backends ignore the field, harmless cross-engine).
- `WeightSyncer` combines `SaveSamplerResult.path` (a relative snapshot dir name) with the deployment's `hot_load_bucket_url` to form a fully-qualified URI before forwarding; cached after the first lookup.
- `DeploymentManager.wait_for_hotload` recognises vLLM's per-adapter `loaded_adapters[].status="loaded"` shape in addition to the FA `current_snapshot_identity` shape.

Without this floor the cookbook can resolve to `1.2.0a66`, which lacks all three behaviors: vLLM hotload either 404s at the gateway (no `path`), downloads nothing useful (relative path treated as a URI), or hangs in the SDK wait loop after the proxy reports success.

## Release timing

`1.2.0a67` is **not yet on PyPI** as of this PR. The trigger is the merge of [fw-ai-external/python-sdk#73 \"release: 1.2.0-alpha.67\"](https://github.com/fw-ai-external/python-sdk/pull/73); once that lands, `publish-pypi.yml` uploads the wheel automatically. After the wheel is up, this PR can be merged and any subsequent CI run will pick up the new version without further changes.

If this lands before the SDK release, fresh `pip install -e training[dev]` runs will fail to resolve the requirement until `1.2.0a67` is published. So either:
1. Wait for `fw-ai-external/python-sdk#73` to merge + PyPI to publish, then merge this PR; **or**
2. Merge this PR now and accept brief breakage of fresh installs (existing envs are unaffected) while we wait for the SDK release.

## Visual

```mermaid
sequenceDiagram
  participant SDK as stainless-sdks/python-sdk#133
  participant Pub as fw-ai-external/python-sdk#73
  participant PyPI as PyPI fireworks-ai==1.2.0a67
  participant Cook as cookbook (this PR)
  participant CI as fireworks-1 single-shape CI

  SDK->>Pub: auto-mirror (release-please)
  Note over Pub: human merges release PR
  Pub->>PyPI: publish-pypi.yml on Release published
  Cook->>Cook: floor bumped to >=1.2.0a67
  CI->>PyPI: pip install fireworks-ai[training]>=1.2.0a67,<2
  PyPI-->>CI: 1.2.0a67 wheel
```

## Test plan

- [ ] `fw-ai-external/python-sdk#73` is merged and `1.2.0a67` is visible on PyPI.
- [ ] `pip install -e training[dev]` from a clean env resolves `fireworks-ai==1.2.0a67`.
- [ ] Fireworks-1 follow-up: bump the `train-firetitan-py/cookbook` submodule pointer to this PR's merge commit so single-shape CI installs the new floor.

Made with [Cursor](https://cursor.com)