### PR TITLE
build: constrain transformers to >=5.0,<5.4 (match trainer image)

### DIFF
--- a/training/pyproject.toml
+++ b/training/pyproject.toml
@@ -13,7 +13,16 @@ dependencies = [
     "datasets",
     "tiktoken",
     "numpy",
-    "transformers",
+    # transformers 5.4+ adds `kimi_k25` to
+    # `MODELS_WITH_INCORRECT_HUB_TOKENIZER_CLASS`, which routes Kimi-K2.5/K2.6
+    # through `TokenizersBackend`'s tiktoken auto-convert. The conversion
+    # collapses gaps in `tokenizer_config.json`'s `added_tokens_decoder` and
+    # silently shifts special-token IDs by 1-3 vs the canonical mapping that
+    # inference uses (e.g. `<|media_end|>` 163604 -> 163601). The trainer
+    # image (serving/train_firetitan/Dockerfile) pins exactly 5.3.0; this
+    # range keeps local dev / CI / external users inside the same
+    # known-safe zone.
+    "transformers>=5.0,<5.4",
     "python-dotenv",
     "wandb",
     "orjson",


### PR DESCRIPTION
## Summary

The trainer image (`serving/train_firetitan/Dockerfile:62`) explicitly pins `transformers==5.3.0`. Cookbook itself had no constraint — anyone who `pip install fireworks-training-cookbook` locally got whatever's on PyPI today, which can silently disagree with production training behavior. This adds a matching range constraint.

## Why this matters

transformers 5.4+ added `kimi_k25` to its [`MODELS_WITH_INCORRECT_HUB_TOKENIZER_CLASS`](https://github.com/huggingface/transformers/blob/main/src/transformers/models/auto/tokenization_auto.py) blocklist. That forces Kimi-K2.5/K2.6 through `TokenizersBackend`'s tiktoken auto-convert, which collapses gaps in `tokenizer_config.json`'s `added_tokens_decoder` and shifts special-token IDs by 1-3 vs the canonical mapping that inference uses:

| token | canonical (inference) | shifted (transformers 5.5.x) |
|---|---|---|
| `<\|media_end\|>` | 163604 | 163601 |
| `[EOT]` | 163593 | 163591 |
| `</think>` | 163607 | 163604 |
| `<\|tool_calls_section_begin\|>` | 163595 | 163593 |

A LoRA fit through cookbook on transformers 5.5+ would emit IDs that inference decodes as `<\|media_end\|>[EOT]<\|tool_calls_section_begin\|>…` instead of `</think><\|tool_calls_section_begin\|><\|tool_call_begin\|>…`.

## Context: not the actual cause of FIR2-1631

I initially diagnosed Heidi V2's `<|media_end|>[EOT]` regression as this exact issue. It is **not**: V2's trainer image was already pinned to 5.3.0 (commit `9cebad884f`, May 12, before V2's May 16 training). On 5.3.0, Kimi-K2.6 loads via the slow `TikTokenTokenizer` directly and produces canonical IDs. So FIR2-1631 has a different root cause and the investigation continues.

This PR is a forward-looking guardrail so the next person working on cookbook locally (or any CI environment without the trainer-image pin) doesn't trip the same wire I did.

## Test plan

- [x] On transformers 5.3.0: Kimi-K2.6 main load yields `TikTokenTokenizer` with canonical IDs.
- [x] On transformers 5.5.3: same load yields `TokenizersBackend` with shifted IDs.
- [x] Existing cookbook unit tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts dependency version constraints, with the main impact being that installs will refuse `transformers` 5.4+ (potentially affecting users who relied on newer versions).
> 
> **Overview**
> Aligns the cookbook’s runtime dependencies with the known-good training environment by replacing the unconstrained `transformers` dependency with a pinned range `transformers>=5.0,<5.4`.
> 
> Adds inline rationale documenting a tokenizer ID-shift issue introduced in `transformers` 5.4+ for Kimi models, to prevent local dev/CI from silently diverging from the trainer image behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aad5f574fb24b27507a91c5a3dac083dd205e6db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->