### PR TITLE
Revert public-only cookbook staging drift

### DIFF
--- a/training/README.md
+++ b/training/README.md
@@ -14,7 +14,7 @@ Each recipe is a single Python file you can fork and customize.
 | IGPO (multi-turn turn-level Information Gain) | `recipes/igpo_loop.py` | GRPO + per-turn IG rewards for agent trajectories (Wang et al., ICLR 2026). |
 | DPO | `recipes/dpo_loop.py` | Direct preference optimization with cached reference logprobs. |
 | ORPO | `recipes/orpo_loop.py` | Odds-ratio preference optimization -- no reference model needed. |
-| SFT | `recipes/sft_loop.py` | Supervised fine-tuning with response-only cross-entropy loss. |
+| SFT | `recipes/sft_loop.py` | Supervised fine-tuning with response-only cross-entropy loss. Set `pipeline_depth>=2` to enable client-side pipelining (Tinker async pattern) for **+25-35% throughput** on long-context / production runs. See module docstring for tuning guidance. |
 
 ## Getting started
 

--- a/training/recipes/dpo_loop.py
+++ b/training/recipes/dpo_loop.py
@@ -104,9 +104,7 @@ class Config:
     learning_rate: float = 1e-5
     epochs: int = 1
     batch_size: int = 4
-    """Number of preference pairs per optimizer step. For managed (V2) jobs
-    this is set from ``BaseTrainingConfig.batch_size_samples`` via the
-    cookbook orchestrator."""
+    """Number of preference pairs per optimizer step."""
     max_seq_len: int | None = None
     max_pairs: int | None = None
     """Cap on *valid rendered pairs* after schema/length filtering."""

--- a/training/recipes/orpo_loop.py
+++ b/training/recipes/orpo_loop.py
@@ -98,9 +98,7 @@ class Config:
     learning_rate: float = 1e-5
     epochs: int = 1
     batch_size: int = 4
-    """Number of preference pairs per optimizer step. For managed (V2) jobs
-    this is set from ``BaseTrainingConfig.batch_size_samples`` via the
-    cookbook orchestrator."""
+    """Number of preference pairs per optimizer step."""
     seed: int = 0
     """Seed for deterministic per-epoch shuffling of preference pairs."""
     max_seq_len: int | None = None

--- a/training/recipes/sft_loop.py
+++ b/training/recipes/sft_loop.py
@@ -466,9 +466,6 @@ class Config:
     learning_rate: float = 1e-4
     epochs: int = 3
     batch_size: int = 32
-    """Number of training samples per optimizer step. For managed (V2) jobs
-    this is set from ``BaseTrainingConfig.batch_size_samples`` via the
-    cookbook orchestrator."""
     max_seq_len: int | None = None
     max_examples: int | None = None
     lora_rank: int = 0


### PR DESCRIPTION
## Summary
- revert the public-only batch-size docstring change from fw-ai/cookbook#406 so SFT/DPO/ORPO match internal staging again
- restore the SFT README row owned by internal staging, undoing the public-only README drift from fw-ai/cookbook#422

## Context
The internal staging diverge check in fw-ai/fireworks#26738 failed because these public-only changes were merged directly into `fw-ai/cookbook` instead of flowing from `fw-ai/fireworks/public-repos/cookbook` through promotion.

Direct public commits identified:
- `ec7cb4b2` / fw-ai/cookbook#422, authored by `Hecate0821`, changed `training/README.md`
- `9861bbcc` / fw-ai/cookbook#406, authored by `hershalb`, changed SFT/DPO/ORPO batch-size docstrings

This PR restores the public mirror to the internal staging source of truth for the affected files.

## Verification
```bash
git diff --stat origin/main...HEAD
```
Result: 4 doc-only files changed.

No runtime tests were run because this only reverts README/docstring drift.