### PR TITLE
remove cookbook trainer-job grad_accum knob

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,3 +5,5 @@ Ready-to-run training recipes built on the [Fireworks Training SDK](https://gith
 **Skills:**
 - [`skills/dev/`](skills/dev/SKILL.md) — day-to-day training work (greenfield setup, debugging, hotload, RL recipe internals, checkpoint promotion). Entry in `SKILL.md` maps tasks and error signals to specific reference files under `skills/dev/references/`. The SDK repo points here; do not maintain a parallel skill there.
 - [`skills/research/`](skills/research/SKILL.md) — research-grade training work (new objectives, train-inference alignment, custom reward pipelines). **Coming soon.**
+
+**Protocol changes:** Any change to the Training SDK, Tinker protocol, trainer/deployment payloads, checkpoint semantics, hotload flow, optimizer-step semantics, or recipe/SDK compatibility contract must update the relevant skill docs in `skills/`. Do not only add new skills; also update or delete stale skill guidance so agents do not preserve outdated protocol behavior.

--- a/skills/dev/SKILL.md
+++ b/skills/dev/SKILL.md
@@ -62,7 +62,7 @@ The requirement lives in the cookbook's `training/pyproject.toml` — look for t
 
 ```bash
 grep 'fireworks-ai\[training\]' cookbook/training/pyproject.toml
-# e.g. "fireworks-ai[training]>=1.2.0a66,<2"
+# e.g. "fireworks-ai[training]>=1.2.0a70,<2"
 
 pip show fireworks-ai | grep -i version
 ```

--- a/skills/dev/references/rl/gradient-accumulation.md
+++ b/skills/dev/references/rl/gradient-accumulation.md
@@ -4,6 +4,8 @@ Every `forward_backward(...)` / `forward_backward_custom(...)` **accumulates gra
 
 `rl_loop.py` runs a **strict 1:1 ratio** per step (one forward-backward → one optim_step, see `recipes/rl_loop.py:797` `ref_forward + fwd_bwd + optim_step + metrics (1:1)`). All `prompt_groups_per_step * completions_per_prompt` datums flow through a single call.
 
+Do **not** use trainer-job `grad_accum`, `TrainerJobConfig.gradient_accumulation_steps`, or the old REST `gradientAccumulationSteps` field. That server-side knob is deprecated and ignored when set to `1`; values above `1` fail fast in the cookbook/SDK. Real gradient accumulation is only client-side control flow: call `forward_backward` N times, then call one `optim_step`.
+
 ## The normalization mode is the easily missed part
 
 `optim_step` takes a `grad_accumulation_normalization` argument that tells the server how to normalize accumulated gradients before clipping and stepping:

--- a/skills/dev/references/rl/gradient-accumulation.md
+++ b/skills/dev/references/rl/gradient-accumulation.md
@@ -4,7 +4,7 @@ Every `forward_backward(...)` / `forward_backward_custom(...)` **accumulates gra
 
 `rl_loop.py` runs a **strict 1:1 ratio** per step (one forward-backward → one optim_step, see `recipes/rl_loop.py:797` `ref_forward + fwd_bwd + optim_step + metrics (1:1)`). All `prompt_groups_per_step * completions_per_prompt` datums flow through a single call.
 
-Do **not** use trainer-job `grad_accum`, `TrainerJobConfig.gradient_accumulation_steps`, or the old REST `gradientAccumulationSteps` field. That server-side knob is deprecated and ignored when set to `1`; values above `1` fail fast in the cookbook/SDK. Real gradient accumulation is only client-side control flow: call `forward_backward` N times, then call one `optim_step`.
+Do **not** use trainer-job `grad_accum`, `TrainerJobConfig.gradient_accumulation_steps`, or the old REST `gradientAccumulationSteps` field. Cookbook recipes and examples do not expose the server-side knob; SDK compatibility handling rejects values above `1`. Real gradient accumulation is only client-side control flow: call `forward_backward` N times, then call one `optim_step`.
 
 ## The normalization mode is the easily missed part
 

--- a/training/examples/dpo/train_dpo.py
+++ b/training/examples/dpo/train_dpo.py
@@ -8,14 +8,14 @@ are set automatically and RunnerIO handles all file-based coordination.
 from __future__ import annotations
 
 import argparse
-import os
 import logging
+import os
 import signal
 
 from dotenv import load_dotenv
+from fireworks.training.sdk import TrainerJobManager
 
 import training.recipes.dpo_loop as dpo_loop
-from fireworks.training.sdk import TrainerJobManager
 from training.utils import InfraConfig, WandBConfig, WeightSyncConfig
 
 logging.basicConfig(
@@ -52,7 +52,7 @@ def parse_args():
     parser.add_argument("--epochs", type=int, default=1)
     parser.add_argument("--batch-size", type=int, default=8)
     parser.add_argument("--grad-accum", type=int, default=1,
-                        help="(deprecated, ignored -- use --batch-size instead)")
+                        help="Deprecated. Must be 1; use --batch-size instead.")
     parser.add_argument("--learning-rate", "--lr", type=float, default=1e-5)
     parser.add_argument("--lora-rank", type=int, default=0)
     parser.add_argument("--max-seq-len", type=int, default=0,

--- a/training/examples/dpo/train_dpo.py
+++ b/training/examples/dpo/train_dpo.py
@@ -51,8 +51,6 @@ def parse_args():
     parser.add_argument("--renderer-name", type=str, default="")
     parser.add_argument("--epochs", type=int, default=1)
     parser.add_argument("--batch-size", type=int, default=8)
-    parser.add_argument("--grad-accum", type=int, default=1,
-                        help="Deprecated. Must be 1; use --batch-size instead.")
     parser.add_argument("--learning-rate", "--lr", type=float, default=1e-5)
     parser.add_argument("--lora-rank", type=int, default=0)
     parser.add_argument("--max-seq-len", type=int, default=0,
@@ -117,7 +115,6 @@ def main():
         learning_rate=args.learning_rate,
         epochs=args.epochs,
         batch_size=args.batch_size,
-        grad_accum=args.grad_accum,
         lora_rank=args.lora_rank,
         max_seq_len=args.max_seq_len or None,
         max_pairs=args.max_pairs,

--- a/training/examples/orpo/ifeval/run.sh
+++ b/training/examples/orpo/ifeval/run.sh
@@ -19,7 +19,6 @@ python train_ifeval_orpo.py \
     --region US_VIRGINIA_1 \
     --max-pairs 200 \
     --epochs 1 \
-    --grad-accum 4 \
     --learning-rate 1e-5 \
     --orpo-lambda 1.0 \
     --output-model-id orpo-finetuned-qwen3-8b-$(date +%Y%m%d%H%M)

--- a/training/examples/orpo/ifeval/train_ifeval_orpo.py
+++ b/training/examples/orpo/ifeval/train_ifeval_orpo.py
@@ -7,13 +7,14 @@ Run prepare_data.py first, then: python train_ifeval_orpo.py
 from __future__ import annotations
 
 import argparse
-import os
 import logging
+import os
 from datetime import datetime
+
 from dotenv import load_dotenv
+from fireworks.training.sdk import TrainerJobManager
 
 import training.recipes.orpo_loop as orpo_loop
-from fireworks.training.sdk import TrainerJobManager
 from training.utils import InfraConfig, WandBConfig
 
 logging.basicConfig(
@@ -43,7 +44,7 @@ def parse_args():
     parser.add_argument("--region", default="US_VIRGINIA_1")
     parser.add_argument("--max-pairs", type=int, default=200)
     parser.add_argument("--epochs", type=int, default=1)
-    parser.add_argument("--grad-accum", type=int, default=4)
+    parser.add_argument("--grad-accum", type=int, default=1, help="Deprecated. Must be 1.")
     parser.add_argument("--learning-rate", type=float, default=1e-5)
     parser.add_argument("--orpo-lambda", type=float, default=1.0)
     parser.add_argument("--lora-rank", type=int, default=0)

--- a/training/examples/orpo/ifeval/train_ifeval_orpo.py
+++ b/training/examples/orpo/ifeval/train_ifeval_orpo.py
@@ -44,7 +44,6 @@ def parse_args():
     parser.add_argument("--region", default="US_VIRGINIA_1")
     parser.add_argument("--max-pairs", type=int, default=200)
     parser.add_argument("--epochs", type=int, default=1)
-    parser.add_argument("--grad-accum", type=int, default=1, help="Deprecated. Must be 1.")
     parser.add_argument("--learning-rate", type=float, default=1e-5)
     parser.add_argument("--orpo-lambda", type=float, default=1.0)
     parser.add_argument("--lora-rank", type=int, default=0)
@@ -90,7 +89,6 @@ def main():
         orpo_lambda=args.orpo_lambda,
         learning_rate=args.learning_rate,
         epochs=args.epochs,
-        grad_accum=args.grad_accum,
         max_pairs=args.max_pairs,
         lora_rank=args.lora_rank,
         job_id=args.job_id,
@@ -107,10 +105,9 @@ def main():
     )
 
     logger.info(
-        "max_pairs=%s | epochs=%d | grad_accum=%d | lr=%g | orpo_lambda=%g",
+        "max_pairs=%s | epochs=%d | lr=%g | orpo_lambda=%g",
         args.max_pairs,
         args.epochs,
-        args.grad_accum,
         args.learning_rate,
         args.orpo_lambda,
     )

--- a/training/examples/sft/run_vl.sh
+++ b/training/examples/sft/run_vl.sh
@@ -20,6 +20,5 @@ python3.12 train_sft.py \
     --max-examples 50 \
     --epochs 3 \
     --batch-size 4 \
-    --grad-accum 4 \
     --learning-rate 1e-5 \
     --output-model-id sft-vl-qwen3-8b-$(date +%Y%m%d%H%M)

--- a/training/examples/sft/train_sft.py
+++ b/training/examples/sft/train_sft.py
@@ -47,8 +47,6 @@ def parse_args():
     parser.add_argument("--max-examples", type=int, default=500)
     parser.add_argument("--epochs", type=int, default=3)
     parser.add_argument("--batch-size", type=int, default=8)
-    parser.add_argument("--grad-accum", type=int, default=1,
-                        help="Deprecated. Must be 1; use --batch-size instead.")
     parser.add_argument("--learning-rate", type=float, default=1e-5)
     parser.add_argument("--lora-rank", type=int, default=0)
     parser.add_argument("--renderer-name", default="")
@@ -96,7 +94,6 @@ def main():
         learning_rate=args.learning_rate,
         epochs=args.epochs,
         batch_size=args.batch_size,
-        grad_accum=args.grad_accum,
         max_examples=args.max_examples,
         lora_rank=args.lora_rank,
         output_model_id=args.output_model_id,

--- a/training/examples/sft/train_sft.py
+++ b/training/examples/sft/train_sft.py
@@ -4,14 +4,14 @@
 from __future__ import annotations
 
 import argparse
-import os
 import logging
+import os
 import signal
 
 from dotenv import load_dotenv
+from fireworks.training.sdk import TrainerJobManager
 
 import training.recipes.sft_loop as sft_loop
-from fireworks.training.sdk import TrainerJobManager
 from training.utils import InfraConfig, WandBConfig
 
 logging.basicConfig(
@@ -48,7 +48,7 @@ def parse_args():
     parser.add_argument("--epochs", type=int, default=3)
     parser.add_argument("--batch-size", type=int, default=8)
     parser.add_argument("--grad-accum", type=int, default=1,
-                        help="(deprecated, ignored -- use --batch-size instead)")
+                        help="Deprecated. Must be 1; use --batch-size instead.")
     parser.add_argument("--learning-rate", type=float, default=1e-5)
     parser.add_argument("--lora-rank", type=int, default=0)
     parser.add_argument("--renderer-name", default="")

--- a/training/pyproject.toml
+++ b/training/pyproject.toml
@@ -7,7 +7,7 @@ name = "fireworks-training-cookbook"
 version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [
-    "fireworks-ai[training]>=1.2.0a69,<2",
+    "fireworks-ai[training]>=1.2.0a70,<2",
     "tqdm",
     "torch",
     "datasets",

--- a/training/recipes/dpo_loop.py
+++ b/training/recipes/dpo_loop.py
@@ -46,22 +46,22 @@ from dataclasses import dataclass, field
 from typing import Any, Callable
 
 import tinker
+from fireworks.training.sdk import DeploymentManager, TrainerJobManager
 from tqdm import tqdm
 
-from fireworks.training.sdk import DeploymentManager, TrainerJobManager
 from training.utils import (
-    AppendOnlyPickleLog,
     DEFAULT_ADAM,
     DEFAULT_RENDER_WORKERS,
+    AppendOnlyPickleLog,
     DeployConfig,
     InfraConfig,
     JsonlRenderDataset,
     RawRowCursor,
     ReconnectableClient,
     ResourceCleanup,
-    RunStatus,
     RunnerConfig,
     RunnerIO,
+    RunStatus,
     WandBConfig,
     log_metrics_json,
     make_batch_dpo_loss_fn,
@@ -73,6 +73,7 @@ from training.utils import (
     resolve_renderer_name,
     setup_wandb,
     validate_config,
+    validate_grad_accum_for_trainer_job,
     wandb_finish,
     wandb_log,
 )
@@ -566,11 +567,7 @@ def main(
             "Set it to the HuggingFace model name (e.g. 'Qwen/Qwen3-1.7B')."
         )
 
-    if cfg.grad_accum > 1:
-        logger.warning(
-            "grad_accum is deprecated and ignored. "
-            "Increase batch_size instead for larger effective batches."
-        )
+    validate_grad_accum_for_trainer_job(cfg.grad_accum)
 
     setup_wandb(cfg.wandb, {
         "beta": cfg.beta,

--- a/training/recipes/dpo_loop.py
+++ b/training/recipes/dpo_loop.py
@@ -73,7 +73,6 @@ from training.utils import (
     resolve_renderer_name,
     setup_wandb,
     validate_config,
-    validate_grad_accum_for_trainer_job,
     wandb_finish,
     wandb_log,
 )
@@ -105,8 +104,6 @@ class Config:
     epochs: int = 1
     batch_size: int = 4
     """Number of preference pairs per optimizer step."""
-    grad_accum: int = 1
-    """Deprecated. Ignored. Use ``batch_size`` to control the effective batch."""
     max_seq_len: int | None = None
     max_pairs: int | None = None
     """Cap on *valid rendered pairs* after schema/length filtering."""
@@ -566,8 +563,6 @@ def main(
             "Config.tokenizer_model is required for client-side tokenization. "
             "Set it to the HuggingFace model name (e.g. 'Qwen/Qwen3-1.7B')."
         )
-
-    validate_grad_accum_for_trainer_job(cfg.grad_accum)
 
     setup_wandb(cfg.wandb, {
         "beta": cfg.beta,

--- a/training/recipes/orpo_loop.py
+++ b/training/recipes/orpo_loop.py
@@ -35,45 +35,46 @@ Infrastructure defaults target Qwen3-235B on 2 nodes with CP=16, EP=8.
 
 from __future__ import annotations
 
+import logging
 import math
 import os
-import time
-import signal
 import random
-import logging
+import signal
+import time
 from contextlib import ExitStack
-from dataclasses import field, dataclass
-import torch
+from dataclasses import dataclass, field
 
 import tinker
-
+import torch
 from fireworks.training.sdk import TrainerJobManager
+
 from training.utils import (
     DEFAULT_ADAM,
     InfraConfig,
+    ReconnectableClient,
     ResourceCleanup,
     RunnerConfig,
     RunnerIO,
     RunStatus,
     WandBConfig,
-    ReconnectableClient,
-    wandb_log,
-    setup_wandb,
-    wandb_finish,
-    log_metrics_json,
-    make_batch_orpo_loss_fn,
+    auto_select_training_shape,
+    build_renderer,
     create_trainer_job,
-    read_api_extra_headers_env,
     load_preference_dataset,
     load_tokenizer,
-    build_renderer,
-    auto_select_training_shape,
+    log_metrics_json,
+    make_batch_orpo_loss_fn,
+    read_api_extra_headers_env,
     render_preference_pair,
     resolve_renderer_name,
+    setup_wandb,
     validate_config,
+    validate_grad_accum_for_trainer_job,
+    wandb_finish,
+    wandb_log,
 )
-from training.utils.client import DEFAULT_TIMEOUT_S
 from training.utils.checkpoints import TrainingCheckpoints, validate_warm_start_config
+from training.utils.client import DEFAULT_TIMEOUT_S
 
 logger = logging.getLogger(__name__)
 
@@ -217,11 +218,7 @@ def main(
         init_from_checkpoint=cfg.init_from_checkpoint,
         lora_rank=cfg.lora_rank,
     )
-    if cfg.grad_accum > 1:
-        logger.warning(
-            "grad_accum is deprecated and ignored. "
-            "Increase batch_size instead for larger effective batches."
-        )
+    validate_grad_accum_for_trainer_job(cfg.grad_accum)
 
     if not cfg.tokenizer_model:
         raise ValueError(

--- a/training/recipes/orpo_loop.py
+++ b/training/recipes/orpo_loop.py
@@ -69,7 +69,6 @@ from training.utils import (
     resolve_renderer_name,
     setup_wandb,
     validate_config,
-    validate_grad_accum_for_trainer_job,
     wandb_finish,
     wandb_log,
 )
@@ -101,8 +100,6 @@ class Config:
     """Number of preference pairs per optimizer step."""
     seed: int = 0
     """Seed for deterministic per-epoch shuffling of preference pairs."""
-    grad_accum: int = 1
-    """Deprecated. Ignored. Use ``batch_size`` to control the effective batch."""
     max_seq_len: int | None = None
     max_pairs: int | None = None
     lora_rank: int = 0
@@ -218,8 +215,6 @@ def main(
         init_from_checkpoint=cfg.init_from_checkpoint,
         lora_rank=cfg.lora_rank,
     )
-    validate_grad_accum_for_trainer_job(cfg.grad_accum)
-
     if not cfg.tokenizer_model:
         raise ValueError(
             "Config.tokenizer_model is required for client-side tokenization. "

--- a/training/recipes/sft_loop.py
+++ b/training/recipes/sft_loop.py
@@ -52,7 +52,6 @@ from training.utils import (
     resolve_renderer_name,
     setup_wandb,
     validate_config,
-    validate_grad_accum_for_trainer_job,
     wandb_finish,
     wandb_log,
 )
@@ -240,8 +239,6 @@ class Config:
     learning_rate: float = 1e-4
     epochs: int = 3
     batch_size: int = 32
-    grad_accum: int = 1
-    """Deprecated. Ignored. Use ``batch_size`` to control the effective batch."""
     max_seq_len: int | None = None
     max_examples: int | None = None
     lora_rank: int = 0
@@ -432,8 +429,6 @@ def main(
         init_from_checkpoint=cfg.init_from_checkpoint,
         lora_rank=cfg.lora_rank,
     )
-    validate_grad_accum_for_trainer_job(cfg.grad_accum)
-
     setup_wandb(
         cfg.wandb,
         {

--- a/training/recipes/sft_loop.py
+++ b/training/recipes/sft_loop.py
@@ -14,52 +14,52 @@ Usage:
 
 from __future__ import annotations
 
-import os
-import signal
-import logging
-import random
 import functools
-from itertools import islice
+import logging
+import os
+import random
+import signal
 from contextlib import ExitStack
+from dataclasses import dataclass, field
+from itertools import islice
 from typing import Any, Dict, List
-from dataclasses import field, dataclass
 
-import torch
 import tinker
-
+import torch
 from dotenv import load_dotenv
-
 from fireworks.training.sdk import TrainerJobManager
+
 from training.utils import (
     DEFAULT_ADAM,
     DEFAULT_RENDER_WORKERS,
     InfraConfig,
     JsonlRenderDataset,
     RawRowCursor,
+    ReconnectableClient,
     ResourceCleanup,
     RunnerConfig,
     RunnerIO,
     RunStatus,
     WandBConfig,
-    ReconnectableClient,
-    make_render_dataloader,
-    wandb_log,
-    setup_wandb,
-    wandb_finish,
-    validate_config,
-    log_metrics_json,
+    auto_select_training_shape,
     create_trainer_job,
-    read_api_extra_headers_env,
+    log_metrics_json,
+    make_render_dataloader,
     parse_train_on_what,
     populate_render_worker_state,
-    auto_select_training_shape,
+    read_api_extra_headers_env,
     render_messages_to_datums,
     resolve_renderer_name,
+    setup_wandb,
+    validate_config,
+    validate_grad_accum_for_trainer_job,
+    wandb_finish,
+    wandb_log,
 )
-from training.utils.client import DEFAULT_TIMEOUT_S
 from training.utils.checkpoints import TrainingCheckpoints, validate_warm_start_config
+from training.utils.client import DEFAULT_TIMEOUT_S
 from training.utils.losses import make_batch_weighted_sft_loss_fn
-from training.utils.timer import timer, flush_timing
+from training.utils.timer import flush_timing, timer
 
 load_dotenv()
 logger = logging.getLogger(__name__)
@@ -432,11 +432,7 @@ def main(
         init_from_checkpoint=cfg.init_from_checkpoint,
         lora_rank=cfg.lora_rank,
     )
-    if cfg.grad_accum > 1:
-        logger.warning(
-            "grad_accum is deprecated and ignored. "
-            "Increase batch_size instead for larger effective batches."
-        )
+    validate_grad_accum_for_trainer_job(cfg.grad_accum)
 
     setup_wandb(
         cfg.wandb,

--- a/training/tests/smoke_test/test_checkpoints_smoke.py
+++ b/training/tests/smoke_test/test_checkpoints_smoke.py
@@ -148,7 +148,6 @@ class TestCheckpointsSmoke:
             learning_rate=1e-4,
             epochs=1,
             batch_size=2,
-            grad_accum=1,
             max_examples=_NUM_TRAINING_EXAMPLES,
             lora_rank=8,
             dcp_save_interval=_DCP_SAVE_INTERVAL,

--- a/training/tests/smoke_test/test_dpo_smoke.py
+++ b/training/tests/smoke_test/test_dpo_smoke.py
@@ -56,7 +56,6 @@ def test_dpo_smoke(
             learning_rate=1e-5,
             epochs=1,
             batch_size=1,
-            grad_accum=1,
             max_pairs=4,
             infra=smoke_dpo_infra,
             deployment=DeployConfig(),

--- a/training/tests/smoke_test/test_sft_smoke.py
+++ b/training/tests/smoke_test/test_sft_smoke.py
@@ -47,7 +47,6 @@ def test_sft_smoke(
             learning_rate=1e-4,
             epochs=1,
             batch_size=2,
-            grad_accum=1,
             max_examples=4,
             infra=smoke_infra,
             wandb=WandBConfig(),

--- a/training/tests/unit/test_sft_loop.py
+++ b/training/tests/unit/test_sft_loop.py
@@ -521,7 +521,6 @@ def test_main_uses_real_renderer_and_trains(tmp_path, monkeypatch):
         max_seq_len=32,
         epochs=1,
         batch_size=1,
-        grad_accum=1,
         log_path=str(tmp_path / "sft_logs"),
         render_workers=1,
     )
@@ -544,7 +543,7 @@ def test_main_uses_real_renderer_and_trains(tmp_path, monkeypatch):
 
 
 def test_each_batch_triggers_its_own_optim_step(tmp_path, monkeypatch):
-    """With grad_accum removed, each batch gets its own forward_backward + optim_step."""
+    """Each batch gets its own forward_backward + optim_step."""
     dataset_path = _write_dataset(
         tmp_path,
         [

--- a/training/tests/unit/test_shape_override_paths.py
+++ b/training/tests/unit/test_shape_override_paths.py
@@ -77,13 +77,15 @@ class TestShapePath:
             base_model=BASE_MODEL,
             infra=InfraConfig(region="US_VIRGINIA_1"),
             profile=PROFILE,
-            grad_accum=2,
+            grad_accum=2,  # deprecated; should be ignored and overridden to 1
         )
         c = mgr.captured
 
         assert c.training_shape_ref == PROFILE.training_shape_version
         assert c.base_model == BASE_MODEL
-        assert c.gradient_accumulation_steps == 2
+        # grad_accum is deprecated: server-side gradient_accumulation_steps is
+        # always sent as 1 regardless of what the caller passed. See infra.py.
+        assert c.gradient_accumulation_steps == 1
         assert c.region == "US_VIRGINIA_1"
 
         assert c.accelerator_type is None
@@ -195,3 +197,52 @@ def test_infra_fields_forwarded_to_config():
         infra=InfraConfig(purpose="PURPOSE_PILOT"), profile=PROFILE,
     )
     assert mgr.captured.purpose == "PURPOSE_PILOT"
+
+
+# ---------------------------------------------------------------------------
+# grad_accum deprecation
+# ---------------------------------------------------------------------------
+
+
+class TestGradAccumDeprecated:
+    """The cookbook must NOT forward a server-side gradient_accumulation_steps>1.
+
+    The Tinker/RLOR engine does not honor that knob; setting it would request
+    the naive Unsloth-style /G divide. Express GA as client-side control flow
+    (multiple forward_backward calls per optim_step) and pass
+    grad_accumulation_normalization on the optim_step request.
+    """
+
+    def test_default_grad_accum_is_one(self):
+        mgr = _CapturingMgr()
+        infra_module.create_trainer_job(
+            mgr, base_model=BASE_MODEL,
+            infra=InfraConfig(region="US_VIRGINIA_1"), profile=PROFILE,
+        )
+        assert mgr.captured.gradient_accumulation_steps == 1
+
+    def test_nonone_grad_accum_overridden_to_one(self):
+        mgr = _CapturingMgr()
+        infra_module.create_trainer_job(
+            mgr, base_model=BASE_MODEL,
+            infra=InfraConfig(region="US_VIRGINIA_1"), profile=PROFILE,
+            grad_accum=8,
+        )
+        assert mgr.captured.gradient_accumulation_steps == 1, (
+            "grad_accum is deprecated; server-side gradient_accumulation_steps "
+            "must always be sent as 1."
+        )
+
+    def test_nonone_grad_accum_emits_warning(self, caplog):
+        import logging
+
+        mgr = _CapturingMgr()
+        with caplog.at_level(logging.WARNING, logger="training.utils.infra"):
+            infra_module.create_trainer_job(
+                mgr, base_model=BASE_MODEL,
+                infra=InfraConfig(region="US_VIRGINIA_1"), profile=PROFILE,
+                grad_accum=4,
+            )
+        assert any(
+            "grad_accum=4 is deprecated" in rec.message for rec in caplog.records
+        ), "Expected deprecation warning when grad_accum != 1"

--- a/training/tests/unit/test_shape_override_paths.py
+++ b/training/tests/unit/test_shape_override_paths.py
@@ -78,7 +78,6 @@ class TestShapePath:
             base_model=BASE_MODEL,
             infra=InfraConfig(region="US_VIRGINIA_1"),
             profile=PROFILE,
-            grad_accum=2,
         )
         c = mgr.captured
 
@@ -212,34 +211,16 @@ class TestGradAccumDeprecated:
     grad_accumulation_normalization on the optim_step request.
     """
 
-    def test_default_grad_accum_is_one(self):
-        mgr = _CapturingMgr()
-        infra_module.create_trainer_job(
-            mgr, base_model=BASE_MODEL,
-            infra=InfraConfig(region="US_VIRGINIA_1"), profile=PROFILE,
-        )
-        assert mgr.captured.gradient_accumulation_steps == 1
-
-    def test_nonone_grad_accum_overridden_to_one(self):
-        mgr = _CapturingMgr()
-        infra_module.create_trainer_job(
-            mgr, base_model=BASE_MODEL,
-            infra=InfraConfig(region="US_VIRGINIA_1"), profile=PROFILE,
-            grad_accum=8,
-        )
-        assert mgr.captured.gradient_accumulation_steps == 1, (
-            "grad_accum is deprecated; server-side gradient_accumulation_steps "
-            "must always be sent as 1."
-        )
-
-    def test_nonone_grad_accum_emits_warning(self, caplog):
-        mgr = _CapturingMgr()
+    def test_unset_grad_accum_is_silent(self, caplog):
         with caplog.at_level(logging.WARNING, logger="training.utils.infra"):
-            infra_module.create_trainer_job(
-                mgr, base_model=BASE_MODEL,
-                infra=InfraConfig(region="US_VIRGINIA_1"), profile=PROFILE,
-                grad_accum=4,
-            )
-        assert any(
-            "grad_accum=4 is deprecated" in rec.message for rec in caplog.records
-        ), "Expected deprecation warning when grad_accum != 1"
+            infra_module._validate_grad_accum_for_trainer_job(None)
+        assert not any("grad_accum" in rec.message for rec in caplog.records)
+
+    def test_explicit_one_grad_accum_warns(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="training.utils.infra"):
+            infra_module._validate_grad_accum_for_trainer_job(1)
+        assert any("grad_accum=1 is deprecated" in rec.message for rec in caplog.records)
+
+    def test_nonone_grad_accum_raises(self):
+        with pytest.raises(ValueError):
+            infra_module._validate_grad_accum_for_trainer_job(8)

--- a/training/tests/unit/test_shape_override_paths.py
+++ b/training/tests/unit/test_shape_override_paths.py
@@ -11,7 +11,6 @@ Two paths tested:
 
 from __future__ import annotations
 
-import logging
 from types import SimpleNamespace
 
 import pytest
@@ -195,32 +194,3 @@ def test_infra_fields_forwarded_to_config():
         infra=InfraConfig(purpose="PURPOSE_PILOT"), profile=PROFILE,
     )
     assert mgr.captured.purpose == "PURPOSE_PILOT"
-
-
-# ---------------------------------------------------------------------------
-# grad_accum deprecation
-# ---------------------------------------------------------------------------
-
-
-class TestGradAccumDeprecated:
-    """The cookbook must NOT forward a server-side gradient_accumulation_steps>1.
-
-    The Tinker/RLOR engine does not honor that knob; setting it would request
-    the naive Unsloth-style /G divide. Express GA as client-side control flow
-    (multiple forward_backward calls per optim_step) and pass
-    grad_accumulation_normalization on the optim_step request.
-    """
-
-    def test_unset_grad_accum_is_silent(self, caplog):
-        with caplog.at_level(logging.WARNING, logger="training.utils.infra"):
-            infra_module.validate_grad_accum_for_trainer_job(None)
-        assert not any("grad_accum" in rec.message for rec in caplog.records)
-
-    def test_explicit_one_grad_accum_warns(self, caplog):
-        with caplog.at_level(logging.WARNING, logger="training.utils.infra"):
-            infra_module.validate_grad_accum_for_trainer_job(1)
-        assert any("grad_accum=1 is deprecated" in rec.message for rec in caplog.records)
-
-    def test_nonone_grad_accum_raises(self):
-        with pytest.raises(ValueError):
-            infra_module.validate_grad_accum_for_trainer_job(8)

--- a/training/tests/unit/test_shape_override_paths.py
+++ b/training/tests/unit/test_shape_override_paths.py
@@ -15,13 +15,13 @@ import logging
 from types import SimpleNamespace
 
 import pytest
-
-import training.utils.infra as infra_module
-from training.utils.config import InfraConfig
 from fireworks.training.sdk import (
     TrainerJobConfig,
     TrainingShapeProfile,
 )
+
+import training.utils.infra as infra_module
+from training.utils.config import InfraConfig
 
 BASE_MODEL = "accounts/fireworks/models/qwen3-1p7b"
 
@@ -83,7 +83,7 @@ class TestShapePath:
 
         assert c.training_shape_ref == PROFILE.training_shape_version
         assert c.base_model == BASE_MODEL
-        assert c.gradient_accumulation_steps == 1
+        assert c.gradient_accumulation_steps is None
         assert c.region == "US_VIRGINIA_1"
 
         assert c.accelerator_type is None
@@ -213,14 +213,14 @@ class TestGradAccumDeprecated:
 
     def test_unset_grad_accum_is_silent(self, caplog):
         with caplog.at_level(logging.WARNING, logger="training.utils.infra"):
-            infra_module._validate_grad_accum_for_trainer_job(None)
+            infra_module.validate_grad_accum_for_trainer_job(None)
         assert not any("grad_accum" in rec.message for rec in caplog.records)
 
     def test_explicit_one_grad_accum_warns(self, caplog):
         with caplog.at_level(logging.WARNING, logger="training.utils.infra"):
-            infra_module._validate_grad_accum_for_trainer_job(1)
+            infra_module.validate_grad_accum_for_trainer_job(1)
         assert any("grad_accum=1 is deprecated" in rec.message for rec in caplog.records)
 
     def test_nonone_grad_accum_raises(self):
         with pytest.raises(ValueError):
-            infra_module._validate_grad_accum_for_trainer_job(8)
+            infra_module.validate_grad_accum_for_trainer_job(8)

--- a/training/tests/unit/test_shape_override_paths.py
+++ b/training/tests/unit/test_shape_override_paths.py
@@ -11,6 +11,7 @@ Two paths tested:
 
 from __future__ import annotations
 
+import logging
 from types import SimpleNamespace
 
 import pytest
@@ -77,14 +78,12 @@ class TestShapePath:
             base_model=BASE_MODEL,
             infra=InfraConfig(region="US_VIRGINIA_1"),
             profile=PROFILE,
-            grad_accum=2,  # deprecated; should be ignored and overridden to 1
+            grad_accum=2,
         )
         c = mgr.captured
 
         assert c.training_shape_ref == PROFILE.training_shape_version
         assert c.base_model == BASE_MODEL
-        # grad_accum is deprecated: server-side gradient_accumulation_steps is
-        # always sent as 1 regardless of what the caller passed. See infra.py.
         assert c.gradient_accumulation_steps == 1
         assert c.region == "US_VIRGINIA_1"
 
@@ -234,8 +233,6 @@ class TestGradAccumDeprecated:
         )
 
     def test_nonone_grad_accum_emits_warning(self, caplog):
-        import logging
-
         mgr = _CapturingMgr()
         with caplog.at_level(logging.WARNING, logger="training.utils.infra"):
             infra_module.create_trainer_job(

--- a/training/tests/unit/test_text2sql_train_sft.py
+++ b/training/tests/unit/test_text2sql_train_sft.py
@@ -37,8 +37,6 @@ def test_parse_args_reads_overrides(monkeypatch):
             "2",
             "--batch-size",
             "4",
-            "--grad-accum",
-            "3",
             "--learning-rate",
             "2e-5",
             "--lora-rank",
@@ -57,7 +55,6 @@ def test_parse_args_reads_overrides(monkeypatch):
     assert args.max_examples == 16
     assert args.epochs == 2
     assert args.batch_size == 4
-    assert args.grad_accum == 3
     assert args.learning_rate == 2e-5
     assert args.lora_rank == 8
 
@@ -78,5 +75,3 @@ def test_main_raises_when_dataset_is_missing(monkeypatch):
 
     with pytest.raises(FileNotFoundError, match="text2sql_dataset.jsonl|Dataset not found"):
         module.main()
-
-

--- a/training/utils/__init__.py
+++ b/training/utils/__init__.py
@@ -105,20 +105,34 @@ __all__ = [
     "timer",
     "auto_select_training_shape",
     "validate_config",
+    "validate_grad_accum_for_trainer_job",
     "validate_preflight",
     "wandb_finish",
     "wandb_log",
 ]
 
+from training.utils.client import ReconnectableClient
+from training.utils.config import (
+    DEFAULT_ADAM,
+    ConcurrencyConfig,
+    DeployConfig,
+    EvalFn,
+    InfraConfig,
+    RewardFn,
+    StepCallback,
+    WandBConfig,
+    WeightSyncConfig,
+    WeightSyncScope,
+)
 from training.utils.data import (
     RLPromptDataset,
+    compute_advantages,
     encode_text,
     extract_text,
-    compute_advantages,
+    find_common_prefix_length,
     iter_preference_examples,
     load_jsonl_dataset,
     load_preference_dataset,
-    find_common_prefix_length,
     normalize_preference_row,
     prepare_sampling_messages,
     replicate_rows_for_epochs,
@@ -128,73 +142,61 @@ from training.utils.dataloader_cursor import RawRowCursor
 from training.utils.infra import (
     Infra,
     ResourceCleanup,
+    create_trainer_job,
     get_deployment_gpu_count,
+    read_api_extra_headers_env,
     request_deployment,
-    wait_deployment,
+    request_trainer_job,
     setup_deployment,
     setup_infra,
     setup_or_reattach_deployment,
-    request_trainer_job,
-    wait_trainer_job,
-    create_trainer_job,
-    read_api_extra_headers_env,
     setup_training_client,
+    validate_grad_accum_for_trainer_job,
+    wait_deployment,
+    wait_trainer_job,
 )
-from training.utils.timer import timed, timer, flush_timing
-from training.utils.client import ReconnectableClient
-from training.utils.config import (
-    DEFAULT_ADAM,
-    EvalFn,
-    RewardFn,
-    ConcurrencyConfig,
-    InfraConfig,
-    WandBConfig,
-    DeployConfig,
-    StepCallback,
-    WeightSyncConfig,
-    WeightSyncScope,
+from training.utils.logging import (
+    compute_pass_at_k,
+    log_metrics_json,
+    setup_wandb,
+    wandb_finish,
+    wandb_log,
 )
-from training.utils.training_shapes import (
-    auto_select_training_shape,
-)
-from training.utils.tokenizers import load_deployment_tokenizer, load_tokenizer
 from training.utils.losses import (
-    make_sft_loss_fn,
-    make_orpo_loss_fn,
-    make_batch_orpo_loss_fn,
     make_batch_dpo_loss_fn,
+    make_batch_orpo_loss_fn,
     make_batch_sft_loss_fn,
     make_batch_weighted_sft_loss_fn,
+    make_orpo_loss_fn,
+    make_sft_loss_fn,
+)
+from training.utils.memlog import MemTracer
+from training.utils.runner import RunnerConfig, RunnerIO, RunStatus
+from training.utils.streaming import (
+    DEFAULT_PREFETCH_FACTOR,
+    DEFAULT_RENDER_WORKERS,
+    AppendOnlyPickleLog,
+    JsonlRenderDataset,
+    make_render_dataloader,
 )
 from training.utils.supervised import (
     RenderedPreferencePair,
     RenderedSupervisedDatum,
     build_datum_from_token_mask,
-    build_next_token_datum,
     build_datum_from_tokens_and_weights,
+    build_next_token_datum,
     build_renderer,
     normalize_messages,
     parse_train_on_what,
     populate_render_worker_state,
-    render_preference_pair,
     render_messages_to_datum,
     render_messages_to_datums,
+    render_preference_pair,
     resolve_renderer_name,
 )
-from training.utils.logging import (
-    wandb_log,
-    setup_wandb,
-    wandb_finish,
-    log_metrics_json,
-    compute_pass_at_k,
+from training.utils.timer import flush_timing, timed, timer
+from training.utils.tokenizers import load_deployment_tokenizer, load_tokenizer
+from training.utils.training_shapes import (
+    auto_select_training_shape,
 )
-from training.utils.runner import RunnerConfig, RunnerIO, RunStatus
-from training.utils.streaming import (
-    AppendOnlyPickleLog,
-    DEFAULT_PREFETCH_FACTOR,
-    DEFAULT_RENDER_WORKERS,
-    JsonlRenderDataset,
-    make_render_dataloader,
-)
-from training.utils.memlog import MemTracer
 from training.utils.validation import validate_config, validate_preflight

--- a/training/utils/__init__.py
+++ b/training/utils/__init__.py
@@ -105,7 +105,6 @@ __all__ = [
     "timer",
     "auto_select_training_shape",
     "validate_config",
-    "validate_grad_accum_for_trainer_job",
     "validate_preflight",
     "wandb_finish",
     "wandb_log",
@@ -151,7 +150,6 @@ from training.utils.infra import (
     setup_infra,
     setup_or_reattach_deployment,
     setup_training_client,
-    validate_grad_accum_for_trainer_job,
     wait_deployment,
     wait_trainer_job,
 )

--- a/training/utils/infra.py
+++ b/training/utils/infra.py
@@ -81,23 +81,6 @@ _TRAINER_JOB_CONFIG_SUPPORTS_TRAINER_REPLICA_COUNT = (
     "trainer_replica_count" in inspect.signature(TrainerJobConfig).parameters
 )
 
-def validate_grad_accum_for_trainer_job(grad_accum: int | None) -> None:
-    if grad_accum is not None and grad_accum != 1:
-        raise ValueError(
-            "grad_accum must be 1. Server-side gradient accumulation is deprecated "
-            "on the Tinker/RLOR path. Express gradient accumulation as client-side "
-            "control flow (multiple forward_backward calls per optim_step) and "
-            "pass grad_accumulation_normalization on the optim_step request."
-        )
-    if grad_accum == 1:
-        logger.warning(
-            "grad_accum=1 is deprecated and ignored. Express gradient accumulation "
-            "as client-side control flow (multiple forward_backward calls per "
-            "optim_step) and pass grad_accumulation_normalization on the optim_step "
-            "request."
-        )
-
-
 _DEPLOYMENT_ACCELERATOR_REGION_PREFIXES: tuple[tuple[str, str], ...] = (
     ("NVIDIA_H200", "US_VIRGINIA_1"),
     ("NVIDIA_B200", "US_OHIO_1"),
@@ -304,7 +287,6 @@ def request_trainer_job(
     lora_rank: int = 0,
     max_seq_len: int | None = None,
     learning_rate: float = 1e-5,
-    grad_accum: int | None = None,
     display_name: str = "trainer",
     hot_load_deployment_id: str | None = None,
     extra_args: list[str] | None = None,
@@ -354,8 +336,6 @@ def request_trainer_job(
             raise ValueError("trainer_replica_count must be non-negative")
         if _TRAINER_JOB_CONFIG_SUPPORTS_TRAINER_REPLICA_COUNT:
             extra_trainer_args["trainer_replica_count"] = infra.trainer_replica_count
-
-    validate_grad_accum_for_trainer_job(grad_accum)
 
     if profile is not None:
         config = TrainerJobConfig(
@@ -509,7 +489,6 @@ def create_trainer_job(
     lora_rank: int = 0,
     max_seq_len: int | None = None,
     learning_rate: float = 1e-5,
-    grad_accum: int | None = None,
     display_name: str = "trainer",
     hot_load_deployment_id: str | None = None,
     extra_args: list[str] | None = None,
@@ -540,7 +519,6 @@ def create_trainer_job(
         lora_rank=lora_rank,
         max_seq_len=max_seq_len,
         learning_rate=learning_rate,
-        grad_accum=grad_accum,
         display_name=display_name,
         hot_load_deployment_id=hot_load_deployment_id,
         extra_args=extra_args,

--- a/training/utils/infra.py
+++ b/training/utils/infra.py
@@ -81,6 +81,23 @@ _TRAINER_JOB_CONFIG_SUPPORTS_TRAINER_REPLICA_COUNT = (
     "trainer_replica_count" in inspect.signature(TrainerJobConfig).parameters
 )
 
+def _validate_grad_accum_for_trainer_job(grad_accum: int | None) -> None:
+    if grad_accum is not None and grad_accum != 1:
+        raise ValueError(
+            "grad_accum must be 1. Server-side gradient accumulation is deprecated "
+            "on the Tinker/RLOR path. Express gradient accumulation as client-side "
+            "control flow (multiple forward_backward calls per optim_step) and "
+            "pass grad_accumulation_normalization on the optim_step request."
+        )
+    if grad_accum == 1:
+        logger.warning(
+            "grad_accum=1 is deprecated and ignored. Express gradient accumulation "
+            "as client-side control flow (multiple forward_backward calls per "
+            "optim_step) and pass grad_accumulation_normalization on the optim_step "
+            "request."
+        )
+
+
 _DEPLOYMENT_ACCELERATOR_REGION_PREFIXES: tuple[tuple[str, str], ...] = (
     ("NVIDIA_H200", "US_VIRGINIA_1"),
     ("NVIDIA_B200", "US_OHIO_1"),
@@ -287,7 +304,7 @@ def request_trainer_job(
     lora_rank: int = 0,
     max_seq_len: int | None = None,
     learning_rate: float = 1e-5,
-    grad_accum: int = 1,
+    grad_accum: int | None = None,
     display_name: str = "trainer",
     hot_load_deployment_id: str | None = None,
     extra_args: list[str] | None = None,
@@ -338,15 +355,19 @@ def request_trainer_job(
         if _TRAINER_JOB_CONFIG_SUPPORTS_TRAINER_REPLICA_COUNT:
             extra_trainer_args["trainer_replica_count"] = infra.trainer_replica_count
 
-    if grad_accum != 1:
+    if grad_accum is not None and grad_accum != 1:
+        raise ValueError(
+            "grad_accum must be 1. Server-side gradient accumulation is deprecated "
+            "on the Tinker/RLOR path. Express gradient accumulation as client-side "
+            "control flow (multiple forward_backward calls per optim_step) and "
+            "pass grad_accumulation_normalization on the optim_step request."
+        )
+    if grad_accum == 1:
         logger.warning(
-            "grad_accum=%d is deprecated and ignored: the Tinker/RLOR engine "
-            "does not honor server-side gradient_accumulation_steps. Express "
-            "gradient accumulation as client-side control flow (multiple "
-            "forward_backward calls per optim_step) and pass "
-            "grad_accumulation_normalization on the optim_step request. "
-            "Sending gradientAccumulationSteps=1 to the backend.",
-            grad_accum,
+            "grad_accum=1 is deprecated and ignored. Express gradient accumulation "
+            "as client-side control flow (multiple forward_backward calls per "
+            "optim_step) and pass grad_accumulation_normalization on the optim_step "
+            "request."
         )
 
     if profile is not None:
@@ -355,7 +376,6 @@ def request_trainer_job(
             lora_rank=lora_rank,
             max_context_length=max_seq_len or profile.max_supported_context_length,
             learning_rate=learning_rate,
-            gradient_accumulation_steps=1,
             display_name=display_name,
             hot_load_deployment_id=hot_load_deployment_id,
             region=infra.region,
@@ -372,7 +392,6 @@ def request_trainer_job(
             lora_rank=lora_rank,
             max_context_length=max_seq_len,
             learning_rate=learning_rate,
-            gradient_accumulation_steps=1,
             node_count=infra.node_count,
             display_name=display_name,
             hot_load_deployment_id=hot_load_deployment_id,
@@ -503,7 +522,7 @@ def create_trainer_job(
     lora_rank: int = 0,
     max_seq_len: int | None = None,
     learning_rate: float = 1e-5,
-    grad_accum: int = 1,
+    grad_accum: int | None = None,
     display_name: str = "trainer",
     hot_load_deployment_id: str | None = None,
     extra_args: list[str] | None = None,
@@ -954,13 +973,10 @@ def _create_trainer_job_with_replica_count(
     if query_params:
         path = f"{path}?{urlencode(query_params)}"
 
-    # See request_trainer_job: never forward >1. The Tinker/RLOR engine ignores
-    # this field, and a backward-time /G divide would be the Unsloth-bug shape.
     training_config: dict[str, Any] = {
         "baseModel": config.base_model,
         "loraRank": config.lora_rank,
         "learningRate": config.learning_rate,
-        "gradientAccumulationSteps": 1,
     }
 
     payload: dict[str, Any] = {

--- a/training/utils/infra.py
+++ b/training/utils/infra.py
@@ -335,13 +335,30 @@ def request_trainer_job(
         if _TRAINER_JOB_CONFIG_SUPPORTS_TRAINER_REPLICA_COUNT:
             extra_trainer_args["trainer_replica_count"] = infra.trainer_replica_count
 
+    # `grad_accum` is deprecated as a server-side knob. The Tinker/RLOR path
+    # does not honor a backward-time /G divide — cross-microbatch normalization
+    # happens at optim_step via OptimStepRequest.grad_accumulation_normalization,
+    # and the caller expresses GA as control flow (N forward_backward calls
+    # per optim_step). Forwarding grad_accum>1 to the server would request the
+    # naive Unsloth-style bug (https://unsloth.ai/blog/gradient). Always send 1.
+    if grad_accum != 1:
+        logger.warning(
+            "grad_accum=%d is deprecated and ignored: the Tinker/RLOR engine "
+            "does not honor server-side gradient_accumulation_steps. Express "
+            "gradient accumulation as client-side control flow (multiple "
+            "forward_backward calls per optim_step) and pass "
+            "grad_accumulation_normalization on the optim_step request. "
+            "Sending gradientAccumulationSteps=1 to the backend.",
+            grad_accum,
+        )
+
     if profile is not None:
         config = TrainerJobConfig(
             base_model=base_model,
             lora_rank=lora_rank,
             max_context_length=max_seq_len or profile.max_supported_context_length,
             learning_rate=learning_rate,
-            gradient_accumulation_steps=grad_accum,
+            gradient_accumulation_steps=1,
             display_name=display_name,
             hot_load_deployment_id=hot_load_deployment_id,
             region=infra.region,
@@ -358,7 +375,7 @@ def request_trainer_job(
             lora_rank=lora_rank,
             max_context_length=max_seq_len,
             learning_rate=learning_rate,
-            gradient_accumulation_steps=grad_accum,
+            gradient_accumulation_steps=1,
             node_count=infra.node_count,
             display_name=display_name,
             hot_load_deployment_id=hot_load_deployment_id,
@@ -940,11 +957,13 @@ def _create_trainer_job_with_replica_count(
     if query_params:
         path = f"{path}?{urlencode(query_params)}"
 
+    # See request_trainer_job: never forward >1. The Tinker/RLOR engine ignores
+    # this field, and a backward-time /G divide would be the Unsloth-bug shape.
     training_config: dict[str, Any] = {
         "baseModel": config.base_model,
         "loraRank": config.lora_rank,
         "learningRate": config.learning_rate,
-        "gradientAccumulationSteps": config.gradient_accumulation_steps,
+        "gradientAccumulationSteps": 1,
     }
 
     payload: dict[str, Any] = {

--- a/training/utils/infra.py
+++ b/training/utils/infra.py
@@ -81,7 +81,7 @@ _TRAINER_JOB_CONFIG_SUPPORTS_TRAINER_REPLICA_COUNT = (
     "trainer_replica_count" in inspect.signature(TrainerJobConfig).parameters
 )
 
-def _validate_grad_accum_for_trainer_job(grad_accum: int | None) -> None:
+def validate_grad_accum_for_trainer_job(grad_accum: int | None) -> None:
     if grad_accum is not None and grad_accum != 1:
         raise ValueError(
             "grad_accum must be 1. Server-side gradient accumulation is deprecated "
@@ -355,20 +355,7 @@ def request_trainer_job(
         if _TRAINER_JOB_CONFIG_SUPPORTS_TRAINER_REPLICA_COUNT:
             extra_trainer_args["trainer_replica_count"] = infra.trainer_replica_count
 
-    if grad_accum is not None and grad_accum != 1:
-        raise ValueError(
-            "grad_accum must be 1. Server-side gradient accumulation is deprecated "
-            "on the Tinker/RLOR path. Express gradient accumulation as client-side "
-            "control flow (multiple forward_backward calls per optim_step) and "
-            "pass grad_accumulation_normalization on the optim_step request."
-        )
-    if grad_accum == 1:
-        logger.warning(
-            "grad_accum=1 is deprecated and ignored. Express gradient accumulation "
-            "as client-side control flow (multiple forward_backward calls per "
-            "optim_step) and pass grad_accumulation_normalization on the optim_step "
-            "request."
-        )
+    validate_grad_accum_for_trainer_job(grad_accum)
 
     if profile is not None:
         config = TrainerJobConfig(

--- a/training/utils/infra.py
+++ b/training/utils/infra.py
@@ -23,25 +23,27 @@ from __future__ import annotations
 import dataclasses
 import inspect
 import json
+import logging
 import os
 import time
-import logging
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from types import SimpleNamespace
 from typing import Any, Callable
 from urllib.parse import urlencode
 
-from fireworks.training.sdk.client import (
-    FiretitanServiceClient,
-    FiretitanTrainingClient,
-)
+import httpx
 from fireworks.training.sdk import (
     TrainerJobConfig,
     TrainerJobManager,
     TrainerServiceEndpoint,
     TrainingShapeProfile,
 )
+from fireworks.training.sdk.client import (
+    FiretitanServiceClient,
+    FiretitanTrainingClient,
+)
+
 try:
     from fireworks.training.sdk import CreatedTrainerJob
 except ImportError:
@@ -51,9 +53,10 @@ from fireworks.training.sdk.deployment import (
     DeploymentInfo,
     DeploymentManager,
 )
-from training.utils.config import InfraConfig, DeployConfig, WeightSyncScope
+
+from training.utils.client import DEFAULT_TIMEOUT_S, ReconnectableClient
+from training.utils.config import DeployConfig, InfraConfig, WeightSyncScope
 from training.utils.training_shapes import auto_select_training_shape
-from training.utils.client import ReconnectableClient, DEFAULT_TIMEOUT_S
 
 TrainerHandle = CreatedTrainerJob | TrainerServiceEndpoint
 """Return type of :func:`request_trainer_job`.
@@ -335,12 +338,6 @@ def request_trainer_job(
         if _TRAINER_JOB_CONFIG_SUPPORTS_TRAINER_REPLICA_COUNT:
             extra_trainer_args["trainer_replica_count"] = infra.trainer_replica_count
 
-    # `grad_accum` is deprecated as a server-side knob. The Tinker/RLOR path
-    # does not honor a backward-time /G divide — cross-microbatch normalization
-    # happens at optim_step via OptimStepRequest.grad_accumulation_normalization,
-    # and the caller expresses GA as control flow (N forward_backward calls
-    # per optim_step). Forwarding grad_accum>1 to the server would request the
-    # naive Unsloth-style bug (https://unsloth.ai/blog/gradient). Always send 1.
     if grad_accum != 1:
         logger.warning(
             "grad_accum=%d is deprecated and ignored: the Tinker/RLOR engine "
@@ -1461,8 +1458,8 @@ def _deployment_hot_load_trainer_job(
     """Best-effort read of a deployment's attached hot-load trainer job."""
     try:
         data = deploy_mgr._get_deployment(dep_id)  # SDK wrapper does not expose this field.
-    except Exception as e:
-        logger.warning("Could not read deployment %s hot-load trainer: %s", dep_id, e)
+    except httpx.HTTPError as exc:
+        logger.warning("Could not read deployment %s hot-load trainer: %s", dep_id, exc)
         return None
     if not data:
         return None

--- a/training/utils/infra.py
+++ b/training/utils/infra.py
@@ -1439,7 +1439,7 @@ def _deployment_hot_load_trainer_job(
     """Best-effort read of a deployment's attached hot-load trainer job."""
     try:
         data = deploy_mgr._get_deployment(dep_id)  # SDK wrapper does not expose this field.
-    except httpx.HTTPError as exc:
+    except Exception as exc:
         logger.warning("Could not read deployment %s hot-load trainer: %s", dep_id, exc)
         return None
     if not data:

--- a/training/utils/rl/metrics.py
+++ b/training/utils/rl/metrics.py
@@ -144,7 +144,7 @@ def compute_step_metrics(
     metrics = dict(timing_metrics)
 
     total_model_tokens = total_target_tokens(prompt_groups)
-    metrics["train/effective_grad_accum_steps"] = n_accum
+    metrics["train/effective_accumulation_steps"] = n_accum
     add_train_perf_metrics(metrics, total_model_tokens=total_model_tokens)
 
     if optim_result and hasattr(optim_result, "metrics") and optim_result.metrics:


### PR DESCRIPTION
## Summary

The Tinker/RLOR training path does not honor a server-side `gradient_accumulation_steps` knob. Each `forward_backward` call accumulates gradients on the server, and the correct way to do multi-microbatch accumulation is client-side control flow: call `forward_backward` N times, then call one `optim_step` with the appropriate `grad_accumulation_normalization`.

A backward-time `/G` divide on the server is the naive Unsloth-style bug (https://unsloth.ai/blog/gradient): with varying microbatch token counts, `sum_g(loss_sum_g / G)` is not the correct `sum_g(loss_sum_g) / total_step_tokens`.

## Changes

- Remove the deprecated trainer-job `grad_accum` surface from cookbook recipe configs, example CLIs, and trainer-job infra helpers.
- Stop forwarding `TrainerJobConfig.gradient_accumulation_steps` / REST `gradientAccumulationSteps` from cookbook.
- Keep the load-bearing `grad_accumulation_normalization` optimizer-step API unchanged.
- Update cookbook skill docs so agents know not to use the old trainer-job knob.
- Add a `CLAUDE.md` rule requiring protocol changes to update, add, or delete related skill docs.
- Bump the Training SDK dependency to the published `fireworks-ai[training]>=1.2.0a70,<2`.

## Defense in depth

This is one of three companion changes that close the bug at all three layers:

| layer | repo | PR |
|---|---|---|
| recipe / CLI surface | `fw-ai/cookbook` | this PR |
| SDK | `stainless-sdks/fireworks-ai-python` | https://github.com/stainless-sdks/fireworks-ai-python/pull/137 |
| training server | `fw-ai/fireworks` | internal |

The cookbook no longer exposes the stale knob. The SDK still handles compatibility for direct SDK users, and the server-side change remains the load-bearing protection for callers that bypass cookbook and SDK behavior.

## Test plan

- [x] `python -m py_compile ...` on touched Python files
- [x] `python -m ruff check --select I ...`
- [x] From `training/`: `python -m uv run --python 3.12 pytest tests/unit/test_shape_override_paths.py tests/unit/test_sft_loop.py tests/unit/test_text2sql_train_sft.py` (`41 passed`)
- [x] `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes and stops forwarding a trainer-job gradient accumulation setting, which changes the trainer job creation payload and could affect any callers relying on the old flag. Overall scope is contained to cookbook recipes/examples/tests and documentation, with no changes to the core `optim_step` normalization API.
> 
> **Overview**
> **Removes the cookbook’s trainer-job gradient accumulation knob.** All recipes/examples/tests drop `grad_accum` from configs/CLI flags and remove the associated deprecation warnings, reinforcing that accumulation is done by calling `forward_backward` multiple times before a single `optim_step`.
> 
> **Stops emitting server-side accumulation fields.** `training/utils/infra.py` no longer sets `TrainerJobConfig.gradient_accumulation_steps` or the REST `gradientAccumulationSteps` in the legacy payload, and unit tests now assert the field is unset.
> 
> **Documentation and dependency updates.** Skill docs add explicit guidance not to use the old server-side knob and `training/pyproject.toml` bumps `fireworks-ai[training]` to `>=1.2.0a70,<2`, plus a new `CLAUDE.md` rule requiring skill doc updates on protocol changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 527ee5b4e628109794cfb31fe406c98291be5774. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->