### PR TITLE
Add Agent Lightning protocol rollout example

### DIFF
--- a/training/examples/rl/README.md
+++ b/training/examples/rl/README.md
@@ -14,6 +14,9 @@ Two minimal rollouts for the async recipe (`training/recipes/async_rl_loop.py`):
 - `single_turn_token_in/` — pre-tokenized rows; one `/v1/completions` call per
   `rollout_fn` invocation (recipe invokes `rollout_fn` `completions_per_prompt`
   times per row).
+- `agent_lightning_protocol/` — protocol-level Agent Lightning alignment;
+  a triplet provider returns token/logprob/reward records and the cookbook
+  adapter converts them into `RolloutSample`.
 - `multi_turn_message_in/` — OpenAI-style messages; ports AReaL's
   `examples/multi_turn_math/` retry loop.
 

--- a/training/examples/rl/agent_lightning_protocol/__init__.py
+++ b/training/examples/rl/agent_lightning_protocol/__init__.py
@@ -1,0 +1,1 @@
+"""Agent Lightning protocol-level async RL example."""

--- a/training/examples/rl/agent_lightning_protocol/rollout.py
+++ b/training/examples/rl/agent_lightning_protocol/rollout.py
@@ -1,0 +1,231 @@
+"""Agent Lightning protocol-level rollout example.
+
+This example shows the intended integration boundary:
+
+    agent code / tracer -> triplets -> cookbook RolloutSample
+
+It does not import Agent Lightning or start its store/runners.  In a real
+integration, replace ``make_triplet_provider`` with a function that executes
+your Agent Lightning rollout and returns its trace triplets.  The triplets only
+need the protocol fields consumed by ``make_agent_lightning_rollout_fn``:
+
+* ``prompt.token_ids``
+* ``response.token_ids``
+* ``response.logprobs``
+* ``reward``
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+from collections.abc import Awaitable, Callable, Sequence
+from typing import TYPE_CHECKING, Any
+
+from training.examples.rl.vanilla_sampler import build_deployment_sampler
+from training.utils.rl.rollout import (
+    InferenceCall,
+    RolloutSample,
+    TrajectoryAssembler,
+    pack_payload_to_sample,
+)
+from training.utils.rl.rollout.service import Role
+
+if TYPE_CHECKING:
+    from training.recipes.async_rl_loop import RolloutFn, RolloutSetup
+
+logger = logging.getLogger(__name__)
+
+TripletProvider = Callable[[Any], Sequence[Any] | Awaitable[Sequence[Any]]]
+
+
+def make_rollout_fn(setup: "RolloutSetup") -> "RolloutFn":
+    return make_agent_lightning_rollout_fn(
+        make_triplet_provider(setup),
+        tokenizer_id=setup.tokenizer_id,
+    )
+
+
+def make_triplet_provider(setup: "RolloutSetup"):
+    """Return a provider shaped like an Agent Lightning trace adapter.
+
+    The implementation below is deliberately tiny: it samples once from the
+    cookbook deployment and wraps that call as one Agent-Lightning-like triplet.
+    If your agent already runs under Agent Lightning, keep the returned triplet
+    shape and swap this function's internals for your trace/span adapter.
+    """
+    sampler = build_deployment_sampler(setup)
+    sample_kwargs = dict(setup.sample_kwargs)
+
+    async def provider(sample_prompt: dict[str, Any]) -> list[dict[str, Any]]:
+        prompt_token_ids = list(sample_prompt.get("prompt_token_ids") or [])
+        if not prompt_token_ids:
+            return []
+
+        completions = await sampler.sample_with_prompt_tokens(
+            prompt_token_ids,
+            n=1,
+            **sample_kwargs,
+        )
+        if not completions:
+            return []
+
+        completion = completions[0]
+        prompt_len = int(completion.prompt_len)
+        full_tokens = list(completion.full_tokens)
+        output_tokens = full_tokens[prompt_len:]
+        output_logprobs = list(completion.inference_logprobs or [])
+
+        if getattr(completion, "logprobs_echoed", False) and len(output_logprobs) == len(full_tokens):
+            output_logprobs = output_logprobs[prompt_len:]
+        if not output_tokens or len(output_logprobs) != len(output_tokens):
+            return []
+
+        return [
+            {
+                "prompt": {"token_ids": prompt_token_ids},
+                "response": {
+                    "token_ids": output_tokens,
+                    "logprobs": output_logprobs,
+                    "finish_reason": getattr(completion, "finish_reason", "stop"),
+                },
+                # Real Agent Lightning integrations usually infer this from
+                # the final reward span.  This toy row carries it directly.
+                "reward": float(sample_prompt.get("reward", 0.0)),
+            }
+        ]
+
+    return provider
+
+
+def make_agent_lightning_rollout_fn(
+    triplet_provider: TripletProvider,
+    *,
+    tokenizer_id: str | None = None,
+    role_before: Role = "user",
+    swallow_exceptions: bool = True,
+):
+    """Build ``rollout_fn(row) -> RolloutSample | None`` from triplets.
+
+    This helper lives in the example on purpose: it demonstrates the protocol
+    shape without adding a supported cookbook API surface.
+    """
+
+    async def rollout_fn(row: Any) -> RolloutSample | None:
+        try:
+            triplets = await _maybe_await(triplet_provider(row))
+            return await agent_lightning_triplets_to_sample(
+                list(triplets),
+                tokenizer_id=tokenizer_id,
+                role_before=role_before,
+            )
+        except Exception:
+            if not swallow_exceptions:
+                raise
+            logger.exception("Agent Lightning protocol example failed; dropping sample")
+            return None
+
+    return rollout_fn
+
+
+async def agent_lightning_triplets_to_sample(
+    triplets: Sequence[Any],
+    *,
+    tokenizer_id: str | None = None,
+    total_reward: float | None = None,
+    role_before: Role = "user",
+) -> RolloutSample:
+    payload = agent_lightning_triplets_to_payload(
+        triplets,
+        tokenizer_id=tokenizer_id,
+        total_reward=total_reward,
+        role_before=role_before,
+    )
+    return await pack_payload_to_sample(payload, tokenizer_id=tokenizer_id)
+
+
+def agent_lightning_triplets_to_payload(
+    triplets: Sequence[Any],
+    *,
+    tokenizer_id: str | None = None,
+    total_reward: float | None = None,
+    role_before: Role = "user",
+):
+    if not triplets:
+        raise ValueError("Agent Lightning triplet list is empty")
+
+    assembler = TrajectoryAssembler(tokenizer_id=tokenizer_id)
+    inferred_reward: float | None = None
+
+    for triplet in triplets:
+        prompt = _mapping(_field(triplet, "prompt"), "triplet.prompt")
+        response = _mapping(_field(triplet, "response"), "triplet.response")
+        assembler.add_call(
+            InferenceCall(
+                input_tokens=_token_ids(prompt, "triplet.prompt"),
+                output_tokens=_token_ids(response, "triplet.response"),
+                output_logprobs=_response_logprobs(response),
+                finish_reason=str(_field(response, "finish_reason", default="stop") or "stop"),
+            ),
+            role_before=role_before,
+        )
+        reward = _field(triplet, "reward", default=None)
+        if reward is not None:
+            inferred_reward = float(reward)
+
+    return assembler.to_payload(
+        total_reward=float(total_reward) if total_reward is not None else inferred_reward,
+    )
+
+
+def _mapping(value: Any, name: str) -> Any:
+    if not isinstance(value, dict) and not hasattr(value, "__dict__"):
+        raise TypeError(f"{name} must be dict-like or object-like, got {type(value).__name__}")
+    return value
+
+
+def _field(value: Any, name: str, *, default: Any = ...):
+    if isinstance(value, dict):
+        if name in value:
+            return value[name]
+    elif hasattr(value, name):
+        return getattr(value, name)
+
+    if default is not ...:
+        return default
+    raise ValueError(f"missing required field {name!r} on {type(value).__name__}")
+
+
+def _token_ids(value: Any, name: str) -> list[int]:
+    token_ids = _field(value, "token_ids", default=None)
+    if token_ids is None:
+        token_ids = _field(value, "tokens", default=None)
+    if not token_ids:
+        raise ValueError(f"{name} is missing non-empty token_ids")
+    return [int(t) for t in token_ids]
+
+
+def _response_logprobs(response: Any) -> list[float]:
+    raw = _field(response, "logprobs", default=None)
+    if raw is None:
+        raw = _field(response, "token_logprobs", default=None)
+    if raw is None:
+        raise ValueError("triplet.response is missing logprobs")
+
+    if isinstance(raw, dict):
+        raw = raw.get("token_logprobs") or raw.get("content") or raw.get("logprobs")
+
+    values = []
+    for item in raw or []:
+        if isinstance(item, dict):
+            item = item.get("logprob")
+        elif hasattr(item, "logprob"):
+            item = item.logprob
+        values.append(float(item) if item is not None else 0.0)
+    return values
+
+
+async def _maybe_await(value: Any) -> Any:
+    if inspect.isawaitable(value):
+        return await value
+    return value

--- a/training/examples/rl/agent_lightning_protocol/train.py
+++ b/training/examples/rl/agent_lightning_protocol/train.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+"""Minimal async RL wiring for the Agent Lightning protocol adapter.
+
+Rows are pre-tokenized here to keep the example focused on the integration
+boundary.  The rollout provider wraps one sampled completion as an
+Agent-Lightning-like triplet, then ``make_agent_lightning_rollout_fn`` converts
+that triplet into the cookbook's token-native ``RolloutSample``.
+"""
+
+from __future__ import annotations
+
+from training.examples.rl.agent_lightning_protocol.rollout import make_rollout_fn
+from training.recipes.async_rl_loop import Config, main
+from training.utils import DeployConfig
+
+
+if __name__ == "__main__":
+    cfg = Config(
+        log_path="/tmp/rl-agent-lightning-protocol",
+        base_model="accounts/fireworks/models/example",
+        prompt_groups_per_step=1,
+        completions_per_prompt=2,
+        deployment=DeployConfig(tokenizer_model="example-tokenizer"),
+    )
+    rows = [
+        {"id": "agl-protocol-1", "prompt_token_ids": [1, 2, 3], "reward": 1.0},
+    ]
+    main(cfg, rollout_fn_factory=make_rollout_fn, rows=rows)

--- a/training/tests/unit/test_agent_lightning_rollout_adapter.py
+++ b/training/tests/unit/test_agent_lightning_rollout_adapter.py
@@ -1,0 +1,155 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+import training.examples.rl.agent_lightning_protocol.rollout as agl_example_rollout
+from training.utils.rl.rollout import (
+    PrefixMismatch,
+)
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_agent_lightning_triplets_pack_multi_turn_dicts():
+    triplets = [
+        {
+            "prompt": {"token_ids": [10, 11]},
+            "response": {
+                "token_ids": [20],
+                "logprobs": [{"logprob": -0.2}],
+                "finish_reason": "stop",
+            },
+            "reward": None,
+        },
+        {
+            "prompt": {"token_ids": [10, 11, 20, 30]},
+            "response": {
+                "token_ids": [40, 41],
+                "logprobs": [{"logprob": -0.4}, {"logprob": -0.5}],
+                "finish_reason": "length",
+            },
+            "reward": 1.0,
+        },
+    ]
+
+    sample = _run(agl_example_rollout.agent_lightning_triplets_to_sample(
+        triplets,
+        tokenizer_id="tok",
+    ))
+
+    assert sample.tokens == [10, 11, 20, 30, 40, 41]
+    assert sample.logprobs == [0.0, 0.0, -0.2, 0.0, -0.4, -0.5]
+    assert sample.loss_mask == [0, 0, 1, 0, 1, 1]
+    assert sample.reward == 1.0
+    assert sample.finish_reason == "length"
+
+
+def test_agent_lightning_triplets_accept_objects_and_total_reward_override():
+    triplet = SimpleNamespace(
+        prompt=SimpleNamespace(token_ids=[1, 2]),
+        response=SimpleNamespace(
+            token_ids=[3],
+            logprobs=[SimpleNamespace(logprob=-0.3)],
+            finish_reason="stop",
+        ),
+        reward=0.0,
+    )
+
+    sample = _run(agl_example_rollout.agent_lightning_triplets_to_sample(
+        [triplet],
+        total_reward=0.75,
+    ))
+
+    assert sample.tokens == [1, 2, 3]
+    assert sample.logprobs == [0.0, 0.0, -0.3]
+    assert sample.loss_mask == [0, 0, 1]
+    assert sample.reward == 0.75
+
+
+def test_agent_lightning_payload_uses_trajectory_assembler_prefix_guard():
+    triplets = [
+        {
+            "prompt": {"token_ids": [1, 2]},
+            "response": {"token_ids": [3], "logprobs": [-0.3]},
+            "reward": None,
+        },
+        {
+            "prompt": {"token_ids": [1, 99, 3, 4]},
+            "response": {"token_ids": [5], "logprobs": [-0.5]},
+            "reward": 1.0,
+        },
+    ]
+
+    with pytest.raises(PrefixMismatch):
+        agl_example_rollout.agent_lightning_triplets_to_payload(triplets)
+
+
+def test_make_agent_lightning_rollout_fn_drops_bad_sample_by_default():
+    async def provider(_row):
+        return [
+            {
+                "prompt": {"token_ids": [1, 2]},
+                "response": {"token_ids": [3]},
+                "reward": 1.0,
+            }
+        ]
+
+    rollout_fn = agl_example_rollout.make_agent_lightning_rollout_fn(provider)
+
+    assert _run(rollout_fn({"id": "row"})) is None
+
+
+def test_make_agent_lightning_rollout_fn_can_raise_for_debugging():
+    def provider(_row):
+        return [
+            {
+                "prompt": {"token_ids": [1, 2]},
+                "response": {"token_ids": [3]},
+                "reward": 1.0,
+            }
+        ]
+
+    rollout_fn = agl_example_rollout.make_agent_lightning_rollout_fn(
+        provider,
+        swallow_exceptions=False,
+    )
+
+    with pytest.raises(ValueError, match="logprobs"):
+        _run(rollout_fn({"id": "row"}))
+
+
+def test_agent_lightning_protocol_example_rollout(monkeypatch):
+    class FakeSampler:
+        async def sample_with_prompt_tokens(self, prompt_token_ids, *, n, **_kwargs):
+            assert prompt_token_ids == [10, 11]
+            assert n == 1
+            return [
+                SimpleNamespace(
+                    prompt_len=2,
+                    full_tokens=[10, 11, 12, 13],
+                    inference_logprobs=[-0.12, -0.13],
+                    logprobs_echoed=False,
+                    finish_reason="stop",
+                )
+            ]
+
+    monkeypatch.setattr(
+        agl_example_rollout,
+        "build_deployment_sampler",
+        lambda _setup: FakeSampler(),
+    )
+    setup = SimpleNamespace(
+        sample_kwargs={"temperature": 0.7},
+        tokenizer_id="tok",
+    )
+
+    rollout_fn = agl_example_rollout.make_rollout_fn(setup)
+    sample = _run(rollout_fn({"prompt_token_ids": [10, 11], "reward": 0.5}))
+
+    assert sample.tokens == [10, 11, 12, 13]
+    assert sample.logprobs == [0.0, 0.0, -0.12, -0.13]
+    assert sample.loss_mask == [0, 0, 1, 1]
+    assert sample.reward == 0.5


### PR DESCRIPTION
## Summary
- Add an example-only Agent Lightning protocol rollout showing triplet-to-RolloutSample conversion without importing Agent Lightning backend/store/runner components
- Wire a minimal train.py through recipes.async_rl_loop
- Add unit coverage for triplet packing, prefix mismatch guarding, error handling, and the example rollout factory

## Sensitive data review
- Reviewed changed files for credentials, private keys, local paths, and common token prefixes
- Only placeholder model/tokenizer names and toy token IDs/rewards are present

## Tests
```bash
uv run --directory training --extra dev python -m pytest   tests/unit/test_agent_lightning_rollout_adapter.py   tests/unit/test_eval_protocol_rollout_adapter.py   tests/unit/test_rollout_assembler.py   tests/unit/test_rollout_types.py -q
```

Result: 40 passed, 1 warning.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new example + unit tests without changing core training/recipe logic; risk is limited to potential confusion if users copy the example’s triplet/logprob handling incorrectly.
> 
> **Overview**
> Adds a new `agent_lightning_protocol` async-RL example that demonstrates converting Agent Lightning-style *triplets* (prompt/response token IDs, logprobs, reward) into the cookbook’s token-native `RolloutSample` via `TrajectoryAssembler` and `pack_payload_to_sample`, including optional async providers and a safe “drop bad samples” mode.
> 
> Includes a minimal `train.py` wiring for `recipes.async_rl_loop.main`, updates the async RL examples README to list the new example, and adds unit tests covering multi-turn packing, object/dict triplet shapes, prefix-mismatch guarding, and exception behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c2e79c4d9d917a6429284ef98173397c9e2e913. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->