### PR TITLE
Use Tinker

### DIFF
--- a/training/utils/config.py
+++ b/training/utils/config.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from fireworks.training.sdk.client import FiretitanTrainingClient
 from fireworks.training.sdk.deployment import DeploymentConfig
 
-DEFAULT_ADAM = dict(beta1=0.9, beta2=0.999, eps=1e-8, weight_decay=0.01, grad_clip_norm=1.0)
+DEFAULT_ADAM = dict(beta1=0.9, beta2=0.95, eps=1e-12, weight_decay=0, grad_clip_norm=1.0)
 
 RewardFn = Callable[[str, dict], float]
 """Signature: (completion_text, dataset_row) -> reward_float."""

--- a/training/utils/config.py
+++ b/training/utils/config.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from fireworks.training.sdk.client import FiretitanTrainingClient
 from fireworks.training.sdk.deployment import DeploymentConfig
 
-DEFAULT_ADAM = dict(beta1=0.9, beta2=0.95, eps=1e-12, weight_decay=0, grad_clip_norm=1.0)
+DEFAULT_ADAM = dict(beta1=0.9, beta2=0.95, eps=1e-12, weight_decay=0.01, grad_clip_norm=1.0)
 
 RewardFn = Callable[[str, dict], float]
 """Signature: (completion_text, dataset_row) -> reward_float."""


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Only default Adam hyperparameters change; training dynamics may shift slightly for recipes that rely on the shared constant without overrides.
> 
> **Overview**
> Updates the shared **`DEFAULT_ADAM`** optimizer defaults in `training/utils/config.py` to match Tinker-oriented training: **`beta2`** changes from `0.999` to **`0.95`**, and **`eps`** from `1e-8` to **`1e-12`**. **`beta1`**, weight decay, and grad clip are unchanged.
> 
> Recipes that build **`tinker.AdamParams(..., **DEFAULT_ADAM)`** (e.g. multihop QA IGPO, frozen lake RL, reconnect/LR tooling) pick up the new defaults unless they override these fields locally.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9af3190e96c88ab03da1bfd7d56a7f4f15c9f1bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->