### PR TITLE
[codex] Fix SFT tool renderer parity

### DIFF
--- a/training/renderer/gemma4.py
+++ b/training/renderer/gemma4.py
@@ -423,6 +423,8 @@ class Gemma4Renderer(Renderer):
     share across threads. The underlying tokenizer must also be thread-safe.
     """
 
+    expects_openai_tool_wrappers = True
+
     def __init__(self, tokenizer: Tokenizer, *, enable_thinking: bool = False):
         super().__init__(tokenizer)
         self.enable_thinking = enable_thinking

--- a/training/renderer/mistral.py
+++ b/training/renderer/mistral.py
@@ -140,6 +140,8 @@ class MistralRenderer(Renderer):
     Instruct v0.3+, Ministral 8B 2410, Mistral Small 3 Instruct).
     """
 
+    expects_openai_tool_wrappers = True
+
     def __init__(self, tokenizer: Tokenizer) -> None:
         super().__init__(tokenizer)
         self.default_system_prompt = self._detect_default_system_prompt()

--- a/training/renderer/verifier/utils/hf_parity.py
+++ b/training/renderer/verifier/utils/hf_parity.py
@@ -35,6 +35,8 @@ from tinker_cookbook.tokenizer_utils import get_tokenizer
 # ``tinker_cookbook.renderers.get_renderer``.
 import training.renderer  # noqa: F401
 from training.utils.supervised import normalize_messages
+from training.utils.supervised import parse_train_on_what
+from training.utils.supervised import render_messages_to_datums
 
 
 @dataclasses.dataclass
@@ -45,6 +47,13 @@ class HFParityResult:
     first_divergence_idx: int | None
     renderer_decoded: list[str]
     hf_decoded: list[str]
+
+
+@dataclasses.dataclass
+class HFSupervisedParityResult:
+    examples: list[HFParityResult]
+    match: bool
+    first_mismatch_example: int | None
 
 
 def _decode_each(tokenizer: Any, ids: list[int]) -> list[str]:
@@ -71,6 +80,76 @@ def _first_divergence(a: list[int], b: list[int]) -> int | None:
     if len(a) != len(b):
         return n
     return None
+
+
+def _hf_tokens(
+    tokenizer: Any,
+    messages: list[dict],
+    *,
+    add_generation_prompt: bool,
+    tools: list[dict] | None = None,
+    apply_chat_template_kwargs: dict[str, Any] | None = None,
+) -> list[int]:
+    kwargs: dict[str, Any] = {
+        "tokenize": True,
+        "add_generation_prompt": add_generation_prompt,
+    }
+    if tools is not None:
+        kwargs["tools"] = tools
+    kwargs.update(apply_chat_template_kwargs or {})
+    hf_result = tokenizer.apply_chat_template(messages, **kwargs)
+    if hasattr(hf_result, "input_ids"):
+        return [int(t) for t in list(hf_result.input_ids)]  # type: ignore[arg-type]
+    return [int(t) for t in list(hf_result)]  # type: ignore[arg-type]
+
+
+_SPLIT_REQUIRED_TRAINING_MODES = {
+    "all_assistant_messages",
+    "all_messages",
+    "all_tokens",
+    "all_user_and_system_messages",
+    "customized",
+}
+
+
+def _expected_supervised_prefixes(
+    *,
+    renderer: Any,
+    messages: list[dict],
+    train_on_what: Any,
+) -> list[list[dict]]:
+    train_mode = parse_train_on_what(train_on_what)
+    if any(("weight" in m) or ("trainable" in m) for m in messages):
+        train_mode = parse_train_on_what("customized")
+    if getattr(renderer, "has_extension_property", False):
+        return [messages]
+    if train_mode.value not in _SPLIT_REQUIRED_TRAINING_MODES:
+        return [messages]
+    user_message_idxs = [
+        idx for idx, message in enumerate(messages) if message.get("role") == "user"
+    ]
+    if len(user_message_idxs) <= 1:
+        return [messages]
+    return [
+        messages[:next_user_idx]
+        for next_user_idx in [*user_message_idxs[1:], len(messages)]
+    ]
+
+
+def _build_result(
+    tokenizer: Any,
+    renderer_tokens: list[int],
+    hf_tokens: list[int],
+) -> HFParityResult:
+    first_div = _first_divergence(renderer_tokens, hf_tokens)
+    return HFParityResult(
+        renderer_tokens=renderer_tokens,
+        hf_tokens=hf_tokens,
+        match=first_div is None,
+        first_divergence_idx=first_div,
+        renderer_decoded=_decode_each(tokenizer, renderer_tokens),
+        hf_decoded=_decode_each(tokenizer, hf_tokens),
+    )
 
 
 def compare_renderer_to_hf(
@@ -103,27 +182,74 @@ def compare_renderer_to_hf(
         renderer_input, _weights = renderer.build_supervised_example(normalized)
     renderer_tokens = [int(t) for t in renderer_input.to_ints()]
 
-    # ``apply_chat_template(tokenize=True)`` returns either a list or a
-    # ``BatchEncoding`` depending on the transformers version; normalize.
-    hf_result = tokenizer.apply_chat_template(
+    hf_tokens = _hf_tokens(
+        tokenizer,
         messages,
-        tokenize=True,
         add_generation_prompt=add_generation_prompt,
-        **(apply_chat_template_kwargs or {}),
+        apply_chat_template_kwargs=apply_chat_template_kwargs,
     )
-    if hasattr(hf_result, "input_ids"):
-        hf_tokens = [int(t) for t in list(hf_result.input_ids)]  # type: ignore[arg-type]
-    else:
-        hf_tokens = [int(t) for t in list(hf_result)]  # type: ignore[arg-type]
 
-    first_div = _first_divergence(renderer_tokens, hf_tokens)
-    return HFParityResult(
-        renderer_tokens=renderer_tokens,
-        hf_tokens=hf_tokens,
-        match=first_div is None,
-        first_divergence_idx=first_div,
-        renderer_decoded=_decode_each(tokenizer, renderer_tokens),
-        hf_decoded=_decode_each(tokenizer, hf_tokens),
+    return _build_result(tokenizer, renderer_tokens, hf_tokens)
+
+
+def compare_supervised_rendering_to_hf(
+    *,
+    renderer_name: str,
+    tokenizer_model: str,
+    messages: list[dict],
+    tools: list[dict] | None = None,
+    train_on_what: Any = "all_assistant_messages",
+    apply_chat_template_kwargs: dict[str, Any] | None = None,
+) -> HFSupervisedParityResult:
+    """Compare SFT ``render_messages_to_datums`` outputs to HF tokenization.
+
+    Multi-turn renderers that disaggregate training examples are compared one
+    split prefix at a time, which catches missing per-prefix tool declarations
+    and thinking-template drift.
+    """
+    tokenizer = get_tokenizer(tokenizer_model)
+    if not getattr(tokenizer, "chat_template", None):
+        raise RuntimeError(
+            f"Tokenizer {tokenizer_model!r} has no chat_template; "
+            "HF parity comparison is not meaningful."
+        )
+
+    renderer = get_renderer(renderer_name, tokenizer)
+    rendered_examples = render_messages_to_datums(
+        messages,
+        renderer=renderer,
+        train_on_what=train_on_what,
+        tools=tools,
+    )
+    prefixes = _expected_supervised_prefixes(
+        renderer=renderer,
+        messages=messages,
+        train_on_what=train_on_what,
+    )
+    if len(rendered_examples) != len(prefixes):
+        raise RuntimeError(
+            f"rendered example count mismatch: {len(rendered_examples)} != {len(prefixes)}"
+        )
+
+    example_results: list[HFParityResult] = []
+    for rendered, prefix_messages in zip(rendered_examples, prefixes, strict=True):
+        hf_tokens = _hf_tokens(
+            tokenizer,
+            prefix_messages,
+            add_generation_prompt=False,
+            tools=tools,
+            apply_chat_template_kwargs=apply_chat_template_kwargs,
+        )
+        example_results.append(_build_result(tokenizer, rendered.token_ids, hf_tokens))
+
+    first_mismatch = next(
+        (idx for idx, result in enumerate(example_results) if not result.match),
+        None,
+    )
+    return HFSupervisedParityResult(
+        examples=example_results,
+        match=first_mismatch is None,
+        first_mismatch_example=first_mismatch,
     )
 
 
@@ -156,3 +282,14 @@ def format_divergence(result: HFParityResult, *, context: int = 6) -> str:
         dec = result.hf_decoded[i] if i < len(result.hf_decoded) else ""
         lines.append(f"  {marker} idx={i}  tok={tok}  decoded={dec!r}")
     return "\n".join(lines)
+
+
+def format_supervised_divergence(
+    result: HFSupervisedParityResult,
+    *,
+    context: int = 6,
+) -> str:
+    if result.match:
+        return "all supervised examples match"
+    idx = result.first_mismatch_example or 0
+    return f"example {idx} diverged:\n{format_divergence(result.examples[idx], context=context)}"

--- a/training/tests/unit/test_renderer_hf_parity.py
+++ b/training/tests/unit/test_renderer_hf_parity.py
@@ -32,8 +32,11 @@ import pytest
 
 from training.renderer.verifier.utils.hf_parity import (
     HFParityResult,
+    HFSupervisedParityResult,
+    compare_supervised_rendering_to_hf,
     compare_renderer_to_hf,
     format_divergence,
+    format_supervised_divergence,
 )
 
 
@@ -47,6 +50,18 @@ class _Case:
     xfail_reason: str | None = None  # if set, mark the test xfail with this reason
 
 
+@dataclasses.dataclass
+class _SupervisedCase:
+    case_id: str
+    renderer: str
+    tokenizer_model: str
+    messages: list[dict]
+    tools: list[dict] | None = None
+    train_on_what: str = "all_assistant_messages"
+    apply_chat_template_kwargs: dict[str, Any] = dataclasses.field(default_factory=dict)
+    xfail_reason: str | None = None
+
+
 _SHORT_MSGS = [
     {"role": "system", "content": "Answer with a single integer and nothing else."},
     {"role": "user", "content": "2 + 2 = ?"},
@@ -57,6 +72,20 @@ _MULTI_TURN_MSGS = [
     {"role": "assistant", "content": "4."},
     {"role": "user", "content": "And 3+3?"},
 ]
+_WEATHER_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "description": "Get the current weather for a city.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "city": {"type": "string", "description": "City name."},
+            },
+            "required": ["city"],
+        },
+    },
+}
 
 
 _CASES: list[_Case] = [
@@ -155,6 +184,60 @@ _CASES: list[_Case] = [
 _PARAM = pytest.mark.parametrize("case", _CASES, ids=[c.case_id for c in _CASES])
 
 
+_SUPERVISED_CASES: list[_SupervisedCase] = [
+    _SupervisedCase(
+        case_id="kimi_k25-tools-multiturn-sft",
+        renderer="kimi_k25",
+        tokenizer_model="moonshotai/Kimi-K2.5",
+        tools=[_WEATHER_TOOL],
+        messages=[
+            {"role": "system", "content": "Be precise."},
+            {"role": "user", "content": "Weather in SF?"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": {"city": "SF"},
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "name": "get_weather",
+                "content": "Foggy.",
+            },
+            {"role": "assistant", "content": "SF is foggy."},
+            {"role": "user", "content": "And NYC?"},
+            {"role": "assistant", "content": "NYC is clear."},
+        ],
+    ),
+    _SupervisedCase(
+        case_id="mistral-tools-sft",
+        renderer="mistral",
+        tokenizer_model="mistralai/Ministral-3-3B-Instruct-2512",
+        tools=[_WEATHER_TOOL],
+        messages=[
+            {"role": "system", "content": "Be precise."},
+            {"role": "user", "content": "Weather in SF?"},
+            {"role": "assistant", "content": "I will check."},
+        ],
+    ),
+]
+
+_SUPERVISED_PARAM = pytest.mark.parametrize(
+    "case",
+    _SUPERVISED_CASES,
+    ids=[c.case_id for c in _SUPERVISED_CASES],
+)
+
+
 @_PARAM
 @pytest.mark.timeout(180)
 def test_renderer_matches_hf_chat_template(case: _Case) -> None:
@@ -176,3 +259,24 @@ def test_renderer_matches_hf_chat_template(case: _Case) -> None:
         pytest.skip(f"tokenizer unavailable for {case.tokenizer_model!r}: {exc}")
 
     assert result.match, format_divergence(result)
+
+
+@_SUPERVISED_PARAM
+@pytest.mark.timeout(180)
+def test_supervised_rendering_matches_hf_chat_template(case: _SupervisedCase) -> None:
+    if case.xfail_reason:
+        pytest.xfail(case.xfail_reason)
+
+    try:
+        result: HFSupervisedParityResult = compare_supervised_rendering_to_hf(
+            renderer_name=case.renderer,
+            tokenizer_model=case.tokenizer_model,
+            messages=case.messages,
+            tools=case.tools,
+            train_on_what=case.train_on_what,
+            apply_chat_template_kwargs=case.apply_chat_template_kwargs,
+        )
+    except (OSError, ValueError, RuntimeError) as exc:
+        pytest.skip(f"tokenizer unavailable for {case.tokenizer_model!r}: {exc}")
+
+    assert result.match, format_supervised_divergence(result)

--- a/training/tests/unit/test_supervised_rendering.py
+++ b/training/tests/unit/test_supervised_rendering.py
@@ -305,7 +305,7 @@ def test_normalize_messages_supports_openai_tool_call_shape():
 
     tool_call = normalized[0]["tool_calls"][0]
     assert tool_call.function.name == "lake_move"
-    assert tool_call.function.arguments == '{"action": "RIGHT"}'
+    assert tool_call.function.arguments == '{"action":"RIGHT"}'
 
 
 def test_normalize_messages_keeps_tool_metadata_and_thinking_parts():

--- a/training/utils/supervised.py
+++ b/training/utils/supervised.py
@@ -273,9 +273,11 @@ def _normalize_tool_calls(tool_calls: Any) -> list[ToolCall]:
         if isinstance(function, Mapping) and isinstance(function.get("name"), str):
             raw_args = function.get("arguments", {})
             if isinstance(raw_args, str):
-                parsed_args = json.loads(raw_args) if raw_args else {}
+                if raw_args:
+                    json.loads(raw_args)
+                arguments = raw_args or "{}"
             elif isinstance(raw_args, Mapping):
-                parsed_args = dict(raw_args)
+                arguments = json.dumps(dict(raw_args))
             else:
                 raise TypeError(
                     f"Unsupported tool call arguments type: {type(raw_args)!r}"
@@ -284,7 +286,7 @@ def _normalize_tool_calls(tool_calls: Any) -> list[ToolCall]:
                 ToolCall(
                     function=ToolCall.FunctionBody(
                         name=function["name"],
-                        arguments=json.dumps(parsed_args),
+                        arguments=arguments,
                     ),
                     id=tool_call.get("id"),
                 )
@@ -293,6 +295,26 @@ def _normalize_tool_calls(tool_calls: Any) -> list[ToolCall]:
 
         raise ValueError(f"Unsupported tool call shape: {tool_call}")
     return normalized
+
+
+def _tool_specs_for_prefix_builder(
+    renderer: Renderer,
+    tools: Sequence[Mapping[str, Any]],
+) -> list[Mapping[str, Any]]:
+    """Return the tool shape expected by a renderer's tool-prefix hook.
+
+    Most upstream Tinker renderers accept plain function specs and wrap them
+    internally. A few cookbook-local renderers mirror HF's
+    ``apply_chat_template(..., tools=...)`` surface directly and need the
+    original OpenAI ``{"type": "function", "function": ...}`` wrappers.
+    """
+    if getattr(renderer, "expects_openai_tool_wrappers", False):
+        return [t for t in tools if isinstance(t, Mapping)]
+    return [
+        t["function"]
+        for t in tools
+        if isinstance(t, Mapping) and isinstance(t.get("function"), Mapping)
+    ]
 
 
 def _normalize_image_part(part: Mapping[str, Any]) -> dict[str, Any]:
@@ -870,11 +892,7 @@ def render_messages_to_datums(
     if tools:
         prefix_builder = getattr(renderer, "create_conversation_prefix_with_tools", None)
         if prefix_builder is not None:
-            tool_specs = [
-                t["function"]
-                for t in tools
-                if isinstance(t, Mapping) and isinstance(t.get("function"), Mapping)
-            ]
+            tool_specs = _tool_specs_for_prefix_builder(renderer, tools)
             if tool_specs:
                 system_prompt = ""
                 if normalized_messages and normalized_messages[0].get("role") == "system":


### PR DESCRIPTION
## Summary

- add a CPU-only L1 supervised rendering parity helper that compares `render_messages_to_datums()` outputs to HuggingFace `apply_chat_template()` token IDs per split example
- add L1 coverage for Kimi K2.5 multi-turn tool SFT rows and Mistral tool SFT rows
- fix SFT tool-prefix shape handling for renderers that expect raw OpenAI tool wrappers, and preserve raw JSON strings in OpenAI tool call arguments to avoid token drift

## Root Cause

The SFT tool path handled top-level dataset `tools`, but normalized the tool schema into one function-spec shape for every renderer. That matches Kimi-style prefix builders, but Mistral/Gemma mirror HF's `tools=` input and need the original OpenAI `{"type":"function","function":...}` wrapper. Separately, OpenAI `function.arguments` strings were parsed and re-serialized, which can change byte/token layout even when the JSON value is equivalent.

## Validation

- `PYTHONPATH=. python -m pytest training/tests/unit/test_renderer_hf_parity.py -q` (`12 passed, 1 xfailed`)
- `PYTHONPATH=. python -m pytest training/tests/unit/test_supervised_rendering.py -q` (`37 passed`)
- `PYTHONPATH=. python -m pytest training/tests/unit/test_mistral_renderer.py -q` (`14 passed`)
- `PYTHONPATH=. python -m pytest training/tests/unit/test_sft_loop.py -q` (`31 passed`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches supervised SFT rendering for tool definitions and tool-call argument normalization, which can change training tokenization/weights for tool-using datasets. Added parity tests reduce regression risk but mismatches could still affect model behavior if edge-case tool schemas/arguments differ.
> 
> **Overview**
> Fixes SFT tool-rendering parity with HuggingFace chat templates by (1) preserving raw OpenAI `function.arguments` JSON strings during `normalize_messages` (avoiding re-serialization token drift) and (2) passing renderer-appropriate tool spec shapes when building tool prefixes (some renderers now opt into receiving OpenAI-style `{"type":"function","function":...}` wrappers via `expects_openai_tool_wrappers`).
> 
> Adds a CPU-only supervised parity helper that compares `render_messages_to_datums()` token IDs against `tokenizer.apply_chat_template()` **per split training example**, plus new unit coverage for multi-turn tool SFT rows (Kimi K2.5) and tool-prefixed SFT rows (Mistral).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e9284c2765ea3ef58e8463e34485428067e8fb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->