### PR TITLE
fix(dpo): wire periodic dcp checkpoint interval

### DIFF
--- a/training/examples/dpo/train_dpo.py
+++ b/training/examples/dpo/train_dpo.py
@@ -16,7 +16,7 @@ from dotenv import load_dotenv
 from fireworks.training.sdk import TrainerJobManager
 
 import training.recipes.dpo_loop as dpo_loop
-from training.utils import InfraConfig, WandBConfig, WeightSyncConfig
+from training.utils import InfraConfig, WandBConfig
 
 logging.basicConfig(
     level=logging.INFO,
@@ -64,7 +64,12 @@ def parse_args():
     parser.add_argument("--beta", type=float, default=0.1)
     parser.add_argument("--ref-cache-concurrency", type=int, default=8)
     parser.add_argument("--ref-cache-batch-size", type=int, default=512)
-    parser.add_argument("--weight-sync-interval", type=int, default=0)
+    parser.add_argument(
+        "--weight-sync-interval",
+        type=int,
+        default=0,
+        help="Deprecated and ignored by DPO; kept for CLI compatibility.",
+    )
     parser.add_argument("--dcp-save-interval", type=int, default=0)
 
     # Infrastructure
@@ -122,6 +127,7 @@ def main():
         init_from_checkpoint=args.init_from_checkpoint,
         ref_cache_concurrency=args.ref_cache_concurrency,
         ref_cache_batch_size=args.ref_cache_batch_size,
+        dcp_save_interval=args.dcp_save_interval,
         infra=InfraConfig(
             training_shape_id=args.training_shape_id or None,
             ref_training_shape_id=args.ref_training_shape_id or None,
@@ -129,10 +135,6 @@ def main():
             region=args.region,
             custom_image_tag=args.custom_image_tag or None,
             purpose=args.purpose or None,
-        ),
-        weight_sync=WeightSyncConfig(
-            weight_sync_interval=args.weight_sync_interval,
-            dcp_save_interval=args.dcp_save_interval,
         ),
         wandb=WandBConfig(
             project=args.wandb_project,

--- a/training/tests/e2e/test_dpo_resume_e2e.py
+++ b/training/tests/e2e/test_dpo_resume_e2e.py
@@ -16,7 +16,7 @@ import tempfile
 
 import pytest
 
-from training.utils import InfraConfig, DeployConfig, WeightSyncConfig
+from training.utils import InfraConfig, DeployConfig
 from training.recipes.dpo_loop import Config, main
 
 logger = logging.getLogger(__name__)
@@ -52,6 +52,7 @@ class TestDPOResumeE2E:
         sdk_managers,
         e2e_region,
         e2e_model,
+        e2e_tokenizer_model,
         e2e_training_accelerator,
         custom_image_tag,
     ):
@@ -78,13 +79,14 @@ class TestDPOResumeE2E:
                 log_path=log_dir,
                 base_model=e2e_model,
                 dataset=dataset_path,
+                tokenizer_model=e2e_tokenizer_model,
                 beta=0.1,
                 learning_rate=1e-5,
                 epochs=1,
                 max_pairs=8,
+                dcp_save_interval=2,
                 infra=shared_infra,
                 deployment=DeployConfig(),
-                weight_sync=WeightSyncConfig(weight_sync_interval=0, dcp_save_interval=2),
             )
 
             phase1_metrics = main(phase1_config, rlor_mgr=rlor_mgr, deploy_mgr=deploy_mgr)
@@ -105,13 +107,13 @@ class TestDPOResumeE2E:
                 log_path=log_dir,
                 base_model=e2e_model,
                 dataset=dataset_path,
+                tokenizer_model=e2e_tokenizer_model,
                 beta=0.1,
                 learning_rate=1e-5,
                 epochs=1,
                 max_pairs=8,
                 infra=shared_infra,
                 deployment=DeployConfig(),
-                weight_sync=WeightSyncConfig(weight_sync_interval=0),
                 init_from_checkpoint=f"{phase1_job_id}:{dcp_name}",
             )
 

--- a/training/tests/smoke_test/test_dpo_smoke.py
+++ b/training/tests/smoke_test/test_dpo_smoke.py
@@ -38,7 +38,7 @@ def test_dpo_smoke(
     smoke_dpo_infra,
 ):
     from training.recipes.dpo_loop import Config, main
-    from training.utils import DeployConfig, WeightSyncConfig, WandBConfig
+    from training.utils import DeployConfig, WandBConfig
 
     rlor_mgr, deploy_mgr = smoke_sdk_managers
 
@@ -57,9 +57,9 @@ def test_dpo_smoke(
             epochs=1,
             batch_size=1,
             max_pairs=4,
+            dcp_save_interval=0,
             infra=smoke_dpo_infra,
             deployment=DeployConfig(),
-            weight_sync=WeightSyncConfig(weight_sync_interval=0, dcp_save_interval=0),
             wandb=WandBConfig(),
         )
 

--- a/training/tests/unit/test_dpo_loop.py
+++ b/training/tests/unit/test_dpo_loop.py
@@ -382,6 +382,7 @@ class TestTrainLoop:
                 adam_params={"lr": 1e-4},
                 cfg=cfg,
                 step_offset=0,
+                cursor=_new_cursor(max_rows=4),
                 ckpt=ckpt,
             )
         )

--- a/training/tests/unit/test_dpo_loop.py
+++ b/training/tests/unit/test_dpo_loop.py
@@ -356,6 +356,42 @@ class TestTrainLoop:
             for pair in batch:
                 assert "ref_chosen" in pair and "ref_rejected" in pair
 
+    def test_periodic_dcp_checkpoint_uses_top_level_interval(self, tmp_path, monkeypatch):
+        """DPO saves resumable checkpoints from Config.dcp_save_interval."""
+        events: dict = {}
+        _stub_train_step_deps(monkeypatch, events)
+
+        class FakeCheckpoints:
+            def __init__(self):
+                self.saves = []
+
+            def save(self, name, **kwargs):
+                self.saves.append((name, kwargs))
+
+        ds = _make_pair_dataset(tmp_path, n=4)
+        cfg = module.Config(
+            log_path=str(tmp_path), beta=0.2, epochs=1, batch_size=2,
+            dcp_save_interval=1, render_workers=0,
+        )
+        ckpt = FakeCheckpoints()
+
+        step = asyncio.run(
+            module._train_loop(
+                ds, None,
+                _FakeReference(), _FakePolicy(),
+                adam_params={"lr": 1e-4},
+                cfg=cfg,
+                step_offset=0,
+                ckpt=ckpt,
+            )
+        )
+
+        assert step == 2
+        assert ckpt.saves == [
+            ("step-1", {"resumable": True, "promotable": False, "data_consumed": 2}),
+            ("step-2", {"resumable": True, "promotable": False, "data_consumed": 4}),
+        ]
+
     def test_multi_epoch_uses_ref_cache_log(self, tmp_path, monkeypatch):
         events: dict = {}
         _stub_train_step_deps(monkeypatch, events)


### PR DESCRIPTION
## Summary
- Route DPO `--dcp-save-interval` into the top-level `Config.dcp_save_interval` field that the recipe actually reads.
- Update DPO resume/smoke tests and add a unit regression that periodic DCP saves call `ckpt.save()`.
- Keep the old `--weight-sync-interval` DPO flag as deprecated/ignored for CLI compatibility.

## Code Overview
```mermaid
flowchart LR
    CLI[train_dpo.py args] --> CFG[DPO Config]
    CFG --> LOOP[dpo_loop._train_loop]
    LOOP -->|every dcp_save_interval steps| CKPT[TrainingCheckpoints.save resumable]
    CKPT --> RESUME[DCP resume checkpoint]
```

## Test Plan
- `PYTHONPATH="train-firetitan-py/cookbook:train-firetitan-py:${PYTHONPATH:-}" python -m pytest "train-firetitan-py/cookbook/training/tests/unit/test_dpo_loop.py" "train-firetitan-py/firetitan/train/managed/tests/test_training_orchestrator.py" -q` passed before rebasing cookbook to latest `origin/main`.
- After rebase, local `python -m pytest training/tests/unit/test_dpo_loop.py -q` fails during collection because the local installed `tinker_cookbook.renderers.base` lacks upstream's new `ParseTermination` dependency; no test assertion ran.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: mainly wires an existing DPO checkpoint interval flag into the config used by the training loop and updates tests; behavior change is limited to enabling periodic DCP saves when the interval is set.
> 
> **Overview**
> Fixes DPO periodic checkpointing by passing `--dcp-save-interval` from `train_dpo.py` into the top-level `Config.dcp_save_interval` that `dpo_loop` actually uses for `ckpt.save()` cadence.
> 
> Removes DPO’s `WeightSyncConfig` plumbing (while keeping `--weight-sync-interval` as a deprecated/ignored CLI flag for compatibility) and updates smoke/E2E resume tests plus adds a unit regression test asserting periodic resumable DCP checkpoints are saved at the configured interval.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8b8f35a985d105d69e31ce0ee3247da5d15e1bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->