### PR TITLE
fix(tokenizers): pin moonshotai/Kimi-K2.6 to working revision (FIR2-1631)

### DIFF
--- a/training/tests/unit/test_tokenizers.py
+++ b/training/tests/unit/test_tokenizers.py
@@ -17,10 +17,10 @@ def test_load_tokenizer_forwards_optional_revision(monkeypatch):
         tokenizers.transformers.AutoTokenizer, "from_pretrained", fake_from_pretrained
     )
 
-    result = tokenizers.load_tokenizer("moonshotai/Kimi-K2.6", "2755962")
+    result = tokenizers.load_tokenizer("Qwen/Qwen3-8B", "2755962")
 
     assert result is fake_tokenizer
-    assert captured["model"] == "moonshotai/Kimi-K2.6"
+    assert captured["model"] == "Qwen/Qwen3-8B"
     assert captured["kwargs"] == {
         "revision": "2755962",
         "trust_remote_code": True,
@@ -41,6 +41,49 @@ def test_load_tokenizer_treats_empty_revision_as_unset(monkeypatch):
     tokenizers.load_tokenizer("Qwen/Qwen3-8B", "")
 
     assert captured["kwargs"]["revision"] is None
+
+
+def test_load_tokenizer_pins_default_revision_for_kimi_k2_6(monkeypatch):
+    """FIR2-1631 regression guard.
+
+    Loading `moonshotai/Kimi-K2.6` without an explicit revision must pin to
+    the known-good commit that ships `tokenizer.json` and bypasses
+    transformers v5.x's broken fast-tokenizer auto-convert. Without this
+    pin, special-token IDs at training time disagree with inference and the
+    LoRA emits IDs that decode as `<|media_end|>[EOT]…`.
+    """
+    captured: dict = {}
+
+    def fake_from_pretrained(model, **kwargs):
+        captured.update(model=model, kwargs=kwargs)
+        return object()
+
+    monkeypatch.setattr(
+        tokenizers.transformers.AutoTokenizer, "from_pretrained", fake_from_pretrained
+    )
+
+    tokenizers.load_tokenizer("moonshotai/Kimi-K2.6")
+
+    assert captured["kwargs"]["revision"] == (
+        "81bcaaa79473ace391bcb4b6e6e08a87263767c8"
+    )
+
+
+def test_load_tokenizer_explicit_revision_overrides_default(monkeypatch):
+    """Caller-supplied revision must win, even for pinned models."""
+    captured: dict = {}
+
+    def fake_from_pretrained(model, **kwargs):
+        captured.update(model=model, kwargs=kwargs)
+        return object()
+
+    monkeypatch.setattr(
+        tokenizers.transformers.AutoTokenizer, "from_pretrained", fake_from_pretrained
+    )
+
+    tokenizers.load_tokenizer("moonshotai/Kimi-K2.6", "deadbeef")
+
+    assert captured["kwargs"]["revision"] == "deadbeef"
 
 
 def test_load_deployment_tokenizer_uses_generic_deploy_config_fields(monkeypatch):

--- a/training/utils/tokenizers.py
+++ b/training/utils/tokenizers.py
@@ -7,6 +7,23 @@ from typing import Any
 import transformers
 
 
+# Default tokenizer revisions for models whose latest Hub tokenizer is known
+# broken under transformers >=5.x. The bug: transformers v5 has
+# `model_type == "kimi_k25"` on its `MODELS_WITH_INCORRECT_HUB_TOKENIZER_CLASS`
+# blocklist and unconditionally routes those checkpoints through
+# `TokenizersBackend` (auto-converting `tiktoken.model` via a regex with the
+# wrong special-token pattern). The fast-convert collapses the gaps in
+# `added_tokens_decoder` and shifts every special-token ID by 1-3 vs the
+# canonical mapping (e.g. trains write `163604` thinking it's `</think>`;
+# inference decodes the same ID as `<|media_end|>`). The pinned revisions
+# below ship a precompiled `tokenizer.json` + a `TikTokenTokenizerFast`
+# wrapper so AutoTokenizer loads them directly without triggering the
+# conversion. See FIR2-1631.
+_DEFAULT_TOKENIZER_REVISIONS: dict[str, str] = {
+    "moonshotai/kimi-k2.6": "81bcaaa79473ace391bcb4b6e6e08a87263767c8",
+}
+
+
 def load_tokenizer(
     tokenizer_model: str | None,
     tokenizer_revision: str | None = None,
@@ -14,11 +31,17 @@ def load_tokenizer(
     """Load a tokenizer with cookbook defaults.
 
     ``tokenizer_revision`` is optional; empty strings are treated as unset so
-    existing configs keep resolving HuggingFace ``main``.
+    existing configs keep resolving HuggingFace ``main``. For models on the
+    ``_DEFAULT_TOKENIZER_REVISIONS`` list, an unset revision falls back to
+    the pinned-known-good commit instead of ``main``.
     """
+    effective_revision = tokenizer_revision or None
+    if effective_revision is None and tokenizer_model:
+        effective_revision = _DEFAULT_TOKENIZER_REVISIONS.get(tokenizer_model.lower())
+
     return transformers.AutoTokenizer.from_pretrained(
         tokenizer_model,
-        revision=tokenizer_revision or None,
+        revision=effective_revision,
         trust_remote_code=True,
     )
 


### PR DESCRIPTION
**Closing — wrong diagnosis.** My investigation was run against a venv with transformers 5.5.3, where Kimi-K2.6 hits the auto-convert bug. But the trainer Dockerfile already pins transformers to 5.3.0 (`Dockerfile:62`), where `kimi_k25` is NOT on `MODELS_WITH_INCORRECT_HUB_TOKENIZER_CLASS` and `AutoTokenizer.from_pretrained` loads the slow `TikTokenTokenizer` class directly with canonical IDs.

Verified on a fresh transformers 5.3.0 install loading the current Kimi-K2.6 main: `<|media_end|>` → 163604, `[EOT]` → 163593, `<think>` → 163606, `</think>` → 163607 — all canonical. No shift.

So this PR fixes a problem that doesn't exist in the actual trainer image. Heidi V2's `<|media_end|>[EOT]` symptom has a different cause — re-opening investigation under FIR2-1631.