### PR TITLE
feat(training): avoid reattaching deployment to same trainer

### DIFF
--- a/training/utils/infra.py
+++ b/training/utils/infra.py
@@ -1436,6 +1436,20 @@ def _get_alive_deployment(
     return existing
 
 
+def _deployment_hot_load_trainer_job(
+    deploy_mgr: DeploymentManager, dep_id: str,
+) -> str | None:
+    """Best-effort read of a deployment's attached hot-load trainer job."""
+    try:
+        data = deploy_mgr._get_deployment(dep_id)  # SDK wrapper does not expose this field.
+    except Exception as e:
+        logger.warning("Could not read deployment %s hot-load trainer: %s", dep_id, e)
+        return None
+    if not data:
+        return None
+    return data.get("hotLoadTrainerJob") or data.get("hot_load_trainer_job")
+
+
 def _register_deployment_cleanup(
     cleanup: ResourceCleanup | None, dep_id: str,
 ) -> None:
@@ -1488,6 +1502,16 @@ def _provision_trainer_owned(
     existing = _get_alive_deployment(deploy_mgr, deploy_cfg.deployment_id)
     if existing is not None:
         dep_id = deploy_cfg.deployment_id
+        current_trainer = _deployment_hot_load_trainer_job(deploy_mgr, dep_id)
+        if current_trainer == trainer_job_name:
+            logger.info(
+                "Deployment %s is already attached to trainer %s; waiting for readiness without re-attach",
+                dep_id,
+                trainer_job_name,
+            )
+            _register_deployment_cleanup(cleanup, dep_id)
+            return existing, dep_id
+
         prev_identity = _read_replica_identity(deploy_mgr, dep_id, base_model)
         deploy_mgr.update(
             dep_id,


### PR DESCRIPTION
## Summary

Cherry-picks commit `ca3439e` (originally authored by @Hecate0821 on the unmerged `codex/early-rl-deployment-ci` branch) onto `main`, so the same-trainer no-op reattach guard finally lands on cookbook `main`.

## Why

`fireworks` PR [#24697](https://github.com/fw-ai/fireworks/pull/24697) ("Overlap RL deployment startup in training shape CI", merged May 6) introduced an "early RL deployment" optimization in the e2e shape test: the deployment is created with `hot_load_trainer_job` already wired to the eventual policy trainer, then later "re-attached" to the same trainer once `setup_infra` runs.

That PR's body cited `fw-ai/cookbook@ca3439e43b9c75849470a3765ffa368308af86c7` as the cookbook companion that makes this safe — but `ca3439e` was authored on a `codex/early-rl-deployment-ci` branch and **never merged**. As a result, fireworks `main` is now broken on this path:

- `_provision_trainer_owned` unconditionally PATCHes `hot_load_trainer_job`, even when the new value matches the current one.
- The deployment-watcher renders the helm values, sees no diff (`No diff, skipping.`), and does not roll the serving pod.
- The recipe's `_wait_for_reattach_settled` future polls for a fresh pod identity for 600s and times out:

```
RuntimeError: Infrastructure provisioning failed:
Deployment: Re-attach for deployment '...' did not produce a fresh pod within 600s (prev_identity='...').
```

Concrete failure on `main`: <https://github.com/fw-ai/fireworks/actions/runs/25478628815/job/74860869321>

Two earlier in-flight fixes by @Hecate0821 ([#318](https://github.com/fw-ai/cookbook/pull/318), [#319](https://github.com/fw-ai/cookbook/pull/319), Apr 16) target the same root cause but were both closed without merge.

## What this changes

In `training/utils/infra.py::_provision_trainer_owned`, before issuing the PATCH, read the deployment's currently attached `hotLoadTrainerJob`. If it matches `trainer_job_name`, skip the PATCH and the `_wait_for_reattach_settled` wait — the existing pod is already pointed at the right trainer.

```python
current_trainer = _deployment_hot_load_trainer_job(deploy_mgr, dep_id)
if current_trainer == trainer_job_name:
    logger.info(
        "Deployment %s is already attached to trainer %s; waiting for "
        "readiness without re-attach",
        dep_id, trainer_job_name,
    )
    _register_deployment_cleanup(cleanup, dep_id)
    return existing, dep_id
```

Different-trainer reattach behavior is unchanged.

## Test plan

- [ ] Re-run fireworks Single Shape CI for a LoRA RL shape (e.g. `gemma4-31b-lora-r64-0.294.0-256k-rl-cliff-tp2`) after bumping the fireworks cookbook submodule pin to a SHA containing this fix — same-trainer reattach should return ~immediately instead of timing out at 600s.
- [ ] Confirm a different-trainer reattach path still triggers the rolling restart and waits for a new pod identity.

## Follow-up on the fireworks side

A separate fireworks PR will bump `train-firetitan-py/cookbook` to a SHA that includes this commit so nightly Single Shape CI stops failing.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches deployment provisioning/reattach logic and adds a read via private `DeploymentManager._get_deployment`, which could be brittle across SDK versions; behavior changes could affect rollout/settle waiting paths.
> 
> **Overview**
> Avoids a no-op deployment reattach during PER_TRAINER provisioning by first reading the deployment’s currently attached hot-load trainer job and **skipping the PATCH/settle wait when it already matches** the target trainer.
> 
> Adds a best-effort helper (`_deployment_hot_load_trainer_job`) that fetches the raw deployment payload (including `hotLoadTrainerJob`) and logs a warning on failure, so existing behavior falls back to the prior reattach flow when the field can’t be read.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 552f6dc0009d8bb7e8986211fe8d4d26daeda61d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->