### PR TITLE
fix(renderer): align Qwen3.6 SFT renderer inference

### DIFF
--- a/training/renderer/_qwen3_split.py
+++ b/training/renderer/_qwen3_split.py
@@ -89,8 +89,8 @@ class Qwen3_5DisableThinkingSplitRenderer(
 #                                        inference time.
 #
 #   `qwen3_6_disable_thinking`   — empty think block in generation prompt
-#                                    (`enable_thinking=false`). Alias of
-#                                    Qwen3.5 disable-thinking renderer.
+#                                    (`enable_thinking=false`) with Qwen3.6's
+#                                    tool-argument formatting.
 #                                    Use for non-thinking SFT (text2sql,
 #                                    structured output, format compliance);
 #                                    customers must also pass
@@ -98,7 +98,7 @@ class Qwen3_5DisableThinkingSplitRenderer(
 #                                    time to keep train↔inference parity.
 
 
-class Qwen3_6SplitRenderer(Qwen3_5SplitRenderer):
+class Qwen3_6ToolCallFormattingMixin:
     def _format_tool_call_xml(self, tool_call):
         """Match Qwen3.6's tool-argument serialization.
 
@@ -119,11 +119,19 @@ class Qwen3_6SplitRenderer(Qwen3_5SplitRenderer):
         return "\n".join(lines)
 
 
-class Qwen3_6DisableThinkingSplitRenderer(Qwen3_5DisableThinkingSplitRenderer):
+class Qwen3_6SplitRenderer(Qwen3_6ToolCallFormattingMixin, Qwen3_5SplitRenderer):
     pass
 
 
-class Qwen3_6PreserveThinkingSplitRenderer(Qwen3_5SplitRenderer):
+class Qwen3_6DisableThinkingSplitRenderer(
+    Qwen3_6ToolCallFormattingMixin, Qwen3_5DisableThinkingSplitRenderer
+):
+    pass
+
+
+class Qwen3_6PreserveThinkingSplitRenderer(
+    Qwen3_6ToolCallFormattingMixin, Qwen3_5SplitRenderer
+):
     """Qwen3.6 with interleave thinking — historical assistant `<think>`
     blocks preserved across turns.
 

--- a/training/renderer/_qwen3_split.py
+++ b/training/renderer/_qwen3_split.py
@@ -16,6 +16,8 @@ override before any caller resolves a renderer via ``get_renderer``.
 
 from __future__ import annotations
 
+import json
+
 from tinker_cookbook.renderers import register_renderer
 from tinker_cookbook.renderers.qwen3 import (
     Qwen3DisableThinkingRenderer,
@@ -62,19 +64,17 @@ class Qwen3_5DisableThinkingSplitRenderer(
 
 
 # Qwen3.6 ships with the same vocab, special tokens, and tokenizer as
-# Qwen3.5. The chat template adds one new opt-in feature:
-# `preserve_thinking`. Default invocation (`preserve_thinking`
-# undefined or false) produces output byte-identical to Qwen3.5's
-# template, so the Qwen3.5 renderer family is correct for the default
-# non-interleave-thinking case on Qwen3.6 models.
+# Qwen3.5. The chat template is close to Qwen3.5's template, but differs in
+# two places: the opt-in `preserve_thinking` flag and JSON serialization for
+# non-string scalar tool-call arguments.
 #
 # Three Qwen3.6 renderer variants:
 #
-#   `qwen3_6`                    — default; alias of Qwen3.5 renderer
+#   `qwen3_6`                    — default; Qwen3.5 behavior with Qwen3.6's
+#                                    tool-argument formatting
 #                                    (`strip_thinking_from_history=True`).
-#                                    Matches HF apply_chat_template default
-#                                    args. Use for normal SFT/DPO/RL where
-#                                    historical thinking should be stripped.
+#                                    Use for normal SFT/DPO/RL where historical
+#                                    thinking should be stripped.
 #
 #   `qwen3_6_preserve_thinking`  — interleave thinking enabled
 #                                    (`strip_thinking_from_history=False`).
@@ -99,7 +99,24 @@ class Qwen3_5DisableThinkingSplitRenderer(
 
 
 class Qwen3_6SplitRenderer(Qwen3_5SplitRenderer):
-    pass
+    def _format_tool_call_xml(self, tool_call):
+        """Match Qwen3.6's tool-argument serialization.
+
+        Qwen3.5 stringifies scalar non-container values with Jinja's
+        ``string`` filter. Qwen3.6 uses ``tojson`` for every non-string value,
+        which changes booleans/None from Python spellings (``True``/``None``)
+        to JSON spellings (``true``/``null``).
+        """
+        args = json.loads(tool_call.function.arguments) if tool_call.function.arguments else {}
+        lines = [f"<tool_call>\n<function={tool_call.function.name}>"]
+        for param_name, param_value in args.items():
+            if isinstance(param_value, str):
+                value_str = param_value
+            else:
+                value_str = json.dumps(param_value)
+            lines.append(f"<parameter={param_name}>\n{value_str}\n</parameter>")
+        lines.append("</function>\n</tool_call>")
+        return "\n".join(lines)
 
 
 class Qwen3_6DisableThinkingSplitRenderer(Qwen3_5DisableThinkingSplitRenderer):

--- a/training/tests/unit/test_qwen3_6_preserve_thinking.py
+++ b/training/tests/unit/test_qwen3_6_preserve_thinking.py
@@ -196,6 +196,8 @@ def test_qwen3_6_tool_call_scalar_args_use_json_spelling() -> None:
 
     from training.renderer._qwen3_split import (
         Qwen3_5SplitRenderer,
+        Qwen3_6DisableThinkingSplitRenderer,
+        Qwen3_6PreserveThinkingSplitRenderer,
         Qwen3_6SplitRenderer,
     )
 
@@ -215,17 +217,26 @@ def test_qwen3_6_tool_call_scalar_args_use_json_spelling() -> None:
     )
 
     qwen3_5 = Qwen3_5SplitRenderer.__new__(Qwen3_5SplitRenderer)
-    qwen3_6 = Qwen3_6SplitRenderer.__new__(Qwen3_6SplitRenderer)
+    qwen3_6_renderers = [
+        Qwen3_6SplitRenderer.__new__(Qwen3_6SplitRenderer),
+        Qwen3_6DisableThinkingSplitRenderer.__new__(
+            Qwen3_6DisableThinkingSplitRenderer
+        ),
+        Qwen3_6PreserveThinkingSplitRenderer.__new__(
+            Qwen3_6PreserveThinkingSplitRenderer
+        ),
+    ]
 
     rendered_35 = qwen3_5._format_tool_call_xml(tool_call)
-    rendered_36 = qwen3_6._format_tool_call_xml(tool_call)
-
     assert "<parameter=enabled>\nTrue\n</parameter>" in rendered_35
     assert "<parameter=unset>\nNone\n</parameter>" in rendered_35
-    assert "<parameter=enabled>\ntrue\n</parameter>" in rendered_36
-    assert "<parameter=unset>\nnull\n</parameter>" in rendered_36
-    assert "<parameter=note>\nalready a string\n</parameter>" in rendered_36
-    assert "<parameter=items>\n[1, 2]\n</parameter>" in rendered_36
+
+    for renderer in qwen3_6_renderers:
+        rendered_36 = renderer._format_tool_call_xml(tool_call)
+        assert "<parameter=enabled>\ntrue\n</parameter>" in rendered_36
+        assert "<parameter=unset>\nnull\n</parameter>" in rendered_36
+        assert "<parameter=note>\nalready a string\n</parameter>" in rendered_36
+        assert "<parameter=items>\n[1, 2]\n</parameter>" in rendered_36
 
 
 # --------------------------------------------------------------------------

--- a/training/tests/unit/test_qwen3_6_preserve_thinking.py
+++ b/training/tests/unit/test_qwen3_6_preserve_thinking.py
@@ -22,6 +22,8 @@ Both tests skip cleanly if HF Hub is unreachable.
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
 
@@ -188,6 +190,44 @@ def _build_renderer_tokens(renderer_name: str, tokenizer) -> list[int]:
     return [int(t) for t in model_input.to_ints()]
 
 
+def test_qwen3_6_tool_call_scalar_args_use_json_spelling() -> None:
+    """Qwen3.6 differs from Qwen3.5 for non-string scalar tool arguments."""
+    from tinker_cookbook.renderers.base import ToolCall
+
+    from training.renderer._qwen3_split import (
+        Qwen3_5SplitRenderer,
+        Qwen3_6SplitRenderer,
+    )
+
+    tool_call = ToolCall(
+        function=ToolCall.FunctionBody(
+            name="set_flags",
+            arguments=json.dumps(
+                {
+                    "enabled": True,
+                    "limit": 3,
+                    "note": "already a string",
+                    "unset": None,
+                    "items": [1, 2],
+                }
+            ),
+        )
+    )
+
+    qwen3_5 = Qwen3_5SplitRenderer.__new__(Qwen3_5SplitRenderer)
+    qwen3_6 = Qwen3_6SplitRenderer.__new__(Qwen3_6SplitRenderer)
+
+    rendered_35 = qwen3_5._format_tool_call_xml(tool_call)
+    rendered_36 = qwen3_6._format_tool_call_xml(tool_call)
+
+    assert "<parameter=enabled>\nTrue\n</parameter>" in rendered_35
+    assert "<parameter=unset>\nNone\n</parameter>" in rendered_35
+    assert "<parameter=enabled>\ntrue\n</parameter>" in rendered_36
+    assert "<parameter=unset>\nnull\n</parameter>" in rendered_36
+    assert "<parameter=note>\nalready a string\n</parameter>" in rendered_36
+    assert "<parameter=items>\n[1, 2]\n</parameter>" in rendered_36
+
+
 # --------------------------------------------------------------------------
 # Test 1 — Behavioral: kwarg flips historical-thinking presence
 # --------------------------------------------------------------------------
@@ -195,7 +235,7 @@ def _build_renderer_tokens(renderer_name: str, tokenizer) -> list[int]:
 
 @pytest.mark.timeout(180)
 def test_default_renderer_drops_historical_thinking() -> None:
-    """`qwen3_6` (alias of qwen3_5, strip_thinking_from_history=True)
+    """`qwen3_6` (default strip_thinking_from_history=True)
     must drop the reasoning from historical assistant turns.
 
     The historical reasoning string must NOT appear in the rendered

--- a/training/tests/unit/test_renderer_hf_parity.py
+++ b/training/tests/unit/test_renderer_hf_parity.py
@@ -91,10 +91,9 @@ _CASES: list[_Case] = [
         messages=_SHORT_MSGS,
         apply_chat_template_kwargs={"enable_thinking": False},
     ),
-    # Qwen3.6 aliases the qwen3_5 renderer family
-    # (see training/renderer/_qwen3_split.py). Validate parity against the
-    # 3.6 tokenizer's `apply_chat_template` for default invocation
-    # (no `preserve_thinking` kwarg → byte-identical to Qwen3.5).
+    # Qwen3.6 is close to Qwen3.5 but has its own template differences
+    # (preserve_thinking and scalar tool-argument JSON semantics). Validate
+    # parity against the 3.6 tokenizer's `apply_chat_template`.
     _Case(
         case_id="qwen3_6-thinking-single-turn",
         renderer="qwen3_6",

--- a/training/tests/unit/test_supervised_rendering.py
+++ b/training/tests/unit/test_supervised_rendering.py
@@ -686,11 +686,12 @@ def test_resolve_renderer_name_prefers_qwen3_5() -> None:
     assert resolve_renderer_name("Qwen/Qwen3.5-397B-A17B") == "qwen3_5"
 
 
-def test_resolve_renderer_name_prefers_qwen3_6() -> None:
-    """Qwen3.6 models should resolve to the qwen3_6 renderer (alias of qwen3_5)."""
-    assert resolve_renderer_name("Qwen/Qwen3.6-27B") == "qwen3_6"
-    assert resolve_renderer_name("Qwen/Qwen3.6-9B") == "qwen3_6"
-    assert resolve_renderer_name("custom/qwen3_6-finetune") == "qwen3_6"
+def test_resolve_renderer_name_prefers_qwen3_5_for_qwen3_6() -> None:
+    """Qwen3.6 defaults to the broadly supported qwen3_5 renderer."""
+    assert resolve_renderer_name("Qwen/Qwen3.6-27B") == "qwen3_5"
+    assert resolve_renderer_name("Qwen/Qwen3.6-9B") == "qwen3_5"
+    assert resolve_renderer_name("custom/qwen3_6-finetune") == "qwen3_5"
+    assert resolve_renderer_name("accounts/fireworks/models/qwen3p6-27b") == "qwen3_5"
 
 
 def test_resolve_renderer_name_prefers_gemma4() -> None:

--- a/training/tests/unit/test_supervised_rendering.py
+++ b/training/tests/unit/test_supervised_rendering.py
@@ -686,12 +686,12 @@ def test_resolve_renderer_name_prefers_qwen3_5() -> None:
     assert resolve_renderer_name("Qwen/Qwen3.5-397B-A17B") == "qwen3_5"
 
 
-def test_resolve_renderer_name_prefers_qwen3_5_for_qwen3_6() -> None:
-    """Qwen3.6 defaults to the broadly supported qwen3_5 renderer."""
-    assert resolve_renderer_name("Qwen/Qwen3.6-27B") == "qwen3_5"
-    assert resolve_renderer_name("Qwen/Qwen3.6-9B") == "qwen3_5"
-    assert resolve_renderer_name("custom/qwen3_6-finetune") == "qwen3_5"
-    assert resolve_renderer_name("accounts/fireworks/models/qwen3p6-27b") == "qwen3_5"
+def test_resolve_renderer_name_prefers_qwen3_6() -> None:
+    """Qwen3.6 models should resolve to the dedicated qwen3_6 renderer."""
+    assert resolve_renderer_name("Qwen/Qwen3.6-27B") == "qwen3_6"
+    assert resolve_renderer_name("Qwen/Qwen3.6-9B") == "qwen3_6"
+    assert resolve_renderer_name("custom/qwen3_6-finetune") == "qwen3_6"
+    assert resolve_renderer_name("accounts/fireworks/models/qwen3p6-27b") == "qwen3_6"
 
 
 def test_resolve_renderer_name_prefers_gemma4() -> None:

--- a/training/utils/supervised.py
+++ b/training/utils/supervised.py
@@ -91,11 +91,16 @@ def resolve_renderer_name(
     # Qwen3.6 reuses Qwen3.5's vocab + special tokens; the chat template only
     # adds an opt-in `preserve_thinking` flag (renders historical thinking
     # for ALL assistant turns when true). Default invocation produces output
-    # byte-identical to Qwen3.5's template, so the qwen3_5 renderer family
-    # is correct for non-interleave-thinking workflows on Qwen3.6 checkpoints.
-    # Same alias pattern as the kimi-k25 → Kimi-K2.6 case above.
-    if "qwen3.6" in normalized_model_name or "qwen3_6" in normalized_model_name:
-        return "qwen3_6"
+    # byte-identical to Qwen3.5's template, so resolve Qwen3.6 to the broadly
+    # supported qwen3_5 renderer. Advanced interleave-thinking workflows can
+    # still opt in explicitly with renderer_name="qwen3_6_preserve_thinking".
+    if (
+        "qwen3.6" in normalized_model_name
+        or "qwen3_6" in normalized_model_name
+        or "qwen3-6" in normalized_model_name
+        or "qwen3p6" in normalized_model_name
+    ):
+        return "qwen3_5"
     if "qwen3.5" in normalized_model_name or "qwen3_5" in normalized_model_name:
         return "qwen3_5"
     if "gemma-4" in normalized_model_name or "gemma4" in normalized_model_name:

--- a/training/utils/supervised.py
+++ b/training/utils/supervised.py
@@ -88,19 +88,18 @@ def resolve_renderer_name(
         return "minimax_m2"
     if "qwen3-vl" in normalized_model_name:
         return "qwen3_vl_instruct"
-    # Qwen3.6 reuses Qwen3.5's vocab + special tokens; the chat template only
-    # adds an opt-in `preserve_thinking` flag (renders historical thinking
-    # for ALL assistant turns when true). Default invocation produces output
-    # byte-identical to Qwen3.5's template, so resolve Qwen3.6 to the broadly
-    # supported qwen3_5 renderer. Advanced interleave-thinking workflows can
-    # still opt in explicitly with renderer_name="qwen3_6_preserve_thinking".
+    # Qwen3.6 is close to Qwen3.5, but its HF chat template adds
+    # `preserve_thinking` and serializes non-string tool arguments with JSON
+    # semantics. Route to the local qwen3_6 renderer family so those template
+    # differences stay explicit while keeping qwen3_6_preserve_thinking
+    # available as an opt-in variant.
     if (
         "qwen3.6" in normalized_model_name
         or "qwen3_6" in normalized_model_name
         or "qwen3-6" in normalized_model_name
         or "qwen3p6" in normalized_model_name
     ):
-        return "qwen3_5"
+        return "qwen3_6"
     if "qwen3.5" in normalized_model_name or "qwen3_5" in normalized_model_name:
         return "qwen3_5"
     if "gemma-4" in normalized_model_name or "gemma4" in normalized_model_name:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Verified the Hugging Face `chat_template` fields for `Qwen/Qwen3.5-9B`, `Qwen/Qwen3.5-27B`, and `Qwen/Qwen3.6-27B`.
- Qwen3.5 templates match each other, but Qwen3.6 is not identical: it adds `preserve_thinking` handling and changes non-string scalar tool arguments to JSON semantics.
- Route Qwen3.6 tokenizer/model IDs to the dedicated local `qwen3_6` renderer by default, including Fireworks-style `qwen3p6` IDs.
- Update the local Qwen3.6 renderer family so default, disable-thinking, and preserve-thinking variants all format scalar tool arguments like HF Qwen3.6 (`true`/`null`) instead of Qwen3.5/Python stringification (`True`/`None`).

## HF template check

- `Qwen/Qwen3.5-9B`: `sha256=a4aee8afcf2e0711942cf848899be66016f8d14a889ff9ede07bca099c28f715`
- `Qwen/Qwen3.5-27B`: `sha256=a4aee8afcf2e0711942cf848899be66016f8d14a889ff9ede07bca099c28f715`
- `Qwen/Qwen3.6-27B`: `sha256=e84f32a23fdda27689f868aa4a1a5621f41133e51a48d7f3efcbea2839574259`

Relevant Qwen3.5 -> Qwen3.6 diff:

```diff
-{%- if loop.index0 > ns.last_query_index %}
+{%- if (preserve_thinking is defined and preserve_thinking is true) or (loop.index0 > ns.last_query_index) %}
...
-{%- set args_value = args_value | tojson | safe if args_value is mapping or (args_value is sequence and args_value is not string) else args_value | string %}
+{%- set args_value = args_value | string if args_value is string else args_value | tojson | safe %}
```

## CI note

The failed unit job on commit `1a4c26b` was `tests/unit/test_frozen_lake_visual_rollout.py::test_visual_rollout_preserves_prior_completion_tokens`, a Kimi visual rollout token snapshot (`163593` vs expected `163595`). That path is unrelated to this Qwen3.6 renderer change, so this PR does not change it.

## Tests

- `python3 -m py_compile training/renderer/_qwen3_split.py training/tests/unit/test_qwen3_6_preserve_thinking.py`
- `python3 -m py_compile training/utils/supervised.py training/renderer/_qwen3_split.py training/tests/unit/test_supervised_rendering.py training/tests/unit/test_renderer_hf_parity.py training/tests/unit/test_qwen3_6_preserve_thinking.py`
- `git diff --check`

Focused pytest could not run in this container because `pytest` is not installed.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://fireworks-ai.slack.com/archives/C08FFA581C1/p1778308976174459?thread_ts=1778308976.174459&cid=C08FFA581C1)

<div><a href="https://cursor.com/agents/bc-a896791c-0a3d-5aef-a1b4-69b164e9c883"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a896791c-0a3d-5aef-a1b4-69b164e9c883"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

