### PR TITLE
fix: preserve train/inference_kld in async RL metrics file

### DIFF
--- a/training/recipes/async_rl_loop.py
+++ b/training/recipes/async_rl_loop.py
@@ -718,11 +718,8 @@ def main(
                 loop_stats=loop_stats,
                 completions_per_prompt=cfg.completions_per_prompt,
             )
-            # Capture the per-rollout reference KL for the human summary line
-            # before the train/* stripping below removes it.
+            # Per-rollout reference KL for the human summary line below.
             ref_kl = metrics.get("train/ref_kl", 0.0)
-            # train/* already logged per-minibatch above; strip the averages.
-            metrics = {k: v for k, v in metrics.items() if not k.startswith("train/")}
             metrics["rollout/step"] = rollout_id
             metrics["train/step"] = step  # monotonic fallback for the wandb global step
             for k, v in ctx_metadata.items():
@@ -739,7 +736,9 @@ def main(
                 metrics.get("rollout/accuracy", 0.0) * 100,
                 ref_kl,
             )
-            wandb_log(metrics)
+            wandb_metrics = {k: v for k, v in metrics.items() if not k.startswith("train/")}
+            wandb_metrics["train/step"] = step
+            wandb_log(wandb_metrics)
             # Report the number of trained target tokens, not raw rollout length.
             write_running_step(
                 runner,


### PR DESCRIPTION
## Description

The async RL loop (`async_rl_loop.py`, used by the `vision` variant of the `rl_train` CI) stripped **all** `train/*` metrics from a single `metrics` dict that is shared by both the wandb logger and the per-step metrics file. Because managed `rl_train` runs disable wandb (`WANDB_MODE=disabled`), the CI summary reads only the metrics file — so vision/async runs surfaced **no `train/inference_kld`** curve or table, while the synchronous `rl_loop` (text variant) always did.

This decouples the two sinks:
- The **metrics file** now receives the full `metrics` dict (including all `train/*`), exactly like the synchronous `rl_loop`.
- The **wandb** step-level payload still drops `train/*` to avoid double-logging the averages already emitted per-minibatch on the `train/step` axis (`train/step` is re-added since it's the x-axis step metric).

This is the clean version of an earlier allow-list patch — instead of hand-listing which `train/*` keys to preserve, we simply stop mutating the shared dict, so any future `train/*` metric reaches the file automatically.

## Architecture / Code Overview Diagram

```mermaid
flowchart TD
    M[compute_step_metrics produces metrics dict with train/*] --> FILE[write_running_step to metrics.jsonl FULL train/* kept]
    M --> W[wandb_metrics drop train/* re-add train/step]
    W --> WL[wandb_log step-level]
    MB[per-minibatch loop] -->|train/* on train/step axis| WL
    FILE --> CI[rl_train CI summary: KLD curve + table]
```

## Type of Change

- [x] Bug fix
- [x] Refactoring

## Testing

- `py_compile` clean; no linter errors.
- Behaviorally equivalent (for the metrics file) to the allow-list version that produced run [27189441312](https://github.com/fw-ai/fireworks/actions/runs/27189441312), whose `metrics.jsonl` contained `train/inference_kld`. The `rl_train` (vision) workflow will exercise this end-to-end.
- [ ] Added/updated tests
- [x] Tested manually

> Note: the `vision` `rl_train` path also depends on two not-yet-landed changes on `vision-image-completions-logprobs` (logprobs `content[]` parse — hard prerequisite; and `raw_reward`/`raw_accuracy` alignment). Those are tracked separately; this PR is the KLD-metrics fix only.

## Change Size

- [x] Small (< 200 LOC)

## Checklist

- [x] Self-reviewed my code
- [x] Change is the **minimum necessary** diff
- [x] No new linter warnings/errors
- [x] No secrets or credentials in the diff
- [x] Visual diagram included

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small logging-path change only; no training, checkpoint, or weight-sync logic is modified.
> 
> **Overview**
> The async RL loop no longer strips **`train/*`** keys from the shared **`metrics`** dict before writing runner progress. **`write_running_step`** now receives the full step metrics (including **`train/inference_kld`** and other **`train/*`** averages), matching synchronous **`rl_loop`** behavior so **`rl_train`** CI summaries can plot KLD when wandb is disabled.
> 
> Wandb logging is decoupled: a filtered **`wandb_metrics`** dict still omits **`train/*`** at the rollout step to avoid duplicating per-minibatch **`train/*`** already logged on the **`train/step`** axis, with **`train/step`** re-added for the global step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12a9af567cfbcdd475920227663516036a2a1c7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->