### PR TITLE
chore(training): bump fireworks-ai SDK to 1.2.0a68

### DIFF
--- a/training/pyproject.toml
+++ b/training/pyproject.toml
@@ -7,7 +7,7 @@ name = "fireworks-training-cookbook"
 version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [
-    "fireworks-ai[training]>=1.2.0a67,<2",
+    "fireworks-ai[training]>=1.2.0a68,<2",
     "tqdm",
     "torch",
     "datasets",


### PR DESCRIPTION
Bumps the training cookbook dependency from `fireworks-ai[training]>=1.2.0a67,<2` to `>=1.2.0a68,<2`.

`1.2.0a68` includes the revert for stainless-sdks/fireworks-ai-python#133, removing the hotload `path` request field that prod currently rejects.

Validation:
- `python3.11 -m pip install --dry-run --pre -e "training[dev]"` resolves `fireworks-ai-1.2.0a68`.