### PR TITLE
fix(rl): align managed RFT rollout requests

### DIFF
--- a/training/recipes/async_rl_loop.py
+++ b/training/recipes/async_rl_loop.py
@@ -188,6 +188,13 @@ class RolloutSetup:
     extras: dict[str, Any] = field(default_factory=dict)
 
 
+def _rollout_inference_base_url(inference_url: str) -> str:
+    base = inference_url.rstrip("/")
+    if base.endswith("/inference") or ".direct.fireworks.ai" in base:
+        return base
+    return f"{base}/inference"
+
+
 RolloutFn = Callable[[dict], Awaitable[RolloutSample | None]]
 RolloutFnFactory = Callable[[RolloutSetup], RolloutFn]
 
@@ -521,7 +528,7 @@ def main(
             tokenizer=tokenizer,
             tokenizer_id=cfg.deployment.tokenizer_model,
             sample_kwargs=sample_kwargs,
-            inference_base_url=deploy_mgr.inference_url,
+            inference_base_url=_rollout_inference_base_url(deploy_mgr.inference_url),
             api_key=api_key,
             model=inference_model,
             completions_per_prompt=cfg.completions_per_prompt,

--- a/training/recipes/async_rl_loop.py
+++ b/training/recipes/async_rl_loop.py
@@ -188,13 +188,6 @@ class RolloutSetup:
     extras: dict[str, Any] = field(default_factory=dict)
 
 
-def _rollout_inference_base_url(inference_url: str) -> str:
-    base = inference_url.rstrip("/")
-    if base.endswith("/inference") or ".direct.fireworks.ai" in base:
-        return base
-    return f"{base}/inference"
-
-
 RolloutFn = Callable[[dict], Awaitable[RolloutSample | None]]
 RolloutFnFactory = Callable[[RolloutSetup], RolloutFn]
 
@@ -528,7 +521,7 @@ def main(
             tokenizer=tokenizer,
             tokenizer_id=cfg.deployment.tokenizer_model,
             sample_kwargs=sample_kwargs,
-            inference_base_url=_rollout_inference_base_url(deploy_mgr.inference_url),
+            inference_base_url=deploy_mgr.inference_url,
             api_key=api_key,
             model=inference_model,
             completions_per_prompt=cfg.completions_per_prompt,

--- a/training/tests/unit/test_async_rl_loop_runner.py
+++ b/training/tests/unit/test_async_rl_loop_runner.py
@@ -433,6 +433,7 @@ class TestAsyncRunArtifactWrites:
         dropped).
         """
         events: list[str] = []
+        rollout_setup_urls: list[str] = []
 
         def fake_setup_infra(**_kwargs):
             events.append("setup_infra_done")
@@ -455,7 +456,9 @@ class TestAsyncRunArtifactWrites:
 
         async_rl_loop.main(
             _async_config(tmp_path),
-            rollout_fn_factory=lambda _setup: lambda _row: None,
+            rollout_fn_factory=lambda setup: (
+                rollout_setup_urls.append(setup.inference_base_url) or (lambda _row: None)
+            ),
             rows=[{"id": "row-1"}],
         )
 
@@ -464,6 +467,7 @@ class TestAsyncRunArtifactWrites:
         assert status["message"] == "done"
         assert status["details"][0]["percent"] == 100
         assert "training_started" in events
+        assert rollout_setup_urls == ["https://inference.unit.test/inference"]
 
     def test_failed_status_written_when_async_loop_raises(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path

--- a/training/tests/unit/test_async_rl_loop_runner.py
+++ b/training/tests/unit/test_async_rl_loop_runner.py
@@ -467,7 +467,7 @@ class TestAsyncRunArtifactWrites:
         assert status["message"] == "done"
         assert status["details"][0]["percent"] == 100
         assert "training_started" in events
-        assert rollout_setup_urls == ["https://inference.unit.test/inference"]
+        assert rollout_setup_urls == ["https://inference.unit.test"]
 
     def test_failed_status_written_when_async_loop_raises(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path

--- a/training/tests/unit/test_eval_protocol_rollout_adapter.py
+++ b/training/tests/unit/test_eval_protocol_rollout_adapter.py
@@ -1,7 +1,7 @@
 import asyncio
 from types import SimpleNamespace
 
-from eval_protocol.models import EvaluationRow, InputMetadata
+from eval_protocol.models import EvaluationRow, InputMetadata, Message
 from eval_protocol.pytest import evaluation_test
 
 from training.utils.rl.rollout import (
@@ -23,6 +23,11 @@ def _sample_from_row(row: EvaluationRow) -> RolloutSample:
         loss_mask=[0, 1, 1],
         reward=reward,
     )
+
+
+class _FakeTokenizer:
+    def encode(self, text: str, add_special_tokens: bool = False) -> list[int]:
+        return [ord(char) for char in text]
 
 
 def test_load_eval_protocol_input_rows_from_decorated_evaluator():
@@ -80,7 +85,17 @@ def test_eval_protocol_adapter_invokes_processor_one_row_and_scores():
     rollout_fn = make_eval_protocol_rollout_fn_factory(
         evaluator,
         sample_converter=_sample_from_row,
-    )(SimpleNamespace(model="runtime-model", sample_kwargs={"top_p": 0.9}))
+    )(
+        SimpleNamespace(
+            model="runtime-model",
+            sample_kwargs={
+                "top_p": 0.9,
+                "http_timeout": 30,
+                "max_seq_len": 2048,
+            },
+            inference_base_url="https://inference.unit.test",
+        )
+    )
 
     sample = _run(rollout_fn(input_row))
 
@@ -93,12 +108,57 @@ def test_eval_protocol_adapter_invokes_processor_one_row_and_scores():
                 "model": "runtime-model",
                 "temperature": 0.7,
                 "top_p": 0.9,
+                "api_base": "https://inference.unit.test/v1",
             },
             "steps": 7,
             "semaphore_value": 1,
             "kwargs": {"custom": "value"},
         },
     ]
+
+
+def test_eval_protocol_adapter_synthesizes_token_trace_when_processor_omits_it():
+    class FakeProcessor:
+        def __call__(self, rows, _config):
+            async def finish():
+                row = rows[0]
+                row.messages = [
+                    Message(role="user", content="hi"),
+                    Message(role="assistant", content="ok"),
+                ]
+                row.execution_metadata.extra = {"reward": 0.5}
+                return row
+
+            return [finish()]
+
+    input_row = EvaluationRow(input_metadata=InputMetadata(row_id="row-1"))
+
+    @evaluation_test(input_rows=[[input_row]], rollout_processor=FakeProcessor())
+    def evaluator(row: EvaluationRow) -> EvaluationRow:
+        return row
+
+    rollout_fn = make_eval_protocol_rollout_fn_factory(
+        evaluator,
+        sample_converter=lambda row: RolloutSample(
+            tokens=row.execution_metadata.extra["token_turn_traces"][0]["prompt_ids"]
+            + row.execution_metadata.extra["token_turn_traces"][0]["completion_ids"],
+            logprobs=[0.0]
+            * (
+                len(row.execution_metadata.extra["token_turn_traces"][0]["prompt_ids"])
+                + len(row.execution_metadata.extra["token_turn_traces"][0]["completion_ids"])
+            ),
+            loss_mask=[0] * len(row.execution_metadata.extra["token_turn_traces"][0]["prompt_ids"])
+            + [1] * len(row.execution_metadata.extra["token_turn_traces"][0]["completion_ids"]),
+            reward=row.execution_metadata.extra["reward"],
+        ),
+    )(SimpleNamespace(model="runtime-model", tokenizer=_FakeTokenizer()))
+
+    sample = _run(rollout_fn(input_row))
+
+    assert sample.reward == 0.5
+    assert sample.loss_mask[-2:] == [1, 1]
+    assert sample.tokens[-2:] == [ord("o"), ord("k")]
+    assert len(sample.tokens) == len(sample.logprobs) == len(sample.loss_mask)
 
 
 def test_eval_protocol_adapter_accepts_custom_row_factory():

--- a/training/tests/unit/test_eval_protocol_rollout_adapter.py
+++ b/training/tests/unit/test_eval_protocol_rollout_adapter.py
@@ -6,6 +6,8 @@ from eval_protocol.pytest import evaluation_test
 
 from training.utils.rl.rollout import (
     RolloutSample,
+    default_completion_params_factory,
+    get_eval_protocol_params,
     load_eval_protocol_input_rows,
     make_eval_protocol_rollout_fn_factory,
 )
@@ -108,13 +110,33 @@ def test_eval_protocol_adapter_invokes_processor_one_row_and_scores():
                 "model": "runtime-model",
                 "temperature": 0.7,
                 "top_p": 0.9,
-                "api_base": "https://inference.unit.test/v1",
+                "api_base": "https://inference.unit.test/inference/v1",
             },
             "steps": 7,
             "semaphore_value": 1,
             "kwargs": {"custom": "value"},
         },
     ]
+
+
+def test_eval_protocol_adapter_preserves_direct_route_api_base():
+    @evaluation_test(
+        input_rows=[[EvaluationRow(input_metadata=InputMetadata(row_id="row-1"))]],
+        completion_params=[{}],
+        rollout_processor=object(),
+    )
+    def evaluator(row: EvaluationRow) -> EvaluationRow:
+        return row
+
+    params = default_completion_params_factory(
+        SimpleNamespace(
+            model="runtime-model",
+            inference_base_url="https://deployment.us-east-1.direct.fireworks.ai",
+        ),
+        get_eval_protocol_params(evaluator),
+    )
+
+    assert params["api_base"] == "https://deployment.us-east-1.direct.fireworks.ai/v1"
 
 
 def test_eval_protocol_adapter_synthesizes_token_trace_when_processor_omits_it():

--- a/training/utils/rl/rollout/eval_protocol.py
+++ b/training/utils/rl/rollout/eval_protocol.py
@@ -30,6 +30,11 @@ ProcessorFactory = Callable[[Any, EPParameters], Any]
 
 logger = logging.getLogger(__name__)
 
+_LITELLM_EXCLUDED_SAMPLE_KWARGS = {
+    "http_timeout",
+    "max_seq_len",
+}
+
 
 def get_eval_protocol_params(evaluator: Any) -> EPParameters:
     """Return ``EPParameters`` attached by ``@evaluation_test``.
@@ -139,6 +144,7 @@ def make_eval_protocol_rollout_fn_factory(
                             "eval-protocol evaluator must return EvaluationRow "
                             f"or None, got {type(result).__name__}."
                         )
+                _ensure_token_turn_traces(result, setup)
                 return sample_converter(result)
             except Exception:
                 if not swallow_exceptions:
@@ -169,11 +175,118 @@ def default_completion_params_factory(setup: Any, params: EPParameters) -> dict[
     completion_params = _first_completion_params(params.completion_params)
     setup_sample_kwargs = getattr(setup, "sample_kwargs", None) if setup is not None else None
     if isinstance(setup_sample_kwargs, dict):
-        completion_params.update(setup_sample_kwargs)
+        completion_params.update(
+            {
+                key: value
+                for key, value in setup_sample_kwargs.items()
+                if key not in _LITELLM_EXCLUDED_SAMPLE_KWARGS
+            }
+        )
+    setup_inference_base_url = getattr(setup, "inference_base_url", None) if setup is not None else None
+    if setup_inference_base_url and "api_base" not in completion_params:
+        completion_params["api_base"] = _normalize_litellm_api_base(str(setup_inference_base_url))
     setup_model = getattr(setup, "model", None) if setup is not None else None
     if setup_model:
         completion_params["model"] = setup_model
     return completion_params
+
+
+def _normalize_litellm_api_base(inference_base_url: str) -> str:
+    base = inference_base_url.rstrip("/")
+    if base.endswith("/v1"):
+        return base
+    return f"{base}/v1"
+
+
+def _ensure_token_turn_traces(row: EvaluationRow, setup: Any) -> None:
+    extra = row.execution_metadata.extra or {}
+    if extra.get("token_turn_traces"):
+        return
+
+    tokenizer = getattr(setup, "tokenizer", None) if setup is not None else None
+    if tokenizer is None:
+        return
+
+    messages = list(row.messages or [])
+    assistant_idx = None
+    for idx in range(len(messages) - 1, -1, -1):
+        if getattr(messages[idx], "role", None) == "assistant":
+            assistant_idx = idx
+            break
+    if assistant_idx is None:
+        return
+
+    assistant = messages[assistant_idx]
+    completion_text = getattr(assistant, "content", None) or ""
+    if not completion_text:
+        return
+
+    prompt_text = _messages_to_trace_text(messages[:assistant_idx])
+    prompt_ids = _tokenize_text(tokenizer, prompt_text)
+    completion_ids = _tokenize_text(tokenizer, completion_text)
+    if not completion_ids:
+        return
+
+    extra["token_turn_traces"] = [
+        {
+            "prompt_ids": prompt_ids,
+            "completion_ids": completion_ids,
+            "completion_logprobs": _extract_message_logprobs(assistant, len(completion_ids)),
+        }
+    ]
+    row.execution_metadata.extra = extra
+
+
+def _messages_to_trace_text(messages: Sequence[Any]) -> str:
+    parts: list[str] = []
+    for message in messages:
+        role = getattr(message, "role", "") or ""
+        content = getattr(message, "content", "") or ""
+        parts.append(f"{role}: {content}")
+    return "\n".join(parts)
+
+
+def _tokenize_text(tokenizer: Any, text: str) -> list[int]:
+    if not text:
+        return []
+    try:
+        return [int(token) for token in tokenizer.encode(text, add_special_tokens=False)]
+    except TypeError:
+        return [int(token) for token in tokenizer.encode(text)]
+
+
+def _extract_message_logprobs(message: Any, expected_len: int) -> list[float]:
+    raw = getattr(message, "logprobs", None)
+    values = _flatten_logprob_values(raw)
+    if len(values) < expected_len:
+        values.extend([0.0] * (expected_len - len(values)))
+    return values[:expected_len]
+
+
+def _flatten_logprob_values(raw: Any) -> list[float]:
+    if raw is None:
+        return []
+    if isinstance(raw, dict):
+        if isinstance(raw.get("content"), list):
+            values: list[float] = []
+            for item in raw["content"]:
+                if isinstance(item, dict) and item.get("logprob") is not None:
+                    values.append(float(item["logprob"]))
+            return values
+        if raw.get("logprob") is not None:
+            return [float(raw["logprob"])]
+    if isinstance(raw, Sequence) and not isinstance(raw, (str, bytes)):
+        values = []
+        for item in raw:
+            if isinstance(item, dict) and item.get("logprob") is not None:
+                values.append(float(item["logprob"]))
+            elif item is not None:
+                try:
+                    values.append(float(item))
+                except (TypeError, ValueError):
+                    pass
+        return values
+    return []
 
 
 async def _run_single_row_rollout(

--- a/training/utils/rl/rollout/eval_protocol.py
+++ b/training/utils/rl/rollout/eval_protocol.py
@@ -193,9 +193,16 @@ def default_completion_params_factory(setup: Any, params: EPParameters) -> dict[
 
 def _normalize_litellm_api_base(inference_base_url: str) -> str:
     base = inference_base_url.rstrip("/")
+    is_direct_route = ".direct.fireworks.ai" in base
+    if base.endswith("/inference/v1") or (is_direct_route and base.endswith("/v1")):
+        return base
+    if base.endswith("/inference"):
+        return f"{base}/v1"
     if base.endswith("/v1"):
         return base
-    return f"{base}/v1"
+    if is_direct_route:
+        return f"{base}/v1"
+    return f"{base}/inference/v1"
 
 
 def _ensure_token_turn_traces(row: EvaluationRow, setup: Any) -> None:


### PR DESCRIPTION
## Summary

Fix the cookbook async RL rollout path used by managed RFT E2B:

- Normalize Fireworks gateway/direct inference URLs in one place before passing LiteLLM api_base.
- Filter runtime-only sample kwargs that are not valid completion request fields.
- Synthesize token turn traces when eval-protocol output omits them so managed sample conversion can produce trainable samples.

## URL normalization

The eval-protocol adapter now owns LiteLLM api_base normalization directly:

- Fireworks gateway base like https://dev.api.fireworks.ai becomes https://dev.api.fireworks.ai/inference/v1.
- Fireworks gateway inference base ending /inference becomes /inference/v1.
- Existing /inference/v1 values are preserved.
- Direct deployment routes append /v1 unless already present.

This avoids splitting URL construction across async_rl_loop and the eval-protocol adapter.

## Diagram

Dataset row -> eval-protocol rollout -> normalized LiteLLM api_base -> LiteLLM completion -> token_turn_traces -> managed sample converter -> trainer fwd/bwd.

## Testing

- Unit coverage added and updated in training/tests/unit/test_eval_protocol_rollout_adapter.py and training/tests/unit/test_async_rl_loop_runner.py.
- Targeted tests passed: 23 passed.
- Validated through managed RFT E2B smoke jobs from the Fireworks repo: rollout, fwd/bwd, optim step, and hotload all progressed.

## Notes

This PR intentionally excludes the temporary hotload path workaround. The final fix for that issue is in the Fireworks E2B template SDK pin PR, which uses fireworks-ai training SDK 1.2.0a70 or newer.
