### PR TITLE
fix(training): avoid duplicate final DCP save

### DIFF
--- a/training/recipes/rl_loop.py
+++ b/training/recipes/rl_loop.py
@@ -675,6 +675,8 @@ def main(
                 client_loss_builder(adv, ref_lp, prompt_lens, inf_lp, old_policy_logprobs),
             )
 
+        last_dcp_save_step: int | None = None
+
         def train_step(
             step: int,
             prompt_groups: list[PromptGroup],
@@ -689,6 +691,8 @@ def main(
             batches, not optim steps) so resume accounting is independent of
             the minibatch count.
             """
+            nonlocal last_dcp_save_step
+
             if not prompt_groups:
                 raise ValueError("train_step requires at least one prompt group")
 
@@ -751,6 +755,7 @@ def main(
                     promotable=False,
                     data_consumed=cursor.value,
                 )
+                last_dcp_save_step = step
                 logger.info("[step %d] dcp_save: done (%.1fs)", step, _time.time() - t0)
 
             metrics = compute_step_metrics(
@@ -842,11 +847,17 @@ def main(
         if cfg.save_final_checkpoint and global_step > step_offset:
             try:
                 cp_name = f"step-{global_step}"
+                save_resumable_final = last_dcp_save_step != global_step
+                if not save_resumable_final:
+                    logger.info(
+                        "[step %d] final checkpoint: reusing existing DCP checkpoint and saving promotable sampler snapshot",
+                        global_step,
+                    )
                 ckpt.save(
                     cp_name,
-                    resumable=True,
+                    resumable=save_resumable_final,
                     promotable=True,
-                    data_consumed=cursor.value,
+                    data_consumed=cursor.value if save_resumable_final else None,
                 )
 
                 if getattr(cfg, "output_model_id", None):


### PR DESCRIPTION
## Description

Avoids rewriting the final resumable DCP checkpoint when the normal `dcp_save_interval` path already saved the same final step.

The final checkpoint path now:
- reuses the existing DCP checkpoint when `last_dcp_save_step == global_step`
- still saves the promotable sampler snapshot
- only writes dataloader metadata when it actually performs a resumable DCP save

This prevents regional checkpoint sync from racing a duplicate final overwrite of the same `step-N` directory.

## Testing

- `python3 -m py_compile training/recipes/rl_loop.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches checkpointing logic in the RL training loop; a mistake could leave the final step without a resumable DCP checkpoint or incorrect `dataloader.json` metadata, impacting resume behavior.
> 
> **Overview**
> Prevents the RL loop from re-writing the final resumable DCP checkpoint when the periodic `dcp_save_interval` already saved `step-N`.
> 
> The loop now tracks `last_dcp_save_step`, and the final checkpoint path conditionally skips the resumable DCP save (and `data_consumed`/`dataloader.json` write) while still saving a promotable sampler snapshot and logging when it is reusing the existing DCP directory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 326fdc06f3ea35156dc708cbd958ec17e8ea3a04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->