### PR TITLE
Fix cookbook RL KL metrics and penalty

### DIFF
--- a/skills/dev/references/rl/async-rl.md
+++ b/skills/dev/references/rl/async-rl.md
@@ -210,9 +210,16 @@ sync wall time.
 ### Other useful metrics
 
 - `train/ppo_kl` — intra-step KL between the current policy and the
-  `old_policy_logprobs` snapshot.  Large with `ppo_n_minibatches > 1` means
-  the inner loop is genuinely doing work; a near-zero value means
-  `ppo_n_minibatches=1` would have the same effect at lower cost.
+  `old_policy_logprobs` snapshot.  This is not policy/reference KL. Large
+  with `ppo_n_minibatches > 1` means the inner loop is genuinely doing work;
+  a near-zero value means `ppo_n_minibatches=1` would have the same effect at
+  lower cost.
+- `train/kl_loss`, `train/kl_penalty`, `train/kl_coef` — policy/reference KL
+  diagnostics for KL-regularized losses. `kl_loss` is the unscaled k3-style
+  estimate `exp(ref - policy) - (ref - policy) - 1`; `kl_penalty` is
+  `kl_coef * kl_loss`. `train/mean_kl` is a legacy alias for `train/kl_loss`.
+- `train/mean_logprob_diff` — signed `policy_logprob - reference_logprob`
+  diagnostic. It is useful for debugging but is not a KL.
 - `train/inference_kld`, `train/inference_diff` — drift between the policy
   used to sample and the policy at training time.  Should track `O`: at `O=0`
   these are ~0; at `O=4` they grow but should remain bounded.  Spikes that

--- a/training/README.md
+++ b/training/README.md
@@ -118,6 +118,23 @@ addition to the LoRA policy trainer. Auto-selection picks an
 appropriate validated reference shape unless `ref_training_shape_id`
 is set explicitly.
 
+**RL KL metrics** -- `train/ppo_kl` is not policy-vs-reference KL. In
+the cookbook client-side losses it is the k3-style drift between the
+current policy and the proximal `old_policy_logprobs` snapshot used for
+PPO ratios. Policy-vs-reference KL is logged as:
+
+| Metric | Meaning |
+| --- | --- |
+| `train/kl_loss` | Unscaled k3-style policy/reference KL, `exp(ref - policy) - (ref - policy) - 1`, averaged over active response tokens |
+| `train/kl_penalty` | `kl_beta * kl_loss` contribution to the loss for KL-regularized losses |
+| `train/kl_coef` | KL coefficient (`kl_beta`) |
+| `train/mean_kl` | Legacy alias for `train/kl_loss` |
+| `train/mean_logprob_diff` | Signed legacy diagnostic, `policy_logprob - reference_logprob`; not a KL |
+
+Related drift metrics such as `train/inference_kld` and
+`train/inference_diff` compare training-time policy logprobs with the
+inference deployment that sampled the rollout; they are not reference KL.
+
 **DPO / ORPO** -- also requires:
 
 | Field | What to set |

--- a/training/examples/rl/frozen_lake/train_frozen_lake.py
+++ b/training/examples/rl/frozen_lake/train_frozen_lake.py
@@ -912,10 +912,10 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
                     metrics["rollout/filter_drops"] = loop_stats.get("filter_drops", 0)
 
                 avg_reward = metrics.get("rollout/reward", 0.0)
-                avg_kl = metrics.get("train/mean_kl", 0.0)
+                avg_kl = metrics.get("train/kl_loss", metrics.get("train/mean_kl", 0.0))
                 mean_loss = metrics.get("train/mean_loss", 0.0)
                 adv_loss = metrics.get("train/mean_adv_loss", 0.0)
-                kl_pen = metrics.get("train/mean_kl_penalty", 0.0)
+                kl_pen = metrics.get("train/kl_penalty", metrics.get("train/mean_kl_penalty", 0.0))
                 mask_r = metrics.get("train/mask_ratio", 0.0)
                 inf_kld = metrics.get("train/inference_kld", 0.0)
                 logger.info(

--- a/training/tests/unit/test_batched_losses.py
+++ b/training/tests/unit/test_batched_losses.py
@@ -14,6 +14,7 @@ from training.utils.losses import (
 )
 from training.utils.rl.common import _normalize_prompt_lens
 from training.utils.rl.gspo import GSPOConfig
+from training.utils.rl.igpo import make_igpo_loss_fn
 from training.utils.rl.client_losses import CLIENT_LOSSES
 from training.utils.rl.losses import (
     LossConfig,
@@ -261,6 +262,27 @@ class TestPolicyReferenceKL:
 
         with pytest.raises(ValueError, match="requires reference logprobs"):
             loss_fn([self._datum()], [torch.zeros(4, requires_grad=True)])
+
+    def test_igpo_kl_beta_backpropagates_reference_penalty(self):
+        loss_fn = make_igpo_loss_fn(
+            per_token_advantages=[[0.0, 0.0, 0.0, 0.0]],
+            ref_logprobs=[[-2.0, -2.0, -2.0, -2.0]],
+            prompt_lens=[2],
+            inf_logprobs=[[0.0, 0.0, 0.0, 0.0]],
+            prox_logprobs=[[0.0, 0.0, 0.0, 0.0]],
+            kl_beta=0.5,
+        )
+        logprobs = torch.zeros(4, requires_grad=True)
+
+        loss, metrics = loss_fn([self._datum()], [logprobs])
+        loss.backward()
+
+        assert logprobs.grad is not None
+        assert logprobs.grad[1:].abs().sum() > 0
+        assert metrics["kl_loss"] > 0
+        assert metrics["mean_kl"] == pytest.approx(metrics["kl_loss"])
+        assert metrics["kl_penalty"] == pytest.approx(0.5 * metrics["kl_loss"])
+        assert metrics["kl_coef"] == pytest.approx(0.5)
 
 
 class TestBatchDPOLoss:

--- a/training/tests/unit/test_batched_losses.py
+++ b/training/tests/unit/test_batched_losses.py
@@ -152,7 +152,7 @@ class TestKLBetaRoutesToClientSide:
     ``loss_fn_inputs`` are exactly ``{target_tokens, logprobs, advantages}``
     -- no ``ref_logprobs`` field is ever sent to the trainer. So when a
     caller sets ``kl_beta > 0`` expecting a KL penalty, the builtin PPO
-    kernel silently drops the ``kl_beta * (pi - pi_ref)`` term.
+    kernel silently drops the policy/reference KL term.
 
     Fix: ``loss_path`` is now an **explicit** user choice. Picking
     ``"builtin"`` with ``kl_beta > 0`` raises in :func:`validate_loss_path`
@@ -217,6 +217,50 @@ class TestKLBetaRoutesToClientSide:
         validate_loss_path(
             LossConfig(policy_loss="grpo", loss_path="client", kl_beta=0.01),
         )
+
+
+class TestPolicyReferenceKL:
+    @staticmethod
+    def _datum():
+        return build_datum_from_token_mask(
+            token_ids=[10, 11, 12, 13],
+            token_mask=[0, 1, 1, 1],
+        ).datum
+
+    def test_grpo_kl_beta_backpropagates_reference_penalty(self):
+        builder = build_loss_fn(LossConfig(policy_loss="grpo", kl_beta=0.5))
+        loss_fn = builder(
+            advantages=[0.0],
+            ref_logprobs=[[-2.0, -2.0, -2.0, -2.0]],
+            prompt_lens=[2],
+            inf_logprobs=[[0.0, 0.0, 0.0, 0.0]],
+            prox_logprobs=[[0.0, 0.0, 0.0, 0.0]],
+        )
+        logprobs = torch.zeros(4, requires_grad=True)
+
+        loss, metrics = loss_fn([self._datum()], [logprobs])
+        loss.backward()
+
+        assert logprobs.grad is not None
+        assert logprobs.grad[1:].abs().sum() > 0
+        assert metrics["kl_loss"] > 0
+        assert metrics["mean_kl"] == pytest.approx(metrics["kl_loss"])
+        assert metrics["kl_penalty"] == pytest.approx(0.5 * metrics["kl_loss"])
+        assert metrics["mean_kl_penalty"] == pytest.approx(metrics["kl_penalty"])
+        assert metrics["kl_coef"] == pytest.approx(0.5)
+
+    def test_grpo_kl_beta_requires_reference_logprobs(self):
+        builder = build_loss_fn(LossConfig(policy_loss="grpo", kl_beta=0.5))
+        loss_fn = builder(
+            advantages=[0.0],
+            ref_logprobs=[],
+            prompt_lens=[2],
+            inf_logprobs=[[0.0, 0.0, 0.0, 0.0]],
+            prox_logprobs=[[0.0, 0.0, 0.0, 0.0]],
+        )
+
+        with pytest.raises(ValueError, match="requires reference logprobs"):
+            loss_fn([self._datum()], [torch.zeros(4, requires_grad=True)])
 
 
 class TestBatchDPOLoss:

--- a/training/utils/rl/common.py
+++ b/training/utils/rl/common.py
@@ -76,6 +76,40 @@ def validate_inference_logprobs_for_sample(
         )
 
 
+def validate_reference_logprobs_for_sample(
+    policy_loss: str,
+    sample_idx: int,
+    ref_lp: List[float],
+    required: int,
+) -> None:
+    """Ensure one sample has reference logprobs when KL regularization is enabled."""
+    policy_label = _format_policy_loss_label(policy_loss)
+    if not ref_lp:
+        raise ValueError(
+            f"{policy_label} requires reference logprobs for sample {sample_idx} when kl_beta > 0 "
+            f"but got empty list. Ensure the run provisions a reference forward path."
+        )
+
+    if len(ref_lp) < required:
+        raise ValueError(
+            f"{policy_label} requires at least {required} reference logprobs "
+            f"for sample {sample_idx} when kl_beta > 0, got {len(ref_lp)}."
+        )
+
+
+def policy_reference_kl_loss(
+    policy_logprobs: torch.Tensor,
+    reference_logprobs: torch.Tensor,
+) -> torch.Tensor:
+    """k3-style per-token policy/reference KL estimate.
+
+    Matches the SDK-style GRPO penalty ``exp(ref - policy) - (ref - policy) - 1``.
+    The returned tensor keeps gradients through ``policy_logprobs``.
+    """
+    log_ratio = reference_logprobs - policy_logprobs
+    return torch.exp(log_ratio) - log_ratio - 1.0
+
+
 @dataclass
 class SampleContext:
     """Pre-computed tensors for a single sample in the RL loss loop.
@@ -135,6 +169,7 @@ def run_loss_loop(
     logprobs_list: List[torch.Tensor],
     policy_loss: str,
     policy_fn: PolicyFn,
+    require_ref_logprobs: bool = False,
 ) -> LossLoopResult:
     """Shared loss loop: tensor setup, TIS weight, inference metrics, KL.
 
@@ -144,7 +179,9 @@ def run_loss_loop(
     from training.utils.rl.tis import compute_tis_weight
 
     total_loss = torch.tensor(0.0, requires_grad=True)
-    total_kl = 0.0
+    total_ref_kl = 0.0
+    total_ref_logprob_diff = 0.0
+    ref_num_tokens = 0
     total_inf_diff = 0.0
     total_inf_kld = 0.0
     total_ppo_kl = 0.0
@@ -175,7 +212,16 @@ def run_loss_loop(
         if active_count == 0:
             continue
 
-        ref_lp = ref_logprobs[i] if ref_logprobs else []
+        ref_lp = ref_logprobs[i] if i < len(ref_logprobs) else []
+        has_ref_logprobs = len(ref_lp) >= response_start + resp_len
+        if require_ref_logprobs:
+            validate_reference_logprobs_for_sample(
+                policy_loss,
+                i,
+                ref_lp,
+                response_start + resp_len,
+            )
+            has_ref_logprobs = True
         resp_ref = torch.tensor(
             [ref_lp[response_start + j] if (response_start + j) < len(ref_lp) else 0.0 for j in range(resp_len)],
             dtype=resp_pi.dtype,
@@ -238,15 +284,23 @@ def run_loss_loop(
         per_token_loss, extra = policy_fn(ctx)
 
         total_loss = total_loss + per_token_loss.sum()
-        total_kl += ((pi_detached - resp_ref) * resp_mask).sum().item()
+        if has_ref_logprobs:
+            ref_kl = policy_reference_kl_loss(pi_detached, resp_ref)
+            total_ref_kl += (ref_kl * resp_mask).sum().item()
+            total_ref_logprob_diff += ((pi_detached - resp_ref) * resp_mask).sum().item()
+            ref_num_tokens += active_count
         num_tokens += active_count
         for k, v in extra.items():
             extra_sums[k] = extra_sums.get(k, 0.0) + v
 
     n_samples = max(inf_num_samples, 1)
-    base_metrics: Dict[str, float] = {
-        "mean_kl": total_kl / num_tokens if num_tokens > 0 else 0.0,
-    }
+    base_metrics: Dict[str, float] = {}
+    if ref_num_tokens > 0:
+        kl_loss = total_ref_kl / ref_num_tokens
+        base_metrics["kl_loss"] = kl_loss
+        # Legacy alias kept for dashboards that already chart train/mean_kl.
+        base_metrics["mean_kl"] = kl_loss
+        base_metrics["mean_logprob_diff"] = total_ref_logprob_diff / ref_num_tokens
     if inf_num_samples > 0:
         base_metrics["inference_diff"] = total_inf_diff / inf_num_samples
         base_metrics["inference_kld"] = total_inf_kld / inf_num_samples

--- a/training/utils/rl/grpo.py
+++ b/training/utils/rl/grpo.py
@@ -13,7 +13,7 @@ from typing import Any, Dict, List, Tuple, Union
 import torch
 import tinker
 
-from training.utils.rl.common import _normalize_prompt_lens, run_loss_loop
+from training.utils.rl.common import _normalize_prompt_lens, policy_reference_kl_loss, run_loss_loop
 from training.utils.rl.tis import SAFETY_CLAMP, TISConfig
 
 
@@ -50,7 +50,8 @@ def make_grpo_loss_fn(
 
         surr1 = -ratio * ctx.adv
         surr2 = -clipped_ratio * ctx.adv
-        kl_penalty = kl_beta * (ctx.pi_detached - ctx.resp_ref)
+        kl_loss = policy_reference_kl_loss(ctx.resp_pi, ctx.resp_ref)
+        kl_penalty = kl_beta * kl_loss
         per_token_loss = (torch.maximum(surr1, surr2) * ctx.tis_weight + kl_penalty) * ctx.resp_mask
 
         return per_token_loss, {
@@ -58,7 +59,7 @@ def make_grpo_loss_fn(
             "ratio_mean": ratio_mean,
             "resp_len": float(len(ctx.resp_pi)),
             "adv_term": (-ctx.adv * ctx.resp_pi * ctx.resp_mask).sum().item(),
-            "kl_term": (kl_beta * ctx.resp_pi * ctx.resp_mask).sum().item(),
+            "kl_penalty": (kl_penalty.detach() * ctx.resp_mask).sum().item(),
         }
 
     def loss_fn(
@@ -68,6 +69,7 @@ def make_grpo_loss_fn(
         result = run_loss_loop(
             advantages, ref_logprobs, inf_logprobs, prompt_lens,
             prox_logprobs, tis_config, data, logprobs_list, "grpo", policy_fn,
+            require_ref_logprobs=kl_beta > 0.0,
         )
         ns = result.n_samples
         nt = result.num_tokens
@@ -80,7 +82,10 @@ def make_grpo_loss_fn(
         metrics["total_resp_tokens"] = total_resp
         metrics["mask_ratio"] = nt / total_resp if total_resp > 0 else 0.0
         metrics["mean_adv_loss"] = result.extra_sums.get("adv_term", 0.0) / nt if nt > 0 else 0.0
-        metrics["mean_kl_penalty"] = result.extra_sums.get("kl_term", 0.0) / nt if nt > 0 else 0.0
+        metrics["kl_penalty"] = result.extra_sums.get("kl_penalty", 0.0) / nt if nt > 0 else 0.0
+        metrics["kl_coef"] = kl_beta
+        # Legacy alias kept for dashboards that already chart train/mean_kl_penalty.
+        metrics["mean_kl_penalty"] = metrics["kl_penalty"]
         metrics["mean_loss"] = result.total_loss.item() / nt if nt > 0 else 0.0
         return result.total_loss, metrics
 

--- a/training/utils/rl/igpo.py
+++ b/training/utils/rl/igpo.py
@@ -272,14 +272,21 @@ def make_igpo_loss_fn(
     When ``prox_logprobs`` is ``None``, the forward-pass logprobs are used as
     the proximity baseline (ratio=1, clipping is a no-op).
     """
-    from training.utils.rl.common import _get_loss_mask
+    from training.utils.rl.common import (
+        _get_loss_mask,
+        policy_reference_kl_loss,
+        validate_reference_logprobs_for_sample,
+    )
 
     def loss_fn(
         data: List[tinker.Datum],
         logprobs_list: List[torch.Tensor],
     ) -> Tuple[torch.Tensor, Dict[str, float]]:
         total_loss = torch.tensor(0.0, requires_grad=True)
-        total_kl = 0.0
+        total_ref_kl = 0.0
+        total_ref_logprob_diff = 0.0
+        ref_num_tokens = 0
+        total_kl_penalty = 0.0
         num_tokens = 0
         total_resp_tokens = 0
 
@@ -301,7 +308,16 @@ def make_igpo_loss_fn(
             if active_count == 0:
                 continue
 
-            ref_lp = ref_logprobs[i] if ref_logprobs and i < len(ref_logprobs) else []
+            ref_lp = ref_logprobs[i] if i < len(ref_logprobs) else []
+            has_ref_logprobs = len(ref_lp) >= response_start + resp_len
+            if kl_beta > 0.0:
+                validate_reference_logprobs_for_sample(
+                    "igpo",
+                    i,
+                    ref_lp,
+                    response_start + resp_len,
+                )
+                has_ref_logprobs = True
             resp_ref = torch.tensor(
                 [
                     ref_lp[response_start + j]
@@ -364,22 +380,35 @@ def make_igpo_loss_fn(
 
             surr1 = -ratio * resp_adv
             surr2 = -clipped * resp_adv
-            kl_penalty = kl_beta * (resp_pi.detach() - resp_ref)
+            kl_loss = policy_reference_kl_loss(resp_pi, resp_ref)
+            kl_penalty = kl_beta * kl_loss
             per_token_loss = (
                 torch.maximum(surr1, surr2) * tis_weight + kl_penalty
             ) * resp_mask
 
             total_loss = total_loss + per_token_loss.sum()
-            total_kl += ((resp_pi.detach() - resp_ref) * resp_mask).sum().item()
+            if has_ref_logprobs:
+                kl_loss_detached = policy_reference_kl_loss(resp_pi.detach(), resp_ref)
+                total_ref_kl += (kl_loss_detached * resp_mask).sum().item()
+                total_ref_logprob_diff += ((resp_pi.detach() - resp_ref) * resp_mask).sum().item()
+                total_kl_penalty += (kl_penalty.detach() * resp_mask).sum().item()
+                ref_num_tokens += active_count
             num_tokens += active_count
             total_resp_tokens += resp_len
 
         metrics = {
-            "mean_kl": total_kl / num_tokens if num_tokens > 0 else 0.0,
             "active_tokens": num_tokens,
             "total_resp_tokens": total_resp_tokens,
             "mask_ratio": num_tokens / total_resp_tokens if total_resp_tokens > 0 else 0.0,
+            "kl_coef": kl_beta,
         }
+        if ref_num_tokens > 0:
+            kl_loss_mean = total_ref_kl / ref_num_tokens
+            metrics["kl_loss"] = kl_loss_mean
+            # Legacy alias kept for dashboards that already chart train/mean_kl.
+            metrics["mean_kl"] = kl_loss_mean
+            metrics["mean_logprob_diff"] = total_ref_logprob_diff / ref_num_tokens
+            metrics["kl_penalty"] = total_kl_penalty / ref_num_tokens
         return total_loss, metrics
 
     return loss_fn

--- a/training/utils/rl/losses.py
+++ b/training/utils/rl/losses.py
@@ -144,8 +144,8 @@ def validate_loss_path(args: LossArgs, profile: Any | None = None) -> None:
 
     - the loss is registered as client-side-only (no builtin kernel),
     - ``args.kl_beta > 0`` (builtin datums have no ``ref_logprobs`` field, so
-      the KL term ``kl_beta * (pi - pi_ref)`` would be silently dropped --
-      see :func:`build_builtin_loss_datums`),
+      the policy/reference KL term would be silently dropped -- see
+      :func:`build_builtin_loss_datums`),
     - ``profile.pipeline_parallelism > 1`` (server kernels don't support PP).
     """
     if args.loss_path == "client":

--- a/training/utils/rl/reinforce.py
+++ b/training/utils/rl/reinforce.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, List, Tuple, Union
 import torch
 import tinker
 
-from training.utils.rl.common import _normalize_prompt_lens, run_loss_loop
+from training.utils.rl.common import _normalize_prompt_lens, policy_reference_kl_loss, run_loss_loop
 from training.utils.rl.tis import SAFETY_CLAMP, TISConfig
 
 
@@ -49,15 +49,16 @@ def make_reinforce_loss_fn(
         ratio = torch.exp(log_ratio)
         per_token_loss = -ratio * ctx.adv
         if kl_beta > 0.0:
-            per_token_loss = per_token_loss + kl_beta * (ctx.pi_detached - ctx.resp_ref)
+            per_token_loss = per_token_loss + kl_beta * policy_reference_kl_loss(ctx.resp_pi, ctx.resp_ref)
         per_token_loss = per_token_loss * ctx.resp_mask
+        kl_penalty = kl_beta * policy_reference_kl_loss(ctx.resp_pi, ctx.resp_ref)
 
         active = ctx.resp_mask > 0.5
         return per_token_loss, {
             "resp_len": float(len(ctx.resp_pi)),
             "ratio_mean": ratio.detach()[active].mean().item(),
             "adv_term": (-ctx.adv * ratio.detach() * ctx.resp_mask).sum().item(),
-            "kl_term": (kl_beta * ctx.pi_detached * ctx.resp_mask).sum().item(),
+            "kl_penalty": (kl_penalty.detach() * ctx.resp_mask).sum().item(),
         }
 
     def loss_fn(
@@ -75,6 +76,7 @@ def make_reinforce_loss_fn(
             logprobs_list,
             "reinforce",
             policy_fn,
+            require_ref_logprobs=kl_beta > 0.0,
         )
         nt = result.num_tokens
         total_resp = int(result.extra_sums.get("resp_len", 0.0))
@@ -86,7 +88,10 @@ def make_reinforce_loss_fn(
         metrics["mask_ratio"] = nt / total_resp if total_resp > 0 else 0.0
         metrics["is_ratio_mean"] = result.extra_sums.get("ratio_mean", 0.0) / ns if ns > 0 else 0.0
         metrics["mean_adv_loss"] = result.extra_sums.get("adv_term", 0.0) / nt if nt > 0 else 0.0
-        metrics["mean_kl_penalty"] = result.extra_sums.get("kl_term", 0.0) / nt if nt > 0 else 0.0
+        metrics["kl_penalty"] = result.extra_sums.get("kl_penalty", 0.0) / nt if nt > 0 else 0.0
+        metrics["kl_coef"] = kl_beta
+        # Legacy alias kept for dashboards that already chart train/mean_kl_penalty.
+        metrics["mean_kl_penalty"] = metrics["kl_penalty"]
         metrics["mean_loss"] = result.total_loss.item() / nt if nt > 0 else 0.0
         return result.total_loss, metrics
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add explicit `kl_loss`, `kl_penalty`, and `kl_coef` metrics for policy/reference KL in cookbook RL losses.
- Use the k3-style policy/reference KL penalty with gradients for client-side GRPO, REINFORCE, and IGPO.
- Clarify cookbook docs that `train/ppo_kl` is current-policy vs old/proximal-policy drift, not reference KL.

## Tests
- `.venv/bin/python -m pytest tests/unit/test_batched_losses.py tests/unit/test_cispo_loss.py`
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://fireworks-ai.slack.com/archives/C08FFA581C1/p1778118334735719?thread_ts=1778118334.735719&cid=C08FFA581C1)

<div><a href="https://cursor.com/agents/bc-0ef630fb-3ec5-4a21-826c-27037e49a375"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0ef630fb-3ec5-4a21-826c-27037e49a375"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

