### PR TITLE
fix: mark cookbook deployments for training

### DIFF
--- a/skills/dev/references/rl/hotload.md
+++ b/skills/dev/references/rl/hotload.md
@@ -17,7 +17,10 @@ DeployConfig(weight_sync_scope=WeightSyncScope.PER_TRAINER, ...)
 ```
 
 1. Create the trainer via `TrainerJobManager.create_and_wait(...)`.
-2. Create the deployment via `DeploymentManager.create_or_get(DeploymentConfig(hot_load_trainer_job=<trainer_job>, ...))`. The deployment copies the trainer's bucket URL at creation.
+2. Create the deployment via `DeploymentManager.create_or_get(DeploymentConfig(hot_load_trainer_job=<trainer_job>, ...))`.
+   The deployment copies the trainer's bucket URL at creation. Cookbook-created serving deployments are training
+   deployments (`forTraining=true` in the CreateDeployment payload), which is required for private Fireworks-owned
+   deployment shape versions pinned by training shapes.
 3. The **trainer owns** the checkpoints. Promote reads them from the trainer's bucket without any deployment ID.
 4. On resume, the deployment is re-attached to the new trainer (PATCH `hotLoadTrainerJob`), which briefly restarts the serving pod.
 

--- a/training/tests/unit/test_infra.py
+++ b/training/tests/unit/test_infra.py
@@ -80,6 +80,7 @@ def test_setup_deployment_omits_placement_for_shape_backed_create():
     assert captured["shape_timeout"] == 30
     assert captured["timeout"] == 60
     assert captured["json"]["deploymentShape"] == "accounts/fireworks/deploymentShapes/rft-kimi-k2p5-v2"
+    assert captured["json"]["forTraining"] is True
     assert "placement" not in captured["json"]
 
 

--- a/training/utils/infra.py
+++ b/training/utils/infra.py
@@ -839,6 +839,7 @@ def _create_deployment_via_cookbook(
         "minReplicaCount": config.min_replica_count,
         "maxReplicaCount": config.max_replica_count,
         "enableHotLoad": True,
+        "forTraining": True,
     }
     if config.hot_load_bucket_type:
         body["hotLoadBucketType"] = config.hot_load_bucket_type


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: a single additional boolean is sent in the deployment create payload, with a unit test update and documentation clarification.
> 
> **Overview**
> Cookbook deployment creation now includes **`forTraining: true`** in the CreateDeployment payload (in `_create_deployment_via_cookbook`), ensuring training-pinned/private deployment shape versions are allowed.
> 
> Updates the infra unit test to assert the new field is present, and clarifies the `PER_TRAINER` hotload docs to note cookbook-created serving deployments are created as training deployments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a06bd07e4370db0adb7d3d62dd6a086936f7f5ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->