### PR TITLE
Support tokenizer revisions in training recipes

### DIFF
--- a/training/recipes/async_rl_loop.py
+++ b/training/recipes/async_rl_loop.py
@@ -40,7 +40,6 @@ from dataclasses import dataclass, field
 from typing import Any, Awaitable, Callable
 
 import tinker
-import transformers
 
 from fireworks.training.sdk import DeploymentManager, TrainerJobManager
 from training.utils.client import GradAccNormalization
@@ -52,6 +51,7 @@ from training.utils import (
     ResourceCleanup,
     WandBConfig,
     WeightSyncConfig,
+    load_deployment_tokenizer,
     load_jsonl_dataset,
     read_api_extra_headers_env,
     setup_wandb,
@@ -331,9 +331,7 @@ def main(
         policy = infra.policy
         reference = infra.reference
 
-        tokenizer = transformers.AutoTokenizer.from_pretrained(
-            cfg.deployment.tokenizer_model, trust_remote_code=True,
-        )
+        tokenizer = load_deployment_tokenizer(cfg.deployment)
         weight_syncer = WeightSyncer(
             policy_client=policy,
             deploy_mgr=deploy_mgr,

--- a/training/recipes/dpo_loop.py
+++ b/training/recipes/dpo_loop.py
@@ -660,7 +660,10 @@ def main(
 
         max_seq_len = infra.max_seq_len
         init_args = (
-            cfg.tokenizer_model, cfg.renderer_name, max_seq_len, cfg.tokenizer_revision,
+            cfg.tokenizer_model,
+            cfg.renderer_name,
+            max_seq_len,
+            cfg.tokenizer_revision,
         )
         _init_pair_worker(*init_args)
         worker_init_fn = functools.partial(_init_pair_worker, *init_args)

--- a/training/recipes/dpo_loop.py
+++ b/training/recipes/dpo_loop.py
@@ -96,6 +96,7 @@ class Config:
     base_model: str = "accounts/fireworks/models/qwen3-8b"
     dataset: str = ""
     tokenizer_model: str = ""  # HuggingFace model name for client-side tokenization
+    tokenizer_revision: str = ""  # Optional HuggingFace revision for client-side tokenization
     renderer_name: str = ""
 
     beta: float = 0.1
@@ -151,6 +152,7 @@ def _init_pair_worker(
     tokenizer_model: str,
     renderer_name: str,
     max_seq_len: int,
+    tokenizer_revision: str = "",
     _worker_id: int | None = None,
 ) -> None:
     """DataLoader ``worker_init_fn`` for DPO preference-pair rendering.
@@ -161,6 +163,7 @@ def _init_pair_worker(
     populate_render_worker_state(
         _pair_worker_state,
         tokenizer_model=tokenizer_model,
+        tokenizer_revision=tokenizer_revision,
         renderer_name=renderer_name,
         max_seq_len=max_seq_len,
     )
@@ -657,7 +660,7 @@ def main(
 
         max_seq_len = infra.max_seq_len
         init_args = (
-            cfg.tokenizer_model, cfg.renderer_name, max_seq_len,
+            cfg.tokenizer_model, cfg.renderer_name, max_seq_len, cfg.tokenizer_revision,
         )
         _init_pair_worker(*init_args)
         worker_init_fn = functools.partial(_init_pair_worker, *init_args)

--- a/training/recipes/igpo_loop.py
+++ b/training/recipes/igpo_loop.py
@@ -54,6 +54,7 @@ from training.utils import (
     wandb_finish,
     validate_config,
     log_metrics_json,
+    load_deployment_tokenizer,
     setup_deployment,
     create_trainer_job,
     read_api_extra_headers_env,
@@ -393,12 +394,8 @@ def main(
             if reference_ep else None
         )
 
-        import transformers
-
         inference_model = dep_info.inference_model if dep_info else cfg.base_model
-        tokenizer = transformers.AutoTokenizer.from_pretrained(
-            cfg.deployment.tokenizer_model, trust_remote_code=True
-        )
+        tokenizer = load_deployment_tokenizer(cfg.deployment)
         sampler = DeploymentSampler(
             inference_url=deploy_mgr.inference_url,
             model=inference_model,

--- a/training/recipes/orpo_loop.py
+++ b/training/recipes/orpo_loop.py
@@ -22,6 +22,7 @@ Config args:
     base_model       Fireworks model ID (default: qwen3-235b-a22b-instruct-2507)
     dataset          Path to preference JSONL file
     tokenizer_model  HuggingFace model name for client-side tokenization
+    tokenizer_revision Optional HuggingFace revision for client-side tokenization
     orpo_lambda      Weight for odds-ratio loss term (default: 1.0)
     learning_rate    Adam learning rate (default: 1e-5)
     epochs           Number of passes over the dataset (default: 1)
@@ -64,6 +65,7 @@ from training.utils import (
     create_trainer_job,
     read_api_extra_headers_env,
     load_preference_dataset,
+    load_tokenizer,
     build_renderer,
     auto_select_training_shape,
     render_preference_pair,
@@ -88,6 +90,7 @@ class Config:
     base_model: str = "accounts/fireworks/models/qwen3-235b-a22b-instruct-2507"
     dataset: str = ""
     tokenizer_model: str = ""
+    tokenizer_revision: str = ""
     renderer_name: str = ""
 
     orpo_lambda: float = 1.0
@@ -308,11 +311,7 @@ def main(
 
         # -- Data ----------------------------------------------------------------
 
-        import transformers
-
-        tokenizer = transformers.AutoTokenizer.from_pretrained(
-            cfg.tokenizer_model, trust_remote_code=True
-        )
+        tokenizer = load_tokenizer(cfg.tokenizer_model, cfg.tokenizer_revision)
         renderer = build_renderer(tokenizer, cfg.tokenizer_model, cfg.renderer_name)
         logger.info(
             "Using renderer=%s for preference tokenization",

--- a/training/recipes/rl_loop.py
+++ b/training/recipes/rl_loop.py
@@ -419,7 +419,9 @@ def main(
         reference_job_id = infra.reference_job_id or infra.policy_job_id
 
         tokenizer = transformers.AutoTokenizer.from_pretrained(
-            cfg.deployment.tokenizer_model, trust_remote_code=True,
+            cfg.deployment.tokenizer_model,
+            revision=cfg.deployment.tokenizer_revision or None,
+            trust_remote_code=True,
         )
         # Adaptive concurrency — window adjusts based on server-side prefill queue.
         # For fixed (no rate limiting), use FixedConcurrencyController instead.

--- a/training/recipes/rl_loop.py
+++ b/training/recipes/rl_loop.py
@@ -38,7 +38,6 @@ from dataclasses import field, dataclass
 from concurrent.futures import ThreadPoolExecutor
 
 import tinker
-import transformers
 
 from fireworks.training.sdk import DeploymentManager, TrainerJobManager
 from fireworks.training.sdk.client import GradAccNormalization
@@ -63,6 +62,7 @@ from training.utils import (
     validate_config,
     log_metrics_json,
     compute_advantages,
+    load_deployment_tokenizer,
     read_api_extra_headers_env,
     load_jsonl_dataset,
     prepare_sampling_messages,
@@ -418,11 +418,7 @@ def main(
         policy_job_id = infra.policy_job_id
         reference_job_id = infra.reference_job_id or infra.policy_job_id
 
-        tokenizer = transformers.AutoTokenizer.from_pretrained(
-            cfg.deployment.tokenizer_model,
-            revision=cfg.deployment.tokenizer_revision or None,
-            trust_remote_code=True,
-        )
+        tokenizer = load_deployment_tokenizer(cfg.deployment)
         # Adaptive concurrency — window adjusts based on server-side prefill queue.
         # For fixed (no rate limiting), use FixedConcurrencyController instead.
         initial_window = cfg.concurrency.initial_window or (8 * infra.deployment_gpu_count)

--- a/training/recipes/sft_loop.py
+++ b/training/recipes/sft_loop.py
@@ -76,6 +76,7 @@ def _init_render_worker(
     renderer_name: str,
     train_on_what_str: str,
     max_seq_len: int,
+    tokenizer_revision: str = "",
     _worker_id: int | None = None,
 ) -> None:
     """DataLoader ``worker_init_fn`` for SFT chat-row rendering.
@@ -86,6 +87,7 @@ def _init_render_worker(
     populate_render_worker_state(
         _worker_state,
         tokenizer_model=tokenizer_model,
+        tokenizer_revision=tokenizer_revision,
         renderer_name=renderer_name,
         max_seq_len=max_seq_len,
         train_on_what=parse_train_on_what(train_on_what_str),
@@ -231,6 +233,7 @@ class Config:
     base_model: str = "accounts/fireworks/models/qwen3-8b"
     dataset: str = ""
     tokenizer_model: str = ""  # HuggingFace model name for chat template, e.g. "Qwen/Qwen3-1.7B"
+    tokenizer_revision: str = ""  # Optional HuggingFace revision for client-side tokenization
     renderer_name: str = ""
     train_on_what: str = "all_assistant_messages"
 
@@ -560,8 +563,11 @@ def main(
             else min(os.cpu_count() or 1, DEFAULT_RENDER_WORKERS)
         )
         init_args = (
-            cfg.tokenizer_model, cfg.renderer_name,
-            cfg.train_on_what, cfg.max_seq_len,
+            cfg.tokenizer_model,
+            cfg.renderer_name,
+            cfg.train_on_what,
+            cfg.max_seq_len,
+            cfg.tokenizer_revision,
         )
         _init_render_worker(*init_args)
         worker_init_fn = functools.partial(_init_render_worker, *init_args)

--- a/training/tests/unit/test_dpo_loop.py
+++ b/training/tests/unit/test_dpo_loop.py
@@ -52,6 +52,25 @@ def _setup_pair_worker(monkeypatch, max_seq_len: int = 8) -> None:
 
 
 class TestRenderPairWorker:
+    def test_init_pair_worker_forwards_tokenizer_revision(self, monkeypatch):
+        captured: dict = {}
+
+        def fake_populate_render_worker_state(state, **kwargs):
+            captured["state"] = state
+            captured["kwargs"] = kwargs
+
+        monkeypatch.setattr(
+            module, "populate_render_worker_state", fake_populate_render_worker_state
+        )
+
+        module._init_pair_worker("moonshotai/Kimi-K2.6", "kimi_k25", 4096, "2755962")
+
+        assert captured["state"] is module._pair_worker_state
+        assert captured["kwargs"]["tokenizer_model"] == "moonshotai/Kimi-K2.6"
+        assert captured["kwargs"]["tokenizer_revision"] == "2755962"
+        assert captured["kwargs"]["renderer_name"] == "kimi_k25"
+        assert captured["kwargs"]["max_seq_len"] == 4096
+
     def test_returns_none_when_schema_unrecognized(self, monkeypatch):
         _setup_pair_worker(monkeypatch)
         assert module._render_pair_worker({"unknown": "schema"}) is None

--- a/training/tests/unit/test_frozen_lake_visual_rollout.py
+++ b/training/tests/unit/test_frozen_lake_visual_rollout.py
@@ -214,6 +214,11 @@ async def test_visual_rollout_preserves_prior_completion_tokens(monkeypatch):
     _FakeImageClient.requested_prompt_ids = []
     _FakeImageClient.requested_image_counts = []
     _FakeImageClient.requested_prompt_texts = []
+    tool_prefill_id = 99
+    monkeypatch.setattr(
+        "training.examples.rl.frozen_lake.frozen_lake_rollout._build_kimi_toolcall_generation_prefill_token_ids",
+        lambda tokenizer_name_or_path: [tool_prefill_id],
+    )
     monkeypatch.setattr(
         "training.examples.rl.frozen_lake.frozen_lake_rollout.FireworksV1ImageCompletionsClient",
         _FakeImageClient,
@@ -247,13 +252,13 @@ async def test_visual_rollout_preserves_prior_completion_tokens(monkeypatch):
 
     assert len(token_turn_traces) == 2
     assert token_turn_traces[0]["prompt_ids"] == [10, 11, 12]
-    assert token_turn_traces[0]["completion_ids"] == [163595, 101, 90]
-    assert token_turn_traces[1]["prompt_ids"] == [10, 11, 12, 163595, 101, 90, 91, 92]
-    assert token_turn_traces[1]["completion_ids"] == [163595, 102, 90]
+    assert token_turn_traces[0]["completion_ids"] == [tool_prefill_id, 101, 90]
+    assert token_turn_traces[1]["prompt_ids"] == [10, 11, 12, tool_prefill_id, 101, 90, 91, 92]
+    assert token_turn_traces[1]["completion_ids"] == [tool_prefill_id, 102, 90]
 
     assert _FakeImageClient.requested_prompt_ids == [
-        [10, 11, 12, 163595],
-        [10, 11, 12, 163595, 101, 90, 91, 92, 163595],
+        [10, 11, 12, tool_prefill_id],
+        [10, 11, 12, tool_prefill_id, 101, 90, 91, 92, tool_prefill_id],
     ]
     assert _FakeImageClient.requested_prompt_texts == [
         "prompt:initial<|tool_calls_section_begin|>",

--- a/training/tests/unit/test_sft_loop.py
+++ b/training/tests/unit/test_sft_loop.py
@@ -80,6 +80,28 @@ def _test_datum(test_id: str):
     )
 
 
+def test_init_render_worker_forwards_tokenizer_revision(monkeypatch):
+    captured: dict = {}
+
+    def fake_populate_render_worker_state(state, **kwargs):
+        captured["state"] = state
+        captured["kwargs"] = kwargs
+
+    monkeypatch.setattr(
+        module, "populate_render_worker_state", fake_populate_render_worker_state
+    )
+
+    module._init_render_worker(
+        "moonshotai/Kimi-K2.6", "kimi_k25", "all_assistant_messages", 4096, "2755962"
+    )
+
+    assert captured["state"] is module._worker_state
+    assert captured["kwargs"]["tokenizer_model"] == "moonshotai/Kimi-K2.6"
+    assert captured["kwargs"]["tokenizer_revision"] == "2755962"
+    assert captured["kwargs"]["renderer_name"] == "kimi_k25"
+    assert captured["kwargs"]["max_seq_len"] == 4096
+
+
 def test_main_rejects_adapter_plus_init_from_checkpoint(tmp_path, monkeypatch):
     """warm_start_from_adapter and init_from_checkpoint are mutually exclusive."""
     dataset_path = _write_dataset(

--- a/training/tests/unit/test_supervised_rendering.py
+++ b/training/tests/unit/test_supervised_rendering.py
@@ -883,7 +883,7 @@ def test_populate_render_worker_state_writes_canonical_keys(monkeypatch):
     assert state["custom_extra"] == "hello"
 
 
-def test_populate_render_worker_state_uses_trust_remote_code(monkeypatch):
+def test_populate_render_worker_state_uses_trust_remote_code_and_revision(monkeypatch):
     """trust_remote_code=True is required for Kimi / Qwen image processors."""
     from training.utils import supervised as sup
 
@@ -901,8 +901,10 @@ def test_populate_render_worker_state_uses_trust_remote_code(monkeypatch):
     populate_render_worker_state(
         {},
         tokenizer_model="m",
+        tokenizer_revision="abc123",
         renderer_name="r",
         max_seq_len=1,
     )
     assert captured["model"] == "m"
     assert captured["kwargs"].get("trust_remote_code") is True
+    assert captured["kwargs"].get("revision") == "abc123"

--- a/training/tests/unit/test_supervised_rendering.py
+++ b/training/tests/unit/test_supervised_rendering.py
@@ -860,9 +860,7 @@ def test_populate_render_worker_state_writes_canonical_keys(monkeypatch):
     fake_tokenizer = object()
     fake_renderer = object()
     monkeypatch.setattr(
-        sup.transformers.AutoTokenizer,
-        "from_pretrained",
-        lambda model, **kwargs: fake_tokenizer,
+        sup, "load_tokenizer", lambda model, revision=None: fake_tokenizer
     )
     monkeypatch.setattr(sup, "build_renderer", lambda *a, **k: fake_renderer)
 
@@ -883,19 +881,16 @@ def test_populate_render_worker_state_writes_canonical_keys(monkeypatch):
     assert state["custom_extra"] == "hello"
 
 
-def test_populate_render_worker_state_uses_trust_remote_code_and_revision(monkeypatch):
-    """trust_remote_code=True is required for Kimi / Qwen image processors."""
+def test_populate_render_worker_state_forwards_tokenizer_revision(monkeypatch):
     from training.utils import supervised as sup
 
     captured: dict = {}
 
-    def fake_from_pretrained(model, **kwargs):
-        captured.update(model=model, kwargs=kwargs)
+    def fake_load_tokenizer(model, revision=None):
+        captured.update(model=model, revision=revision)
         return object()
 
-    monkeypatch.setattr(
-        sup.transformers.AutoTokenizer, "from_pretrained", fake_from_pretrained
-    )
+    monkeypatch.setattr(sup, "load_tokenizer", fake_load_tokenizer)
     monkeypatch.setattr(sup, "build_renderer", lambda *a, **k: object())
 
     populate_render_worker_state(
@@ -906,5 +901,4 @@ def test_populate_render_worker_state_uses_trust_remote_code_and_revision(monkey
         max_seq_len=1,
     )
     assert captured["model"] == "m"
-    assert captured["kwargs"].get("trust_remote_code") is True
-    assert captured["kwargs"].get("revision") == "abc123"
+    assert captured["revision"] == "abc123"

--- a/training/tests/unit/test_tokenizers.py
+++ b/training/tests/unit/test_tokenizers.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import training.utils.tokenizers as tokenizers
+
+
+def test_load_tokenizer_forwards_optional_revision(monkeypatch):
+    captured: dict = {}
+    fake_tokenizer = object()
+
+    def fake_from_pretrained(model, **kwargs):
+        captured.update(model=model, kwargs=kwargs)
+        return fake_tokenizer
+
+    monkeypatch.setattr(
+        tokenizers.transformers.AutoTokenizer, "from_pretrained", fake_from_pretrained
+    )
+
+    result = tokenizers.load_tokenizer("moonshotai/Kimi-K2.6", "2755962")
+
+    assert result is fake_tokenizer
+    assert captured["model"] == "moonshotai/Kimi-K2.6"
+    assert captured["kwargs"] == {
+        "revision": "2755962",
+        "trust_remote_code": True,
+    }
+
+
+def test_load_tokenizer_treats_empty_revision_as_unset(monkeypatch):
+    captured: dict = {}
+
+    def fake_from_pretrained(model, **kwargs):
+        captured.update(model=model, kwargs=kwargs)
+        return object()
+
+    monkeypatch.setattr(
+        tokenizers.transformers.AutoTokenizer, "from_pretrained", fake_from_pretrained
+    )
+
+    tokenizers.load_tokenizer("Qwen/Qwen3-8B", "")
+
+    assert captured["kwargs"]["revision"] is None
+
+
+def test_load_deployment_tokenizer_uses_generic_deploy_config_fields(monkeypatch):
+    captured: dict = {}
+
+    def fake_load_tokenizer(model, revision=None):
+        captured.update(model=model, revision=revision)
+        return object()
+
+    monkeypatch.setattr(tokenizers, "load_tokenizer", fake_load_tokenizer)
+
+    tokenizers.load_deployment_tokenizer(
+        SimpleNamespace(tokenizer_model="model/name", tokenizer_revision="abc123")
+    )
+
+    assert captured == {"model": "model/name", "revision": "abc123"}

--- a/training/utils/__init__.py
+++ b/training/utils/__init__.py
@@ -69,7 +69,9 @@ __all__ = [
     "find_common_prefix_length",
     "iter_preference_examples",
     "load_jsonl_dataset",
+    "load_deployment_tokenizer",
     "load_preference_dataset",
+    "load_tokenizer",
     "replicate_rows_for_epochs",
     "log_metrics_json",
     "make_render_dataloader",
@@ -155,6 +157,7 @@ from training.utils.config import (
 from training.utils.training_shapes import (
     auto_select_training_shape,
 )
+from training.utils.tokenizers import load_deployment_tokenizer, load_tokenizer
 from training.utils.losses import (
     make_sft_loss_fn,
     make_orpo_loss_fn,

--- a/training/utils/config.py
+++ b/training/utils/config.py
@@ -152,6 +152,8 @@ class DeployConfig:
     tokenizer_model: str | None = None
     """HuggingFace model name for the tokenizer (e.g. ``Qwen/Qwen3-1.7B``).
     Required for client-side tokenization (GRPO)."""
+    tokenizer_revision: str | None = None
+    """Optional HuggingFace revision for client-side tokenization."""
     sample_timeout: int = 600
     """HTTP read timeout in seconds for sampling completions (default 10 min).
     Increase for R3 + long completions where responses can be very large."""

--- a/training/utils/supervised.py
+++ b/training/utils/supervised.py
@@ -21,7 +21,6 @@ from typing import Any, Iterable, Mapping, Sequence
 
 import torch
 import tinker
-import transformers
 from tinker_cookbook.model_info import get_recommended_renderer_name
 from tinker_cookbook.renderers import (
     Message,
@@ -37,6 +36,7 @@ import training.renderer.nemotron as _nemotron_renderer  # noqa: F401 — trigge
 import training.renderer.minimax_m2 as _minimax_m2_renderer  # noqa: F401 — triggers register_renderer
 import training.renderer.gemma4 as _gemma4_renderer  # noqa: F401 — triggers register_renderer
 import training.renderer.deepseek_v4 as _deepseek_v4_renderer  # noqa: F401 — triggers register_renderer
+from training.utils.tokenizers import load_tokenizer
 
 
 @dataclass(frozen=True)
@@ -167,11 +167,7 @@ def populate_render_worker_state(
     ``extras`` (e.g. ``train_on_what`` for SFT). Reuses ``trust_remote_code``
     for HF tokenizer load -- required by Kimi / Qwen image processors.
     """
-    tokenizer = transformers.AutoTokenizer.from_pretrained(
-        tokenizer_model,
-        revision=tokenizer_revision or None,
-        trust_remote_code=True,
-    )
+    tokenizer = load_tokenizer(tokenizer_model, tokenizer_revision)
     state.update(
         tokenizer=tokenizer,
         renderer=build_renderer(tokenizer, tokenizer_model, renderer_name),

--- a/training/utils/supervised.py
+++ b/training/utils/supervised.py
@@ -150,6 +150,7 @@ def populate_render_worker_state(
     state: dict,
     *,
     tokenizer_model: str,
+    tokenizer_revision: str | None = None,
     renderer_name: str,
     max_seq_len: int,
     **extras: Any,
@@ -168,6 +169,7 @@ def populate_render_worker_state(
     """
     tokenizer = transformers.AutoTokenizer.from_pretrained(
         tokenizer_model,
+        revision=tokenizer_revision or None,
         trust_remote_code=True,
     )
     state.update(

--- a/training/utils/tokenizers.py
+++ b/training/utils/tokenizers.py
@@ -1,0 +1,31 @@
+"""Shared HuggingFace tokenizer loading helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import transformers
+
+
+def load_tokenizer(
+    tokenizer_model: str | None,
+    tokenizer_revision: str | None = None,
+) -> Any:
+    """Load a tokenizer with cookbook defaults.
+
+    ``tokenizer_revision`` is optional; empty strings are treated as unset so
+    existing configs keep resolving HuggingFace ``main``.
+    """
+    return transformers.AutoTokenizer.from_pretrained(
+        tokenizer_model,
+        revision=tokenizer_revision or None,
+        trust_remote_code=True,
+    )
+
+
+def load_deployment_tokenizer(deployment: Any) -> Any:
+    """Load the tokenizer configured on a deployment config-like object."""
+    return load_tokenizer(
+        getattr(deployment, "tokenizer_model", None),
+        getattr(deployment, "tokenizer_revision", None),
+    )


### PR DESCRIPTION
## Summary
- Add optional `tokenizer_revision` config for SFT, DPO, and ORPO client-side tokenization.
- Add optional `DeployConfig.tokenizer_revision` for RL, async RL, and IGPO deployment-side client tokenization.
- Route all cookbook loops through shared tokenizer helpers so `AutoTokenizer.from_pretrained(..., revision=..., trust_remote_code=True)` behavior is generic and consistent.
- Keep the revision optional: empty strings / `None` resolve HuggingFace default revision exactly as before.

## Validation
- `/tmp/kimi-tokenizer-revision-venv/bin/python -m py_compile training/utils/tokenizers.py training/utils/supervised.py training/recipes/sft_loop.py training/recipes/dpo_loop.py training/recipes/orpo_loop.py training/recipes/rl_loop.py training/recipes/async_rl_loop.py training/recipes/igpo_loop.py`
- `/tmp/kimi-tokenizer-revision-venv/bin/python -m pytest training/tests/unit/test_tokenizers.py training/tests/unit/test_supervised_rendering.py::test_populate_render_worker_state_forwards_tokenizer_revision training/tests/unit/test_dpo_loop.py::TestRenderPairWorker::test_init_pair_worker_forwards_tokenizer_revision training/tests/unit/test_sft_loop.py::test_init_render_worker_forwards_tokenizer_revision -q`
- `/tmp/kimi-tokenizer-revision-venv/bin/python -m pytest training/tests/unit/test_tokenizers.py training/tests/unit/test_supervised_rendering.py training/tests/unit/test_sft_loop.py training/tests/unit/test_dpo_loop.py training/tests/unit/test_orpo_loop.py training/tests/unit/test_rl_loop.py -q`
- `/tmp/kimi-tokenizer-revision-venv/bin/python` loaded `moonshotai/Kimi-K2.6` at revision `2755962d07cb42aa2d988a35bcb65cd4a9c2de82` with `transformers==5.3.0` as `TikTokenTokenizer` and matched the trainer-side GCS tokenizer snapshot for tested samples.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches tokenization setup used by multiple training loops; a mis-specified `revision`/`tokenizer_model` could change tokenization and break dataset rendering or sampling, but the change is mostly config plumbing with added unit coverage.
> 
> **Overview**
> Adds optional `tokenizer_revision` support for client-side tokenization in `sft_loop`, `dpo_loop`, and `orpo_loop`, and for deployment-based tokenization in `rl_loop`, `async_rl_loop`, and `igpo_loop` via `DeployConfig`.
> 
> Introduces shared helpers `load_tokenizer`/`load_deployment_tokenizer` (always `trust_remote_code=True`, treats empty revision as unset) and routes recipe + supervised DataLoader worker initialization through them, removing direct `transformers.AutoTokenizer.from_pretrained(...)` usage.
> 
> Updates/expands unit tests to verify revision forwarding (including worker init and supervised rendering) and adds dedicated tests for the new tokenizer helper module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31561cc85df458b8b123c2d0144d53e8aaf7db7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->