### PR TITLE
fix(deepmath): avoid math_verify SIGALRM deadlock in async rollouts

### DIFF
--- a/training/examples/rl/deepmath/_mathverify_worker.py
+++ b/training/examples/rl/deepmath/_mathverify_worker.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Out-of-process worker for math_verify symbolic comparison.
+
+Runs as a standalone subprocess driven by ``train_deepmath._MathVerifyService``.
+Protocol: one JSON request per stdin line ``[pred_str, gt_str]``; one JSON
+response per stdout line (``true``/``false``).
+
+This exists because math_verify cannot be safely bounded in-process:
+its built-in timeout uses ``signal.SIGALRM`` (fires into arbitrary asyncio
+event-loop code), and disabling it leaves sympy's ``hyperexpand``/``lerchphi``
+expansions unbounded — a worker *thread* running such an expansion can't be
+interrupted and leaks. A subprocess can simply be killed.
+"""
+
+import json
+import sys
+
+from math_verify import parse, verify
+
+
+def main() -> None:
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            pred_str, gt_str = json.loads(line)
+            pred = parse(pred_str)
+            gt = parse(gt_str)
+            # timeout_seconds=0 disables math_verify's SIGALRM timeout; the
+            # parent process bounds us by killing this worker instead.
+            result = bool(pred and gt and verify(pred, gt, timeout_seconds=0))
+        except Exception:
+            result = False
+        sys.stdout.write(json.dumps(result) + "\n")
+        sys.stdout.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/training/examples/rl/deepmath/test_reward.py
+++ b/training/examples/rl/deepmath/test_reward.py
@@ -3,6 +3,8 @@
 
 import json
 import os
+import tempfile
+import textwrap
 import threading
 import time
 
@@ -11,6 +13,7 @@ from train_deepmath import (
     deepmath_reward,
     extract_answer_from_completion,
     math_verify,
+    _MathVerifyService,
 )
 
 
@@ -91,40 +94,69 @@ def test_reward_with_real_dataset():
     assert passed >= 15, f"Too many failures: only {passed}/{len(rows)} matched"
 
 
-def test_math_verify_thread_safe_timeout():
-    """math_verify wrapper must NOT use signal.SIGALRM (which breaks asyncio).
+def test_math_verify_correctness():
+    """The out-of-process math_verify returns correct symbolic results."""
+    assert math_verify(r"\boxed{42}", r"\boxed{42}") is True
+    assert math_verify(r"\boxed{42}", r"\boxed{43}") is False
+    assert math_verify(r"\boxed{\frac{1}{2}}", r"\boxed{0.5}") is True
+    print("  [PASS] test_math_verify_correctness")
 
-    Verifies two properties:
-      1. Works correctly from a non-main thread (SIGALRM-based timeout would raise
-         ValueError there).
-      2. Returns False without blocking forever if the comparison is too slow,
-         without raising into surrounding code.
+
+def test_math_verify_thread_safe():
+    """math_verify must work when called from a non-main thread.
+
+    math_verify's native timeout uses signal.SIGALRM, which only works on the
+    main thread; our out-of-process wrapper must not depend on that.
     """
-    from sympy import Symbol
-
-    # Property 1: call from a worker thread (signal.alarm() would raise here).
-    result = []
+    results = []
 
     def _worker():
-        result.append(math_verify(Symbol("x") + 1, Symbol("x") + 1))
+        results.append(math_verify(r"\boxed{7}", r"\boxed{7}"))
 
     t = threading.Thread(target=_worker)
     t.start()
-    t.join(2.0)
-    assert not t.is_alive(), "math_verify wrapper hung in worker thread"
-    assert result == [True], f"expected [True], got {result}"
+    t.join(15.0)
+    assert not t.is_alive(), "math_verify hung when called from a worker thread"
+    assert results == [True], f"expected [True], got {results}"
+    print("  [PASS] test_math_verify_thread_safe")
 
-    # Property 2: a very short timeout returns False (slow comparison cut off)
-    # without raising.
-    class Slow:
-        def __eq__(self, other):
-            time.sleep(2)
-            return True
 
-    fast_result = math_verify(Slow(), Slow(), timeout=0.05)
-    assert fast_result is False, f"slow comparison should return False, got {fast_result}"
+def test_math_verify_killable_timeout():
+    """A wedged worker is killed on timeout — fast False, no leaked thread/proc.
 
-    print("  [PASS] test_math_verify_thread_safe_timeout")
+    This is the property the in-process (thread-based) approach could not
+    provide: a runaway sympy expansion can only be bounded by killing the
+    process it runs in.
+    """
+    # A stand-in worker that hangs forever instead of computing.
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as f:
+        f.write(textwrap.dedent("""
+            import sys, time
+            for _line in sys.stdin:
+                time.sleep(3600)
+        """))
+        slow_worker = f.name
+
+    try:
+        svc = _MathVerifyService(worker_path=slow_worker)
+        t0 = time.time()
+        result = svc.verify(r"\\boxed{1}", r"\\boxed{2}", timeout=0.5)
+        elapsed = time.time() - t0
+        assert result is False, f"wedged worker should yield False, got {result}"
+        assert elapsed < 5.0, f"timeout not enforced — took {elapsed:.1f}s"
+        assert svc._proc is None, "wedged worker process was not killed"
+        # Reader threads must not leak: after the kill, none should survive.
+        leaked = [
+            th for th in threading.enumerate()
+            if th.name.startswith("Thread-") and th.is_alive() and th.daemon
+        ]
+        # Give any just-killed reader a moment to observe EOF and exit.
+        time.sleep(0.5)
+        still = [th for th in leaked if th.is_alive()]
+        assert not still, f"reader thread leaked after worker kill: {still}"
+    finally:
+        os.unlink(slow_worker)
+    print("  [PASS] test_math_verify_killable_timeout")
 
 
 def main():
@@ -135,7 +167,9 @@ def main():
     test_reward_numeric()
     test_reward_latex_fractions()
     test_reward_symbolic()
-    test_math_verify_thread_safe_timeout()
+    test_math_verify_correctness()
+    test_math_verify_thread_safe()
+    test_math_verify_killable_timeout()
     test_reward_with_real_dataset()
     print("\nAll tests passed!")
 

--- a/training/examples/rl/deepmath/test_reward.py
+++ b/training/examples/rl/deepmath/test_reward.py
@@ -1,13 +1,16 @@
 #!/usr/bin/env python3
 """Unit tests for the DeepMath reward function."""
 
-import os
 import json
+import os
+import threading
+import time
 
 from train_deepmath import (
     extract_boxed,
     deepmath_reward,
     extract_answer_from_completion,
+    math_verify,
 )
 
 
@@ -88,6 +91,42 @@ def test_reward_with_real_dataset():
     assert passed >= 15, f"Too many failures: only {passed}/{len(rows)} matched"
 
 
+def test_math_verify_thread_safe_timeout():
+    """math_verify wrapper must NOT use signal.SIGALRM (which breaks asyncio).
+
+    Verifies two properties:
+      1. Works correctly from a non-main thread (SIGALRM-based timeout would raise
+         ValueError there).
+      2. Returns False without blocking forever if the comparison is too slow,
+         without raising into surrounding code.
+    """
+    from sympy import Symbol
+
+    # Property 1: call from a worker thread (signal.alarm() would raise here).
+    result = []
+
+    def _worker():
+        result.append(math_verify(Symbol("x") + 1, Symbol("x") + 1))
+
+    t = threading.Thread(target=_worker)
+    t.start()
+    t.join(2.0)
+    assert not t.is_alive(), "math_verify wrapper hung in worker thread"
+    assert result == [True], f"expected [True], got {result}"
+
+    # Property 2: a very short timeout returns False (slow comparison cut off)
+    # without raising.
+    class Slow:
+        def __eq__(self, other):
+            time.sleep(2)
+            return True
+
+    fast_result = math_verify(Slow(), Slow(), timeout=0.05)
+    assert fast_result is False, f"slow comparison should return False, got {fast_result}"
+
+    print("  [PASS] test_math_verify_thread_safe_timeout")
+
+
 def main():
     print("Running reward function unit tests...")
     test_extract_boxed()
@@ -96,6 +135,7 @@ def main():
     test_reward_numeric()
     test_reward_latex_fractions()
     test_reward_symbolic()
+    test_math_verify_thread_safe_timeout()
     test_reward_with_real_dataset()
     print("\nAll tests passed!")
 

--- a/training/examples/rl/deepmath/train_deepmath.py
+++ b/training/examples/rl/deepmath/train_deepmath.py
@@ -67,9 +67,10 @@ class _MathVerifyService:
         with self._lock:
             try:
                 self._ensure()
-                assert self._proc is not None and self._proc.stdin and self._proc.stdout
-                self._proc.stdin.write(json.dumps([pred_str, gt_str]) + "\n")
-                self._proc.stdin.flush()
+                proc = self._proc
+                assert proc is not None and proc.stdin and proc.stdout
+                proc.stdin.write(json.dumps([pred_str, gt_str]) + "\n")
+                proc.stdin.flush()
 
                 result = [False]
                 done = threading.Event()
@@ -78,7 +79,7 @@ class _MathVerifyService:
                     # If the worker wedges and we kill it, readline() unblocks
                     # on EOF — so this thread never leaks.
                     try:
-                        line = self._proc.stdout.readline()  # type: ignore[union-attr]
+                        line = proc.stdout.readline()  # type: ignore[union-attr]
                         result[0] = bool(json.loads(line)) if line.strip() else False
                     except Exception:
                         result[0] = False
@@ -148,6 +149,8 @@ class TrainArgs:
     region: str = "US_OHIO_1"
     deployment_region: str | None = None
     deployment_replica_count: int | None = None
+    trainer_replica_count: int | None = None
+    """Run-level data-parallel trainer replicas for HSDP launches."""
     max_rows: int = 1500
     epochs: int = 3
     completions_per_prompt: int = 8
@@ -156,6 +159,10 @@ class TrainArgs:
     temperature: float = 1.0
     max_completion_tokens: int = 30 * 1024
     prompt_groups_per_step: int = 32
+    lora_rank: int = 0
+    """LoRA rank (0 = full-param).  When > 0, auto_select_training_shape
+    picks a LoRA training shape and the reference model reuses the policy
+    trainer (no extra GPUs)."""
     router_replay: bool = False
     trajectory_dir: str | None = None
     """Directory to save per-step trajectory JSONL files."""
@@ -191,6 +198,13 @@ def parse_args() -> TrainArgs:
     parser.add_argument("--region")
     parser.add_argument("--deployment-region")
     parser.add_argument("--deployment-replica-count", type=int)
+    parser.add_argument(
+        "--trainer-replicas",
+        "--trainer-replica-count",
+        dest="trainer_replica_count",
+        type=int,
+        help="Run-level data-parallel trainer replicas for HSDP launches",
+    )
 
     parser.add_argument("--max-rows", type=int)
     parser.add_argument("--epochs", type=int)
@@ -201,6 +215,8 @@ def parse_args() -> TrainArgs:
     parser.add_argument("--max-completion-tokens", type=int)
 
     parser.add_argument("--prompt-groups-per-step", type=int)
+    parser.add_argument("--lora-rank", type=int,
+                        help="LoRA rank (0 = full-param, e.g. 64 or 128 for LoRA)")
 
     parser.add_argument("--trajectory-dir",
                         help="Directory to save per-step trajectory JSONL files")
@@ -372,6 +388,7 @@ def main():
         temperature=args.temperature,
         epochs=args.epochs,
         max_rows=args.max_rows,
+        lora_rank=args.lora_rank,
         prompt_groups_per_step=args.prompt_groups_per_step,
         trajectory_dir=args.trajectory_dir,
         tis=TISConfig(cap=2.0),
@@ -383,6 +400,7 @@ def main():
         infra=InfraConfig(
             training_shape_id=args.training_shape,
             ref_training_shape_id=args.ref_training_shape,
+            trainer_replica_count=args.trainer_replica_count,
             region=args.region,
         ),
         deployment=DeployConfig(
@@ -433,7 +451,7 @@ def main():
         config,
         rlor_mgr=rlor_mgr,
         deploy_mgr=deploy_mgr,
-        cleanup_on_exit=not args.skip_cleanup,
+        cancel_on_exit=not args.skip_cleanup,
     )
 
     logger.info("Training complete. Final metrics: %s", metrics)

--- a/training/examples/rl/deepmath/train_deepmath.py
+++ b/training/examples/rl/deepmath/train_deepmath.py
@@ -7,8 +7,10 @@ Run prepare_data.py first, then: python train_deepmath.py
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import re
+import subprocess
 import sys
 import logging
 import threading
@@ -22,26 +24,87 @@ _SRC = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..")
 if _SRC not in sys.path:
     sys.path.insert(0, _SRC)
 
-from math_verify import parse as math_parse, verify as _math_verify_raw
+
+class _MathVerifyService:
+    """Runs math_verify symbolic comparison in a killable subprocess.
+
+    math_verify cannot be bounded safely in-process: its built-in timeout uses
+    ``signal.SIGALRM`` (the alarm fires into arbitrary asyncio event-loop code
+    and wedges rollouts), and disabling it leaves sympy's hyperexpand/lerchphi
+    expansions unbounded. A worker *thread* running such an expansion can't be
+    interrupted, so it leaks — enough leaked threads starve the GIL and stall
+    the trainer. A subprocess can simply be killed, which also unblocks our
+    reader thread (the pipe closes on kill), so nothing leaks.
+    """
+
+    _WORKER = os.path.join(os.path.dirname(os.path.abspath(__file__)), "_mathverify_worker.py")
+
+    def __init__(self, worker_path: str | None = None):
+        self._worker_path = worker_path or self._WORKER
+        self._lock = threading.Lock()
+        self._proc: subprocess.Popen | None = None
+
+    def _ensure(self) -> None:
+        if self._proc is None or self._proc.poll() is not None:
+            self._proc = subprocess.Popen(
+                [sys.executable, self._worker_path],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                text=True,
+                bufsize=1,
+            )
+
+    def _kill(self) -> None:
+        if self._proc is not None:
+            try:
+                self._proc.kill()
+                self._proc.wait()
+            except Exception:
+                pass
+            self._proc = None
+
+    def verify(self, pred_str: str, gt_str: str, timeout: float = 5.0) -> bool:
+        with self._lock:
+            try:
+                self._ensure()
+                assert self._proc is not None and self._proc.stdin and self._proc.stdout
+                self._proc.stdin.write(json.dumps([pred_str, gt_str]) + "\n")
+                self._proc.stdin.flush()
+
+                result = [False]
+                done = threading.Event()
+
+                def _read() -> None:
+                    # If the worker wedges and we kill it, readline() unblocks
+                    # on EOF — so this thread never leaks.
+                    try:
+                        line = self._proc.stdout.readline()  # type: ignore[union-attr]
+                        result[0] = bool(json.loads(line)) if line.strip() else False
+                    except Exception:
+                        result[0] = False
+                    finally:
+                        done.set()
+
+                reader = threading.Thread(target=_read, daemon=True)
+                reader.start()
+                if done.wait(timeout):
+                    return result[0]
+                # Worker is stuck on a pathological sympy expansion — kill it
+                # (also unblocks the reader). It respawns on the next call.
+                self._kill()
+                return False
+            except Exception:
+                self._kill()
+                return False
 
 
-def math_verify(gold, target, timeout: float = 5.0) -> bool:
-    # math_verify's built-in timeout uses signal.SIGALRM, which is hostile to
-    # asyncio: the alarm fires into arbitrary GC/event-loop code and wedges
-    # rollouts. Disable it (timeout_seconds=0) and run on a daemon thread so
-    # we can move on if sympy is slow.
-    result = [False]
+_math_verify_service = _MathVerifyService()
 
-    def _run():
-        try:
-            result[0] = bool(_math_verify_raw(gold, target, timeout_seconds=0))
-        except Exception:
-            pass
 
-    t = threading.Thread(target=_run, daemon=True)
-    t.start()
-    t.join(timeout)
-    return result[0]
+def math_verify(pred_str: str, gt_str: str, timeout: float = 5.0) -> bool:
+    """Symbolic equality check via the out-of-process math_verify worker."""
+    return _math_verify_service.verify(pred_str, gt_str, timeout=timeout)
+
 
 import training.recipes.rl_loop as rl_loop
 from fireworks.training.sdk import DeploymentManager, TrainerJobManager
@@ -85,8 +148,6 @@ class TrainArgs:
     region: str = "US_OHIO_1"
     deployment_region: str | None = None
     deployment_replica_count: int | None = None
-    trainer_replica_count: int | None = None
-    """Run-level data-parallel trainer replicas for HSDP launches."""
     max_rows: int = 1500
     epochs: int = 3
     completions_per_prompt: int = 8
@@ -95,10 +156,6 @@ class TrainArgs:
     temperature: float = 1.0
     max_completion_tokens: int = 30 * 1024
     prompt_groups_per_step: int = 32
-    lora_rank: int = 0
-    """LoRA rank (0 = full-param).  When > 0, auto_select_training_shape
-    picks a LoRA training shape and the reference model reuses the policy
-    trainer (no extra GPUs)."""
     router_replay: bool = False
     trajectory_dir: str | None = None
     """Directory to save per-step trajectory JSONL files."""
@@ -134,13 +191,6 @@ def parse_args() -> TrainArgs:
     parser.add_argument("--region")
     parser.add_argument("--deployment-region")
     parser.add_argument("--deployment-replica-count", type=int)
-    parser.add_argument(
-        "--trainer-replicas",
-        "--trainer-replica-count",
-        dest="trainer_replica_count",
-        type=int,
-        help="Run-level data-parallel trainer replicas for HSDP launches",
-    )
 
     parser.add_argument("--max-rows", type=int)
     parser.add_argument("--epochs", type=int)
@@ -151,8 +201,6 @@ def parse_args() -> TrainArgs:
     parser.add_argument("--max-completion-tokens", type=int)
 
     parser.add_argument("--prompt-groups-per-step", type=int)
-    parser.add_argument("--lora-rank", type=int,
-                        help="LoRA rank (0 = full-param, e.g. 64 or 128 for LoRA)")
 
     parser.add_argument("--trajectory-dir",
                         help="Directory to save per-step trajectory JSONL files")
@@ -271,9 +319,7 @@ def deepmath_reward(completion: str, row: dict) -> float:
     try:
         pred_boxed = f"\\boxed{{{predicted}}}"
         gt_boxed = f"\\boxed{{{ground_truth}}}"
-        pred_parsed = math_parse(pred_boxed)
-        gt_parsed = math_parse(gt_boxed)
-        if pred_parsed and gt_parsed and math_verify(pred_parsed, gt_parsed):
+        if math_verify(pred_boxed, gt_boxed):
             return 1.0
     except Exception:
         pass
@@ -326,7 +372,6 @@ def main():
         temperature=args.temperature,
         epochs=args.epochs,
         max_rows=args.max_rows,
-        lora_rank=args.lora_rank,
         prompt_groups_per_step=args.prompt_groups_per_step,
         trajectory_dir=args.trajectory_dir,
         tis=TISConfig(cap=2.0),
@@ -338,7 +383,6 @@ def main():
         infra=InfraConfig(
             training_shape_id=args.training_shape,
             ref_training_shape_id=args.ref_training_shape,
-            trainer_replica_count=args.trainer_replica_count,
             region=args.region,
         ),
         deployment=DeployConfig(
@@ -389,7 +433,7 @@ def main():
         config,
         rlor_mgr=rlor_mgr,
         deploy_mgr=deploy_mgr,
-        cancel_on_exit=not args.skip_cleanup,
+        cleanup_on_exit=not args.skip_cleanup,
     )
 
     logger.info("Training complete. Final metrics: %s", metrics)

--- a/training/examples/rl/deepmath/train_deepmath.py
+++ b/training/examples/rl/deepmath/train_deepmath.py
@@ -11,6 +11,7 @@ import os
 import re
 import sys
 import logging
+import threading
 import time
 from dataclasses import dataclass, field
 from typing import cast
@@ -21,7 +22,26 @@ _SRC = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..")
 if _SRC not in sys.path:
     sys.path.insert(0, _SRC)
 
-from math_verify import parse as math_parse, verify as math_verify
+from math_verify import parse as math_parse, verify as _math_verify_raw
+
+
+def math_verify(gold, target, timeout: float = 5.0) -> bool:
+    # math_verify's built-in timeout uses signal.SIGALRM, which is hostile to
+    # asyncio: the alarm fires into arbitrary GC/event-loop code and wedges
+    # rollouts. Disable it (timeout_seconds=0) and run on a daemon thread so
+    # we can move on if sympy is slow.
+    result = [False]
+
+    def _run():
+        try:
+            result[0] = bool(_math_verify_raw(gold, target, timeout_seconds=0))
+        except Exception:
+            pass
+
+    t = threading.Thread(target=_run, daemon=True)
+    t.start()
+    t.join(timeout)
+    return result[0]
 
 import training.recipes.rl_loop as rl_loop
 from fireworks.training.sdk import DeploymentManager, TrainerJobManager

--- a/training/tests/unit/test_train_deepmath.py
+++ b/training/tests/unit/test_train_deepmath.py
@@ -90,8 +90,9 @@ def test_extract_answer_from_completion_supports_multiple_formats(monkeypatch, c
 
 def test_deepmath_reward_supports_exact_and_numeric_fallback(monkeypatch):
     module = _load_module(monkeypatch)
-    monkeypatch.setattr(module, "math_parse", lambda _text: None)
-    monkeypatch.setattr(module, "math_verify", lambda _lhs, _rhs: False)
+    # Disable the symbolic (out-of-process) path so we exercise only the
+    # string-exact and numeric fallbacks.
+    monkeypatch.setattr(module, "math_verify", lambda _pred, _gt: False)
 
     assert module.deepmath_reward(r"Result \boxed{2}", {"ground_truth": "2"}) == 1.0
     assert module.deepmath_reward(r"Result \boxed{2.0}", {"ground_truth": "2"}) == 1.0


### PR DESCRIPTION
## Summary

- DeepMath's reward function calls \`math_verify.verify(...)\` from inside \`async def sample_one_prompt\` (rl_loop.py:629). \`math_verify\`'s built-in 5s timeout uses \`signal.SIGALRM\`, which is hostile to asyncio: the alarm fires into arbitrary code regions (often GC callbacks or event-loop internals), raising \`TimeoutException\` outside the \`math_verify\` caller. The exception gets swallowed (e.g. in \`_weakrefset._remove\`'s gc context) without unwinding the verify call, leaving the rollout loop's task wedged.
- Wrap \`math_verify\` so it's called with \`timeout_seconds=0\` (disabling SIGALRM) and run on a daemon thread with a join-based timeout. Daemon thread leaks on hang but the rollout proceeds; next reward call gets a fresh thread.

## Reproduction

GRPO training on Qwen 3.5-9B against DeepMath-Probability-Hard, 8 prompt-groups × 8 completions × max_completion_tokens=16384. Wedges mid-rollout after 4–6 steps with this signature in stderr:

\`\`\`
Exception ignored in: <function WeakSet.__init__.<locals>._remove at 0x...>
Traceback (most recent call last):
  File "/opt/conda/lib/python3.12/_weakrefset.py", line 39, in _remove
    def _remove(item, selfref=ref(self)):
  File ".../math_verify/utils.py", line 56, in handler
    raise TimeoutException("Operation timed out!")
math_verify.errors.TimeoutException: Operation timed out!
\`\`\`

## Test plan

- [x] \`python training/examples/rl/deepmath/test_reward.py\` — all existing tests pass plus new \`test_math_verify_thread_safe_timeout\`
- [ ] Re-run full GRPO E2E with the fix applied (verified the bug locally; rerun pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes reward-function symbolic verification to use a persistent subprocess with kill-on-timeout semantics, which affects rollout scoring and introduces new process/thread lifecycle behavior that could impact stability/perf if mismanaged.
> 
> **Overview**
> DeepMath’s reward function now performs symbolic equivalence checks via a dedicated `math_verify` subprocess instead of calling `math_verify` in-process, avoiding asyncio/SIGALRM deadlocks and allowing hard timeouts by killing and respawning the worker.
> 
> Adds `_mathverify_worker.py` plus an in-module `_MathVerifyService` that serializes requests over stdin/stdout, enforces timeouts by terminating wedged workers, and updates `deepmath_reward` to use the new `math_verify(pred_str, gt_str)` wrapper. Extends tests to cover correctness, thread-safety, and killable-timeout behavior, and adjusts unit tests to stub only the symbolic path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83dfba247b55d3a4ecd9e886f797d1708c7bbbfe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->