### PR TITLE
Expose SFT render samples

### DIFF
--- a/training/recipes/sft_loop.py
+++ b/training/recipes/sft_loop.py
@@ -15,13 +15,16 @@ Usage:
 from __future__ import annotations
 
 import functools
+import json
 import logging
 import os
 import random
 import signal
+import tempfile
 from contextlib import ExitStack
 from dataclasses import dataclass, field
 from itertools import islice
+from pathlib import Path
 from typing import Any, Dict, List
 
 import tinker
@@ -29,10 +32,12 @@ import torch
 from dotenv import load_dotenv
 from fireworks.training.sdk import TrainerJobManager
 
+from training.utils import fileio
 from training.utils import (
     DEFAULT_ADAM,
     DEFAULT_RENDER_WORKERS,
     InfraConfig,
+    JSONL_ROW_INDEX_KEY,
     JsonlRenderDataset,
     RawRowCursor,
     ReconnectableClient,
@@ -69,6 +74,196 @@ logger = logging.getLogger(__name__)
 # auto carve-out, which run in-process with the same render_fn.
 _worker_state: dict = {}
 
+RENDER_SAMPLE_LIMIT_ENV = "FIRETITAN_SFT_RENDER_SAMPLES_LIMIT"
+DEFAULT_RENDER_SAMPLE_LIMIT = 20
+
+
+def _parse_render_samples_limit(value: str) -> int | None:
+    normalized = value.strip().lower()
+    if normalized in {"all", "full", "unlimited", "-1"}:
+        return None
+    limit = int(normalized)
+    if limit < 0:
+        return None
+    return limit
+
+
+def _resolve_render_samples_limit(config_limit: int | None) -> int | None:
+    env_limit = os.environ.get(RENDER_SAMPLE_LIMIT_ENV)
+    if env_limit is not None:
+        try:
+            return _parse_render_samples_limit(env_limit)
+        except ValueError:
+            logger.warning(
+                "Invalid %s=%r; using default render sample limit %d",
+                RENDER_SAMPLE_LIMIT_ENV,
+                env_limit,
+                DEFAULT_RENDER_SAMPLE_LIMIT,
+            )
+            return DEFAULT_RENDER_SAMPLE_LIMIT
+    if config_limit is None:
+        return DEFAULT_RENDER_SAMPLE_LIMIT
+    if config_limit < 0:
+        return None
+    return int(config_limit)
+
+
+def _decode_tokens(token_ids: list[int]) -> list[str]:
+    tokenizer = _worker_state.get("tokenizer")
+    if tokenizer is None:
+        return ["" for _ in token_ids]
+    decoded: list[str] = []
+    for token_id in token_ids:
+        try:
+            text = tokenizer.decode([int(token_id)], skip_special_tokens=False)
+        except TypeError:
+            text = tokenizer.decode([int(token_id)])
+        except Exception:  # noqa: BLE001 - diagnostic artifact must not break rendering
+            text = ""
+        decoded.append(str(text))
+    return decoded
+
+
+def _render_sample_worker_path() -> str:
+    local_dir = _worker_state.get("render_samples_local_dir") or ""
+    worker_id = _worker_state.get("worker_id")
+    worker_label = "main" if worker_id is None else str(worker_id)
+    return os.path.join(local_dir, f"render_samples.worker-{worker_label}.jsonl")
+
+
+def _remaining_render_sample_capacity() -> int | None:
+    limit = _worker_state.get("render_samples_limit")
+    if limit is None:
+        return None
+    written = int(_worker_state.get("render_samples_written", 0))
+    return max(0, int(limit) - written)
+
+
+def _write_render_samples(row: dict, rendered_examples: list[Any]) -> None:
+    local_dir = _worker_state.get("render_samples_local_dir") or ""
+    if not local_dir:
+        return
+    remaining = _remaining_render_sample_capacity()
+    if remaining == 0:
+        return
+
+    selected = rendered_examples if remaining is None else rendered_examples[:remaining]
+    if not selected:
+        return
+
+    row_index = row.get(JSONL_ROW_INDEX_KEY)
+    try:
+        row_index_int = int(row_index) if row_index is not None else None
+    except (TypeError, ValueError):
+        row_index_int = None
+
+    path = _render_sample_worker_path()
+    try:
+        with open(path, "a", encoding="utf-8") as handle:
+            for split_index, rendered in enumerate(selected):
+                token_ids = [int(x) for x in rendered.token_ids]
+                token_weights = [float(x) for x in rendered.token_weights]
+                datum = rendered.datum
+                target_tokens = [int(x) for x in datum.loss_fn_inputs["target_tokens"].data]
+                training_weights = [float(x) for x in datum.loss_fn_inputs["weights"].data]
+                record = {
+                    # source_jsonl_row_index is 0-based; source_jsonl_line_number
+                    # is 1-based to match editor / CLI line-number conventions.
+                    "source_jsonl_row_index": row_index_int,
+                    "source_jsonl_line_number": row_index_int + 1 if row_index_int is not None else None,
+                    "split_index": split_index,
+                    "worker_id": _worker_state.get("worker_id"),
+                    "renderer": _worker_state.get("resolved_renderer_name", ""),
+                    "train_on_what": _worker_state.get("train_on_what_str", ""),
+                    "token_ids": token_ids,
+                    "decoded_tokens": _decode_tokens(token_ids),
+                    "token_weights": token_weights,
+                    "training_target_token_ids": target_tokens,
+                    "training_loss_weights": training_weights,
+                }
+                handle.write(json.dumps(record, separators=(",", ":"), ensure_ascii=False) + "\n")
+                _worker_state["render_samples_written"] = int(
+                    _worker_state.get("render_samples_written", 0)
+                ) + 1
+    except Exception:  # noqa: BLE001 - best-effort debug artifact
+        if not _worker_state.get("render_samples_error_logged"):
+            logger.warning("Failed to write SFT render sample", exc_info=True)
+            _worker_state["render_samples_error_logged"] = True
+
+
+def _round_robin_render_sample_lines(files: list[Path]) -> list[str]:
+    handles = []
+    try:
+        for path in files:
+            handles.append(path.open(encoding="utf-8"))
+        lines: list[str] = []
+        while handles:
+            next_handles = []
+            for handle in handles:
+                line = handle.readline()
+                if line:
+                    lines.append(line)
+                    next_handles.append(handle)
+                else:
+                    handle.close()
+            handles = next_handles
+        return lines
+    finally:
+        for handle in handles:
+            if not handle.closed:
+                handle.close()
+
+
+def _finalize_render_samples(
+    local_dir: str,
+    output_path: str,
+    render_samples_limit: int | None,
+) -> None:
+    if not local_dir or not output_path:
+        return
+    try:
+        files = sorted(Path(local_dir).glob("render_samples.worker-*.jsonl"))
+        all_lines = _round_robin_render_sample_lines(files)
+        content_parts = all_lines
+        truncated_count = 0
+        if render_samples_limit is not None:
+            content_parts = all_lines[:render_samples_limit]
+            truncated_count = max(0, len(all_lines) - render_samples_limit)
+        if not content_parts:
+            logger.info("No SFT render samples were captured; skipping %s", output_path)
+            return
+        content = "".join(content_parts)
+        content_bytes = content.encode("utf-8")
+        fileio.write_bytes(output_path, content_bytes)
+        logger.info(
+            "Uploaded %d SFT render sample records (%d bytes) to %s",
+            len(content_parts),
+            len(content_bytes),
+            output_path,
+        )
+        if truncated_count:
+            logger.info(
+                "Skipped %d extra SFT render sample records after global limit=%d",
+                truncated_count,
+                render_samples_limit,
+            )
+    except Exception:  # noqa: BLE001 - diagnostic artifact must not fail the job
+        logger.warning("Failed to finalize SFT render samples to %s", output_path, exc_info=True)
+
+
+def _configure_render_sample_state(
+    render_samples_local_dir: str = "",
+    render_samples_limit: int | None = 0,
+    _worker_id: int | None = None,
+) -> None:
+    _worker_state.update(
+        worker_id=_worker_id,
+        render_samples_local_dir=render_samples_local_dir,
+        render_samples_limit=render_samples_limit,
+        render_samples_written=0,
+        render_samples_error_logged=False,
+    )
+
 
 def _init_render_worker(
     tokenizer_model: str,
@@ -76,6 +271,8 @@ def _init_render_worker(
     train_on_what_str: str,
     max_seq_len: int,
     tokenizer_revision: str = "",
+    render_samples_local_dir: str = "",
+    render_samples_limit: int | None = 0,
     _worker_id: int | None = None,
 ) -> None:
     """DataLoader ``worker_init_fn`` for SFT chat-row rendering.
@@ -90,6 +287,15 @@ def _init_render_worker(
         renderer_name=renderer_name,
         max_seq_len=max_seq_len,
         train_on_what=parse_train_on_what(train_on_what_str),
+    )
+    _worker_state.update(
+        resolved_renderer_name=resolve_renderer_name(tokenizer_model, renderer_name),
+        train_on_what_str=train_on_what_str,
+    )
+    _configure_render_sample_state(
+        render_samples_local_dir=render_samples_local_dir,
+        render_samples_limit=render_samples_limit,
+        _worker_id=_worker_id,
     )
 
 
@@ -112,12 +318,14 @@ def _render_one_worker(row: dict) -> tinker.Datum | list[tinker.Datum] | None:
     )
     if not isinstance(rendered_examples, list):
         rendered_examples = [rendered_examples]
-    datums = [
-        rendered.datum
+    valid_rendered_examples = [
+        rendered
         for rendered in rendered_examples
         if 2 <= len(rendered.token_ids) <= _worker_state["max_seq_len"]
         and any(w > 0 for w in rendered.token_weights)
     ]
+    _write_render_samples(row, valid_rendered_examples)
+    datums = [rendered.datum for rendered in valid_rendered_examples]
     if not datums:
         return None
     if len(datums) == 1:
@@ -182,13 +390,20 @@ def _prepare_datasets(
     still does its own per-epoch shuffling.
     """
     training_ds = JsonlRenderDataset(
-        cfg.dataset, _render_one_worker, max_examples=cfg.max_examples,
+        cfg.dataset,
+        _render_one_worker,
+        max_examples=cfg.max_examples,
+        row_index_key=JSONL_ROW_INDEX_KEY,
     )
     if len(training_ds) == 0:
         raise RuntimeError(f"No examples found in {cfg.dataset}")
 
     if cfg.evaluation_dataset:
-        eval_ds = JsonlRenderDataset(cfg.evaluation_dataset, _render_one_worker)
+        eval_ds = JsonlRenderDataset(
+            cfg.evaluation_dataset,
+            _render_one_worker,
+            row_index_key=JSONL_ROW_INDEX_KEY,
+        )
         eval_data = _render_eagerly(eval_ds, len(eval_ds))
         logger.info(
             "Loaded %d eval examples from %s",
@@ -231,6 +446,14 @@ def _prepare_datasets(
 class Config:
     log_path: str
     """Directory for checkpoints and logs. Required, no default."""
+
+    render_samples_file: str = ""
+    """Optional JSONL path for rendered token/mask diagnostic samples."""
+
+    render_samples_limit: int | None = None
+    """Global rendered datum sample cap. ``None`` means default; negative
+    values mean full dump. Can be overridden by
+    FIRETITAN_SFT_RENDER_SAMPLES_LIMIT."""
 
     base_model: str = "accounts/fireworks/models/qwen3-8b"
     dataset: str = ""
@@ -556,17 +779,49 @@ def main(
             if cfg.render_workers is not None
             else min(os.cpu_count() or 1, DEFAULT_RENDER_WORKERS)
         )
-        init_args = (
+        base_init_args = (
             cfg.tokenizer_model,
             cfg.renderer_name,
             cfg.train_on_what,
             cfg.max_seq_len,
             cfg.tokenizer_revision,
         )
-        _init_render_worker(*init_args)
-        worker_init_fn = functools.partial(_init_render_worker, *init_args)
+        _init_render_worker(*base_init_args)
 
         training_dataset, eval_data = _prepare_datasets(cfg)
+
+        render_samples_local_dir = ""
+        render_samples_limit = _resolve_render_samples_limit(cfg.render_samples_limit)
+        if cfg.render_samples_file and render_samples_limit != 0:
+            render_samples_local_dir = stack.enter_context(
+                tempfile.TemporaryDirectory(prefix="sft-render-samples-")
+            )
+            stack.callback(
+                _finalize_render_samples,
+                render_samples_local_dir,
+                cfg.render_samples_file,
+                render_samples_limit,
+            )
+            limit_label = "full dataset" if render_samples_limit is None else str(render_samples_limit)
+            logger.info(
+                "Capturing SFT render samples to %s (global limit=%s)",
+                cfg.render_samples_file,
+                limit_label,
+            )
+        elif cfg.render_samples_file:
+            logger.info("SFT render samples disabled by limit=0 for %s", cfg.render_samples_file)
+
+        init_args = (
+            *base_init_args,
+            render_samples_local_dir,
+            render_samples_limit,
+        )
+        _configure_render_sample_state(
+            render_samples_local_dir=render_samples_local_dir,
+            render_samples_limit=render_samples_limit,
+        )
+        worker_init_fn = functools.partial(_init_render_worker, *init_args)
+
         training_count = len(training_dataset)
         effective_batch_size = max(1, min(cfg.batch_size, training_count))
         if effective_batch_size < cfg.batch_size:
@@ -623,8 +878,6 @@ def main(
             if cfg.warmup_steps > 0 and optim_step_idx <= cfg.warmup_steps:
                 return cfg.learning_rate * (optim_step_idx / cfg.warmup_steps)
             return cfg.learning_rate
-
-        adam_params = tinker.AdamParams(learning_rate=cfg.learning_rate, **adam_kwargs)
 
         # -- Training loop (batch-indexed) -------------------------------------
 

--- a/training/tests/unit/test_sft_loop.py
+++ b/training/tests/unit/test_sft_loop.py
@@ -102,6 +102,158 @@ def test_init_render_worker_forwards_tokenizer_revision(monkeypatch):
     assert captured["kwargs"]["max_seq_len"] == 4096
 
 
+def test_configure_render_sample_state_does_not_repopulate_renderer(tmp_path, monkeypatch):
+    calls = {"populate": 0}
+    tokenizer = object()
+
+    def fake_populate_render_worker_state(state, **kwargs):
+        calls["populate"] += 1
+        state.update(
+            tokenizer=tokenizer,
+            renderer=object(),
+            max_seq_len=kwargs["max_seq_len"],
+            train_on_what=kwargs["train_on_what"],
+        )
+
+    monkeypatch.setattr(
+        module, "populate_render_worker_state", fake_populate_render_worker_state
+    )
+    monkeypatch.setattr(module, "resolve_renderer_name", lambda *args, **kwargs: "unit-renderer")
+
+    module._worker_state.clear()
+    module._init_render_worker("model", "renderer", "all_assistant_messages", 128)
+    module._configure_render_sample_state(str(tmp_path), 3)
+
+    assert calls["populate"] == 1
+    assert module._worker_state["tokenizer"] is tokenizer
+    assert module._worker_state["resolved_renderer_name"] == "unit-renderer"
+    assert module._worker_state["render_samples_local_dir"] == str(tmp_path)
+    assert module._worker_state["render_samples_limit"] == 3
+    assert module._worker_state["render_samples_written"] == 0
+
+
+def test_resolve_render_samples_limit(monkeypatch):
+    monkeypatch.delenv(module.RENDER_SAMPLE_LIMIT_ENV, raising=False)
+
+    assert module._resolve_render_samples_limit(None) == module.DEFAULT_RENDER_SAMPLE_LIMIT
+    assert module._resolve_render_samples_limit(7) == 7
+    assert module._resolve_render_samples_limit(-1) is None
+
+    monkeypatch.setenv(module.RENDER_SAMPLE_LIMIT_ENV, "0")
+    assert module._resolve_render_samples_limit(None) == 0
+
+    monkeypatch.setenv(module.RENDER_SAMPLE_LIMIT_ENV, "full")
+    assert module._resolve_render_samples_limit(3) is None
+
+    monkeypatch.setenv(module.RENDER_SAMPLE_LIMIT_ENV, "not-an-int")
+    assert module._resolve_render_samples_limit(3) == module.DEFAULT_RENDER_SAMPLE_LIMIT
+
+
+def test_write_render_samples_captures_token_debug_payload(tmp_path):
+    class FakeTokenizer:
+        def decode(self, token_ids, skip_special_tokens=False):
+            return f"tok-{token_ids[0]}"
+
+    module._worker_state.clear()
+    module._worker_state.update(
+        tokenizer=FakeTokenizer(),
+        render_samples_local_dir=str(tmp_path),
+        render_samples_limit=1,
+        render_samples_written=0,
+        worker_id=2,
+        resolved_renderer_name="unit-renderer",
+        train_on_what_str="all_assistant_messages",
+    )
+    datum = SimpleNamespace(
+        loss_fn_inputs={
+            "target_tokens": SimpleNamespace(data=[11, 12]),
+            "weights": SimpleNamespace(data=[0.0, 1.0]),
+        }
+    )
+    rendered = SimpleNamespace(
+        token_ids=[10, 11, 12],
+        token_weights=[0.0, 0.0, 1.0],
+        datum=datum,
+    )
+    extra_rendered = SimpleNamespace(token_ids=[13], token_weights=[1.0], datum=datum)
+
+    module._write_render_samples(
+        {module.JSONL_ROW_INDEX_KEY: 4},
+        [rendered, extra_rendered],
+    )
+
+    records = [
+        json.loads(line)
+        for line in (tmp_path / "render_samples.worker-2.jsonl").read_text().splitlines()
+    ]
+    assert records == [
+        {
+            "source_jsonl_row_index": 4,
+            "source_jsonl_line_number": 5,
+            "split_index": 0,
+            "worker_id": 2,
+            "renderer": "unit-renderer",
+            "train_on_what": "all_assistant_messages",
+            "token_ids": [10, 11, 12],
+            "decoded_tokens": ["tok-10", "tok-11", "tok-12"],
+            "token_weights": [0.0, 0.0, 1.0],
+            "training_target_token_ids": [11, 12],
+            "training_loss_weights": [0.0, 1.0],
+        }
+    ]
+    assert module._worker_state["render_samples_written"] == 1
+
+
+def test_finalize_render_samples_uploads_worker_jsonl(tmp_path, monkeypatch):
+    (tmp_path / "render_samples.worker-0.jsonl").write_text('{"worker":0}\n')
+    (tmp_path / "render_samples.worker-1.jsonl").write_text('{"worker":1}\n')
+    uploaded: dict[str, bytes] = {}
+    monkeypatch.setattr(
+        module.fileio,
+        "write_bytes",
+        lambda path, data: uploaded.setdefault(path, data),
+    )
+
+    module._finalize_render_samples(
+        str(tmp_path),
+        "gs://bucket/job/render_samples.jsonl",
+        render_samples_limit=None,
+    )
+
+    assert uploaded == {
+        "gs://bucket/job/render_samples.jsonl": b'{"worker":0}\n{"worker":1}\n',
+    }
+
+
+def test_finalize_render_samples_enforces_global_limit_round_robin(tmp_path, monkeypatch):
+    (tmp_path / "render_samples.worker-0.jsonl").write_text(
+        '{"worker":0,"seq":0}\n{"worker":0,"seq":1}\n'
+    )
+    (tmp_path / "render_samples.worker-1.jsonl").write_text(
+        '{"worker":1,"seq":0}\n{"worker":1,"seq":1}\n'
+    )
+    uploaded: dict[str, bytes] = {}
+    monkeypatch.setattr(
+        module.fileio,
+        "write_bytes",
+        lambda path, data: uploaded.setdefault(path, data),
+    )
+
+    module._finalize_render_samples(
+        str(tmp_path),
+        "gs://bucket/job/render_samples.jsonl",
+        render_samples_limit=3,
+    )
+
+    assert uploaded == {
+        "gs://bucket/job/render_samples.jsonl": (
+            b'{"worker":0,"seq":0}\n'
+            b'{"worker":1,"seq":0}\n'
+            b'{"worker":0,"seq":1}\n'
+        ),
+    }
+
+
 def test_main_rejects_adapter_plus_init_from_checkpoint(tmp_path, monkeypatch):
     """warm_start_from_adapter and init_from_checkpoint are mutually exclusive."""
     dataset_path = _write_dataset(

--- a/training/tests/unit/test_streaming.py
+++ b/training/tests/unit/test_streaming.py
@@ -16,8 +16,6 @@ integration test against ``sft_loop.main``.
 from __future__ import annotations
 
 import json
-import os
-from typing import Any
 
 import pytest
 
@@ -25,6 +23,7 @@ from training.utils.streaming import (
     AppendOnlyPickleLog,
     DEFAULT_PREFETCH_FACTOR,
     DEFAULT_RENDER_WORKERS,
+    JSONL_ROW_INDEX_KEY,
     JsonlRenderDataset,
     _scan_jsonl_offsets,
     make_render_dataloader,
@@ -158,6 +157,39 @@ def test_dataset_init_with_explicit_indices(tmp_path):
     assert len(ds) == 3
     assert ds.num_underlying_rows == 10  # full file still scanned
     assert [ds[i]["id"] for i in range(3)] == [7, 2, 9]
+
+
+def test_dataset_passes_source_row_index_to_render_fn(tmp_path):
+    path = str(tmp_path / "data.jsonl")
+    _write_jsonl(path, [{"i": i} for i in range(5)])
+
+    def render(row: dict) -> dict:
+        return {"id": row["i"], "source_index": row[JSONL_ROW_INDEX_KEY]}
+
+    ds = JsonlRenderDataset(
+        path,
+        render,
+        indices=[4, 1, 3],
+        row_index_key=JSONL_ROW_INDEX_KEY,
+    )
+
+    assert [ds[i] for i in range(3)] == [
+        {"id": 4, "source_index": 4},
+        {"id": 1, "source_index": 1},
+        {"id": 3, "source_index": 3},
+    ]
+
+
+def test_dataset_does_not_add_source_row_index_by_default(tmp_path):
+    path = str(tmp_path / "data.jsonl")
+    _write_jsonl(path, [{"i": 0}])
+
+    def render(row: dict) -> dict:
+        return row
+
+    ds = JsonlRenderDataset(path, render)
+
+    assert ds[0] == {"i": 0}
 
 
 # ---------------------------------------------------------------------------

--- a/training/utils/__init__.py
+++ b/training/utils/__init__.py
@@ -37,6 +37,7 @@ __all__ = [
     "DEFAULT_ADAM",
     "DEFAULT_PREFETCH_FACTOR",
     "DEFAULT_RENDER_WORKERS",
+    "JSONL_ROW_INDEX_KEY",
     "DeployConfig",
     "EvalFn",
     "WeightSyncConfig",
@@ -173,6 +174,7 @@ from training.utils.runner import RunnerConfig, RunnerIO, RunStatus
 from training.utils.streaming import (
     DEFAULT_PREFETCH_FACTOR,
     DEFAULT_RENDER_WORKERS,
+    JSONL_ROW_INDEX_KEY,
     AppendOnlyPickleLog,
     JsonlRenderDataset,
     make_render_dataloader,

--- a/training/utils/streaming.py
+++ b/training/utils/streaming.py
@@ -38,6 +38,7 @@ logger = logging.getLogger(__name__)
 # dataset on a 16 vCPU / 58 GiB orchestrator pod.
 DEFAULT_RENDER_WORKERS = 4
 DEFAULT_PREFETCH_FACTOR = 2
+JSONL_ROW_INDEX_KEY = "_fireworks_jsonl_row_index"
 
 
 # ---------------------------------------------------------------------------
@@ -70,6 +71,8 @@ class JsonlRenderDataset(torch_data.Dataset):
     ``render_fn`` may return ``None`` for rows that should be dropped
     (empty messages, over-length sequences, ...). The companion
     :func:`make_render_dataloader` wires up a collate that filters Nones.
+    ``row_index_key`` opt-in attaches the original 0-based JSONL row
+    index for callers that need source-file diagnostics.
     """
 
     def __init__(
@@ -79,6 +82,7 @@ class JsonlRenderDataset(torch_data.Dataset):
         *,
         max_examples: int | None = None,
         indices: List[int] | None = None,
+        row_index_key: str | None = None,
     ):
         self._path = path
         self._render_fn = render_fn
@@ -88,6 +92,7 @@ class JsonlRenderDataset(torch_data.Dataset):
             if indices is not None
             else list(range(len(self._offsets)))
         )
+        self._row_index_key = row_index_key
 
     def __len__(self) -> int:
         return len(self._index_map)
@@ -97,7 +102,10 @@ class JsonlRenderDataset(torch_data.Dataset):
         with open(self._path) as f:
             f.seek(offset)
             line = f.readline()
-        return self._render_fn(json.loads(line))
+        row = json.loads(line)
+        if self._row_index_key is not None:
+            row[self._row_index_key] = self._index_map[i]
+        return self._render_fn(row)
 
     def with_indices(self, indices: List[int]) -> "JsonlRenderDataset":
         """Return a view of this dataset restricted to ``indices``.
@@ -111,6 +119,7 @@ class JsonlRenderDataset(torch_data.Dataset):
         view._render_fn = self._render_fn
         view._offsets = self._offsets
         view._index_map = list(indices)
+        view._row_index_key = self._row_index_key
         return view
 
     @property


### PR DESCRIPTION
## Summary
- capture sampled SFT rendered datums with source JSONL row, renderer, token IDs, decoded token text, token weights, and final training loss masks
- add config/env controls for default sample cap and full-dump/disabled modes
- preserve original JSONL row index through the streaming dataset

## Validation
- python -m ruff check training/recipes/sft_loop.py training/utils/streaming.py training/tests/unit/test_streaming.py training/tests/unit/test_sft_loop.py
- pytest training/tests/unit/test_streaming.py training/tests/unit/test_sft_loop.py -q was attempted, but local collection is blocked by ImportError: cannot import name ParseTermination from tinker_cookbook.renderers.base via training/renderer/mistral.py

Linear: FIR2-1632

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new diagnostic side-effects to the SFT data-rendering path (per-worker file writes plus end-of-run upload) and threads source-row metadata through the streaming dataset, which could affect training performance or failure modes if misconfigured.
> 
> **Overview**
> Adds an opt-in *render-sample diagnostics* path to `recipes/sft_loop.py`: workers can now emit JSONL records containing source JSONL row index/line number, renderer/train-on-what, token IDs + decoded token text, token weights, and the final loss-mask inputs, then the main process round-robins worker files and uploads a globally capped output file.
> 
> Introduces `Config.render_samples_file`/`render_samples_limit` (plus `FIRETITAN_SFT_RENDER_SAMPLES_LIMIT`) to control disabled/default/full-dump modes, and extends `JsonlRenderDataset` with an optional `row_index_key` (`JSONL_ROW_INDEX_KEY`) so render functions can receive the original 0-based row index; adds unit coverage for these behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20d9f5be2d635b7371d5955298d31403748ccf09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->