### PR TITLE
perf(sft): drop multi-turn renderer splits that have zero training weight

### DIFF
--- a/training/recipes/sft_loop.py
+++ b/training/recipes/sft_loop.py
@@ -114,7 +114,7 @@ def _render_one_worker(row: dict) -> tinker.Datum | list[tinker.Datum] | None:
         rendered.datum
         for rendered in rendered_examples
         if 2 <= len(rendered.token_ids) <= _worker_state["max_seq_len"]
-        and any(w != 0 for w in rendered.token_weights)
+        and any(w > 0 for w in rendered.token_weights)
     ]
     if not datums:
         return None

--- a/training/recipes/sft_loop.py
+++ b/training/recipes/sft_loop.py
@@ -114,6 +114,7 @@ def _render_one_worker(row: dict) -> tinker.Datum | list[tinker.Datum] | None:
         rendered.datum
         for rendered in rendered_examples
         if 2 <= len(rendered.token_ids) <= _worker_state["max_seq_len"]
+        and any(w != 0 for w in rendered.token_weights)
     ]
     if not datums:
         return None

--- a/training/tests/unit/test_sft_loop.py
+++ b/training/tests/unit/test_sft_loop.py
@@ -200,7 +200,7 @@ def test_main_raises_when_all_examples_are_filtered(tmp_path, monkeypatch):
     monkeypatch.setattr(
         module,
         "render_messages_to_datums",
-        lambda *args, **kwargs: SimpleNamespace(token_ids=[1], datum={"id": "too-short"}),
+        lambda *args, **kwargs: SimpleNamespace(token_ids=[1], token_weights=[1.0], datum={"id": "too-short"}),
     )
     monkeypatch.setattr(module, "ReconnectableClient", FakeClient)
 
@@ -289,6 +289,7 @@ def test_main_reduces_batch_size_when_examples_fewer_than_batch_size(tmp_path, m
         "render_messages_to_datums",
         lambda *args, **kwargs: SimpleNamespace(
             token_ids=[1, 2, 3],
+            token_weights=[1.0, 1.0, 1.0],
             datum=SimpleNamespace(
                 model_input=SimpleNamespace(chunks=[SimpleNamespace(tokens=[1, 2, 3])]),
                 loss_fn_inputs={
@@ -391,6 +392,7 @@ def test_main_infers_documented_training_shape_for_supported_model(tmp_path, mon
         "render_messages_to_datums",
         lambda *args, **kwargs: SimpleNamespace(
             token_ids=[1, 2, 3],
+            token_weights=[1.0, 1.0, 1.0],
             datum=SimpleNamespace(
                 model_input=SimpleNamespace(
                     chunks=[SimpleNamespace(tokens=[1, 2, 3])],
@@ -620,7 +622,7 @@ def test_each_batch_triggers_its_own_optim_step(tmp_path, monkeypatch):
             },
             _test_id=content,
         )
-        return SimpleNamespace(token_ids=[1, 2, 3], datum=datum)
+        return SimpleNamespace(token_ids=[1, 2, 3], token_weights=[1.0, 1.0, 1.0], datum=datum)
 
     monkeypatch.setattr(module, "render_messages_to_datums", _fake_render)
 
@@ -720,6 +722,7 @@ def test_main_resume_preserves_epoch_zero_batch_order(tmp_path, monkeypatch):
         "render_messages_to_datums",
         lambda messages, **kwargs: SimpleNamespace(
             token_ids=[1, 2],
+            token_weights=[1.0, 1.0],
             datum=SimpleNamespace(
                 model_input=SimpleNamespace(chunks=[SimpleNamespace(tokens=[1, 2])]),
                 loss_fn_inputs={
@@ -1074,7 +1077,7 @@ def test_eval_auto_carveout_splits_data_and_runs_eval(tmp_path, monkeypatch):
             },
             _test_id=f"example-{row_idx}",
         )
-        return SimpleNamespace(token_ids=[1, 2, 3], datum=datum)
+        return SimpleNamespace(token_ids=[1, 2, 3], token_weights=[1.0, 1.0, 1.0], datum=datum)
 
     monkeypatch.setattr(module, "render_messages_to_datums", _fake_render)
 
@@ -1207,7 +1210,7 @@ def test_eval_auto_carveout_eval_set_is_stable_across_epochs(tmp_path, monkeypat
             },
             _test_id=f"example-{row_idx}",
         )
-        return SimpleNamespace(token_ids=[1, 2, 3], datum=datum)
+        return SimpleNamespace(token_ids=[1, 2, 3], token_weights=[1.0, 1.0, 1.0], datum=datum)
 
     monkeypatch.setattr(module, "render_messages_to_datums", _fake_render)
 


### PR DESCRIPTION
## Summary

`_render_one_worker` already filters rendered datums by token length
(`2 <= len <= max_seq_len`). It does **not** filter out datums whose
`token_weights` are all zero. On datasets with per-message weights
(SFT teacher-force, mixed-supervision conversations, RLOR-style teacher
mimicking), the multi-turn renderer split emits examples whose target
assistant turn has `weight=0` — those examples are pure context for
the prefix and produce zero gradient, but still cost a full forward
pass.

## Measured impact

On one such dataset (Kimi K2.5/K2.6 chat-with-tools, mixed weights):

| Stat | Value |
|---|---|
| Assistant turns with `weight=0` | **73.5 %** |
| Rows with >1 user turn (renderer splits) | 66.1 % |
| Renderer-emitted splits that target a `weight=0` assistant | **88.1 %** |
| Per-step tokens shipped to the trainer that produced zero loss | **~73 %** |

## Fix

A single condition added to the existing datum filter:

```python
datums = [
    rendered.datum
    for rendered in rendered_examples
    if 2 <= len(rendered.token_ids) <= _worker_state["max_seq_len"]
    and any(w != 0 for w in rendered.token_weights)   # NEW
]
```

If a rendered example has zero training weight across all positions,
drop it before the trainer ever sees it.

## Notes

- Same code path is dispatched by managed SFT V2
  (`training_orchestrator._run_sft` → `training.recipes.sft_loop.main`),
  so the perf win flows through to every customer SFT job automatically.
- A more thorough fix would prune zero-loss user-turn boundaries inside
  `tinker_cookbook`'s `build_supervised_examples` so they're never
  rendered in the first place (saves CPU on the dataloader side too).
  This cookbook-side filter is the smallest diff that captures the
  GPU-side win.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes SFT dataset filtering to skip examples with zero training weight, which can alter effective training data/step counts on weighted datasets if weights are mis-specified or all-zero.
> 
> **Overview**
> **SFT rendering now drops zero-loss examples.** `_render_one_worker` filters out renderer-emitted datums whose `token_weights` are entirely non-positive, in addition to the existing sequence-length bounds, to avoid wasting forward passes on examples that contribute no gradient.
> 
> Unit tests update their `render_messages_to_datums` stubs to include `token_weights` so the new filter path is exercised and existing training-loop behaviors remain covered.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7029864e2b67f20e26957c091fe760eebbcb8ae9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->