### PR TITLE
fix(sft): forward top-level dataset tools to renderer

### DIFF
--- a/training/recipes/sft_loop.py
+++ b/training/recipes/sft_loop.py
@@ -103,10 +103,12 @@ def _render_one_worker(row: dict) -> tinker.Datum | list[tinker.Datum] | None:
     messages = row.get("messages", [])
     if not messages:
         return None
+    tools = row.get("tools")
     rendered_examples = render_messages_to_datums(
         messages,
         renderer=_worker_state["renderer"],
         train_on_what=_worker_state["train_on_what"],
+        tools=tools,
     )
     if not isinstance(rendered_examples, list):
         rendered_examples = [rendered_examples]

--- a/training/utils/supervised.py
+++ b/training/utils/supervised.py
@@ -839,9 +839,47 @@ def render_messages_to_datums(
     train_on_what: str | TrainOnWhat = TrainOnWhat.ALL_ASSISTANT_MESSAGES,
     max_seq_len: int | None = None,
     include_loss_mask: bool = False,
+    tools: Sequence[Mapping[str, Any]] | None = None,
 ) -> list[RenderedSupervisedDatum]:
-    """Render a chat row, splitting multi-target rows when required."""
-    normalized_messages = normalize_messages(messages)
+    """Render a chat row, splitting multi-target rows when required.
+
+    When ``tools`` is provided (top-level OpenAI function-calling array
+    with ``{"type": "function", "function": {...}}`` items) and the
+    renderer exposes ``create_conversation_prefix_with_tools``, the tool
+    definitions are encoded as a ``tool_declare``-role message and
+    prepended to the conversation. An existing leading system message's
+    content is preserved as the system prompt passed to the renderer.
+    Renderers without tool support silently drop the field.
+    """
+    normalized_messages = list(normalize_messages(messages))
+
+    if tools:
+        prefix_builder = getattr(renderer, "create_conversation_prefix_with_tools", None)
+        if prefix_builder is not None:
+            tool_specs = [
+                t["function"]
+                for t in tools
+                if isinstance(t, Mapping) and isinstance(t.get("function"), Mapping)
+            ]
+            if tool_specs:
+                system_prompt = ""
+                if normalized_messages and normalized_messages[0].get("role") == "system":
+                    sys_content = normalized_messages.pop(0).get("content")
+                    if isinstance(sys_content, str):
+                        system_prompt = sys_content
+                    elif isinstance(sys_content, list):
+                        system_prompt = "\n".join(
+                            part.get("text", "")
+                            for part in sys_content
+                            if isinstance(part, Mapping) and part.get("type") == "text"
+                        )
+                prefix = prefix_builder(tool_specs, system_prompt=system_prompt)
+                prefix_messages = list(prefix)
+                if any("trainable" in m for m in normalized_messages):
+                    for prefix_msg in prefix_messages:
+                        prefix_msg.setdefault("trainable", False)
+                normalized_messages = prefix_messages + normalized_messages
+
     effective_train_on_what = parse_train_on_what(train_on_what)
     if any("trainable" in m for m in normalized_messages):
         effective_train_on_what = TrainOnWhat.CUSTOMIZED


### PR DESCRIPTION
## Summary

Tool-calling SFT datasets in OpenAI Chat Completions format place function
definitions in a top-level `tools` array alongside `messages`:

```json
{
  "tools": [{"type": "function", "function": {...}}, ...],
  "messages": [...]
}
```

Today the SFT loop drops `row["tools"]` entirely — only `row["messages"]` is
passed to the renderer. For renderers that natively understand tool
declarations (Kimi K2.5/K2.6's `create_conversation_prefix_with_tools`),
this means the model trains without ever seeing what tools are available,
even though the conversation contains `tool_calls` and `role="tool"` turns.

## Fix

`_render_one_worker` now forwards `row.get("tools")` through to
`render_messages_to_datums`. The helper, when given a non-empty tools
array AND a renderer that exposes `create_conversation_prefix_with_tools`,
encodes the tools as a `tool_declare`-role message (the format the
renderer's chat template expects) and prepends it. If the original
conversation has a leading system message, its content is preserved as
the renderer's `system_prompt` so we don't drop it. Renderers without
tool support silently ignore the field — no regression.

## Validation

Rendered 5 real tool-calling rows (21 tools each) against `KimiK25Renderer`:

| Row | msgs | tools | baseline tok | with_tools tok | delta |
|-----|-----:|------:|-------------:|---------------:|------:|
| 0   | 7    | 21    | 30,824       | 39,221         | +8,397 |
| 1   | 7    | 21    | 29,575       | 37,972         | +8,397 |
| 2   | 19   | 21    | 141,179      | 199,958        | +58,779 |
| 3   | 23   | 21    | 180,690      | 247,866        | +67,176 |
| 4   | 8    | 7     | 38,672       | 42,276         | +3,604 |

(Multi-turn rows split into multiple supervised examples — each split
gets the tools prefix, hence the larger deltas on rows 2 and 3.)

## Surface

Backward-compatible: `tools` is an optional kwarg with default `None`.
Existing callers (non-tool datasets, renderers without
`create_conversation_prefix_with_tools`) see no behavior change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes supervised data rendering by injecting a tool-declaration prefix and handling leading system messages, which can alter tokenization/sequence length and example splitting for tool-calling datasets.
> 
> **Overview**
> Tool-calling SFT datasets now propagate the top-level `tools` array through the SFT rendering path, instead of being silently dropped.
> 
> `render_messages_to_datums` accepts an optional `tools` argument and, when the renderer supports `create_conversation_prefix_with_tools`, prepends a rendered tool-declaration prefix (preserving any leading system prompt and marking prefix messages non-trainable when per-message training flags are in use). Renderers without tool support ignore `tools`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70c2bafee942f5a92c5cbc25681435d47b2d94f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->