### PR TITLE
Use SDK deployment annotations

### DIFF
--- a/training/tests/unit/test_infra.py
+++ b/training/tests/unit/test_infra.py
@@ -26,8 +26,8 @@ def test_setup_deployment_omits_placement_for_shape_backed_create():
     captured = {}
 
     class FakeResponse:
-        def __init__(self, payload=None):
-            self._payload = payload or {"name": "accounts/acct/deployments/dep-123", "state": "CREATING"}
+        def __init__(self, payload):
+            self._payload = payload
 
         def raise_for_status(self):
             return None
@@ -54,14 +54,9 @@ def test_setup_deployment_omits_placement_for_shape_backed_create():
                 }
             )
 
-        def _post(self, path, json, timeout):
-            captured["path"] = path
-            captured["json"] = json
-            captured["timeout"] = timeout
-            return FakeResponse()
-
-        def _parse_deployment_info(self, deployment_id, data):
-            return SimpleNamespace(deployment_id=deployment_id, state=data["state"])
+        def create_or_get(self, config):
+            captured["config"] = config
+            return SimpleNamespace(deployment_id=config.deployment_id, state="CREATING")
 
         def wait_for_ready(self, deployment_id, timeout_s):
             return SimpleNamespace(deployment_id=deployment_id, state="READY")
@@ -73,15 +68,15 @@ def test_setup_deployment_omits_placement_for_shape_backed_create():
             deployment_shape="accounts/fireworks/deploymentShapes/rft-kimi-k2p5-v2",
         ),
         "accounts/fireworks/models/kimi-k2p5",
-        InfraConfig(region="US_VIRGINIA_1"),
+        InfraConfig(region="US_VIRGINIA_1", purpose="PURPOSE_PILOT"),
     )
 
     assert info.state == "READY"
     assert captured["shape_timeout"] == 30
-    assert captured["timeout"] == 60
-    assert captured["json"]["deploymentShape"] == "accounts/fireworks/deploymentShapes/rft-kimi-k2p5-v2"
-    assert captured["json"]["forTraining"] is True
-    assert "placement" not in captured["json"]
+    assert captured["config"].deployment_shape == "accounts/fireworks/deploymentShapes/rft-kimi-k2p5-v2"
+    assert captured["config"].region is None
+    assert captured["config"].annotations == {"internal/purpose": "pilot"}
+    assert captured["config"].for_training is True
 
 
 def test_setup_deployment_infers_ohio_for_b200_shape():

--- a/training/tests/unit/test_sdk_compat.py
+++ b/training/tests/unit/test_sdk_compat.py
@@ -49,3 +49,15 @@ def test_to_deployment_config_sets_fixed_replica_count():
     assert isinstance(deployment_config, DeploymentConfig)
     assert deployment_config.min_replica_count == 3
     assert deployment_config.max_replica_count == 3
+
+
+def test_to_deployment_config_sets_purpose_annotation():
+    deploy_cfg = config_module.DeployConfig(deployment_id="dep-123")
+
+    deployment_config = deploy_cfg.to_deployment_config(
+        "accounts/test/models/qwen3-4b",
+        config_module.InfraConfig(purpose="PURPOSE_PILOT"),
+    )
+
+    assert deployment_config.annotations == {"internal/purpose": "pilot"}
+    assert deployment_config.for_training is True

--- a/training/utils/config.py
+++ b/training/utils/config.py
@@ -175,6 +175,11 @@ class DeployConfig:
         if not accel and not self.deployment_shape:
             accel = infra.accelerator_type
         replica_count = 1 if self.replica_count is None else self.replica_count
+        annotations = None
+        if infra.purpose:
+            annotations = {
+                "internal/purpose": infra.purpose.removeprefix("PURPOSE_").lower(),
+            }
         return DeploymentConfig(
             deployment_id=self.deployment_id,
             base_model=base_model,
@@ -189,6 +194,8 @@ class DeployConfig:
             accelerator_type=accel,
             disable_speculative_decoding=self.disable_speculative_decoding,
             extra_values=self.extra_values,
+            annotations=annotations,
+            for_training=True,
         )
 
 

--- a/training/utils/infra.py
+++ b/training/utils/infra.py
@@ -49,7 +49,6 @@ try:
 except ImportError:
     CreatedTrainerJob = Any
 from fireworks.training.sdk.deployment import (
-    DeploymentConfig,
     DeploymentInfo,
     DeploymentManager,
 )
@@ -562,8 +561,6 @@ def request_deployment(
         dep_config.region = _infer_region_from_deployment_shape(
             deploy_mgr, dep_config.deployment_shape
         )
-    if dep_config.region is None:
-        return _create_deployment_via_cookbook(deploy_mgr, dep_config, purpose=infra.purpose)
     return deploy_mgr.create_or_get(dep_config)
 
 
@@ -822,49 +819,6 @@ def get_deployment_gpu_count(
         return replica_count
 
 
-def _create_deployment_via_cookbook(
-    deploy_mgr: DeploymentManager,
-    config: DeploymentConfig,
-    purpose: str | None = None,
-) -> DeploymentInfo:
-    """Create a deployment while leaving placement selection to the control plane."""
-    path = f"/v1/accounts/{deploy_mgr.account_id}/deployments?deploymentId={config.deployment_id}"
-    if config.skip_shape_validation:
-        path += "&skipShapeValidation=true"
-    if config.disable_speculative_decoding:
-        path += "&disableSpeculativeDecoding=true"
-
-    body: dict[str, Any] = {
-        "baseModel": config.base_model,
-        "minReplicaCount": config.min_replica_count,
-        "maxReplicaCount": config.max_replica_count,
-        "enableHotLoad": True,
-        "forTraining": True,
-    }
-    if config.hot_load_bucket_type:
-        body["hotLoadBucketType"] = config.hot_load_bucket_type
-    if config.deployment_shape:
-        body["deploymentShape"] = config.deployment_shape
-    if config.accelerator_type:
-        body["acceleratorType"] = config.accelerator_type
-    if config.extra_args:
-        flat: list[str] = []
-        for arg in config.extra_args:
-            flat.extend(arg.split()) if " " in arg else flat.append(arg)
-        body["extraArgs"] = flat
-    if config.extra_values:
-        body["extraValues"] = config.extra_values
-    if purpose:
-        body["annotations"] = {
-            "internal/purpose": purpose.removeprefix("PURPOSE_").lower(),
-        }
-
-    logger.info("Creating deployment: %s", config.deployment_id)
-    resp = deploy_mgr._post(path, json=body, timeout=60)
-    resp.raise_for_status()
-    return deploy_mgr._parse_deployment_info(config.deployment_id, resp.json())
-
-
 def setup_training_client(
     endpoint: TrainerServiceEndpoint,
     base_model: str,
@@ -1115,6 +1069,8 @@ def setup_infra(
     """
     if needs_inference and deploy_mgr is None:
         raise ValueError("deploy_mgr is required when needs_inference=True")
+    if needs_inference and deploy_cfg is None:
+        raise ValueError("deploy_cfg is required when needs_inference=True")
 
     emit: StatusCallback = on_status or (lambda _: None)
     boot_start = time.time()
@@ -1154,10 +1110,9 @@ def setup_infra(
     # Build a local deploy_cfg copy with deployment_shape filled in; never mutates caller's object.
     local_deploy_cfg: DeployConfig | None = None
     if deploy_cfg is not None:
-        local_deploy_cfg = (
-            dataclasses.replace(deploy_cfg, deployment_shape=resolved_deploy_shape)
-            if resolved_deploy_shape and not deploy_cfg.deployment_shape
-            else deploy_cfg
+        local_deploy_cfg = dataclasses.replace(
+            deploy_cfg,
+            deployment_shape=deploy_cfg.deployment_shape or resolved_deploy_shape,
         )
 
     weight_sync_scope = (


### PR DESCRIPTION
## Issue
PR #215 introduced a cookbook raw deployment-create helper to preserve auto placement for shape-backed deployments. PR #255 later used that helper to pass purpose metadata. The helper now duplicates SDK request construction and drifted from the standard deployment create path.

## Resolution
Convert purpose into SDK `DeploymentConfig.annotations`, preserve the training deployment marker through SDK config, delete the raw deployment POST helper, and route deployment creation through `DeploymentManager.create_or_get()`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the deployment creation path and request payload shape (annotations/`for_training`), which could alter placement or metadata propagation if SDK behavior differs from the removed custom POST.
> 
> **Overview**
> Deployment creation no longer uses the cookbook’s custom raw deployment-POST helper; it now always builds an SDK `DeploymentConfig` (including inferred region-from-shape when needed) and calls `DeploymentManager.create_or_get()`.
> 
> `InfraConfig.purpose` is converted into a deployment `annotations` entry (`internal/purpose`) and deployments are explicitly marked `for_training=True`; unit tests were updated/added to assert the new config fields and annotation behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c16bf0967d0b8fb6864c8b4d9a0bfb3476e575e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->