### PR TITLE
training: pre-validate promote_checkpoint and document env vars

### DIFF
--- a/training/.env.example
+++ b/training/.env.example
@@ -1,0 +1,17 @@
+# Copy to `.env` (same directory) and fill in real values.
+# `python-dotenv` loads this automatically when recipes/examples call
+# `load_dotenv()` from within the cookbook tree.
+
+# --- Fireworks ---
+# Required. Get one at https://fireworks.ai/account/api-keys
+FIREWORKS_API_KEY=
+
+# Optional. Override the control-plane host. Default: https://api.fireworks.ai
+# Use https://dev.api.fireworks.ai for staging.
+# FIREWORKS_BASE_URL=
+
+# --- Weights & Biases (optional) ---
+# Set if you want training/eval metrics streamed to W&B.
+# WANDB_API_KEY=
+# Force-disable W&B without removing the integration: WANDB_MODE=disabled
+# WANDB_MODE=

--- a/training/README.md
+++ b/training/README.md
@@ -43,13 +43,14 @@ uv pip install --pre -e .
 
 ### 2. Set your credentials
 
-Create a `.env` file in the `training/` directory (picked up automatically via `python-dotenv`):
+Copy `training/.env.example` to `training/.env` and fill it in (picked up automatically via `python-dotenv`):
 
 ```bash
-FIREWORKS_API_KEY="your-api-key"
+cp training/.env.example training/.env
+# edit training/.env and set FIREWORKS_API_KEY
 ```
 
-Or export it directly:
+The example file lists every variable the cookbook reads, including optional ones (`FIREWORKS_BASE_URL`, `WANDB_API_KEY`, `WANDB_MODE`). Or export directly instead of using a file:
 
 ```bash
 export FIREWORKS_API_KEY="..."

--- a/training/examples/tools/promote_checkpoint.py
+++ b/training/examples/tools/promote_checkpoint.py
@@ -56,7 +56,7 @@ _COOKBOOK_ROOT = os.path.abspath(
 if _COOKBOOK_ROOT not in sys.path:
     sys.path.insert(0, _COOKBOOK_ROOT)
 
-from fireworks.training.sdk import FireworksClient, TrainerJobManager
+from fireworks.training.sdk import FireworksClient, TrainerJobManager, validate_output_model_id
 from training.utils.checkpoints import _logical_name, _short_name
 
 logging.basicConfig(
@@ -214,6 +214,17 @@ def main() -> None:
     logger.info("Checkpoint:      %s", resolved.full_name)
     logger.info("Base model:      %s", cfg.base_model)
     logger.info("Output model ID: %s", output_model_id)
+
+    # Pre-validate the output model ID before calling promote_checkpoint.
+    # A server-side rejection after the sampler blob has been staged
+    # leaves the blob orphaned, so catch the bad ID locally first.
+    id_errors = validate_output_model_id(output_model_id)
+    if id_errors:
+        logger.error("Invalid output_model_id %r:", output_model_id)
+        for err in id_errors:
+            logger.error("  - %s", err)
+        sys.exit(2)
+
     if cfg.hot_load_deployment_id:
         logger.warning(
             "--hot-load-deployment-id is only needed for deployments that "


### PR DESCRIPTION
## Summary

Two small alignment fixes against the public Training-API surface:

- **`examples/tools/promote_checkpoint.py`** now calls `validate_output_model_id(...)` before `promote_checkpoint(...)` and exits with the validator errors on a bad ID. A server-side rejection after the sampler blob has been staged orphans the blob, so the example should demonstrate the safe flow.
- **`training/.env.example`** is new — a single discoverable file listing every variable the cookbook reads (`FIREWORKS_API_KEY`, optional `FIREWORKS_BASE_URL`, optional `WANDB_API_KEY` / `WANDB_MODE`). `training/README.md` now points users at it.

No public API changes, no recipe behavior changes.

## Test plan

- [ ] `python training/examples/tools/promote_checkpoint.py --job-id <real-job> --base-model accounts/fireworks/models/qwen3-8b --output-model-id INVALID-UPPERCASE` exits 2 with validator errors and does not call the promote API.
- [ ] Same command with a valid output model ID promotes successfully (regression check — happy path unchanged).
- [ ] `cp training/.env.example training/.env` and a recipe run still picks up `FIREWORKS_API_KEY` via `python-dotenv`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)