### PR TITLE
Use Tinker's Beta2=0.95 by default

### DIFF
--- a/training/utils/config.py
+++ b/training/utils/config.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from fireworks.training.sdk.client import FiretitanTrainingClient
 from fireworks.training.sdk.deployment import DeploymentConfig
 
-DEFAULT_ADAM = dict(beta1=0.9, beta2=0.999, eps=1e-8, weight_decay=0.01, grad_clip_norm=1.0)
+DEFAULT_ADAM = dict(beta1=0.9, beta2=0.95, eps=1e-12, weight_decay=0, grad_clip_norm=1.0)
 
 RewardFn = Callable[[str, dict], float]
 """Signature: (completion_text, dataset_row) -> reward_float."""


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Global optimizer default changes can shift convergence and stability for every recipe using DEFAULT_ADAM without explicit overrides.
> 
> **Overview**
> Updates shared **`DEFAULT_ADAM`** in `training/utils/config.py` so cookbook recipes that spread it into `tinker.AdamParams` match Tinker’s defaults instead of the previous PyTorch-style values.
> 
> **`beta2`** goes from `0.999` to **`0.95`**, **`eps`** from `1e-8` to **`1e-12`**, and **`weight_decay`** from `0.01` to **`0`**. **`beta1`** (`0.9`) and **`grad_clip_norm`** (`1.0`) are unchanged.
> 
> Any training entrypoint that builds Adam params with `**DEFAULT_ADAM` (e.g. multihop QA, frozen lake, reconnect tooling) picks up the new behavior automatically unless it overrides those keys locally.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d2efb74a7b76bd3396cdeb386f3e48bcc4ce902. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->