### PR TITLE
Add explicit ref_kl metric for GRPO

### DIFF
--- a/training/examples/rl/frozen_lake/train_frozen_lake.py
+++ b/training/examples/rl/frozen_lake/train_frozen_lake.py
@@ -912,19 +912,19 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
                     metrics["rollout/filter_drops"] = loop_stats.get("filter_drops", 0)
 
                 avg_reward = metrics.get("rollout/reward", 0.0)
-                avg_kl = metrics.get("train/mean_kl", 0.0)
+                avg_ref_kl = metrics.get("train/ref_kl", 0.0)
                 mean_loss = metrics.get("train/mean_loss", 0.0)
                 adv_loss = metrics.get("train/mean_adv_loss", 0.0)
                 kl_pen = metrics.get("train/mean_kl_penalty", 0.0)
                 mask_r = metrics.get("train/mask_ratio", 0.0)
                 inf_kld = metrics.get("train/inference_kld", 0.0)
                 logger.info(
-                    "Step %d | Reward: %.3f | KL: %.4f | Loss: %.4f "
+                    "Step %d | Reward: %.3f | RefKL: %.4f | Loss: %.4f "
                     "(adv=%.4f kl_pen=%.4f) | InfKLD: %.4f | MaskRatio: %.2f",
-                    step, avg_reward, avg_kl, mean_loss, adv_loss, kl_pen, inf_kld, mask_r,
+                    step, avg_reward, avg_ref_kl, mean_loss, adv_loss, kl_pen, inf_kld, mask_r,
                 )
                 reward_history.append(avg_reward)
-                log_metrics_json(step, reward=avg_reward, kl=avg_kl)
+                log_metrics_json(step, reward=avg_reward, ref_kl=avg_ref_kl)
                 _wandb_step[0] = max(_wandb_step[0] + 1, step)
                 wandb_log(metrics, _wandb_step[0])
                 return step, metrics

--- a/training/recipes/async_rl_loop.py
+++ b/training/recipes/async_rl_loop.py
@@ -588,9 +588,9 @@ def main(
                 loop_stats=loop_stats,
                 completions_per_prompt=cfg.completions_per_prompt,
             )
-            # Capture the per-rollout-mean KL for the human summary line
+            # Capture the per-rollout reference KL for the human summary line
             # before the train/* stripping below removes it.
-            mean_kl = metrics.get("train/mean_kl", 0.0)
+            ref_kl = metrics.get("train/ref_kl", 0.0)
             # train/* already logged per-minibatch above; strip the averages.
             metrics = {k: v for k, v in metrics.items() if not k.startswith("train/")}
             metrics["rollout/step"] = rollout_id
@@ -603,12 +603,12 @@ def main(
                     metrics[f"ctx/{k}"] = v
 
             logger.info(
-                "Rollout %d (step %d) | Reward %.3f | Acc %.1f%% | KL %.4f",
+                "Rollout %d (step %d) | Reward %.3f | Acc %.1f%% | RefKL %.4f",
                 rollout_id,
                 step,
                 metrics.get("rollout/reward", 0.0),
                 metrics.get("rollout/accuracy", 0.0) * 100,
-                mean_kl,
+                ref_kl,
             )
             wandb_log(metrics)
             # DCP cadence is in rollout batches, not optim steps, so

--- a/training/recipes/rl_loop.py
+++ b/training/recipes/rl_loop.py
@@ -769,15 +769,15 @@ def main(
             )
             avg_reward = metrics.get("rollout/reward", 0.0)
             avg_acc = metrics.get("rollout/accuracy", 0.0)
-            avg_kl = metrics.get("train/mean_kl", 0.0)
+            avg_ref_kl = metrics.get("train/ref_kl", 0.0)
             logger.info(
-                "Step %d | Reward: %.3f | Acc: %.1f%% | KL: %.4f",
+                "Step %d | Reward: %.3f | Acc: %.1f%% | RefKL: %.4f",
                 step,
                 avg_reward,
                 avg_acc * 100,
-                avg_kl,
+                avg_ref_kl,
             )
-            log_metrics_json(step, reward=avg_reward, accuracy=avg_acc, kl=avg_kl)
+            log_metrics_json(step, reward=avg_reward, accuracy=avg_acc, ref_kl=avg_ref_kl)
             wandb_log(metrics, step)
 
             total_rl_steps = len(rl_dataset) * max(1, cfg.ppo_n_minibatches) - step_offset

--- a/training/tests/unit/test_grpo_loss.py
+++ b/training/tests/unit/test_grpo_loss.py
@@ -1,0 +1,31 @@
+"""Unit tests for GRPO loss metrics."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from training.utils.rl.grpo import make_grpo_loss_fn
+
+
+class TestGRPOMetrics:
+    def test_reports_reference_kl_separately_from_ppo_kl(self):
+        pi_vals = [-2.0, -1.0, -0.5]
+        ref_vals = [-2.0, -1.3, -0.1]
+        pi = torch.tensor(pi_vals, requires_grad=True)
+
+        fn = make_grpo_loss_fn(
+            advantages=[1.0],
+            ref_logprobs=[ref_vals],
+            prompt_len=1,
+            inf_logprobs=[pi_vals],
+            prox_logprobs=[pi_vals],
+            kl_beta=0.0,
+        )
+
+        _, metrics = fn([], [pi])
+
+        ref_log_diff = torch.tensor(ref_vals) - torch.tensor(pi_vals)
+        expected_ref_kl = (torch.exp(ref_log_diff) - ref_log_diff - 1.0).mean().item()
+        assert metrics["ref_kl"] == pytest.approx(expected_ref_kl)
+        assert metrics["ppo_kl"] == pytest.approx(0.0)

--- a/training/utils/rl/common.py
+++ b/training/utils/rl/common.py
@@ -148,6 +148,8 @@ def run_loss_loop(
     total_inf_diff = 0.0
     total_inf_kld = 0.0
     total_ppo_kl = 0.0
+    total_ref_kl = 0.0
+    ref_num_samples = 0
     inf_num_samples = 0
     num_tokens = 0
     tis_metrics_agg: Dict[str, float] = {}
@@ -205,6 +207,7 @@ def run_loss_loop(
         # Filter to loss_mask>0 positions: masked bridge/tool tokens otherwise
         # contaminate sequence-level TIS weight (matches slime/AReaL behavior).
         active_pi = pi_detached[active]
+        active_ref = resp_ref[active]
         active_inf = resp_inf[active]
         active_prox = resp_prox[active]
 
@@ -213,6 +216,10 @@ def run_loss_loop(
         total_inf_kld += (torch.exp(inf_log_diff) - inf_log_diff - 1.0).mean().item()
         ppo_log_diff = active_pi - active_prox
         total_ppo_kl += (torch.exp(ppo_log_diff) - ppo_log_diff - 1.0).mean().item()
+        if ref_lp:
+            ref_log_diff = active_ref - active_pi
+            total_ref_kl += (torch.exp(ref_log_diff) - ref_log_diff - 1.0).mean().item()
+            ref_num_samples += 1
         inf_num_samples += 1
 
         tis_weight_active, bm = compute_tis_weight(active_prox, active_inf, tis_config)
@@ -251,6 +258,8 @@ def run_loss_loop(
         base_metrics["inference_diff"] = total_inf_diff / inf_num_samples
         base_metrics["inference_kld"] = total_inf_kld / inf_num_samples
         base_metrics["ppo_kl"] = total_ppo_kl / inf_num_samples
+    if ref_num_samples > 0:
+        base_metrics["ref_kl"] = total_ref_kl / ref_num_samples
     for k, v in tis_metrics_agg.items():
         base_metrics[k] = v / n_samples
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Emit `ref_kl` from the shared RL loss loop using the reference-vs-policy KL estimator over active response tokens.
- Keep `ppo_kl` scoped to the policy-vs-proximal metric and update GRPO-facing summary/JSON logs to use `ref_kl`.
- Add a GRPO unit test covering `ref_kl` separately from `ppo_kl`.

## Testing
- `python3 -m py_compile training/utils/rl/common.py training/recipes/rl_loop.py training/recipes/async_rl_loop.py training/examples/rl/frozen_lake/train_frozen_lake.py training/tests/unit/test_grpo_loss.py`
- `python -m pytest training/tests/unit/test_grpo_loss.py training/tests/unit/test_cispo_loss.py training/tests/unit/test_rl_metrics_aliases.py` (blocked: `python` not found)
- `python3 -m pytest training/tests/unit/test_grpo_loss.py training/tests/unit/test_cispo_loss.py training/tests/unit/test_rl_metrics_aliases.py` (blocked: `pytest` not installed; environment also lacks `torch` and `tinker`)
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://fireworks-ai.slack.com/archives/C07JZTHEG95/p1778119802248649?thread_ts=1778119802.248649&cid=C07JZTHEG95)

<div><a href="https://cursor.com/agents/bc-2eb74a54-e4fd-5cc3-b1ba-8d5e2697585b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2eb74a54-e4fd-5cc3-b1ba-8d5e2697585b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

