### PR TITLE
chore: align cookbook with fireworks staging

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Fireworks Training Cookbook
 
-Ready-to-run training recipes built on the [Fireworks Training SDK](https://github.com/stainless-sdks/fireworks-ai-python) (`fireworks.training.sdk`). Only `training/` is relevant -- ignore other top-level directories.
+Ready-to-run training recipes built on the [Fireworks Training SDK](https://github.com/fw-ai-external/python-sdk) (`fireworks.training.sdk`). Only `training/` is relevant -- ignore other top-level directories.
 
 **Skills:**
 - [`skills/dev/`](skills/dev/SKILL.md) — day-to-day training work (greenfield setup, debugging, hotload, RL recipe internals, checkpoint promotion). Entry in `SKILL.md` maps tasks and error signals to specific reference files under `skills/dev/references/`. The SDK repo points here; do not maintain a parallel skill there.

--- a/skills/dev/SKILL.md
+++ b/skills/dev/SKILL.md
@@ -80,4 +80,4 @@ If the installed version doesn't satisfy the pin, upgrade first and retry. Only 
 
 ## SDK surface
 
-The training SDK lives at <https://github.com/stainless-sdks/fireworks-ai-python> under `src/fireworks/training/sdk/`. Code outside that directory in that repo is auto-generated — ignore. For any SDK call an agent needs, read the cookbook recipe that already makes it: recipe files are listed in [`references/recipes.md`](references/recipes.md).
+The training SDK lives at <https://github.com/fw-ai-external/python-sdk> under `src/fireworks/training/sdk/`. For any SDK call an agent needs, read the cookbook recipe that already makes it: recipe files are listed in [`references/recipes.md`](references/recipes.md).

--- a/skills/dev/references/rl/hotload.md
+++ b/skills/dev/references/rl/hotload.md
@@ -18,9 +18,8 @@ DeployConfig(weight_sync_scope=WeightSyncScope.PER_TRAINER, ...)
 
 1. Create the trainer via `TrainerJobManager.create_and_wait(...)`.
 2. Create the deployment via `DeploymentManager.create_or_get(DeploymentConfig(hot_load_trainer_job=<trainer_job>, ...))`.
-   The deployment copies the trainer's bucket URL at creation. Cookbook-created serving deployments are training
-   deployments (`forTraining=true` in the CreateDeployment payload), which is required for private Fireworks-owned
-   deployment shape versions pinned by training shapes.
+   The deployment copies the trainer's bucket URL at creation. The Training SDK marks cookbook-created serving
+   deployments as training deployments, which is required for deployment shape versions pinned by training shapes.
 3. The **trainer owns** the checkpoints. Promote reads them from the trainer's bucket without any deployment ID.
 4. On resume, the deployment is re-attached to the new trainer (PATCH `hotLoadTrainerJob`), which briefly restarts the serving pod.
 

--- a/training/tests/unit/test_infra.py
+++ b/training/tests/unit/test_infra.py
@@ -54,14 +54,9 @@ def test_setup_deployment_omits_placement_for_shape_backed_create():
                 }
             )
 
-        def _post(self, path, json, timeout):
-            captured["path"] = path
-            captured["json"] = json
-            captured["timeout"] = timeout
-            return FakeResponse()
-
-        def _parse_deployment_info(self, deployment_id, data):
-            return SimpleNamespace(deployment_id=deployment_id, state=data["state"])
+        def create_or_get(self, config):
+            captured["config"] = config
+            return SimpleNamespace(deployment_id=config.deployment_id, state="CREATING")
 
         def wait_for_ready(self, deployment_id, timeout_s):
             return SimpleNamespace(deployment_id=deployment_id, state="READY")
@@ -78,10 +73,8 @@ def test_setup_deployment_omits_placement_for_shape_backed_create():
 
     assert info.state == "READY"
     assert captured["shape_timeout"] == 30
-    assert captured["timeout"] == 60
-    assert captured["json"]["deploymentShape"] == "accounts/fireworks/deploymentShapes/rft-kimi-k2p5-v2"
-    assert captured["json"]["forTraining"] is True
-    assert "placement" not in captured["json"]
+    assert captured["config"].deployment_shape == "accounts/fireworks/deploymentShapes/rft-kimi-k2p5-v2"
+    assert captured["config"].accelerator_type is None
 
 
 def test_setup_deployment_infers_ohio_for_b200_shape():

--- a/training/utils/infra.py
+++ b/training/utils/infra.py
@@ -49,7 +49,6 @@ try:
 except ImportError:
     CreatedTrainerJob = Any
 from fireworks.training.sdk.deployment import (
-    DeploymentConfig,
     DeploymentInfo,
     DeploymentManager,
 )
@@ -562,8 +561,6 @@ def request_deployment(
         dep_config.region = _infer_region_from_deployment_shape(
             deploy_mgr, dep_config.deployment_shape
         )
-    if dep_config.region is None:
-        return _create_deployment_via_cookbook(deploy_mgr, dep_config, purpose=infra.purpose)
     return deploy_mgr.create_or_get(dep_config)
 
 
@@ -820,49 +817,6 @@ def get_deployment_gpu_count(
     except Exception as e:
         logger.warning("Could not determine GPU count from shape: %s", e)
         return replica_count
-
-
-def _create_deployment_via_cookbook(
-    deploy_mgr: DeploymentManager,
-    config: DeploymentConfig,
-    purpose: str | None = None,
-) -> DeploymentInfo:
-    """Create a deployment while leaving placement selection to the control plane."""
-    path = f"/v1/accounts/{deploy_mgr.account_id}/deployments?deploymentId={config.deployment_id}"
-    if config.skip_shape_validation:
-        path += "&skipShapeValidation=true"
-    if config.disable_speculative_decoding:
-        path += "&disableSpeculativeDecoding=true"
-
-    body: dict[str, Any] = {
-        "baseModel": config.base_model,
-        "minReplicaCount": config.min_replica_count,
-        "maxReplicaCount": config.max_replica_count,
-        "enableHotLoad": True,
-        "forTraining": True,
-    }
-    if config.hot_load_bucket_type:
-        body["hotLoadBucketType"] = config.hot_load_bucket_type
-    if config.deployment_shape:
-        body["deploymentShape"] = config.deployment_shape
-    if config.accelerator_type:
-        body["acceleratorType"] = config.accelerator_type
-    if config.extra_args:
-        flat: list[str] = []
-        for arg in config.extra_args:
-            flat.extend(arg.split()) if " " in arg else flat.append(arg)
-        body["extraArgs"] = flat
-    if config.extra_values:
-        body["extraValues"] = config.extra_values
-    if purpose:
-        body["annotations"] = {
-            "internal/purpose": purpose.removeprefix("PURPOSE_").lower(),
-        }
-
-    logger.info("Creating deployment: %s", config.deployment_id)
-    resp = deploy_mgr._post(path, json=body, timeout=60)
-    resp.raise_for_status()
-    return deploy_mgr._parse_deployment_info(config.deployment_id, resp.json())
 
 
 def setup_training_client(


### PR DESCRIPTION
## Summary

Brings public cookbook back in line with the upstream `fw-ai/fireworks` staging copy under `public-repos/cookbook/`, so the new staging→public promote pipeline stops silently overwriting drift on the next run.

- Removes the legacy `_create_deployment_via_cookbook` helper in `training/utils/infra.py` plus its tests in `training/tests/unit/test_infra.py`. The Training SDK now handles deployment annotations and the for-training flag natively via `DeploymentManager.create_or_get(...)`; cookbook-side payload construction is duplicated work and a divergence risk.
- Updates `skills/dev/references/rl/hotload.md` to drop the cookbook-payload-specific phrasing now that the SDK owns the training-deployment marking.
- Points the SDK URL in `CLAUDE.md` and `skills/dev/SKILL.md` to the official public SDK repo (`fw-ai-external/python-sdk`) instead of the Stainless-mirror URL (`stainless-sdks/fireworks-ai-python`). Stainless is being decommissioned upstream. Also drops the now-obsolete "Code outside that directory in that repo is auto-generated — ignore" sentence, which was specific to the Stainless mirror's layout.

No behavior change for SDK consumers; this is cleanup + documentation pointer fixes.

## Test plan

- [ ] Existing CI on this repo passes (lint + training tests).
- [ ] After merge, the upstream staging-vs-public diverge check on `fw-ai/fireworks` PR #26425 goes green on cookbook.
- [ ] Next staging→public promote run for cookbook produces a no-op (or only forward-drift) diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk cleanup that removes a duplicate deployment-creation code path and updates tests/docs to rely on the Training SDK’s `DeploymentManager.create_or_get` behavior; main risk is subtle differences in deployment creation flags/annotations if SDK behavior diverges.
> 
> **Overview**
> Aligns cookbook deployment provisioning with the Training SDK by deleting the custom `_create_deployment_via_cookbook` POST/payload builder and always using `DeploymentManager.create_or_get(...)` in `training/utils/infra.py`.
> 
> Updates unit tests to assert against the SDK `DeploymentConfig` passed into `create_or_get` (instead of a handcrafted HTTP payload), and refreshes docs to reflect that the SDK (not the cookbook) marks cookbook-created serving deployments as training deployments.
> 
> Updates documentation links to point to the official public SDK repo (`fw-ai-external/python-sdk`) and removes stale wording specific to the old mirror.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48e51442bf0adb76422d275bbd68373aa0bdc42f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->