### PR TITLE
fix(streaming): seek byte offsets in binary mode for JSONL dataset

### DIFF
--- a/training/utils/streaming.py
+++ b/training/utils/streaming.py
@@ -99,10 +99,10 @@ class JsonlRenderDataset(torch_data.Dataset):
 
     def __getitem__(self, i: int) -> Any:
         offset = self._offsets[self._index_map[i]]
-        with open(self._path) as f:
+        with open(self._path, "rb") as f:
             f.seek(offset)
             line = f.readline()
-        row = json.loads(line)
+        row = json.loads(line.decode("utf-8"))
         if self._row_index_key is not None:
             row[self._row_index_key] = self._index_map[i]
         return self._render_fn(row)


### PR DESCRIPTION
JsonlRenderDataset built its byte-offset table from a binary-mode read but then opened the file in text mode for __getitem__ and seeked to those offsets. In text mode, seek() to arbitrary byte offsets is undefined when the file contains multi-byte UTF-8: the seek can land mid-codepoint, the subsequent readline returns a truncated line, and json.loads raises "Expecting value: line 1 column 1 (char 0)". This manifested as flaky DataLoader worker crashes on JSONL files with non-ASCII content (e.g. Qwen3 tokenizer outputs in rendered messages).

Read the line in binary and decode explicitly so seek + readline operate on the same byte coordinate system as the offset table.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line I/O change in lazy JSONL loading; behavior is equivalent for valid UTF-8 lines and fixes incorrect text-mode seeking.
> 
> **Overview**
> **`JsonlRenderDataset.__getitem__`** now opens the JSONL file in **`"rb"`** and **`json.loads(line.decode("utf-8"))`** instead of text mode + raw **`json.loads(line)`**.
> 
> That aligns random access with **`_scan_jsonl_offsets`**, which records **byte** positions. Text-mode **`seek`** to those offsets could land inside a multi-byte UTF-8 character, yielding truncated lines and **`json.loads`** failures—especially under DataLoader workers on non-ASCII rendered training data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 455606598b7f500ff1af404c5cbb99071bda128f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->