### PR TITLE
feat(renderer): add Qwen3.6 renderer family with interleave-thinking variant

### DIFF
--- a/training/renderer/_qwen3_split.py
+++ b/training/renderer/_qwen3_split.py
@@ -1,4 +1,4 @@
-"""Local Qwen3 / Qwen3.5 renderers with multi-turn SFT disaggregate support.
+"""Local Qwen3 / Qwen3.5 / Qwen3.6 renderers with multi-turn SFT disaggregate support.
 
 Upstream ``tinker_cookbook.renderers.qwen3`` and
 ``tinker_cookbook.renderers.qwen3_5`` ship without a
@@ -61,6 +61,128 @@ class Qwen3_5DisableThinkingSplitRenderer(
     pass
 
 
+# Qwen3.6 ships with the same vocab, special tokens, and tokenizer as
+# Qwen3.5. The chat template adds one new opt-in feature:
+# `preserve_thinking`. Default invocation (`preserve_thinking`
+# undefined or false) produces output byte-identical to Qwen3.5's
+# template, so the Qwen3.5 renderer family is correct for the default
+# non-interleave-thinking case on Qwen3.6 models.
+#
+# Three Qwen3.6 renderer variants:
+#
+#   `qwen3_6`                    — default; alias of Qwen3.5 renderer
+#                                    (`strip_thinking_from_history=True`).
+#                                    Matches HF apply_chat_template default
+#                                    args. Use for normal SFT/DPO/RL where
+#                                    historical thinking should be stripped.
+#
+#   `qwen3_6_preserve_thinking`  — interleave thinking enabled
+#                                    (`strip_thinking_from_history=False`).
+#                                    Matches HF apply_chat_template with
+#                                    `preserve_thinking=true`. Use for:
+#                                      * Multi-turn RL training (gets the
+#                                        renderer extension property — each
+#                                        observation is a prefix extension
+#                                        of the previous, no recompute).
+#                                      * Long-horizon agent SFT where prior
+#                                        reasoning is load-bearing at
+#                                        inference time.
+#
+#   `qwen3_6_disable_thinking`   — empty think block in generation prompt
+#                                    (`enable_thinking=false`). Alias of
+#                                    Qwen3.5 disable-thinking renderer.
+#                                    Use for non-thinking SFT (text2sql,
+#                                    structured output, format compliance);
+#                                    customers must also pass
+#                                    `enable_thinking=false` at inference
+#                                    time to keep train↔inference parity.
+
+
+class Qwen3_6SplitRenderer(Qwen3_5SplitRenderer):
+    pass
+
+
+class Qwen3_6DisableThinkingSplitRenderer(Qwen3_5DisableThinkingSplitRenderer):
+    pass
+
+
+class Qwen3_6PreserveThinkingSplitRenderer(Qwen3_5SplitRenderer):
+    """Qwen3.6 with interleave thinking — historical assistant `<think>`
+    blocks preserved across turns.
+
+    Forwards `strip_thinking_from_history=False` to the upstream
+    `Qwen3_5Renderer` (whose Qwen3 base accepts the kwarg). With
+    preserve-thinking on, the renderer satisfies the *extension property*:
+    a shorter prefix of a multi-turn conversation tokenizes to a prefix of
+    the full conversation, so multi-turn RL avoids prefix recomputation per
+    step.
+
+    Token-level output matches HF `apply_chat_template` invoked with
+    `preserve_thinking=true`, including the "empty thinking block"
+    behavior for historical assistants without reasoning content (see
+    `_assistant_header_suffix` override below).
+    """
+
+    def __init__(self, tokenizer, image_processor=None):
+        super().__init__(
+            tokenizer,
+            image_processor=image_processor,
+            strip_thinking_from_history=False,
+        )
+
+    def _assistant_header_suffix(self, message, ctx):
+        """Match HF chat template `preserve_thinking=true` byte-for-byte.
+
+        The official Qwen3.6 chat template, when `preserve_thinking=true`
+        is set, takes the IF branch unconditionally for every assistant
+        turn (historical OR trailing)::
+
+            {{- '<|im_start|>' + role + '\\n<think>\\n'
+                + reasoning_content + '\\n</think>\\n\\n'
+                + content }}
+
+        For assistants without `reasoning_content`, this emits the
+        empty wrapper `<think>\\n\\n</think>\\n\\n` before the visible
+        content. Upstream `Qwen3_5Renderer._assistant_header_suffix`
+        only emits the wrapper for the trailing generation-prompt slot
+        (`ctx.idx > ctx.last_user_index`) — see the `if ctx.idx <=
+        ctx.last_user_index: return ""` early exit there. This override
+        removes that early exit so the wrapper logic also applies to
+        historical assistant turns, matching HF's output for the same
+        conversation when `preserve_thinking=true`.
+
+        The body is otherwise identical to upstream's: detect whether
+        the assistant message carries a `thinking` part (in which case
+        `_preprocess_message_parts` emits the real `<think>...
+        </think>` block, so the suffix returns ""), otherwise emit the
+        empty wrapper.
+
+        Train-inference parity is the rationale: customers training with
+        this renderer and serving the result with the official Qwen3.6
+        chat template at inference (vLLM default, etc.) will see the
+        same tokens at both stages.
+
+        This is the "empty thinking blocks spam context"
+        pattern documented at
+        https://huggingface.co/froggeric/Qwen-Fixed-Chat-Templates.
+        Adopting it here is a deliberate trade-off in favour of
+        train-inference parity over token efficiency. Customers serving
+        with froggeric or another bug-fixed template at inference would
+        see drift; in that case use the default `qwen3_5` renderer
+        family instead, which doesn't emit empty wrappers.
+        """
+        content = message.get("content", "")
+        has_think = False
+        if isinstance(content, list):
+            has_think = any(
+                isinstance(p, dict) and p.get("type") == "thinking"
+                for p in content
+            )
+        elif isinstance(content, str):
+            has_think = "<think>" in content
+        return "" if has_think else "<think>\n\n</think>\n\n"
+
+
 register_renderer("qwen3", lambda tok, ip=None: Qwen3SplitRenderer(tok))
 register_renderer(
     "qwen3_disable_thinking",
@@ -81,6 +203,22 @@ register_renderer(
 register_renderer(
     "qwen3_5_disable_thinking",
     lambda tok, ip=None: Qwen3_5DisableThinkingSplitRenderer(
+        tok, image_processor=ip
+    ),
+)
+register_renderer(
+    "qwen3_6",
+    lambda tok, ip=None: Qwen3_6SplitRenderer(tok, image_processor=ip),
+)
+register_renderer(
+    "qwen3_6_disable_thinking",
+    lambda tok, ip=None: Qwen3_6DisableThinkingSplitRenderer(
+        tok, image_processor=ip
+    ),
+)
+register_renderer(
+    "qwen3_6_preserve_thinking",
+    lambda tok, ip=None: Qwen3_6PreserveThinkingSplitRenderer(
         tok, image_processor=ip
     ),
 )

--- a/training/tests/unit/test_qwen3_6_preserve_thinking.py
+++ b/training/tests/unit/test_qwen3_6_preserve_thinking.py
@@ -1,0 +1,940 @@
+"""Tests for `Qwen3_6PreserveThinkingSplitRenderer` (interleave thinking).
+
+Two complementary tests:
+
+1. *Behavioral*: with assistant turns that carry actual thinking content,
+   the default `qwen3_6` renderer must DROP historical thinking
+   (matches HF `apply_chat_template` default), and the preserve-thinking
+   variant must KEEP it. Renderer-vs-renderer comparison; doesn't need
+   HF Hub access.
+
+2. *HF parity*: the preserve-thinking renderer's tokens must equal what
+   `apply_chat_template(messages, preserve_thinking=True)` produces
+   for the same conversation. Tests two input shapes that mean the same
+   thing semantically:
+     - renderer side uses structured `content` with
+       `{"type": "thinking", "thinking": ...}` parts.
+     - HF side uses a string `content` plus the `reasoning_content`
+       string field that the Qwen3.6 chat template inspects.
+
+Both tests skip cleanly if HF Hub is unreachable.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+_TOKENIZER_MODEL = "Qwen/Qwen3.6-27B"
+
+
+# --- Multi-turn fixture with REAL thinking content -------------------------
+# The historical assistant turn (index=2) carries reasoning the model used
+# to derive "4.". The new user turn (index=3) is the most recent user.
+# Without preserve-thinking, the chat template / renderer should DROP the
+# historical reasoning. With preserve-thinking, it should be retained.
+
+_HISTORICAL_REASONING = "Two plus two: count up by ones from 2, get 3, then 4."
+
+_MESSAGES_RENDERER_INPUT = [
+    {"role": "system", "content": "Answer briefly with just the number."},
+    {"role": "user", "content": "What is 2+2?"},
+    {
+        "role": "assistant",
+        "content": [
+            {"type": "thinking", "thinking": _HISTORICAL_REASONING},
+            {"type": "text", "text": "4."},
+        ],
+    },
+    {"role": "user", "content": "And 3+3?"},
+]
+
+# Same conversation for the HF chat template, in the shape the Qwen3.6
+# chat template understands: `reasoning_content` field on assistant +
+# string `content`. The chat template's `elif message.role ==
+# "assistant"` branch reads `message.reasoning_content` directly when
+# it's a string.
+_MESSAGES_HF_INPUT = [
+    {"role": "system", "content": "Answer briefly with just the number."},
+    {"role": "user", "content": "What is 2+2?"},
+    {
+        "role": "assistant",
+        "content": "4.",
+        "reasoning_content": _HISTORICAL_REASONING,
+    },
+    {"role": "user", "content": "And 3+3?"},
+]
+
+
+# --- Realistic 3-turn fixture: code-review agent ------------------------
+# Two historical assistant turns each carry distinct reasoning. In
+# preserve-thinking mode the model writing turn 3 sees BOTH prior
+# reasoning traces; in default mode it sees neither. This fixture is
+# what an actual long-horizon agent SFT dataset looks like — multi-turn
+# with reasoning that the next turn's answer should build on.
+
+_REASONING_TURN_1 = (
+    "Two nested loops, each iterating arr once. Total iterations "
+    "= len(arr) * len(arr) = n^2. Inner condition is O(1) so outer dominates."
+)
+_REASONING_TURN_2 = (
+    "Use a hash set to record seen values. For each x, check target-x "
+    "in O(1). Single pass = O(n) time, O(n) extra space."
+)
+_VISIBLE_TURN_1 = (
+    "Two nested loops over arr each give n iterations, multiplied = O(n^2)."
+)
+_VISIBLE_TURN_2 = (
+    "Iterate once with a set: for each `a`, check if `target - a` is in "
+    "the set; otherwise add `a` to the set. O(n) time, O(n) space."
+)
+
+_CODE_REVIEW_RENDERER_INPUT = [
+    {
+        "role": "system",
+        "content": "You're a senior engineer reviewing code. Reason step by step.",
+    },
+    {
+        "role": "user",
+        "content": (
+            "Why is this O(n^2)?\n"
+            "```python\n"
+            "for a in arr:\n"
+            "    for b in arr:\n"
+            "        if a + b == target: return True\n"
+            "```"
+        ),
+    },
+    {
+        "role": "assistant",
+        "content": [
+            {"type": "thinking", "thinking": _REASONING_TURN_1},
+            {"type": "text", "text": _VISIBLE_TURN_1},
+        ],
+    },
+    {"role": "user", "content": "How do I get O(n)?"},
+    {
+        "role": "assistant",
+        "content": [
+            {"type": "thinking", "thinking": _REASONING_TURN_2},
+            {"type": "text", "text": _VISIBLE_TURN_2},
+        ],
+    },
+    {"role": "user", "content": "Show me the code."},
+]
+
+_CODE_REVIEW_HF_INPUT = [
+    {
+        "role": "system",
+        "content": "You're a senior engineer reviewing code. Reason step by step.",
+    },
+    {
+        "role": "user",
+        "content": (
+            "Why is this O(n^2)?\n"
+            "```python\n"
+            "for a in arr:\n"
+            "    for b in arr:\n"
+            "        if a + b == target: return True\n"
+            "```"
+        ),
+    },
+    {
+        "role": "assistant",
+        "content": _VISIBLE_TURN_1,
+        "reasoning_content": _REASONING_TURN_1,
+    },
+    {"role": "user", "content": "How do I get O(n)?"},
+    {
+        "role": "assistant",
+        "content": _VISIBLE_TURN_2,
+        "reasoning_content": _REASONING_TURN_2,
+    },
+    {"role": "user", "content": "Show me the code."},
+]
+
+
+def _load_tokenizer():
+    """Try to load the Qwen3.6-27B tokenizer; skip cleanly if unreachable."""
+    try:
+        from tinker_cookbook.tokenizer_utils import get_tokenizer
+
+        tokenizer = get_tokenizer(_TOKENIZER_MODEL)
+    except (OSError, ValueError, RuntimeError) as exc:
+        pytest.skip(f"tokenizer unavailable for {_TOKENIZER_MODEL!r}: {exc}")
+    if not getattr(tokenizer, "chat_template", None):
+        pytest.skip(f"{_TOKENIZER_MODEL!r} has no chat_template")
+    return tokenizer
+
+
+def _decode(tokenizer, tokens: list[int]) -> str:
+    """Decode tokens to a single string (special tokens kept for visibility)."""
+    return tokenizer.decode(tokens, skip_special_tokens=False)
+
+
+def _build_renderer_tokens(renderer_name: str, tokenizer) -> list[int]:
+    """Render the multi-turn fixture via the named renderer."""
+    # Importing the cookbook renderer package registers the local renderer
+    # names (qwen3_6, qwen3_6_preserve_thinking, ...) in tinker_cookbook's
+    # registry.
+    import training.renderer  # noqa: F401  (registration side-effect)
+    from tinker_cookbook.renderers import get_renderer
+
+    from training.utils.supervised import normalize_messages
+
+    renderer = get_renderer(renderer_name, tokenizer)
+    normalized = normalize_messages(_MESSAGES_RENDERER_INPUT)
+    model_input = renderer.build_generation_prompt(normalized, role="assistant")
+    return [int(t) for t in model_input.to_ints()]
+
+
+# --------------------------------------------------------------------------
+# Test 1 — Behavioral: kwarg flips historical-thinking presence
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.timeout(180)
+def test_default_renderer_drops_historical_thinking() -> None:
+    """`qwen3_6` (alias of qwen3_5, strip_thinking_from_history=True)
+    must drop the reasoning from historical assistant turns.
+
+    The historical reasoning string must NOT appear in the rendered
+    output, mirroring what HF `apply_chat_template` does by default.
+    """
+    tokenizer = _load_tokenizer()
+    tokens = _build_renderer_tokens("qwen3_6", tokenizer)
+    decoded = _decode(tokenizer, tokens)
+
+    assert _HISTORICAL_REASONING not in decoded, (
+        "Default qwen3_6 renderer should strip historical thinking, but the "
+        f"reasoning string was present in the rendered output:\n{decoded!r}"
+    )
+
+
+@pytest.mark.timeout(180)
+def test_preserve_thinking_renderer_keeps_historical_thinking() -> None:
+    """`qwen3_6_preserve_thinking` (strip_thinking_from_history=False)
+    must retain the reasoning from historical assistant turns.
+
+    The historical reasoning string MUST appear in the rendered output,
+    matching HF `apply_chat_template(messages, preserve_thinking=True)`.
+    """
+    tokenizer = _load_tokenizer()
+    tokens = _build_renderer_tokens("qwen3_6_preserve_thinking", tokenizer)
+    decoded = _decode(tokenizer, tokens)
+
+    assert _HISTORICAL_REASONING in decoded, (
+        "Preserve-thinking renderer should retain historical thinking, but "
+        f"the reasoning string was missing from the rendered output:\n{decoded!r}"
+    )
+
+
+@pytest.mark.timeout(180)
+def test_default_and_preserve_produce_different_tokens() -> None:
+    """The two variants MUST produce different token sequences when there is
+    real thinking content in history. (If they're identical, the kwarg is
+    not taking effect.)
+    """
+    tokenizer = _load_tokenizer()
+    default_tokens = _build_renderer_tokens("qwen3_6", tokenizer)
+    preserve_tokens = _build_renderer_tokens("qwen3_6_preserve_thinking", tokenizer)
+
+    assert default_tokens != preserve_tokens, (
+        "qwen3_6 (default) and qwen3_6_preserve_thinking produced identical "
+        "tokens — strip_thinking_from_history kwarg is not taking effect "
+        "or the test fixture lacks historical thinking content."
+    )
+
+
+@pytest.mark.timeout(180)
+def test_preserve_thinking_renderer_has_extension_property() -> None:
+    """The preserve-thinking renderer must report
+    `has_extension_property=True` so that the SFT loop's
+    `_build_renderer_supervised_examples` takes the single-example path
+    (instead of the disaggregate per-user-turn split)."""
+    tokenizer = _load_tokenizer()
+
+    import training.renderer  # noqa: F401
+    from tinker_cookbook.renderers import get_renderer
+
+    default_renderer = get_renderer("qwen3_6", tokenizer)
+    preserve_renderer = get_renderer("qwen3_6_preserve_thinking", tokenizer)
+
+    assert default_renderer.has_extension_property is False, (
+        "Default qwen3_6 renderer should NOT have extension property "
+        "(strip_thinking_from_history=True breaks prefix extension)."
+    )
+    assert preserve_renderer.has_extension_property is True, (
+        "qwen3_6_preserve_thinking renderer SHOULD have extension property "
+        "(strip_thinking_from_history=False keeps history-prefix tokenization)."
+    )
+
+
+# --------------------------------------------------------------------------
+# Test 2 — HF parity: preserve renderer matches preserve_thinking template
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.timeout(180)
+def test_preserve_thinking_matches_hf_chat_template_byte_for_byte() -> None:
+    """The preserve-thinking renderer's tokens must equal what
+    `tokenizer.apply_chat_template(messages, preserve_thinking=True)`
+    produces for the same conversation.
+
+    Note: the renderer-side input (`_MESSAGES_RENDERER_INPUT`) uses
+    structured content with a `{"type": "thinking", ...}` part, while
+    the HF-side input (`_MESSAGES_HF_INPUT`) uses string `content`
+    plus `reasoning_content` field — the two shapes the two systems
+    accept. Semantically they represent the same conversation.
+    """
+    tokenizer = _load_tokenizer()
+
+    # Renderer side
+    renderer_tokens = _build_renderer_tokens(
+        "qwen3_6_preserve_thinking", tokenizer
+    )
+
+    # HF side
+    hf_result = tokenizer.apply_chat_template(
+        _MESSAGES_HF_INPUT,
+        tokenize=True,
+        add_generation_prompt=True,
+        preserve_thinking=True,
+    )
+    if hasattr(hf_result, "input_ids"):
+        hf_tokens = [int(t) for t in list(hf_result.input_ids)]  # type: ignore[arg-type]
+    else:
+        hf_tokens = [int(t) for t in list(hf_result)]  # type: ignore[arg-type]
+
+    if renderer_tokens == hf_tokens:
+        return
+
+    # Build a useful failure message showing the first divergence.
+    n = min(len(renderer_tokens), len(hf_tokens))
+    first_div = next(
+        (i for i in range(n) if renderer_tokens[i] != hf_tokens[i]),
+        n,
+    )
+    context = 6
+    lo = max(0, first_div - context)
+    hi = first_div + context + 1
+    lines = [
+        f"renderer tokens={len(renderer_tokens)}  hf tokens={len(hf_tokens)}  "
+        f"first divergence at idx={first_div}",
+        f"renderer[{lo}:{hi}] decoded:",
+    ]
+    for i in range(lo, min(hi, len(renderer_tokens))):
+        marker = "→" if i == first_div else " "
+        lines.append(
+            f"  {marker} idx={i}  tok={renderer_tokens[i]}  "
+            f"decoded={tokenizer.decode([renderer_tokens[i]], skip_special_tokens=False)!r}"
+        )
+    lines.append(f"hf[{lo}:{hi}] decoded:")
+    for i in range(lo, min(hi, len(hf_tokens))):
+        marker = "→" if i == first_div else " "
+        lines.append(
+            f"  {marker} idx={i}  tok={hf_tokens[i]}  "
+            f"decoded={tokenizer.decode([hf_tokens[i]], skip_special_tokens=False)!r}"
+        )
+    pytest.fail("\n".join(lines))
+
+
+# --------------------------------------------------------------------------
+# Test 3 — Realistic 3-turn code-review fixture: validates BOTH historical
+# turns' thinking is correctly handled (default drops both, preserve keeps
+# both).
+# --------------------------------------------------------------------------
+
+
+def _build_renderer_tokens_for(messages, renderer_name: str, tokenizer) -> list[int]:
+    """Render a custom message list via the named renderer."""
+    import training.renderer  # noqa: F401  (registration side-effect)
+    from tinker_cookbook.renderers import get_renderer
+
+    from training.utils.supervised import normalize_messages
+
+    renderer = get_renderer(renderer_name, tokenizer)
+    normalized = normalize_messages(messages)
+    model_input = renderer.build_generation_prompt(normalized, role="assistant")
+    return [int(t) for t in model_input.to_ints()]
+
+
+@pytest.mark.timeout(180)
+def test_code_review_default_drops_both_historical_thinkings() -> None:
+    """3-turn code-review fixture, default qwen3_6 renderer.
+
+    Both historical assistant turns carry distinct reasoning. In default
+    (strip-from-history) mode, the rendered output must contain NEITHER
+    reasoning string — both turns' <think> blocks should be dropped.
+    """
+    tokenizer = _load_tokenizer()
+    tokens = _build_renderer_tokens_for(
+        _CODE_REVIEW_RENDERER_INPUT, "qwen3_6", tokenizer
+    )
+    decoded = _decode(tokenizer, tokens)
+
+    assert _REASONING_TURN_1 not in decoded, (
+        f"qwen3_6 (default) leaked turn-1 reasoning into rendered output:\n"
+        f"  reasoning_1={_REASONING_TURN_1!r}\n  decoded={decoded[:500]!r}..."
+    )
+    assert _REASONING_TURN_2 not in decoded, (
+        f"qwen3_6 (default) leaked turn-2 reasoning into rendered output:\n"
+        f"  reasoning_2={_REASONING_TURN_2!r}\n  decoded={decoded[:500]!r}..."
+    )
+    # Sanity: visible content from BOTH turns must be present (only thinking
+    # is stripped, not the visible answer).
+    assert _VISIBLE_TURN_1 in decoded, (
+        "Default renderer should keep historical visible content; turn-1 visible missing."
+    )
+    assert _VISIBLE_TURN_2 in decoded, (
+        "Default renderer should keep historical visible content; turn-2 visible missing."
+    )
+
+
+@pytest.mark.timeout(180)
+def test_code_review_preserve_keeps_both_historical_thinkings() -> None:
+    """3-turn code-review fixture, qwen3_6_preserve_thinking renderer.
+
+    Both historical assistant turns must retain their <think> blocks in
+    the rendered prefix that the model writing turn 3 will see.
+    """
+    tokenizer = _load_tokenizer()
+    tokens = _build_renderer_tokens_for(
+        _CODE_REVIEW_RENDERER_INPUT, "qwen3_6_preserve_thinking", tokenizer
+    )
+    decoded = _decode(tokenizer, tokens)
+
+    assert _REASONING_TURN_1 in decoded, (
+        f"qwen3_6_preserve_thinking dropped turn-1 reasoning:\n"
+        f"  reasoning_1={_REASONING_TURN_1!r}\n  decoded={decoded[:500]!r}..."
+    )
+    assert _REASONING_TURN_2 in decoded, (
+        f"qwen3_6_preserve_thinking dropped turn-2 reasoning:\n"
+        f"  reasoning_2={_REASONING_TURN_2!r}\n  decoded={decoded[:500]!r}..."
+    )
+    # Visible content also present (sanity).
+    assert _VISIBLE_TURN_1 in decoded
+    assert _VISIBLE_TURN_2 in decoded
+
+
+@pytest.mark.timeout(180)
+def test_code_review_preserve_matches_hf_chat_template() -> None:
+    """3-turn code-review fixture, byte-for-byte HF chat-template parity
+    for the preserve-thinking variant.
+
+    Renderer-side input uses structured `content` parts; HF-side input
+    uses string `content` plus `reasoning_content` field. Same
+    semantic conversation. With `preserve_thinking=True`, the chat
+    template emits `<think>{reasoning_content}</think>` for each
+    historical assistant turn — this must match what the renderer
+    produces from structured thinking parts.
+
+    Adversarial fan-out tests below catch additional failure modes:
+    double-wrapping, empty-block spam, and N-way HF parity across all
+    historical turns.
+    """
+    tokenizer = _load_tokenizer()
+
+    renderer_tokens = _build_renderer_tokens_for(
+        _CODE_REVIEW_RENDERER_INPUT, "qwen3_6_preserve_thinking", tokenizer
+    )
+
+    hf_result = tokenizer.apply_chat_template(
+        _CODE_REVIEW_HF_INPUT,
+        tokenize=True,
+        add_generation_prompt=True,
+        preserve_thinking=True,
+    )
+    if hasattr(hf_result, "input_ids"):
+        hf_tokens = [int(t) for t in list(hf_result.input_ids)]  # type: ignore[arg-type]
+    else:
+        hf_tokens = [int(t) for t in list(hf_result)]  # type: ignore[arg-type]
+
+    if renderer_tokens == hf_tokens:
+        return
+
+    n = min(len(renderer_tokens), len(hf_tokens))
+    first_div = next(
+        (i for i in range(n) if renderer_tokens[i] != hf_tokens[i]), n
+    )
+    context = 6
+    lo = max(0, first_div - context)
+    hi = first_div + context + 1
+    lines = [
+        f"renderer tokens={len(renderer_tokens)}  hf tokens={len(hf_tokens)}  "
+        f"first divergence at idx={first_div}",
+        f"renderer[{lo}:{hi}] decoded:",
+    ]
+    for i in range(lo, min(hi, len(renderer_tokens))):
+        marker = "→" if i == first_div else " "
+        lines.append(
+            f"  {marker} idx={i}  tok={renderer_tokens[i]}  "
+            f"decoded={tokenizer.decode([renderer_tokens[i]], skip_special_tokens=False)!r}"
+        )
+    lines.append(f"hf[{lo}:{hi}] decoded:")
+    for i in range(lo, min(hi, len(hf_tokens))):
+        marker = "→" if i == first_div else " "
+        lines.append(
+            f"  {marker} idx={i}  tok={hf_tokens[i]}  "
+            f"decoded={tokenizer.decode([hf_tokens[i]], skip_special_tokens=False)!r}"
+        )
+    pytest.fail("\n".join(lines))
+
+
+# --------------------------------------------------------------------------
+# Test 4 — Adversarial fan-out: catches well-known multi-turn
+# preserve-thinking failure modes documented by the
+# froggeric/Qwen-Fixed-Chat-Templates community fork
+# (https://huggingface.co/froggeric/Qwen-Fixed-Chat-Templates):
+#   - double-wrapping (thinking tags nest across turns)
+#   - empty-block spam (assistants without reasoning emit empty <think></think>)
+#   - history truncation (a thinking string vanishes after N turns)
+# Even if our renderer inherits any upstream bug, this regression gate
+# detects it.
+# --------------------------------------------------------------------------
+
+# Distinct, recognizable reasoning strings for each historical turn so a
+# count assertion can verify each appears exactly once.
+_REASONING_T1 = "TURN_1_THINK: parse the question carefully before computing."
+_REASONING_T2 = "TURN_2_THINK: previous answer used method A; now apply method B for symmetry."
+_REASONING_T3 = "TURN_3_THINK: combine results from method A and B and check edge cases."
+_VISIBLE_T1 = "Answer for turn 1."
+_VISIBLE_T2 = "Answer for turn 2."
+_VISIBLE_T3 = "Answer for turn 3."
+
+
+def _build_fanout_renderer_input(thinking_per_turn: list) -> list[dict]:
+    """Build a multi-turn renderer-input fixture with N assistant turns.
+
+    `thinking_per_turn[i]` is the reasoning for assistant turn `i+1`,
+    or `None` for an assistant turn with no thinking. A trailing user
+    message is added so the next assistant slot is the one we'd be
+    generating.
+    """
+    msgs: list[dict] = [
+        {"role": "system", "content": "You're a helpful assistant. Reason step by step."},
+        {"role": "user", "content": "Initial question."},
+    ]
+    visible_template = [_VISIBLE_T1, _VISIBLE_T2, _VISIBLE_T3]
+    for i, reasoning in enumerate(thinking_per_turn):
+        visible = (
+            visible_template[i] if i < len(visible_template) else f"Answer for turn {i + 1}."
+        )
+        if reasoning is None:
+            msgs.append({"role": "assistant", "content": visible})
+        else:
+            msgs.append(
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "thinking", "thinking": reasoning},
+                        {"type": "text", "text": visible},
+                    ],
+                }
+            )
+        msgs.append({"role": "user", "content": f"Follow-up question {i + 2}."})
+    return msgs
+
+
+def _build_fanout_hf_input(thinking_per_turn: list) -> list[dict]:
+    """HF-input shape mirror of `_build_fanout_renderer_input`."""
+    msgs: list[dict] = [
+        {"role": "system", "content": "You're a helpful assistant. Reason step by step."},
+        {"role": "user", "content": "Initial question."},
+    ]
+    visible_template = [_VISIBLE_T1, _VISIBLE_T2, _VISIBLE_T3]
+    for i, reasoning in enumerate(thinking_per_turn):
+        visible = (
+            visible_template[i] if i < len(visible_template) else f"Answer for turn {i + 1}."
+        )
+        msg: dict = {"role": "assistant", "content": visible}
+        if reasoning is not None:
+            msg["reasoning_content"] = reasoning
+        msgs.append(msg)
+        msgs.append({"role": "user", "content": f"Follow-up question {i + 2}."})
+    return msgs
+
+
+@pytest.mark.timeout(180)
+def test_fanout_no_double_wrapping_3_historical_turns() -> None:
+    """3 historical assistants each with thinking. After preserve-mode
+    rendering: each reasoning string appears EXACTLY ONCE (not 2x or 3x
+    from accidental nesting), and there are exactly 4 `<think>` opening
+    tags total (3 historical + 1 generation prompt).
+
+    Regression gate for the "double-wrapping" failure mode the froggeric
+    README cites: stacking thinking tags inside each other across turns.
+    """
+    tokenizer = _load_tokenizer()
+    msgs = _build_fanout_renderer_input([_REASONING_T1, _REASONING_T2, _REASONING_T3])
+    tokens = _build_renderer_tokens_for(msgs, "qwen3_6_preserve_thinking", tokenizer)
+    decoded = _decode(tokenizer, tokens)
+
+    for label, s in [
+        ("turn-1", _REASONING_T1),
+        ("turn-2", _REASONING_T2),
+        ("turn-3", _REASONING_T3),
+    ]:
+        count = decoded.count(s)
+        assert count == 1, (
+            f"{label} reasoning should appear exactly once, found {count}x "
+            f"(double-wrapping?) in:\n{decoded[:600]!r}..."
+        )
+
+    for label, s in [
+        ("turn-1", _VISIBLE_T1),
+        ("turn-2", _VISIBLE_T2),
+        ("turn-3", _VISIBLE_T3),
+    ]:
+        count = decoded.count(s)
+        assert count == 1, (
+            f"{label} visible answer should appear exactly once, found {count}x"
+        )
+
+    # 3 historical <think>...</think> + 1 generation prompt <think> = 4 opens, 3 closes
+    open_count = decoded.count("<think>")
+    close_count = decoded.count("</think>")
+    assert open_count == 4, f"expected 4 <think> tags, got {open_count}\n{decoded!r}"
+    assert close_count == 3, (
+        f"expected 3 </think> tags (historical only; generation-prompt "
+        f"<think> is unclosed), got {close_count}\n{decoded!r}"
+    )
+
+
+@pytest.mark.timeout(180)
+def test_fanout_default_mode_drops_all_historical_thinking() -> None:
+    """Same fixture, default qwen3_6 (strip mode).
+
+    All 3 historical reasonings absent, visible answers preserved, only
+    the generation-prompt <think> opening tag remains.
+    """
+    tokenizer = _load_tokenizer()
+    msgs = _build_fanout_renderer_input([_REASONING_T1, _REASONING_T2, _REASONING_T3])
+    tokens = _build_renderer_tokens_for(msgs, "qwen3_6", tokenizer)
+    decoded = _decode(tokenizer, tokens)
+
+    for label, s in [
+        ("turn-1", _REASONING_T1),
+        ("turn-2", _REASONING_T2),
+        ("turn-3", _REASONING_T3),
+    ]:
+        assert s not in decoded, f"default mode leaked {label} reasoning"
+
+    for label, s in [
+        ("turn-1", _VISIBLE_T1),
+        ("turn-2", _VISIBLE_T2),
+        ("turn-3", _VISIBLE_T3),
+    ]:
+        assert s in decoded, f"default mode dropped {label} visible answer"
+
+    open_count = decoded.count("<think>")
+    close_count = decoded.count("</think>")
+    assert open_count == 1, (
+        f"default mode should have exactly 1 <think> (the generation prompt), "
+        f"got {open_count}"
+    )
+    assert close_count == 0, (
+        f"default mode should have 0 </think> (no historical thinking emitted), "
+        f"got {close_count}"
+    )
+
+
+@pytest.mark.timeout(180)
+def test_fanout_mixed_thinking_and_no_thinking_turns() -> None:
+    """Adversarial: assistants 1 and 3 have thinking; assistant 2 doesn't.
+
+    With `Qwen3_6PreserveThinkingSplitRenderer` matching the official
+    Qwen3.6 chat template's `preserve_thinking=true` behavior, the
+    renderer emits `<think>...</think>` for every historical assistant
+    turn:
+    - Turn 1: `<think>\\n{reasoning}\\n</think>\\n\\n{visible}`
+    - Turn 2: `<think>\\n\\n</think>\\n\\n{visible}` (empty wrapper —
+      this is the official template's documented "empty thinking blocks"
+      pattern; our renderer mirrors it for train-inference parity)
+    - Turn 3: `<think>\\n{reasoning}\\n</think>\\n\\n{visible}`
+
+    See `Qwen3_6PreserveThinkingSplitRenderer._assistant_header_suffix`
+    for the rationale. If train-inference parity ever stops being the
+    priority (e.g. customers move to froggeric's bug-fixed template at
+    inference), flip that override and update this test.
+    """
+    tokenizer = _load_tokenizer()
+    msgs = _build_fanout_renderer_input([_REASONING_T1, None, _REASONING_T3])
+    tokens = _build_renderer_tokens_for(msgs, "qwen3_6_preserve_thinking", tokenizer)
+    decoded = _decode(tokenizer, tokens)
+
+    assert _REASONING_T1 in decoded, "turn-1 reasoning missing"
+    assert _REASONING_T3 in decoded, "turn-3 reasoning missing"
+    # Turn 2 had no reasoning_content. The renderer matches HF and emits
+    # an empty think wrapper before the visible answer.
+    assert "<think>\n\n</think>\n\n" + _VISIBLE_T2 in decoded, (
+        "Turn 2 should have an empty <think></think> wrapper before its "
+        "visible answer (matches HF chat template preserve_thinking=true "
+        "behavior — the deliberately-adopted 'empty thinking blocks' "
+        "pattern for train-inference parity)."
+    )
+
+    # 3 historical <think> opens (turn-1 with reasoning, turn-2 empty,
+    # turn-3 with reasoning) + 1 generation prompt = 4 opens.
+    # 3 historical </think> closes; gen prompt is unclosed.
+    open_count = decoded.count("<think>")
+    close_count = decoded.count("</think>")
+    assert open_count == 4, (
+        f"expected 4 <think> tags (3 historical incl. empty wrapper + "
+        f"1 generation prompt), got {open_count}"
+    )
+    assert close_count == 3, (
+        f"expected 3 </think> tags (3 historical closes; gen prompt is "
+        f"unclosed), got {close_count}"
+    )
+
+
+@pytest.mark.timeout(180)
+def test_fanout_preserve_matches_hf_chat_template() -> None:
+    """Byte-for-byte HF parity for the 3-turn fan-out fixture in
+    preserve-thinking mode.
+
+    Strongest possible regression gate: if our renderer's tokens differ
+    from `apply_chat_template(..., preserve_thinking=True)` by even
+    one byte for ANY of the 3 historical turns, fails with a pinpointed
+    first-divergence diff.
+    """
+    tokenizer = _load_tokenizer()
+    renderer_msgs = _build_fanout_renderer_input(
+        [_REASONING_T1, _REASONING_T2, _REASONING_T3]
+    )
+    hf_msgs = _build_fanout_hf_input([_REASONING_T1, _REASONING_T2, _REASONING_T3])
+
+    renderer_tokens = _build_renderer_tokens_for(
+        renderer_msgs, "qwen3_6_preserve_thinking", tokenizer
+    )
+    hf_result = tokenizer.apply_chat_template(
+        hf_msgs,
+        tokenize=True,
+        add_generation_prompt=True,
+        preserve_thinking=True,
+    )
+    if hasattr(hf_result, "input_ids"):
+        hf_tokens = [int(t) for t in list(hf_result.input_ids)]  # type: ignore[arg-type]
+    else:
+        hf_tokens = [int(t) for t in list(hf_result)]  # type: ignore[arg-type]
+
+    if renderer_tokens == hf_tokens:
+        return
+
+    n = min(len(renderer_tokens), len(hf_tokens))
+    first_div = next(
+        (i for i in range(n) if renderer_tokens[i] != hf_tokens[i]), n
+    )
+    context = 6
+    lo = max(0, first_div - context)
+    hi = first_div + context + 1
+    lines = [
+        f"renderer tokens={len(renderer_tokens)}  hf tokens={len(hf_tokens)}  "
+        f"first divergence at idx={first_div}",
+        f"renderer[{lo}:{hi}] decoded:",
+    ]
+    for i in range(lo, min(hi, len(renderer_tokens))):
+        marker = "→" if i == first_div else " "
+        lines.append(
+            f"  {marker} idx={i}  tok={renderer_tokens[i]}  "
+            f"decoded={tokenizer.decode([renderer_tokens[i]], skip_special_tokens=False)!r}"
+        )
+    lines.append(f"hf[{lo}:{hi}] decoded:")
+    for i in range(lo, min(hi, len(hf_tokens))):
+        marker = "→" if i == first_div else " "
+        lines.append(
+            f"  {marker} idx={i}  tok={hf_tokens[i]}  "
+            f"decoded={tokenizer.decode([hf_tokens[i]], skip_special_tokens=False)!r}"
+        )
+    pytest.fail("\n".join(lines))
+
+
+# --------------------------------------------------------------------------
+# Test 5 — High-priority corner cases
+#
+# The four cases below close gaps the fixtures above don't exercise:
+#   - Tool calls in a historical assistant turn alongside thinking
+#   - Empty thinking string (zero-length reasoning content)
+#   - Deep history (5 historical assistant turns)
+#   - Default-mode mixed thinking/no-thinking (symmetry check vs the
+#     preserve-mode mixed test in test_fanout_mixed_thinking_and_no_thinking_turns)
+# --------------------------------------------------------------------------
+
+
+_TOOL_REASONING = "TOOL_THINK: I should call the weather tool to get current temperature."
+_TOOL_VISIBLE = "Let me check the weather for you."
+
+
+@pytest.mark.timeout(180)
+def test_preserve_thinking_with_tool_calls_in_history() -> None:
+    """Historical assistant has BOTH thinking content AND a tool_calls
+    field. The renderer must preserve both: the historical reasoning
+    appears in the prefix, and the tool call name is also rendered.
+
+    Multi-turn agent flows look like this — assistant reasons, calls a
+    tool, gets a tool response, then keeps going. preserve_thinking is
+    meaningful here because the model writing the next turn benefits
+    from seeing both why it called the tool AND what the tool returned.
+    """
+    tokenizer = _load_tokenizer()
+    msgs = [
+        {"role": "system", "content": "You're a helpful assistant with tools."},
+        {"role": "user", "content": "What's the weather in SF?"},
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "thinking", "thinking": _TOOL_REASONING},
+                {"type": "text", "text": _TOOL_VISIBLE},
+            ],
+            "tool_calls": [
+                {
+                    "function": {
+                        "name": "get_weather",
+                        "arguments": '{"city": "San Francisco"}',
+                    }
+                }
+            ],
+        },
+        {"role": "tool", "content": "Sunny, 72F"},
+        {"role": "user", "content": "And NYC?"},
+    ]
+    tokens = _build_renderer_tokens_for(msgs, "qwen3_6_preserve_thinking", tokenizer)
+    decoded = _decode(tokenizer, tokens)
+
+    # Historical thinking preserved
+    assert _TOOL_REASONING in decoded, (
+        f"Historical assistant's thinking dropped despite preserve mode:\n{decoded[:600]!r}"
+    )
+    # Visible content preserved
+    assert _TOOL_VISIBLE in decoded, "Visible content dropped"
+    # Tool call name present in the rendered output
+    assert "get_weather" in decoded, "Tool call name not rendered"
+    # Tool argument value present
+    assert "San Francisco" in decoded, "Tool call arguments not rendered"
+    # Tool response present
+    assert "Sunny, 72F" in decoded, "Tool response not rendered"
+
+
+@pytest.mark.timeout(180)
+def test_preserve_thinking_with_empty_thinking_string() -> None:
+    """Assistant message has a thinking part but the reasoning string is
+    empty (`{"type": "thinking", "thinking": ""}`).
+
+    Two equivalent input shapes should produce the SAME token output:
+      A. Empty thinking part:  `[{type:thinking, thinking:""}, {type:text, text:"hi"}]`
+      B. No thinking part:     `[{type:text, text:"hi"}]` (with our preserve override
+         emitting the empty wrapper from _assistant_header_suffix)
+
+    Both should render to `<|im_start|>assistant\\n<think>\\n\\n</think>\\n\\nhi`.
+    Verifies the renderer treats "explicit empty thinking" and "no
+    thinking" identically in preserve mode (matching HF behavior, where
+    `reasoning_content=""` and missing `reasoning_content` both
+    produce the empty wrapper).
+    """
+    tokenizer = _load_tokenizer()
+    base = [
+        {"role": "system", "content": "Be brief."},
+        {"role": "user", "content": "Hi"},
+    ]
+    msgs_empty_thinking = base + [
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "thinking", "thinking": ""},
+                {"type": "text", "text": "Hello!"},
+            ],
+        },
+        {"role": "user", "content": "Bye"},
+    ]
+    msgs_no_thinking = base + [
+        {"role": "assistant", "content": "Hello!"},
+        {"role": "user", "content": "Bye"},
+    ]
+
+    tokens_empty = _build_renderer_tokens_for(
+        msgs_empty_thinking, "qwen3_6_preserve_thinking", tokenizer
+    )
+    tokens_none = _build_renderer_tokens_for(
+        msgs_no_thinking, "qwen3_6_preserve_thinking", tokenizer
+    )
+
+    assert tokens_empty == tokens_none, (
+        "Empty thinking string and missing thinking part should produce "
+        "identical tokens in preserve mode (both emit the empty wrapper). "
+        "Got len(empty)={} vs len(none)={}".format(len(tokens_empty), len(tokens_none))
+    )
+
+    # Both should contain exactly one empty wrapper before "Hello!"
+    decoded = _decode(tokenizer, tokens_empty)
+    assert "<think>\n\n</think>\n\nHello!" in decoded, (
+        f"Expected empty wrapper before visible content, got:\n{decoded!r}"
+    )
+
+
+@pytest.mark.timeout(180)
+def test_preserve_thinking_deep_history_5_turns() -> None:
+    """5 historical assistant turns, each with distinct reasoning.
+    Verifies preserve mode scales: every historical reasoning appears
+    exactly once, no degradation at depth.
+    """
+    tokenizer = _load_tokenizer()
+    reasonings = [f"DEEP_TURN_{i}_THINK: distinct reasoning for turn {i}." for i in range(1, 6)]
+    msgs = _build_fanout_renderer_input(reasonings)
+    tokens = _build_renderer_tokens_for(msgs, "qwen3_6_preserve_thinking", tokenizer)
+    decoded = _decode(tokenizer, tokens)
+
+    for i, reasoning in enumerate(reasonings, 1):
+        count = decoded.count(reasoning)
+        assert count == 1, (
+            f"Turn {i} reasoning should appear exactly once at depth=5, "
+            f"found {count}x. (regression in deep multi-turn rendering)"
+        )
+
+    # 5 historical <think> opens (one per turn) + 1 generation prompt = 6
+    open_count = decoded.count("<think>")
+    close_count = decoded.count("</think>")
+    assert open_count == 6, (
+        f"expected 6 <think> tags at 5-turn depth (5 historical + 1 gen prompt), "
+        f"got {open_count}"
+    )
+    assert close_count == 5, (
+        f"expected 5 </think> closes (gen prompt is unclosed), got {close_count}"
+    )
+
+
+@pytest.mark.timeout(180)
+def test_default_mode_mixed_thinking_drops_everything() -> None:
+    """Symmetry check: default `qwen3_6` mode with a mixed
+    thinking/no-thinking fixture. Should strip ALL historical thinking
+    and emit NO `<think>` tags for any historical assistant
+    (regardless of whether the assistant carried a thinking part).
+
+    Without this test, default-mode behavior on mixed input is only
+    verified by the all-no-thinking case in
+    `test_fanout_default_mode_drops_all_historical_thinking`.
+    """
+    tokenizer = _load_tokenizer()
+    msgs = _build_fanout_renderer_input([_REASONING_T1, None, _REASONING_T3])
+    tokens = _build_renderer_tokens_for(msgs, "qwen3_6", tokenizer)
+    decoded = _decode(tokenizer, tokens)
+
+    # Both thinking strings absent (the one in turn 1 was stripped, turn 3 too)
+    assert _REASONING_T1 not in decoded, "default mode leaked turn-1 thinking"
+    assert _REASONING_T3 not in decoded, "default mode leaked turn-3 thinking"
+    # All visible answers present
+    assert _VISIBLE_T1 in decoded
+    assert _VISIBLE_T2 in decoded
+    assert _VISIBLE_T3 in decoded
+    # Default mode: no <think> for ANY historical assistant; only the
+    # trailing generation-prompt slot has the open tag.
+    open_count = decoded.count("<think>")
+    close_count = decoded.count("</think>")
+    assert open_count == 1, (
+        f"default mode mixed-thinking should have 1 <think> (gen prompt only), "
+        f"got {open_count}"
+    )
+    assert close_count == 0, (
+        f"default mode should have 0 </think> (no historical thinking emitted), "
+        f"got {close_count}"
+    )

--- a/training/tests/unit/test_renderer_hf_parity.py
+++ b/training/tests/unit/test_renderer_hf_parity.py
@@ -91,6 +91,46 @@ _CASES: list[_Case] = [
         messages=_SHORT_MSGS,
         apply_chat_template_kwargs={"enable_thinking": False},
     ),
+    # Qwen3.6 aliases the qwen3_5 renderer family
+    # (see training/renderer/_qwen3_split.py). Validate parity against the
+    # 3.6 tokenizer's `apply_chat_template` for default invocation
+    # (no `preserve_thinking` kwarg → byte-identical to Qwen3.5).
+    _Case(
+        case_id="qwen3_6-thinking-single-turn",
+        renderer="qwen3_6",
+        tokenizer_model="Qwen/Qwen3.6-27B",
+        messages=_SHORT_MSGS,
+    ),
+    _Case(
+        case_id="qwen3_6-thinking-multi-turn",
+        renderer="qwen3_6",
+        tokenizer_model="Qwen/Qwen3.6-27B",
+        messages=_MULTI_TURN_MSGS,
+    ),
+    _Case(
+        case_id="qwen3_6-disable-thinking",
+        renderer="qwen3_6_disable_thinking",
+        tokenizer_model="Qwen/Qwen3.6-27B",
+        messages=_SHORT_MSGS,
+        apply_chat_template_kwargs={"enable_thinking": False},
+    ),
+    # Qwen3.6 preserve-thinking against an assistant message that has
+    # NO reasoning content. The official Qwen3.6 chat template's
+    # preserve_thinking=true branch emits an empty
+    # `<think>\n\n</think>\n\n` wrapper for every historical assistant
+    # regardless of reasoning content (the "empty thinking blocks spam
+    # context" pattern documented at
+    # https://huggingface.co/froggeric/Qwen-Fixed-Chat-Templates).
+    # `Qwen3_6PreserveThinkingSplitRenderer._assistant_header_suffix`
+    # deliberately mirrors that behavior to preserve byte-level
+    # train-inference parity with the stock HF chat template.
+    _Case(
+        case_id="qwen3_6-preserve-thinking-multi-turn",
+        renderer="qwen3_6_preserve_thinking",
+        tokenizer_model="Qwen/Qwen3.6-27B",
+        messages=_MULTI_TURN_MSGS,
+        apply_chat_template_kwargs={"preserve_thinking": True},
+    ),
     _Case(
         case_id="kimi_k25-single-turn",
         renderer="kimi_k25",

--- a/training/tests/unit/test_supervised_rendering.py
+++ b/training/tests/unit/test_supervised_rendering.py
@@ -686,6 +686,13 @@ def test_resolve_renderer_name_prefers_qwen3_5() -> None:
     assert resolve_renderer_name("Qwen/Qwen3.5-397B-A17B") == "qwen3_5"
 
 
+def test_resolve_renderer_name_prefers_qwen3_6() -> None:
+    """Qwen3.6 models should resolve to the qwen3_6 renderer (alias of qwen3_5)."""
+    assert resolve_renderer_name("Qwen/Qwen3.6-27B") == "qwen3_6"
+    assert resolve_renderer_name("Qwen/Qwen3.6-9B") == "qwen3_6"
+    assert resolve_renderer_name("custom/qwen3_6-finetune") == "qwen3_6"
+
+
 def test_resolve_renderer_name_prefers_gemma4() -> None:
     """Gemma 4 models should resolve to the gemma4 renderer."""
     assert resolve_renderer_name("google/gemma-4-12b-it") == "gemma4"

--- a/training/utils/supervised.py
+++ b/training/utils/supervised.py
@@ -88,6 +88,14 @@ def resolve_renderer_name(
         return "minimax_m2"
     if "qwen3-vl" in normalized_model_name:
         return "qwen3_vl_instruct"
+    # Qwen3.6 reuses Qwen3.5's vocab + special tokens; the chat template only
+    # adds an opt-in `preserve_thinking` flag (renders historical thinking
+    # for ALL assistant turns when true). Default invocation produces output
+    # byte-identical to Qwen3.5's template, so the qwen3_5 renderer family
+    # is correct for non-interleave-thinking workflows on Qwen3.6 checkpoints.
+    # Same alias pattern as the kimi-k25 → Kimi-K2.6 case above.
+    if "qwen3.6" in normalized_model_name or "qwen3_6" in normalized_model_name:
+        return "qwen3_6"
     if "qwen3.5" in normalized_model_name or "qwen3_5" in normalized_model_name:
         return "qwen3_5"
     if "gemma-4" in normalized_model_name or "gemma4" in normalized_model_name:
@@ -197,6 +205,7 @@ def _renderer_uses_images(renderer_name: str) -> bool:
         for marker in (
             "_vl",
             "qwen3_5",
+            "qwen3_6",
             "kimi_k25",
         )
     )


### PR DESCRIPTION
# feat(renderer): add Qwen3.6 renderer family with interleave-thinking variant


## Summary

Adds three Qwen3.6 renderer names to the cookbook, with byte-level HF parity tests and a dedicated capability test for the interleave-thinking variant.

| Renderer name | Behavior | Use case |
|---|---|---|
| `qwen3_6` | Alias of `qwen3_5` (Qwen3.6's default chat template is byte-identical to Qwen3.5 when `preserve_thinking` is unset) | Drop-in replacement for any existing Qwen3.5 SFT recipe, now auto-resolves for `Qwen/Qwen3.6-*` tokenizers |
| `qwen3_6_disable_thinking` | Alias of `qwen3_5_disable_thinking` | Non-thinking SFT (text2sql, structured output, format compliance). Keep train-inference parity by also passing `enable_thinking=false` at inference |
| `qwen3_6_preserve_thinking` | New — subclass of `Qwen3_5SplitRenderer` that passes `strip_thinking_from_history=False` and overrides `_assistant_header_suffix` to emit empty `<think>\n\n</think>\n\n` wrapper for historical assistants without thinking content | Multi-turn SFT where the model should attend to its own prior reasoning at inference. Pair with `chat_template_kwargs.preserve_thinking=true` on each request to keep train-inference parity |

Also adds an auto-resolver entry in `supervised.py` so `Qwen/Qwen3.6-*` tokenizers resolve to `qwen3_6` without a `KeyError` — works around an upstream `tinker_cookbook` registry that pre-dates [thinking-machines-lab/tinker-cookbook#681](https://github.com/thinking-machines-lab/tinker-cookbook/pull/681).

## Why

Qwen3.6 is the first Qwen model whose chat template officially supports **interleaved thinking** (preserved `<think>...</think>` blocks across multi-turn assistant history) via the `preserve_thinking=true` kwarg. The upstream `tinker_cookbook` registers Qwen3.6 to use the existing `qwen3_5` renderer (which has the underlying `strip_thinking_from_history` capability) but does NOT expose a named preserve-thinking renderer for it — making it inconvenient to opt into the feature from cookbook configs.

This PR closes the gap with a named renderer, an auto-resolver path, and a test suite that proves parity with the upstream HF chat template's `preserve_thinking=true` rendering. The pattern mirrors what `kimi_k26` already does for Kimi K2.6.

---

## End-to-end test runs

All three runs target Qwen3.6-27B + LoRA rank 256 + the cookbook branch under test (`fw-ai/fireworks @ yued/test-qwen3_6-renderer`, which bumps the cookbook submodule to `yued/qwen3_6-renderer @ 1563330`).

| Run | Dataset | Hyperparams | Workflow | Outcome | Purpose |
|---|---|---|---|---|---|
| **C** | `multiturn_thinking.jsonl` (200 multi-turn rows derived from a-m-team/AM-DeepSeek-R1-0528-Distilled) | 20 epochs, LR 1e-4, BS 32 | [run 25543348663](https://github.com/fw-ai/fireworks/actions/runs/25543348663) | Training ✓, Deploy ✓, Smoke ✗ ¹ | Pipeline validation — proves renderer + image_processor wiring + SFT loop work end-to-end on real multi-turn data |
| **D v2** | `synthetic_recall_train.jsonl` (120 hand-crafted hidden-info recall rows) | 30 epochs, LR 1e-4, BS 32 | [run 25545099129](https://github.com/fw-ai/fireworks/actions/runs/25545099129) | Training ✓, Deploy ✓, Smoke ✗ ¹ | Capability validation — first half of paired ablation captured before deployment was cleaned up |
| **D v3** | Same as D v2 | Same | [run 25547325991](https://github.com/fw-ai/fireworks/actions/runs/25547325991) | All steps ✓ ² | Final paired ablation + two-number recall test |

¹ The workflow's inference smoke step has two pre-existing bugs (unrelated to this PR): (a) `"\n".join(p for p in ground_truth_parts)` assumes assistant content is `str`, but our structured-content schema makes it `list[dict]` → `TypeError`; (b) it blindly POSTs image content from multimodal datasets to text-only deployments → 400. Both should be filed as a separate workflow PR.

² Dispatched with `run_inference_smoke=false` to skip the broken step. Training, deployment, and our own evaluation scripts all succeeded.

### Training-time metrics

Both runs converged well below the 0.03 memorization target.

| Run | Optim steps | Initial loss | Final loss | Min loss | Curve shape |
|---|---|---|---|---|---|
| **Run C** (200 rows × 20 ep) | 140 | 0.531 | 0.003 | 0.002 | Smooth monotonic decrease, converged ~step 50 |
| **Run D v3** (120 rows × 30 ep) | 120 | 0.808 | 0.005 | 0.004 | Smooth monotonic decrease, converged ~step 35 |

Loss curves (every Nth step):

```
Run C:                                                Run D v3:
  step    1: 0.531  ███                                 step    1: 0.808  ████
  step   22: 0.153  █                                   step    7: 0.055
  step   36: 0.047                                      step   25: 0.042
  step   50: 0.013                                      step   37: 0.010
  step   92: 0.004                                      step   91: 0.006
  step  140: 0.003                                      step  120: 0.005
```

---

## Headline result: paired ablation eval (Run D v3, 30 held-out rows)

The eval set (`tmp/test_data/synthetic_recall_eval.jsonl`) is a stratified held-out split — **0 overlap** with the 120 training rows. Each row is one multi-turn conversation where the FIRST assistant turn places critical info inside `<think>` and the FOLLOW-UP turns require recalling that info to answer correctly. We send each prompt to the deployed model under two conditions:

- **A)** `chat_template_kwargs.preserve_thinking=true` — historical `<think>` blocks are kept in the prompt
- **B)** `chat_template_kwargs.preserve_thinking=false` — historical `<think>` blocks are stripped (default)

Per-template ground-truth checkers verify whether the model's response contains the hidden info from T1's thinking.

| Template | preserve=ON | preserve=OFF | DELTA | Notes |
|---|---|---|---|---|
| `two_number` | **5/5 (100%)** | 0/5 (0%) | **+100 pp** | Recall hidden Y from T1 thinking |
| `recipe` | **5/5 (100%)** | 0/5 (0%) | **+100 pp** | Recall all 3 ingredients (only protein was revealed in T1) |
| `cli_tool` | **5/5 (100%)** | 0/5 (0%) | **+100 pp** | Recall help text for subcommand #2 (only #1 was revealed) |
| `story_plot` | **5/5 (100%)** | 0/5 (0%) | **+100 pp** | Recall planned Act 2 across a 3-turn conversation |
| `refactor` | **4/5 (80%)** | 0/5 (0%) | **+80 pp** | Recall step 2/3 of a 4-step refactor plan |
| `factorial` | 5/5 (100%) | 5/5 (100%) | +0 pp ³ | Numeric chain — model can re-derive from prompt without recall |
| **OVERALL** | **29/30 (97%)** | **5/30 (17%)** | **+80 pp** | Strong causal signal that preserve_thinking is honored at inference |

³ The `factorial` template is the one case where recall is not strictly required — the model can re-derive intermediate values from the chain definition that's already in the user prompt. Both conditions pass for the same reason (re-derivation, not recall). Expected, and a useful negative control showing the eval doesn't false-positive.

**Verdict: STRONG SIGNAL — `qwen3_6_preserve_thinking` renderer + LoRA train the model to USE preserved historical thinking.**

---

## Two-number recall test (Run D v3, 8 trials per condition)

A focused ablation that probes whether the model can recall a specific number that was committed to thinking in T1 but never revealed in the T1 final answer.

**T1 prompt:** *"Pick two distinct random 8-digit integers, X and Y. Verify in your thinking that both are exactly 8 digits. In your final answer output ONLY X."*
**T2 prompt:** *"Now give me Y."*

| Condition | Pass rate | What the model did |
|---|---|---|
| `preserve_thinking=ON` | **6/8 (75%)** | Recalled the original Y from T1's `<think>` block |
| `preserve_thinking=OFF` | **0/8 (0%)** | Invented a brand-new Y (had no access to T1 thinking) |
| **DELTA** | **+75 percentage points** | Causal proof preserve_thinking takes effect at inference |

### Concrete behavior diff

The most informative artifact is the model's T2 thinking content under each condition (same trial, same seed):

> **T1 thinking (both conditions identical):** *"...I'll choose X = 47291836 and Y = **81053729**..."*
> **T1 content (both conditions identical):** *"47291836"*

| Condition | T2 thinking (excerpt) | T2 content |
|---|---|---|
| **preserve=ON** | *"The user is asking for the value of Y, which was defined in the previous turn as one of two distinct random 8-digit integers (X and Y). **Recall Previous Context:** In the previous turn, I generated..."* | **`81053729`** ✓ correct recall |
| **preserve=OFF** | *"User previously asked: 'Pick two distinct random 8-digit integers, X and Y... In your final answer output ONLY X.' I responded with X. Now I need to provide Y..."* (note: the model only sees its own X output and the user's prompt — no thinking context) | `92047153` ✗ invented |

The contrast is unambiguous: preserve=ON, the model literally references its own prior reasoning (*"In the previous turn, I generated..."*); preserve=OFF, the model has no memory of Y and has to make one up. Same trained model, same temperature, same prompt — only the chat-template kwarg differs.

---

## Why Run C scores 0/8 on the same two-number test (sanity check)

Run C's training data (`multiturn_thinking.jsonl`, derived from AM-DeepSeek) has thinking content **only on the LAST assistant turn** of each conversation — historical assistants are bare answers. So the SFT could not teach the recall behavior. Run C two-number test result: 0/8 (preserve=ON) vs 0/8 (preserve=OFF), DELTA +0pp. Expected and a useful sanity check: the renderer alone is not enough; you need training data that exercises the recall pattern. Run D's `synthetic_recall_train.jsonl` is purpose-built to provide that signal.

This is a positive demonstration that the eval is doing the right thing — it correctly identifies an SFT that did NOT teach the capability.

---

## Tests

All in the cookbook PR diff:

| Test file | Coverage | Count |
|---|---|---|
| `test_renderer_hf_parity.py` | Byte-level parity vs HF `apply_chat_template` for Qwen3.6 default / multi-turn / disable-thinking / preserve-thinking | 4 new cases |
| `test_qwen3_6_preserve_thinking.py` (NEW) | Dedicated preserve_thinking behavior tests: basic, realistic 3-turn, adversarial fan-out, corner cases | 16 tests |
| `test_supervised_rendering.py` | Auto-resolver test for `Qwen/Qwen3.6-*` tokenizers | 1 test |
| **Total new test surface** |  | **21 tests** |

Tests pass locally with `pytest training/tests/unit/test_renderer_hf_parity.py training/tests/unit/test_supervised_rendering.py training/tests/unit/test_qwen3_6_preserve_thinking.py`.

---

## Trade-offs

The empty-wrapper-on-historical-turns behavior matches HF's stock chat template at `preserve_thinking=true`, which is documented (e.g. by the [froggeric/Qwen-Fixed-Chat-Templates](https://huggingface.co/froggeric/Qwen-Fixed-Chat-Templates) community) to waste a few tokens per historical turn. We adopt it deliberately for train-inference parity. Customers serving with a bug-fixed template at inference can use the default `qwen3_5` family instead.

---

## Reproducibility — methodology

The datasets and eval scripts used for the E2E validation live in an internal throwaway branch (not shipped with this PR), but the methodology is fully described below. Anyone can replicate the test on their own Qwen3.6-27B LoRA deployment by reconstructing these three artifacts:

### Synthetic recall dataset (used for training Run D)

A small SFT dataset (120 train rows + 30 held-out eval rows, 0 overlap) where **every assistant turn carries thinking content** and follow-up turns require **recalling info from earlier `<think>` blocks** to answer correctly. Six templates × 25 rows each, mix of 2-turn and 3-turn:

| Template | Pattern |
|---|---|
| `two_number` | T1 picks two numbers in `<think>`, outputs only one; T2 asks for the other |
| `recipe` | T1 plans 3 ingredients in `<think>`, outputs only the protein; T2 asks for all three |
| `factorial` | T1 computes a numeric chain in `<think>`, outputs only the final value; T2 asks for an intermediate step |
| `cli_tool` | T1 plans 3 subcommands in `<think>`, outputs help for #1; T2 asks for help on #2 |
| `story_plot` | T1 sketches Acts 1/2/3 in `<think>`, reveals only Act 1; T2 asks for Act 2; T3 asks for Act 3 |
| `refactor` | T1 plans 4 refactor steps in `<think>`, applies step 1; T2 applies step 2; T3 applies step 4 |

Without `preserve_thinking=true` at inference, the model has no access to the hidden info → wrong answer. With it, the model can attend to its own prior reasoning → correct answer.

### Paired-ablation eval script

For each held-out conversation: send the prompt to the deployed model under two conditions, **same trial otherwise**:

- **A)** `chat_template_kwargs.preserve_thinking=true`
- **B)** `chat_template_kwargs.preserve_thinking=false`

Per-template ground-truth checkers (string match for numeric values, word-overlap thresholds for free-form text) verify whether the model's response contains the hidden info from T1's thinking. Headline metric is the DELTA in accuracy between A and B — a positive DELTA is the causal signal that preserve_thinking takes effect at inference and that the SFT taught the model to use it.

### Two-number recall test script

A focused 2-turn ablation that probes one specific recall capability with N trials per condition:

- T1: *"Pick two distinct random N-digit integers X and Y. Verify in your thinking that both are exactly N digits. Output only X."*
- T2: *"Now give me Y."*

Compares pass rate (model's T2 output equals the original Y) under preserve=ON vs preserve=OFF. Designed to be small, deterministic, and runnable in <5 minutes against any deployment.

### What you'd need to replicate

1. A Qwen3.6-27B LoRA deployment trained on a recall-style multi-turn dataset (~120 rows, 30 epochs, LR 1e-4 with `renderer_name=qwen3_6_preserve_thinking` is sufficient)
2. The two scripts above (~250 LOC each, no exotic dependencies — `urllib` + `re` + `json`)
3. API access to chat completions on the deployment with permission to pass `chat_template_kwargs`

---

## Test plan

- [x] Unit tests pass locally (21 new tests + 0 regressions on existing Qwen3 / Qwen3.5 / Kimi K26 paths)
- [x] SFT + deployment validated end-to-end against Qwen3.6-27B LoRA ([Run C](https://github.com/fw-ai/fireworks/actions/runs/25543348663), [Run D v2](https://github.com/fw-ai/fireworks/actions/runs/25545099129), [Run D v3](https://github.com/fw-ai/fireworks/actions/runs/25547325991))
- [x] Paired ablation: +80 percentage point DELTA in recall accuracy (29/30 vs 5/30)
- [x] Two-number recall: +75 percentage point DELTA (6/8 vs 0/8)
- [ ] Reviewer to verify there are no regressions for Qwen3 / Qwen3.5 / Kimi K26 paths

---

## Follow-ups (not blocking this PR)

1. **Workflow smoke step bug** in `.github/workflows/sft_train_and_deploy.yml` — needs (a) handling for structured-content assistant messages (currently crashes with `TypeError` on `"\n".join(...)`) and (b) skipping image content when deployment is text-only (currently 400s). Separate small workflow-level PR.
2. **Vision deployment shape for Qwen3.6-27B** — Qwen3.6-27B is upstream a vision-language model (HF `pipeline_tag: image-text-to-text`) but Fireworks has only `qwen3p6-27b-minimal` (vLLM `--language-model-only`). To validate vision serving, someone needs to build a `qwen3p6-27b-vl` shape. Out of scope for this PR.
3. **KLD verification** — direct comparison of trainer logprobs vs deployment logprobs on identical tokens. The +80pp DELTA already gives strong indirect evidence of train-inference alignment; KLD would be the gold-standard direct measurement.
