### PR TITLE
feat(opd): top-K OPSD distillation modes (reverse/forward KL)

### DIFF
--- a/training/examples/opd/README.md
+++ b/training/examples/opd/README.md
@@ -1,12 +1,56 @@
-# On-Policy Distillation (OPD)
+# On-Policy Distillation (OPD / OPSD)
 
-Train a student on its **own rollouts** to match a teacher. The student samples,
-each rollout is scored by a frozen teacher, and the per-token
-`teacher_logprob − sampling_logprob` is fed to the built-in `importance_sampling`
-loss — a 1-sample Monte-Carlo estimate of reverse KL `KL(π_S ‖ π_T)` that needs
-only the teacher's logprob at the sampled token (no top-K). Recipe:
-`training/recipes/opd_loop.py`; helpers: `training/utils/opd.py`,
-`training/utils/opd_sampling.py`.
+Train a student on its **own rollouts** to match a teacher. All objectives are
+on-policy (the student samples, then is updated toward the teacher). The recipe
+is `training/recipes/opd_loop.py`; the datum/loss helpers are
+`training/utils/opd.py` and `training/utils/opd_sampling.py`.
+
+## Modes
+
+| Mode | KL | source-K model | student training pass |
+|---|---|---|---|
+| `SAMPLED_IS` | reverse KL (1-sample MC) | — (no top-K) | builtin `importance_sampling` |
+| `TOPK_REVERSE_KL` | reverse `KL(S‖T)` | **student** | `forward_backward_custom` |
+| `TOPK_FORWARD_KL` | forward `KL(T‖S)` | **teacher** | builtin `cross_entropy` `[N,K]` |
+
+- **`SAMPLED_IS`** (ships today): per-token advantage `teacher_logprob −
+  sampling_logprob` on the sampled token → `importance_sampling`. A 1-sample
+  estimate of reverse KL; needs **no** top-K. Both logprobs come from inference.
+- **`TOPK_REVERSE_KL`** (recommended OPSD default): analytic reverse KL over the
+  top-K. Reverse KL's expectation is over `π_S`, so the K support is the
+  **student's** top-K. Mode-seeking; matches the OPD literature.
+- **`TOPK_FORWARD_KL`** (opt-in, SDFT-style): cross-entropy against the
+  **teacher's** top-K. Forward KL's expectation is over `π_T`. Mass-covering;
+  for continual-learning, not the distillation default.
+
+## The one rule that matters: source-K (selection) vs gather
+
+- **source K** = the *first* call that **selects** the K token indices (+ that
+  model's logprobs): trainer `forward(loss_fn_config={"top_k": K})` (`@no_grad`)
+  or inference `top_logprobs`.
+- **gather** = the *second* stage that **reads logprobs at those fixed indices**
+  via `target_tokens=[N,K]` (PR #27269).
+
+Only **one** selection per position. The other model and the training
+`forward_backward` must **gather at the same source-K indices** — **never** run a
+second `topK` (it would select different tokens and silently compute the
+per-token KL on mismatched tokens).
+
+## OPSD extraction provenance (`TOPK_REVERSE_KL`)
+
+Source K = student top-K, extracted **on the trainer, forward-only, after
+inference** — not from inference `top_logprobs`:
+
+```text
+1. inference samples rollouts                -> on-policy TOKEN SEQUENCES
+2. trainer forward(top_k=K) over sequences   -> source K = student top-K indices (@no_grad)
+3. gather TEACHER at those indices           -> target logprobs (q)
+4. student forward_backward at those indices -> student logprobs WITH grad -> loss
+```
+
+Inference `top_logprobs` is a cheap approximation (skips step 2) but bakes in the
+train/inference gap (quantized weights, different kernels, truncated/renormalized
+nucleus, cap ≤ 5).
 
 ## Multi-teacher = multi-TARGET routing (one student, N teachers)
 
@@ -17,8 +61,9 @@ routing different prompts to different teacher deployments lets the async
 sampling window **interleave scoring across teachers**, keeping every
 deployment's GPU busy with multiple targets in flight.
 
-Per-prompt **mixture/blend** is intentionally **not** supported — it would be N×
-teacher cost for a single target, the opposite of the throughput goal.
+Per-prompt **mixture/blend** is intentionally **not** supported online — it would
+be N× teacher cost for a single target, the opposite of the throughput goal.
+(`blend_teacher_topk` stays in utils for the future offline top-K path only.)
 
 ```python
 from training.utils.opd import MultiTeacherConfig, TeacherConfig
@@ -47,9 +92,29 @@ The adaptive concurrency controller only watches the *student* deployment, so
 heavily skewed routing can leave some teacher GPUs idle — a data-distribution
 issue, not a code one.
 
-> **Note:** the routed teacher is scored against the row's privileged prompt
-> (`teacher_messages` / default). Per-teacher `TeacherConfig.teacher_messages_key`
-> is **not** consumed yet; a non-default value logs a warning.
+> **Note:** the online loop scores the routed teacher against the row's
+> privileged prompt (`teacher_messages` / default). Per-teacher
+> `TeacherConfig.teacher_messages_key` is **not** consumed online yet; a
+> non-default value logs a warning.
+
+## What's deferred
+
+**Offline top-K KL** (teacher = separate frozen model, or teacher top-K stored in
+the dataset) is **not** built here. The co-located LoRA `kl_distillation` loss
+(`train/nn/kl_distillation.py`) already covers offline distillation and is
+exact — full-vocab KL via the shared lm_head, no top-K approximation. The
+`teacher_topk_from_row` helper remains as a thin hook for that future path.
+
+## Footguns (enforced or to avoid)
+
+- `forward(top_k=K)` is **forward-only** (`@no_grad`): it returns *indices* (+
+  detached logprobs) for selection/verification. It **cannot train** — there is
+  no backward. Training only happens via `forward_backward(_custom)` gathering at
+  those indices. `forward_backward_custom` is two-pass (forward → client loss →
+  CE-surrogate forward+backward) and errors if the loss has no gradient, so a
+  stray extraction can't silently "train".
+- Don't feed the **student's** own top-K as the *teacher* target — that is
+  self-distillation, not OPD.
 
 ## Example
 

--- a/training/examples/opd/README.md
+++ b/training/examples/opd/README.md
@@ -52,6 +52,13 @@ Inference `top_logprobs` is a cheap approximation (skips step 2) but bakes in th
 train/inference gap (quantized weights, different kernels, truncated/renormalized
 nucleus, cap ≤ 5).
 
+**Backend dependency (masked top-K gather).** Steps 2–4 need the RLOR backend to
+(a) gather logprobs at fixed `[N,K]` `target_tokens` in one forward, and (b)
+apply the sampling nucleus (top-p/top-k) mask *inside* top-K selection so the
+top-K is **gathered after masking**. Nucleus masking is the engine's job (it owns
+the sampling params); the cookbook does not reconstruct it client-side. Tracked
+in the backend PR; until it lands these top-K modes are not wired into the loop.
+
 ## Multi-teacher = multi-TARGET routing (one student, N teachers)
 
 This is **routing, not blending**. Each prompt is scored by **exactly one**

--- a/training/utils/opd.py
+++ b/training/utils/opd.py
@@ -1,25 +1,112 @@
-"""Utilities for sampled-token on-policy distillation (OPD).
+"""On-policy distillation datums and losses (online OPD / OPSD).
 
-The Tinker server already has the primitive OPD needs: the built-in
-``importance_sampling`` loss computes
+All objectives here train on *student* rollouts. The focus is the ONLINE path
+(``opd_loop.py``); offline top-K KL distillation is intentionally deferred --
+the co-located LoRA ``kl_distillation`` loss already covers the offline case
+(see "Offline" note below).
 
-    -exp(current_logprob - sampling_logprob) * advantage
+Modes
+-----
+    DistillMode        KL direction          source-K model   student training pass
+    -----------------  --------------------  ---------------  -----------------------------
+    SAMPLED_IS         reverse KL (1-sample) n/a (no top-K)   builtin ``importance_sampling``
+    TOPK_REVERSE_KL    reverse  KL(S || T)   STUDENT          ``forward_backward_custom``
+    TOPK_FORWARD_KL    forward  KL(T || S)   TEACHER          builtin ``cross_entropy`` [N,K]
 
-per token.  Sampled-token OPD uses the teacher/student log-ratio as the dense
-reward, so the per-token advantage is simply
+* ``SAMPLED_IS`` (ships in #391): per-token advantage = ``teacher_logprob -
+  sampling_logprob`` on the sampled token, fed to ``importance_sampling``
+  (``-exp(lp - slp) * advantage``). A 1-sample Monte-Carlo estimate of reverse
+  KL ``KL(pi_S || pi_T)`` -- correct direction, NO top-K. Both logprobs come
+  from INFERENCE (student sampling + teacher-deployment scoring).
+* ``TOPK_REVERSE_KL`` (``reverse_kl_topk_loss``): analytic reverse KL over the
+  top-K. Reverse KL's expectation is over ``pi_S``, so the source K (the K-token
+  support) is the **STUDENT's** top-K. Recommended OPSD default (mode-seeking,
+  matches the literature).
+* ``TOPK_FORWARD_KL``: cross-entropy against the teacher's renormalized top-K.
+  Forward KL's expectation is over ``pi_T``, so the source K is the **TEACHER's**
+  top-K. Mass-covering; opt-in for SDFT-style continual-learning.
 
-    teacher_logprob - sampling_logprob
+Source-K vs gather (the key rule -- see also opd_sampling.py)
+------------------------------------------------------------
+"source K" = the FIRST call that *selects* the K token indices (+ that model's
+logprobs): ``forward(loss_fn_config={"top_k": K})`` (trainer, ``@no_grad``) or
+inference ``top_logprobs``. "gather" = the SECOND stage that reads logprobs AT
+those fixed indices via ``target_tokens=[N,K]`` (PR #27269). The other model and
+the training ``forward_backward`` MUST gather at the SAME source-K indices.
+NEVER run a second ``topK`` selection at stage 2 -- it would pick a *different*
+K set and silently compute per-token KL on mismatched tokens.
 
-for response tokens.  These helpers build server-side datums that encode that
-reward in ``loss_fn_inputs["advantages"]``.
+OPSD extraction provenance (TOPK_REVERSE_KL, source = student)
+--------------------------------------------------------------
+For correctness the student source K is obtained by a trainer-side forward-only
+extraction run AFTER inference, over the sampled rollout tokens -- NOT from the
+inference ``top_logprobs``. Reasons: inference runs quantized weights + different
+kernels + a truncated/renormalized sampling nucleus (capped at top_logprobs<=5),
+i.e. the train/inference gap; reverse KL needs the student's true training-time
+distribution. Flow:
+    1. inference samples rollouts                -> on-policy TOKEN SEQUENCES
+    2. trainer forward(top_k=K) over sequences   -> source K = student top-K indices (@no_grad)
+    3. gather TEACHER at those indices           -> target logprobs (q)
+    4. student forward_backward at those indices -> student logprobs WITH grad -> loss
+Inference ``top_logprobs`` may be used as a cheap approximation (skips step 2)
+but bakes in the train/inference gap.
+
+Custom-loss path is two-pass
+----------------------------
+``forward_backward_custom`` does NOT avoid forward: pass 1 is a server ``forward``
+returning student logprobs at ``target_tokens`` (re-leafed with ``requires_grad``
+on the client); the client loss yields ``dC/dlogprobs``; pass 2 backprops a CE
+surrogate with ``weights = -dC/dlogprobs``. The framework errors if the loss has
+no gradient w.r.t. logprobs, so the detached ``forward(top_k)`` extraction can
+never silently "train".
+
+Masking
+-------
+When inference truncates sampling (top-p/top-k) it renormalizes over the
+surviving nucleus and reports the post-mask ``Choice.sampling_logprob``. When a
+sampling-support mask is present it is applied to BOTH sides: candidates outside
+the support are dropped and the student is renormalized over the same surviving
+slots (``build_topk_datum`` / ``reverse_kl_topk_loss``). No mask (common) ->
+nothing changes.
+
+Offline (deferred)
+------------------
+Offline top-K KL (teacher = separate frozen model, or teacher top-K stored in
+the dataset) is NOT built here -- the co-located full-vocab LoRA
+``kl_distillation`` loss (``train/nn/kl_distillation.py``) already covers offline
+distillation, and is exact (full logits via the shared lm_head, no top-K
+approximation). ``teacher_topk_from_row`` remains as a thin hook for that future
+path but is not wired into the online loop.
 """
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass, field
-from typing import Iterable, Sequence
+from enum import Enum
+from typing import Callable, Iterable, Sequence
 
+import torch
 import tinker
+
+from training.utils.opd_sampling import TopKDist
+
+
+class DistillMode(str, Enum):
+    """OPSD distillation objective. See module docstring for trade-offs."""
+
+    SAMPLED_IS = "sampled_is"
+    TOPK_FORWARD_KL = "topk_forward_kl"
+    TOPK_REVERSE_KL = "topk_reverse_kl"
+
+    @property
+    def needs_teacher_topk(self) -> bool:
+        return self in (DistillMode.TOPK_FORWARD_KL, DistillMode.TOPK_REVERSE_KL)
+
+    @property
+    def uses_custom_loss(self) -> bool:
+        """True when training must go through ``forward_backward_custom``."""
+        return self is DistillMode.TOPK_REVERSE_KL
 
 
 @dataclass
@@ -251,7 +338,7 @@ def build_opd_server_datums(
 
 
 # ---------------------------------------------------------------------------
-# Multi-target teacher routing (one student, N frozen teachers, routed per prompt)
+# Multi-teacher configuration
 # ---------------------------------------------------------------------------
 
 
@@ -283,6 +370,10 @@ class MultiTeacherConfig:
     student samples from its single deployment; routing different prompts to
     different teacher deployments lets the async sampling window interleave
     scoring across teachers so every deployment's GPU stays busy.
+
+    (Weighted mixture-of-teachers on the SAME prompt is intentionally not
+    supported online; ``blend_teacher_topk`` remains in utils for the future
+    offline top-K path only.)
     """
 
     teachers: list[TeacherConfig] = field(default_factory=list)
@@ -294,3 +385,243 @@ class MultiTeacherConfig:
         models = [t.model for t in self.teachers]
         if len(set(models)) != len(models):
             raise ValueError(f"Duplicate teacher models in MultiTeacherConfig: {models}")
+
+
+# ---------------------------------------------------------------------------
+# Teacher top-K renormalization + multi-teacher blend
+# ---------------------------------------------------------------------------
+
+
+def teacher_topk_from_row(
+    row: dict,
+    *,
+    ids_key: str = "teacher_topk_ids",
+    logprobs_key: str = "teacher_topk_logprobs",
+) -> list[TopKDist] | None:
+    """Parse dataset-stored teacher top-K into per-response-position ``TopKDist``.
+
+    DEFERRED offline hook (not wired into the online loop). The offline top-K KL
+    path (teacher = separate frozen model, or golden top-K stored on the row) is
+    deferred in favor of the co-located LoRA ``kl_distillation`` loss. Kept as a
+    thin parser for when that path is built: expects parallel ``[response_len][k]``
+    ``ids`` and ``logprobs`` arrays on the row. Returns ``None`` if absent.
+    """
+    ids_rows = row.get(ids_key)
+    lps_rows = row.get(logprobs_key)
+    if not isinstance(ids_rows, list) or not isinstance(lps_rows, list):
+        return None
+    if len(ids_rows) != len(lps_rows):
+        raise ValueError(
+            f"{ids_key} ({len(ids_rows)}) and {logprobs_key} ({len(lps_rows)}) "
+            "must have the same number of positions."
+        )
+    out: list[TopKDist] = []
+    for ids, lps in zip(ids_rows, lps_rows):
+        out.append(
+            TopKDist(token_ids=[int(t) for t in ids], logprobs=[float(v) for v in lps])
+        )
+    return out
+
+
+def _apply_support_mask(dist: TopKDist, support: set[int] | None) -> TopKDist | None:
+    """Drop teacher candidates outside the student's sampling support nucleus.
+
+    ``support`` is the set of token ids the student could actually sample at this
+    position under its top-p/top-k settings (from inference). Returns ``None`` if
+    no teacher candidate survives (the position is then skipped).
+    """
+    if support is None:
+        return dist
+    kept = [(tid, lp) for tid, lp in zip(dist.token_ids, dist.logprobs) if tid in support]
+    if not kept:
+        return None
+    return TopKDist(token_ids=[t for t, _ in kept], logprobs=[lp for _, lp in kept])
+
+
+def _renormalize_topk(dist: TopKDist) -> tuple[list[int], list[float]]:
+    """Return ``(ids, q_renorm)`` where ``q`` sums to 1 over the candidates."""
+    if not dist.logprobs:
+        return [], []
+    m = max(dist.logprobs)
+    probs = [math.exp(lp - m) for lp in dist.logprobs]
+    z = sum(probs)
+    if z <= 0:
+        return [], []
+    return list(dist.token_ids), [p / z for p in probs]
+
+
+def blend_teacher_topk(
+    per_teacher: Sequence[tuple[TopKDist, float]],
+    *,
+    top_k: int,
+) -> TopKDist:
+    """Blend several teachers' top-K into one renormalized top-K (prob space).
+
+    ``per_teacher`` is ``(dist, weight)`` pairs for the SAME response position.
+    Mass is mixed as ``sum_t w_t * q_t(token)`` over the union of candidate ids,
+    truncated to ``top_k`` and re-expressed as logprobs.
+    """
+    pooled: dict[int, float] = {}
+    total_w = sum(w for _, w in per_teacher) or 1.0
+    for dist, weight in per_teacher:
+        ids, q = _renormalize_topk(dist)
+        for tok_id, prob in zip(ids, q):
+            pooled[tok_id] = pooled.get(tok_id, 0.0) + (weight / total_w) * prob
+    if not pooled:
+        return TopKDist(token_ids=[], logprobs=[])
+    ranked = sorted(pooled.items(), key=lambda kv: kv[1], reverse=True)[:top_k]
+    z = sum(p for _, p in ranked) or 1.0
+    ids = [tok_id for tok_id, _ in ranked]
+    lps = [math.log(max(p / z, 1e-30)) for _, p in ranked]
+    return TopKDist(token_ids=ids, logprobs=lps)
+
+
+# ---------------------------------------------------------------------------
+# [N, K] top-K datum builder (shared by forward- and reverse-KL modes)
+# ---------------------------------------------------------------------------
+
+
+def build_topk_datum(
+    model_input: tinker.ModelInput,
+    topk_by_pos: Sequence[TopKDist | None],
+    *,
+    target_len: int,
+    prompt_len: int,
+    top_k: int,
+    support_ids_by_pos: Sequence[set[int] | None] | None = None,
+) -> tinker.Datum:
+    """Build one ``[N, K]`` datum shared by both top-K distillation modes.
+
+    Encodes per position:
+        ``target_tokens``  int64   ``[N, K]``  teacher top-K ids
+        ``weights``        float32 ``[N, K]``  renormalized teacher prob ``q``,
+                                                0 at padding / non-response slots
+
+    ``topk_by_pos`` is indexed over the RESPONSE window; entry ``j`` lands at
+    target position ``response_start + j`` (``response_start = prompt_len - 1``),
+    matching ``build_opd_server_datums``. A ``None`` entry marks a position with
+    no valid teacher data (or outside the student's sampling nucleus); it gets
+    all-zero weights and is skipped by both losses via the ``weights > 0`` mask.
+
+    ``support_ids_by_pos`` (optional) is the student's top-p/top-k **sampling
+    support** per response position, as surfaced by inference (``sampling.py``
+    renormalizes over this nucleus; see ``Choice.sampling_logprob``). When a mask
+    IS present it is applied to BOTH sides: teacher candidates outside the
+    support are dropped (``q`` renormalized over survivors), and because the
+    surviving slots are the only ones with ``weight > 0``, ``reverse_kl_topk_loss``
+    renormalizes the STUDENT over exactly the same surviving slots -- the
+    masking is two-sided, not teacher-only. When no mask is given (the common
+    case) nothing is filtered.
+
+    For ``TOPK_FORWARD_KL`` the builtin ``cross_entropy`` kernel consumes these
+    directly (loss ``= -sum_k q_k log p_k``). For ``TOPK_REVERSE_KL`` the same
+    datum feeds ``forward_backward_custom`` and ``reverse_kl_topk_loss`` rebuilds
+    ``q`` from ``weights``.
+    """
+    response_start = max(0, prompt_len - 1)
+    ids = [[0] * top_k for _ in range(target_len)]
+    weights = [[0.0] * top_k for _ in range(target_len)]
+    for j, dist in enumerate(topk_by_pos):
+        pos = response_start + j
+        if pos >= target_len or dist is None:
+            continue
+        support = support_ids_by_pos[j] if support_ids_by_pos is not None else None
+        dist = _apply_support_mask(dist, support)
+        if dist is None:
+            continue
+        tok_ids, q = _renormalize_topk(dist)
+        for k, (tok_id, qk) in enumerate(zip(tok_ids[:top_k], q[:top_k])):
+            ids[pos][k] = int(tok_id)
+            weights[pos][k] = float(qk)
+
+    return tinker.Datum(
+        model_input=model_input,
+        loss_fn_inputs={
+            "target_tokens": tinker.TensorData(
+                data=[t for row in ids for t in row],
+                dtype="int64",
+                shape=[target_len, top_k],
+            ),
+            "weights": tinker.TensorData(
+                data=[w for row in weights for w in row],
+                dtype="float32",
+                shape=[target_len, top_k],
+            ),
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Reverse-KL custom loss over teacher top-K (REINFORCE form)
+# ---------------------------------------------------------------------------
+
+
+def reverse_kl_topk_loss(
+    data: list[tinker.Datum],
+    logprobs_list: list[torch.Tensor],
+) -> tuple[torch.Tensor, dict[str, float]]:
+    """Analytical reverse KL ``KL(pi_S || pi_T)`` over the teacher top-K.
+
+    Consumes datums from :func:`build_topk_datum`. The server returns student
+    logprobs at the teacher-top-K ``target_tokens`` (shape ``[N, K]``); we
+    renormalize the student over those K slots, stop-grad the
+    ``[log p_renorm - log q_renorm]`` bracket, and take the mass-weighted sum.
+    Gradient flows only through the outer ``p_renorm`` weight, matching the
+    ``importance_sampling`` convention. ``weights`` carries ``q_renorm`` at valid
+    slots and ``0`` at padding/masked slots; validity is recovered via
+    ``weights > 0``.
+
+    Run this only via ``forward_backward_custom`` (two-pass): pass 1 is a server
+    ``forward`` returning student logprobs at the teacher's ``[N,K]`` target ids,
+    which the framework re-leafs with ``requires_grad`` on the client; this loss
+    then produces ``dC/dlogprobs``; pass 2 backprops a CE surrogate with
+    ``weights = -dC/dlogprobs``. The framework already errors if the loss yields
+    no gradient w.r.t. the logprobs, so no extra guard is needed here. The
+    forward-only top-K extraction (``forward(top_k=K)``, ``@no_grad``) is for KLD
+    verification, never training -- it never reaches pass 2.
+    """
+    device = logprobs_list[0].device if logprobs_list else torch.device("cpu")
+    total_loss = torch.zeros((), device=device)
+    sum_kl = 0.0
+    sum_positions = 0.0
+
+    for i, datum in enumerate(data):
+        student_logp_NK = logprobs_list[i]
+        weights_NK = datum.loss_fn_inputs["weights"].to_torch().to(device)
+
+        slot_mask_NK = weights_NK > 0
+        position_mask_N = slot_mask_NK.any(dim=-1).float()
+
+        safe_weights = weights_NK.clamp(min=1e-30)
+        teacher_log_renorm_NK = torch.where(
+            slot_mask_NK, torch.log(safe_weights), torch.zeros_like(weights_NK)
+        )
+
+        neg_inf = torch.full_like(student_logp_NK, float("-inf"))
+        masked_logp = torch.where(slot_mask_NK, student_logp_NK, neg_inf)
+        log_p_renorm = torch.log_softmax(masked_logp, dim=-1)
+        log_p_renorm = torch.nan_to_num(log_p_renorm, nan=0.0, neginf=0.0)
+        p_renorm = log_p_renorm.exp()
+
+        adv_NK = (log_p_renorm - teacher_log_renorm_NK).detach()
+        per_pos_N = (p_renorm * adv_NK * slot_mask_NK.float()).sum(dim=-1)
+        total_loss = total_loss + (per_pos_N * position_mask_N).sum()
+
+        with torch.no_grad():
+            kl_NK = p_renorm * (log_p_renorm - teacher_log_renorm_NK) * slot_mask_NK.float()
+            sum_kl += (kl_NK.sum(dim=-1) * position_mask_N).sum().item()
+            sum_positions += position_mask_N.sum().item()
+
+    metrics: dict[str, float] = {"opsd/reverse_kl_loss": total_loss.item()}
+    if sum_positions > 0:
+        metrics["opsd/reverse_kl_mean"] = sum_kl / sum_positions
+    metrics["opsd/reverse_kl_positions"] = sum_positions
+    return total_loss, metrics
+
+
+def make_reverse_kl_topk_loss() -> Callable[
+    [list[tinker.Datum], list[torch.Tensor]],
+    tuple[torch.Tensor, dict[str, float]],
+]:
+    """Client loss factory for ``forward_backward_custom`` (reverse-KL top-K)."""
+    return reverse_kl_topk_loss

--- a/training/utils/opd.py
+++ b/training/utils/opd.py
@@ -60,14 +60,16 @@ surrogate with ``weights = -dC/dlogprobs``. The framework errors if the loss has
 no gradient w.r.t. logprobs, so the detached ``forward(top_k)`` extraction can
 never silently "train".
 
-Masking
--------
-When inference truncates sampling (top-p/top-k) it renormalizes over the
-surviving nucleus and reports the post-mask ``Choice.sampling_logprob``. When a
-sampling-support mask is present it is applied to BOTH sides: candidates outside
-the support are dropped and the student is renormalized over the same surviving
-slots (``build_topk_datum`` / ``reverse_kl_topk_loss``). No mask (common) ->
-nothing changes.
+Masking (lives in the RLOR backend, NOT here)
+---------------------------------------------
+Sampling-nucleus (top-p/top-k) masking is a BACKEND concern: the engine owns the
+sampling params and must **gather the top-K after masking** -- select/gather the
+top-K over the post-mask nucleus distribution (and gather the other model at
+those ``[N, K]`` indices). The cookbook consumes already-masked top-K; it does
+NOT reconstruct the nucleus from inference ``top_logprobs`` (lossy: cap <=5,
+token-string ambiguity, quant/kernel gap). The only client-side mask here is the
+``weights > 0`` slot mask in ``reverse_kl_topk_loss`` -- that is datum *shaping*
+(padding / variable-K), not sampling masking.
 
 Offline (deferred)
 ------------------
@@ -423,21 +425,6 @@ def teacher_topk_from_row(
     return out
 
 
-def _apply_support_mask(dist: TopKDist, support: set[int] | None) -> TopKDist | None:
-    """Drop teacher candidates outside the student's sampling support nucleus.
-
-    ``support`` is the set of token ids the student could actually sample at this
-    position under its top-p/top-k settings (from inference). Returns ``None`` if
-    no teacher candidate survives (the position is then skipped).
-    """
-    if support is None:
-        return dist
-    kept = [(tid, lp) for tid, lp in zip(dist.token_ids, dist.logprobs) if tid in support]
-    if not kept:
-        return None
-    return TopKDist(token_ids=[t for t, _ in kept], logprobs=[lp for _, lp in kept])
-
-
 def _renormalize_topk(dist: TopKDist) -> tuple[list[int], list[float]]:
     """Return ``(ids, q_renorm)`` where ``q`` sums to 1 over the candidates."""
     if not dist.logprobs:
@@ -488,30 +475,28 @@ def build_topk_datum(
     target_len: int,
     prompt_len: int,
     top_k: int,
-    support_ids_by_pos: Sequence[set[int] | None] | None = None,
 ) -> tinker.Datum:
     """Build one ``[N, K]`` datum shared by both top-K distillation modes.
 
     Encodes per position:
-        ``target_tokens``  int64   ``[N, K]``  teacher top-K ids
+        ``target_tokens``  int64   ``[N, K]``  source top-K ids
         ``weights``        float32 ``[N, K]``  renormalized teacher prob ``q``,
                                                 0 at padding / non-response slots
 
     ``topk_by_pos`` is indexed over the RESPONSE window; entry ``j`` lands at
     target position ``response_start + j`` (``response_start = prompt_len - 1``),
     matching ``build_opd_server_datums``. A ``None`` entry marks a position with
-    no valid teacher data (or outside the student's sampling nucleus); it gets
-    all-zero weights and is skipped by both losses via the ``weights > 0`` mask.
+    no valid data; it gets all-zero weights and is skipped by both losses via the
+    ``weights > 0`` mask. That ``weights > 0`` mask is purely datum *shaping*
+    (padding / variable-K slots), NOT sampling masking.
 
-    ``support_ids_by_pos`` (optional) is the student's top-p/top-k **sampling
-    support** per response position, as surfaced by inference (``sampling.py``
-    renormalizes over this nucleus; see ``Choice.sampling_logprob``). When a mask
-    IS present it is applied to BOTH sides: teacher candidates outside the
-    support are dropped (``q`` renormalized over survivors), and because the
-    surviving slots are the only ones with ``weight > 0``, ``reverse_kl_topk_loss``
-    renormalizes the STUDENT over exactly the same surviving slots -- the
-    masking is two-sided, not teacher-only. When no mask is given (the common
-    case) nothing is filtered.
+    Sampling-nucleus (top-p/top-k) masking is intentionally NOT done here. The
+    top-K must be **gathered after masking** in the RLOR backend: the engine owns
+    the sampling params and should select/gather the top-K over the post-mask
+    nucleus distribution (and the ``[N, K]`` gather of the other model's logprobs
+    at those indices). The cookbook then just consumes already-masked top-K --
+    reconstructing the nucleus client-side from inference ``top_logprobs`` would
+    be lossy (cap <=5, token-string ambiguity) and duplicate engine logic.
 
     For ``TOPK_FORWARD_KL`` the builtin ``cross_entropy`` kernel consumes these
     directly (loss ``= -sum_k q_k log p_k``). For ``TOPK_REVERSE_KL`` the same
@@ -524,10 +509,6 @@ def build_topk_datum(
     for j, dist in enumerate(topk_by_pos):
         pos = response_start + j
         if pos >= target_len or dist is None:
-            continue
-        support = support_ids_by_pos[j] if support_ids_by_pos is not None else None
-        dist = _apply_support_mask(dist, support)
-        if dist is None:
             continue
         tok_ids, q = _renormalize_topk(dist)
         for k, (tok_id, qk) in enumerate(zip(tok_ids[:top_k], q[:top_k])):

--- a/training/utils/opd_sampling.py
+++ b/training/utils/opd_sampling.py
@@ -1,14 +1,61 @@
-"""Shared OPD token alignment and teacher scoring helpers."""
+"""Shared OPD/OPSD token alignment and teacher scoring helpers.
+
+Covers both the sampled-token path (one teacher logprob per response token,
+used by ``importance_sampling``) and the top-K path (top-K ids + logprobs per
+response position, used by the OPSD top-K modes in ``opd.py``). Both paths share
+the same echo request and the same ``content[1:]`` alignment so there is a
+single source of truth for how the response is walked.
+
+source-K (selection) vs gather (fixed indices)
+----------------------------------------------
+Two different operations, do not confuse them:
+
+* SELECTION ("source K"): pick the top-K token *indices* (+ logprobs) of a
+  model. Either ``_extract_teacher_topk`` here (inference ``top_logprobs``) or
+  the trainer ``forward(loss_fn_config={"top_k": K})`` (exact, ``@no_grad``).
+  Produces the index set used as ``target_tokens``.
+* GATHER ("at fixed indices"): read a model's logprobs AT given indices. This is
+  a plain forward at ``target_tokens=[N,K]`` (PR #27269), NOT a top-K selection.
+
+Rule: only ONE selection per position (the source K). The OTHER model and the
+training ``forward_backward`` must GATHER at those same indices -- never run a
+second ``topK`` selection (it would choose different tokens and misalign the
+per-token KL terms).
+
+Which model is the source K depends on KL direction:
+* reverse KL (OPSD, ``TOPK_REVERSE_KL``): expectation over ``pi_S`` -> source =
+  STUDENT top-K. For correctness extract it on the TRAINER, forward-only, AFTER
+  inference (the inference ``top_logprobs`` carry the train/inference gap: quant
+  weights, different kernels, truncated/renormalized nucleus, cap <=5). Then
+  GATHER the teacher at those student indices.
+* forward KL (SDFT, ``TOPK_FORWARD_KL``): expectation over ``pi_T`` -> source =
+  TEACHER top-K; ``_extract_teacher_topk`` (inference) is the natural source.
+"""
 
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from typing import Any
 
 from fireworks.training.sdk.deployment import DeploymentSampler
 from training.utils.data import prepare_sampling_messages
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class TopKDist:
+    """Teacher top-K distribution at one response position.
+
+    ``token_ids`` and ``logprobs`` are parallel, length ``<= K`` (the API may
+    return fewer than K candidates). ``logprobs`` are raw teacher logprobs;
+    renormalization happens in the datum builders (``opd.py``) so the same
+    extraction feeds both forward- and reverse-KL modes.
+    """
+
+    token_ids: list[int]
+    logprobs: list[float]
 
 
 def _align_completion_logprobs(
@@ -52,30 +99,113 @@ def _align_response_logprobs(
     return aligned[:target_len]
 
 
+def _echo_target_content(
+    response: dict[str, Any],
+    *,
+    target_len: int,
+) -> list[dict[str, Any]] | None:
+    """Return the ``content`` entries that predict ``tokens[1:]``.
+
+    Echo responses include an unconditional first-token slot, then one slot per
+    next-token target.  A generated extra token may follow; it is trimmed.
+    Shared by both the sampled-token and top-K extraction paths.
+    """
+    choices = response.get("choices", [])
+    if not choices:
+        return None
+    logprobs = choices[0].get("logprobs")
+    if not isinstance(logprobs, dict):
+        return None
+    content = logprobs.get("content")
+    if not isinstance(content, list) or len(content) < 2:
+        return None
+    target_content = content[1 : 1 + target_len]
+    if len(target_content) < target_len:
+        return None
+    return target_content
+
+
 def _extract_scored_token_logprobs(
     response: dict[str, Any],
     *,
     target_len: int,
 ) -> list[float] | None:
     """Extract echo logprobs for ``tokens[1:]`` from a completions response."""
-    choices = response.get("choices", [])
-    if not choices:
-        return None
-
-    logprobs = choices[0].get("logprobs")
-    if not isinstance(logprobs, dict):
-        return None
-
-    content = logprobs.get("content")
-    if not isinstance(content, list) or len(content) < 2:
-        return None
-
-    # Echo responses include an unconditional first-token logprob, then one
-    # logprob per next-token target.  A generated extra token may follow; trim it.
-    target_content = content[1 : 1 + target_len]
-    if len(target_content) < target_len:
+    target_content = _echo_target_content(response, target_len=target_len)
+    if target_content is None:
         return None
     return [float(item.get("logprob", 0.0)) for item in target_content]
+
+
+def _candidate_token_id(entry: dict[str, Any], tokenizer: Any | None) -> int | None:
+    """Resolve a top_logprobs / token entry to a single token id.
+
+    Prefers an explicit integer ``token_id``/``id`` (raw_output-style). Falls
+    back to ``tokenizer`` re-encoding of the token string, keeping only
+    unambiguous single-id results. See ``_extract_teacher_topk`` for the
+    lossiness this implies.
+    """
+    for key in ("token_id", "id"):
+        val = entry.get(key)
+        if isinstance(val, int):
+            return val
+    if tokenizer is None:
+        return None
+    token_str = entry.get("token")
+    if not isinstance(token_str, str):
+        return None
+    ids = tokenizer.encode(token_str, add_special_tokens=False)
+    return int(ids[0]) if len(ids) == 1 else None
+
+
+def _extract_teacher_topk(
+    response: dict[str, Any],
+    *,
+    prompt_len: int,
+    response_len: int,
+    target_len: int,
+    tokenizer: Any | None = None,
+) -> list[TopKDist] | None:
+    """Extract per-response-position teacher top-K from an echo response.
+
+    Requires the teacher to have been scored with ``top_logprobs=K`` so that
+    each ``content`` slot carries a ``top_logprobs`` candidate list.
+
+    Token-id resolution is the sharp edge: the completions API returns
+    OpenAI-style ``top_logprobs`` (token *strings*, no ids). ``_candidate_token_id``
+    prefers an explicit id field and otherwise re-encodes the string, dropping
+    ambiguous multi-id tokens (which silently shrinks K). A raw_output-style
+    top-K-ids API would remove this lossiness; until then the top-K modes are
+    only sound for tokenizers whose top_logprobs strings round-trip 1:1.
+    """
+    target_content = _echo_target_content(response, target_len=target_len)
+    if target_content is None:
+        return None
+    response_start = max(0, prompt_len - 1)
+    window = target_content[response_start : response_start + response_len]
+    if len(window) < response_len:
+        return None
+
+    out: list[TopKDist] = []
+    for slot in window:
+        candidates = slot.get("top_logprobs") if isinstance(slot, dict) else None
+        ids: list[int] = []
+        lps: list[float] = []
+        for cand in candidates or []:
+            tok_id = _candidate_token_id(cand, tokenizer)
+            if tok_id is None:
+                continue
+            ids.append(tok_id)
+            lps.append(float(cand.get("logprob", 0.0)))
+        if not ids:
+            # No usable candidates: fall back to the sampled token alone.
+            sampled_id = _candidate_token_id(slot, tokenizer)
+            if sampled_id is None:
+                return None
+            ids = [sampled_id]
+            lps = [float(slot.get("logprob", 0.0))]
+        out.append(TopKDist(token_ids=ids, logprobs=lps))
+    return out
 
 
 def _slice_response_logprobs(
@@ -135,20 +265,14 @@ def _build_teacher_scoring_tokens(
     return list(teacher_prompt_tokens) + completion_tokens, len(completion_tokens)
 
 
-async def _score_with_teacher(
+async def _request_teacher_echo(
     sampler: DeploymentSampler,
     token_ids: list[int],
     *,
-    prompt_len: int,
-    response_len: int,
     top_logprobs: int,
     http_timeout: int,
-) -> list[float] | None:
-    """Score sampled response tokens with the teacher deployment."""
-    target_len = max(0, len(token_ids) - 1)
-    if target_len == 0 or response_len <= 0:
-        return None
-
+) -> dict[str, Any] | None:
+    """Run the shared echo+logprobs teacher request used by both score paths."""
     request_kwargs: dict[str, Any] = {
         "logprobs": True,
         "echo": True,
@@ -168,6 +292,28 @@ async def _score_with_teacher(
     except Exception as exc:
         logger.warning("Teacher scoring failed: %s", exc)
         return None
+    return response
+
+
+async def _score_with_teacher(
+    sampler: DeploymentSampler,
+    token_ids: list[int],
+    *,
+    prompt_len: int,
+    response_len: int,
+    top_logprobs: int,
+    http_timeout: int,
+) -> list[float] | None:
+    """Score sampled response tokens with the teacher deployment (sampled-token path)."""
+    target_len = max(0, len(token_ids) - 1)
+    if target_len == 0 or response_len <= 0:
+        return None
+
+    response = await _request_teacher_echo(
+        sampler, token_ids, top_logprobs=top_logprobs, http_timeout=http_timeout
+    )
+    if response is None:
+        return None
 
     token_logprobs = _extract_scored_token_logprobs(response, target_len=target_len)
     if token_logprobs is None:
@@ -176,4 +322,38 @@ async def _score_with_teacher(
         token_logprobs,
         prompt_len=prompt_len,
         response_len=response_len,
+    )
+
+
+async def _score_teacher_topk(
+    sampler: DeploymentSampler,
+    token_ids: list[int],
+    *,
+    prompt_len: int,
+    response_len: int,
+    top_logprobs: int,
+    http_timeout: int,
+    tokenizer: Any | None = None,
+) -> list[TopKDist] | None:
+    """Score sampled response tokens, returning teacher top-K per position.
+
+    Shares ``_request_teacher_echo`` with :func:`_score_with_teacher`; only the
+    extraction differs (top-K candidates vs the single sampled logprob).
+    """
+    target_len = max(0, len(token_ids) - 1)
+    if target_len == 0 or response_len <= 0:
+        return None
+
+    response = await _request_teacher_echo(
+        sampler, token_ids, top_logprobs=top_logprobs, http_timeout=http_timeout
+    )
+    if response is None:
+        return None
+
+    return _extract_teacher_topk(
+        response,
+        prompt_len=prompt_len,
+        response_len=response_len,
+        target_len=target_len,
+        tokenizer=tokenizer,
     )


### PR DESCRIPTION
## Summary (DRAFT — backend-blocked, not wired into the loop yet)

Adds the analytic top-K On-Policy **Sequence** Distillation objectives on top of
sampled-token OPD:

- `DistillMode {SAMPLED_IS, TOPK_REVERSE_KL, TOPK_FORWARD_KL}`
- `build_topk_datum` + `reverse_kl_topk_loss` (`forward_backward_custom`),
  teacher/student top-K extraction + renorm
- `opd_sampling.py`: `TopKDist`, shared echo parsing (`_request_teacher_echo`),
  teacher top-K extraction/scoring
- Docs: **source-K (selection) vs gather (fixed `[N,K]` indices)** rule, OPSD
  student-source **extraction-after-inference** provenance, KL-direction table

## Why draft

- **Blocked on backend** (fw-ai/fireworks#27858): the analytic top-K modes need a
  single forward that (a) gathers logprobs at fixed `[N,K]` `target_tokens` and
  (b) gathers the top-K **after** applying the sampling nucleus (top-p/top-k)
  mask. The RLOR backend currently flattens `target_tokens` to 1-D, and top-K is
  over the full vocab. The backend PR adds nucleus-masked top-K; the `[N,K]`
  gather is the remaining piece.
- **Masking moved to the backend.** Nucleus masking was removed from this PR
  (`_apply_support_mask` / `support_ids_by_pos` deleted). Reconstructing the
  nucleus client-side from inference `top_logprobs` is lossy (cap <= 5,
  token-string ambiguity, quant/kernel gap); the engine owns the sampling params
  and gathers top-K after masking. The only client-side mask left is the
  `weights > 0` slot mask (datum padding / variable-K), not sampling masking.
- **Not wired** into `opd_loop.py` (loop unchanged vs base PR). Offline top-K KL
  is deferred (LoRA `kl_distillation` covers it).

## Stack

```mermaid
graph TD
  A["#391 codex/opd-loop<br/>sampled-token OPD"] --> B["#481<br/>multi-target routing"]
  B --> C["THIS PR (draft)<br/>top-K OPSD modes"]
  D["fw-ai/fireworks#27858<br/>nucleus-masked top-K gather"] -.backend dep.-> C
```

Stacked on #481. Review the routing PR first. Backend: fw-ai/fireworks#27858.

## Test plan (once backend `[N,K]` + masked top-K land)

- [ ] Wire `TOPK_REVERSE_KL` into the loop (student source-K extraction -> teacher gather)
- [ ] Numerical check: top-K reverse-KL vs full-vocab KL on a tiny model
- [ ] Confirm top-K consumed here is already nucleus-masked by the backend

Made with [Cursor](https://cursor.com)
