### PR TITLE
chore(training): bump fireworks training sdk pin to >=1.2.0a69

### DIFF
--- a/training/pyproject.toml
+++ b/training/pyproject.toml
@@ -7,7 +7,7 @@ name = "fireworks-training-cookbook"
 version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [
-    "fireworks-ai[training]>=1.2.0a68,<2",
+    "fireworks-ai[training]>=1.2.0a69,<2",
     "tqdm",
     "torch",
     "datasets",


### PR DESCRIPTION
## Summary

Bump the cookbook's `fireworks-ai[training]` lower bound from `>=1.2.0a68` to `>=1.2.0a69`.

`1.2.0-alpha.69` is the first SDK release that ships the new hotload-source-URL header path. `WeightSyncer.save_and_hotload` (used by every RL recipe — `rl_loop.py`, `async_rl_loop.py`, `igpo_loop.py`, `train_frozen_lake.py`, `train_multihop_qa_igpo.py`) now resolves the snapshot's full GCS URI and forwards it via the `x-fireworks-hot-load-source-url` request header so vLLM multi-LoRA-backed deployments can materialize the snapshot bytes. With the prior `>=1.2.0a68` pin a user resolving a68 silently drops the header and hotload falls back to the old wire shape — the vLLM proxy never sees the GCS URI and multi-LoRA hotload won't materialize.

```mermaid
flowchart LR
    R["RL recipe<br/>(rl_loop / async_rl_loop / igpo / frozen_lake)"] --> WS["WeightSyncer.save_and_hotload"]
    WS -->|"path=<gs://...>"| DM["DeploymentManager.hotload_and_wait"]
    DM -->|"x-fireworks-hot-load-source-url: <gs://...>"| FW["Fireworks API"]
    FW --> VL["vLLM proxy<br/>materializes snapshot bytes"]
    FW --> FA["FA backend<br/>(unknown header → ignored)"]
```

## Refs

- fw-ai-external/python-sdk#76 — `release: 1.2.0-alpha.69`
- stainless-sdks/fireworks-ai-python#136 — SDK PR adding the header-based wire shape
- Pairs with fw-ai/fireworks#24788 (vLLM proxy reads the new header)

## Test plan

- [ ] Recreate venv with `pip install --pre --upgrade -e training/` and confirm resolver picks up `fireworks-ai==1.2.0a69`
- [ ] Run a frozen-lake smoke run end-to-end and confirm `save_and_hotload` succeeds against a vLLM-backed deployment

Made with [Cursor](https://cursor.com)