### PR TITLE
Hide warm-start adapter path in logs

### DIFF
--- a/training/utils/checkpoints.py
+++ b/training/utils/checkpoints.py
@@ -339,7 +339,7 @@ class TrainingCheckpoints:
             )
 
         if warm_start_from_adapter:
-            logger.info("Fresh start with HF adapter: %s", warm_start_from_adapter)
+            logger.info("Fresh start with HF adapter")
             t0 = time.time()
             self._client.load_adapter(warm_start_from_adapter)
             logger.info("Adapter loaded (%.1fs)", time.time() - t0)


### PR DESCRIPTION
## Summary
- Stop logging the raw warm_start_from_adapter value when loading HF PEFT adapters.

## Testing
- python -m py_compile training/utils/checkpoints.py

Parent Fireworks PR: https://github.com/fw-ai/fireworks/pull/29421

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single log-line change with no behavior or data-path changes beyond log output.
> 
> **Overview**
> **Logging only:** When resume takes the HF PEFT warm-start branch, the info log no longer includes the `warm_start_from_adapter` value (e.g. GCS URI). It now logs a fixed message: `Fresh start with HF adapter`.
> 
> Adapter loading behavior is unchanged; `load_adapter(warm_start_from_adapter)` still uses the configured path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e7b744ff8a5f9122aa69c7a394c8ed6ecd91c84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->