### PR TITLE
[codex] centralize trainer shape selection

### DIFF
--- a/skills/dev/references/rl/custom-loss.md
+++ b/skills/dev/references/rl/custom-loss.md
@@ -33,7 +33,7 @@ All live on `rl_loop.Config`:
 | `policy_loss` | `"grpo"` | `grpo`, `importance_sampling`, `dapo`, `dro`, `gspo`, `reinforce`, `cispo`. Decides server-side vs client-side dispatch. |
 | `completions_per_prompt` | `4` | GRPO group size — responses sampled per prompt. |
 | `prompt_groups_per_step` | `1` | Number of prompt groups per `forward_backward + optim_step` pair. |
-| `kl_beta` | `0.001` | KL-to-reference coefficient. For full-param, requires `cfg.infra.ref_training_shape_id` (provisions a separate forward-only trainer). For LoRA, leave it unset — `setup_infra` uses the shared-session reference on the policy trainer. |
+| `kl_beta` | `0.001` | KL-to-reference coefficient. For full-param, leave `cfg.infra.ref_training_shape_id` unset so trainer creation selects a LoRA-capable shape for the separate reference trainer, which runs forward-only. For LoRA, leave it unset — `setup_infra` uses the shared-session reference on the policy trainer. |
 | `eps_clip`, `eps_clip_high` | `0.2`, `None` | PPO clip for GRPO. |
 | `router_replay` | `False` | Record routing at rollout time and replay during training (MoE models). |
 | `grad_accumulation_normalization` | `NUM_LOSS_TOKENS` | Per-token mean (matches GRPO paper). See [`gradient-accumulation.md`](gradient-accumulation.md). |

--- a/skills/dev/references/shapes.md
+++ b/skills/dev/references/shapes.md
@@ -4,8 +4,8 @@ Shapes are the required entry point for both trainer and deployment. Never hand-
 
 ## Training shape
 
-By default, recipes auto-select the smallest validated training shape that can
-fit the configured model and context length:
+By default, backend trainer creation selects the smallest validated training
+shape that can fit the configured model and context length:
 
 ```python
 cfg.infra.training_shape_id = None
@@ -27,7 +27,7 @@ profile = rlor_mgr.resolve_training_profile(resolved_training_shape_id)
 # profile.accelerator_type, profile.node_count, ...  (read, do not copy to cfg)
 ```
 
-See `training/recipes/sft_loop.py` (search `auto_select_training_shape`) and `training/utils/infra.py` for the shared RL / DPO infra path.
+See `training/recipes/sft_loop.py` and `training/utils/infra.py` for the shared RL / DPO infra path.
 
 ## Deployment shape
 
@@ -42,11 +42,11 @@ That is a **versioned** path (`accounts/fw/deploymentShapes/ds-x/versions/abc123
 
 ## Reference-model shape (RL / DPO)
 
-For **full-parameter** training with a frozen reference, leave `ref_training_shape_id` unset to auto-select a compatible validated shape. Set it explicitly only when you need an override; it can share the same shape as the policy, and the control plane appends `--forward-only` automatically.
+For **full-parameter** training with a frozen reference, leave `ref_training_shape_id` unset so trainer creation selects a compatible LoRA-capable validated shape. Set it explicitly only when you need an override; it can share the same shape as the policy, and the control plane appends `--forward-only` automatically.
 
 For **LoRA** (`lora_rank > 0`), two valid options:
 - **Shared session (recommended, saves GPUs)**: leave `ref_training_shape_id` unset. `setup_infra` uses `policy.create_base_reference()` on the policy trainer for reference logprobs — no separate trainer, no extra GPUs.
-- **Separate LoRA-capable ref trainer**: set `ref_training_shape_id` to a `LORA_TRAINER` shape (typically the same as the policy shape). `setup_infra` provisions a forward-only LoRA ref trainer (its own GPUs) and forwards `lora_rank` to both the trainer request and the ref client so the gateway infers `trainer_mode=LORA_TRAINER` and matches the shape. CP's V2 DPO auto-resolver picks this path by default for LoRA DPO.
+- **Separate LoRA-capable ref trainer**: set `ref_training_shape_id` to a `LORA_TRAINER` shape (typically the same as the policy shape). `setup_infra` provisions a forward-only ref trainer (its own GPUs); the gateway matches `forwardOnly=true` against `trainer_mode=LORA_TRAINER`.
 
 The CI pattern for the saves-GPUs variant is `ref_shape = "" if lora_rank > 0 else <explicit shape>`.
 

--- a/training/README.md
+++ b/training/README.md
@@ -81,10 +81,11 @@ Each recipe has a `Config` dataclass at the top of the file. Open the recipe you
 | `deployment` | `DeployConfig(tokenizer_model="Qwen/Qwen3-8B")` for inference rollouts |
 | `weight_sync` | `WeightSyncConfig(weight_sync_interval=1)` to sync weights to the deployment |
 
-When `training_shape_id` is not set, the cookbook auto-selects validated
-trainer shapes at runtime from Fireworks control-plane data. RL-family
-recipes also auto-select a validated deployment shape, and DPO / KL
-flows request a validated forward-only reference shape. Explicit
+When `training_shape_id` is not set, backend trainer creation selects a
+validated trainer shape from Fireworks control-plane data. RL-family recipes
+also use a validated deployment shape, and DPO / KL flows request reference
+trainers that run forward-only on LoRA-capable validated shapes.
+Explicit
 `training_shape_id`, `ref_training_shape_id`, and deployment-shape
 overrides still take precedence.
 
@@ -115,7 +116,7 @@ It applies to trainer jobs the recipe creates for that run; pre-created
 When `kl_beta > 0` the RL loop provisions a separate forward-only
 reference trainer (with `lora_rank=0`, full-param frozen base) in
 addition to the LoRA policy trainer. Auto-selection picks an
-appropriate validated reference shape unless `ref_training_shape_id`
+appropriate LoRA-capable validated shape unless `ref_training_shape_id`
 is set explicitly.
 
 **DPO / ORPO** -- also requires:

--- a/training/examples/rl/deepmath/train_deepmath.py
+++ b/training/examples/rl/deepmath/train_deepmath.py
@@ -143,7 +143,7 @@ class TrainArgs:
     )
     training_shape: str = field(default_factory=lambda: os.environ.get("TRAINING_SHAPE", ""))
     ref_training_shape: str | None = None
-    """Separate training shape for the forward-only reference model."""
+    """LoRA-capable training shape for the separate reference trainer."""
     deployment_id: str | None = None
     """Omit to auto-create a new deployment; set to reuse an existing one."""
     region: str = "US_OHIO_1"
@@ -160,9 +160,8 @@ class TrainArgs:
     max_completion_tokens: int = 30 * 1024
     prompt_groups_per_step: int = 32
     lora_rank: int = 0
-    """LoRA rank (0 = full-param).  When > 0, auto_select_training_shape
-    picks a LoRA training shape and the reference model reuses the policy
-    trainer (no extra GPUs)."""
+    """LoRA rank (0 = full-param).  Backend trainer creation selects a
+    LoRA-capable shape; LoRA references reuse the policy trainer (no extra GPUs)."""
     router_replay: bool = False
     trajectory_dir: str | None = None
     """Directory to save per-step trajectory JSONL files."""
@@ -190,7 +189,7 @@ def parse_args() -> TrainArgs:
     parser.add_argument("--dataset-path")
     parser.add_argument("--training-shape")
     parser.add_argument("--ref-training-shape",
-                        help="Separate training shape for the forward-only reference model")
+                        help="LoRA-capable training shape for the separate reference trainer")
     parser.add_argument(
         "--deployment-id",
         help="Existing deployment ID to reuse; omit to auto-create",

--- a/training/examples/rl/frozen_lake/train_frozen_lake.py
+++ b/training/examples/rl/frozen_lake/train_frozen_lake.py
@@ -66,7 +66,6 @@ from training.utils import (
     create_trainer_job,
     build_datum_from_token_mask,
     validate_config,
-    auto_select_training_shape,
 )
 from training.utils.rl import PromptGroup
 from training.utils.rl.async_train import RowRequest, run_async_rl_loop
@@ -494,23 +493,13 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
         len(seed_contexts), os.path.abspath(cfg.seed_jsonl_path),
     )
 
-    if not infra.training_shape_id:
-        infra.training_shape_id = auto_select_training_shape(
-            rlor_mgr,
-            base_model=cfg.base_model,
-            trainer_role="policy",
-            lora_rank=cfg.lora_rank,
-            max_seq_len=cfg.max_seq_len,
-        )
-        cfg.training_shape = infra.training_shape_id
-        logger.info(
-            "Auto-selected policy training shape for %s: %s",
-            cfg.base_model, infra.training_shape_id,
-        )
+    # -- Resolve explicit training shapes -----------------------------------
 
-    # -- Resolve training shapes --------------------------------------------
-
-    profile = rlor_mgr.resolve_training_profile(infra.training_shape_id)
+    profile = (
+        rlor_mgr.resolve_training_profile(infra.training_shape_id)
+        if infra.training_shape_id
+        else None
+    )
     if not deploy_cfg.deployment_shape and getattr(profile, "deployment_shape_version", None):
         deploy_cfg.deployment_shape = profile.deployment_shape_version
         cfg.deployment_shape = profile.deployment_shape_version
@@ -528,31 +517,28 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
             pp_rec.recommended_prompts_per_step, prompt_groups_per_step,
         )
 
-    if profile and cfg.max_seq_len is None:
-        cfg.max_seq_len = profile.max_supported_context_length
-        logger.info("max_seq_len from training shape: %d", cfg.max_seq_len)
+    if cfg.max_seq_len is None:
+        if profile:
+            cfg.max_seq_len = profile.max_supported_context_length
+            logger.info("max_seq_len from training shape: %d", cfg.max_seq_len)
+        else:
+            cfg.max_seq_len = 32768
+            logger.info("Training shape will be selected by backend trainer creation")
 
     ref_profile = None
     reference_infra = infra
     reference_launch_profile = None
     reference_needed = cfg.kl_beta > 0 or infra.ref_training_shape_id is not None
     if reference_needed:
-        if not infra.ref_training_shape_id:
-            infra.ref_training_shape_id = auto_select_training_shape(
-                rlor_mgr,
-                base_model=cfg.base_model,
-                trainer_role="reference",
-                lora_rank=cfg.lora_rank,
-                max_seq_len=cfg.max_seq_len,
-            )
+        if infra.ref_training_shape_id:
+            ref_profile = rlor_mgr.resolve_training_profile(infra.ref_training_shape_id)
+            reference_launch_profile = ref_profile
+        else:
             logger.info(
-                "Auto-selected reference training shape for %s: %s",
-                cfg.base_model, infra.ref_training_shape_id,
+                "Reference training shape will be selected by backend trainer creation"
             )
-        ref_profile = rlor_mgr.resolve_training_profile(infra.ref_training_shape_id)
         reference_infra = infra
-        reference_launch_profile = ref_profile
-    use_reference = ref_profile is not None
+    use_reference = reference_needed
     if not use_reference:
         logger.info("No ref_training_shape_id set, skipping reference model")
 

--- a/training/examples/tools/verify_logprobs.py
+++ b/training/examples/tools/verify_logprobs.py
@@ -2,9 +2,9 @@
 """Verify train-inference logprob alignment.
 
 Creates an inference deployment and a policy trainer (plus an optional
-forward-only reference trainer) from training shapes, samples completions,
-runs training forward passes, and compares per-token logprobs on completion
-tokens.
+reference trainer that runs forward-only) from LoRA-capable training shapes,
+samples completions, runs training forward passes, and compares per-token
+logprobs on completion tokens.
 
 Usage:
     export FIREWORKS_API_KEY=...

--- a/training/recipes/orpo_loop.py
+++ b/training/recipes/orpo_loop.py
@@ -57,7 +57,6 @@ from training.utils import (
     RunnerIO,
     RunStatus,
     WandBConfig,
-    auto_select_training_shape,
     build_renderer,
     create_trainer_job,
     load_preference_dataset,
@@ -243,21 +242,17 @@ def main(
             additional_headers=additional_headers,
         )
 
-    if not cfg.infra.training_shape_id:
-        cfg.infra.training_shape_id = auto_select_training_shape(
-            rlor_mgr,
-            base_model=cfg.base_model,
-            trainer_role="policy",
-            lora_rank=cfg.lora_rank,
-            max_seq_len=cfg.max_seq_len,
-        )
-        logger.info("Auto-selected training shape: %s", cfg.infra.training_shape_id)
-
-    profile = rlor_mgr.resolve_training_profile(cfg.infra.training_shape_id)
-    trainer_profile = profile
-
-    if cfg.max_seq_len is None:
-        cfg.max_seq_len = profile.max_supported_context_length
+    if cfg.infra.training_shape_id:
+        profile = rlor_mgr.resolve_training_profile(cfg.infra.training_shape_id)
+        trainer_profile = profile
+        if cfg.max_seq_len is None:
+            cfg.max_seq_len = profile.max_supported_context_length
+    else:
+        profile = None
+        trainer_profile = None
+        if cfg.max_seq_len is None:
+            cfg.max_seq_len = 32768
+        logger.info("Training shape will be selected by backend trainer creation")
 
     runner.set_accelerator_info(profile=profile)
     runner.write_status(RunStatus.PENDING, message="provisioning")

--- a/training/recipes/sft_loop.py
+++ b/training/recipes/sft_loop.py
@@ -41,7 +41,6 @@ from training.utils import (
     RunnerIO,
     RunStatus,
     WandBConfig,
-    auto_select_training_shape,
     create_trainer_job,
     log_metrics_json,
     make_render_dataloader,
@@ -466,15 +465,15 @@ def main(
             "(trainer_job_id is set). The auto-selected training shape may not "
             "match the trainer's actual context length."
         )
-    if (
+    uses_manual_infra = (
         not cfg.infra.training_shape_id
         and (
-            cfg.infra.accelerator_type
+            cfg.infra.skip_validations
+            or cfg.infra.accelerator_type
             or cfg.infra.node_count
-            or cfg.infra.custom_image_tag
-            or cfg.infra.extra_args
         )
-    ):
+    )
+    if uses_manual_infra:
         # Manual infra path: caller has supplied explicit infra fields and
         # no validated training shape exists (e.g. a brand-new base model).
         # create_trainer_job supports this path; we just skip the shape
@@ -496,20 +495,15 @@ def main(
             cfg.max_seq_len,
             cfg.infra.extra_args,
         )
-    else:
-        if not cfg.infra.training_shape_id:
-            cfg.infra.training_shape_id = auto_select_training_shape(
-                rlor_mgr,
-                base_model=cfg.base_model,
-                trainer_role="policy",
-                lora_rank=cfg.lora_rank,
-                max_seq_len=cfg.max_seq_len,
-            )
-            logger.info("Auto-selected training shape: %s", cfg.infra.training_shape_id)
-
+    elif cfg.infra.training_shape_id:
         trainer_profile = rlor_mgr.resolve_training_profile(cfg.infra.training_shape_id)
         if cfg.max_seq_len is None:
             cfg.max_seq_len = trainer_profile.max_supported_context_length
+    else:
+        if cfg.max_seq_len is None:
+            cfg.max_seq_len = 32768
+        trainer_profile = None
+        logger.info("Training shape will be selected by backend trainer creation")
 
     runner.set_accelerator_info(profile=trainer_profile)
     runner.write_status(RunStatus.PENDING, message="provisioning")

--- a/training/tests/smoke_test/conftest.py
+++ b/training/tests/smoke_test/conftest.py
@@ -17,7 +17,7 @@ DEFAULT_SMOKE_BASE_MODEL = "accounts/fireworks/models/qwen3-4b"
 DEFAULT_SMOKE_TOKENIZER_MODEL = "Qwen/Qwen3-4B"
 DEFAULT_SMOKE_TRAINING_SHAPE = "ts-qwen3-4b-smoke-v1"
 DEFAULT_SMOKE_MINIMAL_TRAINING_SHAPE = "qwen3-4b-minimum"
-DEFAULT_SMOKE_MINIMAL_REF_TRAINING_SHAPE = "qwen3-4b-minimum-forward-only"
+DEFAULT_SMOKE_MINIMAL_REF_TRAINING_SHAPE = DEFAULT_SMOKE_MINIMAL_TRAINING_SHAPE
 DEFAULT_SMOKE_BASE_URL = "https://dev.api.fireworks.ai"
 
 
@@ -99,7 +99,7 @@ def smoke_minimal_grpo_infra(
     smoke_minimal_ref_training_shape,
     smoke_custom_image_tag,
 ) -> InfraConfig:
-    """Two minimal 1xGPU training shapes (policy + forward-only reference)."""
+    """Two minimal 1xGPU LoRA-capable shapes; the reference trainer runs forward-only."""
     if smoke_custom_image_tag:
         return InfraConfig(custom_image_tag=smoke_custom_image_tag)
     return InfraConfig(

--- a/training/tests/unit/test_infra_setup.py
+++ b/training/tests/unit/test_infra_setup.py
@@ -128,6 +128,7 @@ def patch_sdk(monkeypatch):
                 "lora_rank": kwargs.get("lora_rank"),
                 "job_id_arg": kwargs.get("job_id"),
                 "trainer_replica_count": getattr(trainer_infra, "trainer_replica_count", None),
+                "profile": kwargs.get("profile"),
             }
         )
         return _trainer_handle(job_id)
@@ -140,11 +141,6 @@ def patch_sdk(monkeypatch):
     monkeypatch.setattr(infra_setup_mod, "ReconnectableClient", _FakeClient)
     monkeypatch.setattr(infra_setup_mod, "_read_replica_identity", lambda *a, **kw: None)
     monkeypatch.setattr(infra_setup_mod, "_wait_for_reattach_settled", lambda *a, **kw: None)
-    monkeypatch.setattr(
-        infra_setup_mod, "auto_select_training_shape",
-        lambda _rlor, **kw: f"auto-{kw['trainer_role']}",
-    )
-
     return SimpleNamespace(trainer_calls=trainer_calls)
 
 
@@ -346,7 +342,7 @@ def test_setup_infra_dpo_full_param_provisions_separate_reference(patch_sdk):
     assert display_names == ["dpo-policy", "dpo-reference"]
     assert infra.reference_job_id == "ref-job"
     assert isinstance(infra.reference, _FakeClient)
-    # Full-param DPO: ref trainer + client both lora_rank=0 (FORWARD_ONLY shape).
+    # Full-param DPO: ref trainer + client both lora_rank=0; backend picks shape.
     ref_call = next(c for c in patch_sdk.trainer_calls if c["display_name"] == "dpo-reference")
     assert ref_call["forward_only"] is True
     assert ref_call["lora_rank"] == 0
@@ -388,7 +384,7 @@ def test_setup_infra_dpo_lora_propagates_lora_rank_to_reference(patch_sdk):
     auto-resolver picks a LORA_TRAINER shape for the ref of a LoRA DPO,
     so the cookbook must request the ref trainer with lora_rank>0 to
     match the shape; otherwise the CreateRlorTrainerJob call is rejected
-    with a 400 (trainer_mode=FORWARD_ONLY vs shape LORA_TRAINER).
+    with a 400 if the backend shape selector and request mode disagree.
     """
     rlor, _ = _make_mgrs()
     cfg = _make_cfg(lora_rank=8, ref_training_shape_id="shape-ref")
@@ -422,9 +418,10 @@ def test_setup_infra_dpo_lora_propagates_lora_rank_to_reference(patch_sdk):
 # ---------------------------------------------------------------------------
 
 
-def test_setup_infra_auto_selects_policy_shape_when_unset(patch_sdk):
+def test_setup_infra_delegates_policy_shape_to_backend_when_unset(patch_sdk):
     rlor, deploy = _make_mgrs()
     cfg = _make_cfg(training_shape_id=None)
+    cfg.deployment.deployment_shape = "accounts/test/deploymentShapes/ds/versions/v1"
 
     infra = setup_infra(
         rlor_mgr=rlor, deploy_mgr=deploy,
@@ -441,11 +438,13 @@ def test_setup_infra_auto_selects_policy_shape_when_unset(patch_sdk):
         role_prefix="grpo", api_key="key",
     )
 
-    assert infra.training_shape_id == "auto-policy"
-    assert infra.policy_profile is not None
+    assert infra.training_shape_id is None
+    assert infra.policy_profile is None
+    policy_call = next(c for c in patch_sdk.trainer_calls if c["display_name"] == "grpo-policy")
+    assert policy_call["profile"] is None
 
 
-def test_setup_infra_auto_selects_reference_shape_for_full_param_with_kl(patch_sdk):
+def test_setup_infra_delegates_full_param_reference_shape_to_backend(patch_sdk):
     rlor, deploy = _make_mgrs()
     cfg = _make_cfg(lora_rank=0, ref_training_shape_id=None)
 
@@ -464,11 +463,15 @@ def test_setup_infra_auto_selects_reference_shape_for_full_param_with_kl(patch_s
         role_prefix="grpo", api_key="key",
     )
 
-    assert infra.ref_training_shape_id == "auto-reference"
+    assert infra.ref_training_shape_id is None
+    assert infra.reference_job_id == "ref-job"
+    ref_call = next(c for c in patch_sdk.trainer_calls if c["display_name"] == "grpo-reference")
+    assert ref_call["profile"] is None
+    assert ref_call["forward_only"] is True
 
 
 def test_setup_infra_does_not_auto_select_ref_for_lora(patch_sdk):
-    """LoRA path skips auto-select — uses shared session instead."""
+    """LoRA path skips separate reference — uses shared session instead."""
     rlor, deploy = _make_mgrs()
     cfg = _make_cfg(lora_rank=64, ref_training_shape_id=None)
 
@@ -561,11 +564,6 @@ def test_parallel_request_phase_precedes_wait_phase(monkeypatch):
     monkeypatch.setattr(infra_setup_mod, "ReconnectableClient", _FakeClient)
     monkeypatch.setattr(infra_setup_mod, "_read_replica_identity", lambda *a, **kw: None)
     monkeypatch.setattr(infra_setup_mod, "_wait_for_reattach_settled", lambda *a, **kw: None)
-    monkeypatch.setattr(
-        infra_setup_mod, "auto_select_training_shape",
-        lambda _rlor, **kw: f"auto-{kw['trainer_role']}",
-    )
-
     rlor, deploy = _make_mgrs(profile=_profile())
     cfg = _make_cfg(lora_rank=0, ref_training_shape_id="shape-ref")
     setup_infra(
@@ -611,11 +609,6 @@ def test_parallel_wait_timing(monkeypatch):
     monkeypatch.setattr(infra_setup_mod, "ReconnectableClient", _FakeClient)
     monkeypatch.setattr(infra_setup_mod, "_read_replica_identity", lambda *a, **kw: None)
     monkeypatch.setattr(infra_setup_mod, "_wait_for_reattach_settled", lambda *a, **kw: None)
-    monkeypatch.setattr(
-        infra_setup_mod, "auto_select_training_shape",
-        lambda _rlor, **kw: f"auto-{kw['trainer_role']}",
-    )
-
     rlor, deploy = _make_mgrs(profile=_profile())
     cfg = _make_cfg(lora_rank=0, ref_training_shape_id="shape-ref")
     setup_infra(
@@ -658,11 +651,6 @@ def test_failure_cleanup_registers_both_resources(monkeypatch):
     monkeypatch.setattr(infra_setup_mod, "ReconnectableClient", _FakeClient)
     monkeypatch.setattr(infra_setup_mod, "_read_replica_identity", lambda *a, **kw: None)
     monkeypatch.setattr(infra_setup_mod, "_wait_for_reattach_settled", lambda *a, **kw: None)
-    monkeypatch.setattr(
-        infra_setup_mod, "auto_select_training_shape",
-        lambda _rlor, **kw: f"auto-{kw['trainer_role']}",
-    )
-
     rlor = MagicMock()
     rlor.resolve_training_profile.return_value = _profile()
     deploy = MagicMock()
@@ -712,11 +700,6 @@ def test_lora_shared_ref_no_ref_trainer_created(monkeypatch):
     monkeypatch.setattr(infra_setup_mod, "ReconnectableClient", _FakeClient)
     monkeypatch.setattr(infra_setup_mod, "_read_replica_identity", lambda *a, **kw: None)
     monkeypatch.setattr(infra_setup_mod, "_wait_for_reattach_settled", lambda *a, **kw: None)
-    monkeypatch.setattr(
-        infra_setup_mod, "auto_select_training_shape",
-        lambda _rlor, **kw: f"auto-{kw['trainer_role']}",
-    )
-
     rlor, deploy = _make_mgrs(profile=_profile())
     cfg = _make_cfg(lora_rank=64)
 
@@ -765,11 +748,6 @@ def test_reuse_path_policy_job_id_set(monkeypatch):
     monkeypatch.setattr(infra_setup_mod, "ReconnectableClient", _FakeClient)
     monkeypatch.setattr(infra_setup_mod, "_read_replica_identity", lambda *a, **kw: None)
     monkeypatch.setattr(infra_setup_mod, "_wait_for_reattach_settled", lambda *a, **kw: None)
-    monkeypatch.setattr(
-        infra_setup_mod, "auto_select_training_shape",
-        lambda _rlor, **kw: f"auto-{kw['trainer_role']}",
-    )
-
     rlor, deploy = _make_mgrs(profile=_profile())
     cfg = _make_cfg(lora_rank=0, policy_job_id="pre-created-policy")
 
@@ -808,11 +786,6 @@ def test_dpo_full_param_no_deployment(monkeypatch):
     monkeypatch.setattr(infra_setup_mod, "request_trainer_job", fake_request_trainer)
     monkeypatch.setattr(infra_setup_mod, "wait_trainer_job", fake_wait_trainer)
     monkeypatch.setattr(infra_setup_mod, "ReconnectableClient", _FakeClient)
-    monkeypatch.setattr(
-        infra_setup_mod, "auto_select_training_shape",
-        lambda _rlor, **kw: f"auto-{kw['trainer_role']}",
-    )
-
     rlor, _ = _make_mgrs(profile=_profile())
     cfg = _make_cfg(lora_rank=0, ref_training_shape_id="shape-ref")
 
@@ -859,11 +832,6 @@ def test_reattach_patch_issued_before_trainer_ready(monkeypatch):
     monkeypatch.setattr(infra_setup_mod, "_read_replica_identity", lambda *a, **kw: "old-pod-id")
     monkeypatch.setattr(infra_setup_mod, "_wait_for_reattach_settled", fake_settle)
     monkeypatch.setattr(infra_setup_mod, "ReconnectableClient", _FakeClient)
-    monkeypatch.setattr(
-        infra_setup_mod, "auto_select_training_shape",
-        lambda _rlor, **kw: f"auto-{kw['trainer_role']}",
-    )
-
     rlor, deploy = _make_mgrs(profile=_profile())
     # Existing live deployment → triggers re-attach path.
     deploy.get.return_value = SimpleNamespace(

--- a/training/tests/unit/test_sft_loop.py
+++ b/training/tests/unit/test_sft_loop.py
@@ -194,11 +194,6 @@ def test_main_raises_when_all_examples_are_filtered(tmp_path, monkeypatch):
     monkeypatch.setattr(module, "resolve_renderer_name", lambda *args, **kwargs: "unit-renderer")
     monkeypatch.setattr(
         module,
-        "auto_select_training_shape",
-        lambda *args, **kwargs: "accounts/test/trainingShapes/sft",
-    )
-    monkeypatch.setattr(
-        module,
         "render_messages_to_datums",
         lambda *args, **kwargs: SimpleNamespace(token_ids=[1], token_weights=[1.0], datum={"id": "too-short"}),
     )
@@ -279,11 +274,6 @@ def test_main_reduces_batch_size_when_examples_fewer_than_batch_size(tmp_path, m
     monkeypatch.setattr(module, "log_metrics_json", lambda *args, **kwargs: None)
     monkeypatch.setattr(module, "populate_render_worker_state", _make_stub_render_worker_state())
     monkeypatch.setattr(module, "resolve_renderer_name", lambda *args, **kwargs: "unit-renderer")
-    monkeypatch.setattr(
-        module,
-        "auto_select_training_shape",
-        lambda *args, **kwargs: "accounts/test/trainingShapes/sft",
-    )
     monkeypatch.setattr(
         module,
         "render_messages_to_datums",
@@ -386,7 +376,6 @@ def test_main_infers_documented_training_shape_for_supported_model(tmp_path, mon
     monkeypatch.setattr(module, "log_metrics_json", lambda *args, **kwargs: None)
     monkeypatch.setattr(module, "populate_render_worker_state", _make_stub_render_worker_state())
     monkeypatch.setattr(module, "resolve_renderer_name", lambda *args, **kwargs: "unit-renderer")
-    monkeypatch.setattr(module, "auto_select_training_shape", _record_auto_select)
     monkeypatch.setattr(
         module,
         "render_messages_to_datums",
@@ -419,10 +408,11 @@ def test_main_infers_documented_training_shape_for_supported_model(tmp_path, mon
     result = module.main(cfg, rlor_mgr=FakeMgr())
 
     assert result["steps"] == 1
-    assert cfg.max_seq_len == 48
-    assert cfg.infra.training_shape_id == "accounts/test/trainingShapes/sft"
-    assert len(events["selection_requests"]) == 1
-    assert events["created_config"].training_shape_ref == "accounts/test/trainingShapes/sft/versions/1"
+    assert cfg.max_seq_len == 32768
+    assert cfg.infra.training_shape_id is None
+    assert len(events["selection_requests"]) == 0
+    assert events["created_config"].auto_select_training_shape is True
+    assert events["created_config"].training_shape_ref is None
     assert events["created_config"].custom_image_tag is None
     assert events["created_config"].accelerator_type is None
     assert events["created_config"].accelerator_count is None
@@ -509,11 +499,6 @@ def test_main_uses_real_renderer_and_trains(tmp_path, monkeypatch):
     monkeypatch.setattr(module, "log_metrics_json", lambda *args, **kwargs: None)
     monkeypatch.setattr(module, "populate_render_worker_state", _make_stub_render_worker_state(renderer=renderer))
     monkeypatch.setattr(module, "resolve_renderer_name", lambda *args, **kwargs: "unit-renderer")
-    monkeypatch.setattr(
-        module,
-        "auto_select_training_shape",
-        lambda *args, **kwargs: "accounts/test/trainingShapes/sft",
-    )
     monkeypatch.setattr(module, "ReconnectableClient", FakeClient)
 
     cfg = module.Config(
@@ -606,11 +591,6 @@ def test_each_batch_triggers_its_own_optim_step(tmp_path, monkeypatch):
     monkeypatch.setattr(module, "log_metrics_json", lambda *args, **kwargs: None)
     monkeypatch.setattr(module, "populate_render_worker_state", _make_stub_render_worker_state())
     monkeypatch.setattr(module, "resolve_renderer_name", lambda *args, **kwargs: "unit-renderer")
-    monkeypatch.setattr(
-        module,
-        "auto_select_training_shape",
-        lambda *args, **kwargs: "accounts/test/trainingShapes/sft",
-    )
     monkeypatch.setattr(module, "ReconnectableClient", FakeClient)
     def _fake_render(messages, **kwargs):
         content = messages[-1]["content"]
@@ -714,11 +694,6 @@ def test_main_resume_preserves_epoch_zero_batch_order(tmp_path, monkeypatch):
     monkeypatch.setattr(module, "resolve_renderer_name", lambda *args, **kwargs: "unit-renderer")
     monkeypatch.setattr(
         module,
-        "auto_select_training_shape",
-        lambda *args, **kwargs: "accounts/test/trainingShapes/sft",
-    )
-    monkeypatch.setattr(
-        module,
         "render_messages_to_datums",
         lambda messages, **kwargs: SimpleNamespace(
             token_ids=[1, 2],
@@ -818,11 +793,6 @@ def test_main_resume_uses_raw_row_cursor_when_filtering_shrinks_batches(tmp_path
     monkeypatch.setattr(module, "log_metrics_json", lambda *args, **kwargs: None)
     monkeypatch.setattr(module, "populate_render_worker_state", _make_stub_render_worker_state())
     monkeypatch.setattr(module, "resolve_renderer_name", lambda *args, **kwargs: "unit-renderer")
-    monkeypatch.setattr(
-        module,
-        "auto_select_training_shape",
-        lambda *args, **kwargs: "accounts/test/trainingShapes/sft",
-    )
     monkeypatch.setattr(module, "make_render_dataloader", lambda *args, **kwargs: raw_batches)
     monkeypatch.setattr(module, "ReconnectableClient", FakeClient)
 
@@ -911,11 +881,6 @@ def test_completed_status_reports_actual_steps_when_filtering_drops_raw_batches(
     monkeypatch.setattr(module, "log_metrics_json", lambda *args, **kwargs: None)
     monkeypatch.setattr(module, "populate_render_worker_state", _make_stub_render_worker_state())
     monkeypatch.setattr(module, "resolve_renderer_name", lambda *args, **kwargs: "unit-renderer")
-    monkeypatch.setattr(
-        module,
-        "auto_select_training_shape",
-        lambda *args, **kwargs: "accounts/test/trainingShapes/sft",
-    )
     monkeypatch.setattr(module, "make_render_dataloader", lambda *args, **kwargs: raw_batches)
     monkeypatch.setattr(module, "ReconnectableClient", FakeClient)
     _patch_resume(monkeypatch, None)
@@ -1055,11 +1020,6 @@ def test_eval_auto_carveout_splits_data_and_runs_eval(tmp_path, monkeypatch):
     monkeypatch.setattr(module, "log_metrics_json", lambda *args, **kwargs: None)
     monkeypatch.setattr(module, "populate_render_worker_state", _make_stub_render_worker_state())
     monkeypatch.setattr(module, "resolve_renderer_name", lambda *args, **kwargs: "unit-renderer")
-    monkeypatch.setattr(
-        module,
-        "auto_select_training_shape",
-        lambda *args, **kwargs: "accounts/test/trainingShapes/sft",
-    )
     monkeypatch.setattr(module, "ReconnectableClient", FakeClient)
     monkeypatch.setattr(
         module,
@@ -1188,11 +1148,6 @@ def test_eval_auto_carveout_eval_set_is_stable_across_epochs(tmp_path, monkeypat
     monkeypatch.setattr(module, "log_metrics_json", lambda *args, **kwargs: None)
     monkeypatch.setattr(module, "populate_render_worker_state", _make_stub_render_worker_state())
     monkeypatch.setattr(module, "resolve_renderer_name", lambda *args, **kwargs: "unit-renderer")
-    monkeypatch.setattr(
-        module,
-        "auto_select_training_shape",
-        lambda *args, **kwargs: "accounts/test/trainingShapes/sft",
-    )
     monkeypatch.setattr(module, "ReconnectableClient", FakeClient)
     monkeypatch.setattr(
         module,

--- a/training/tests/unit/test_shape_override_paths.py
+++ b/training/tests/unit/test_shape_override_paths.py
@@ -82,7 +82,8 @@ class TestShapePath:
 
         assert c.training_shape_ref == PROFILE.training_shape_version
         assert c.base_model == BASE_MODEL
-        assert c.gradient_accumulation_steps is None
+        assert c.gradient_accumulation_steps == 1
+        assert c.auto_select_training_shape is False
         assert c.region == "US_VIRGINIA_1"
 
         assert c.accelerator_type is None

--- a/training/utils/config.py
+++ b/training/utils/config.py
@@ -73,13 +73,14 @@ class InfraConfig:
     When set, infra config is auto-derived from the shape."""
 
     ref_training_shape_id: str | None = None
-    """Training shape ID for a **separate** forward-only reference trainer.
+    """LoRA-capable training shape ID for a **separate** reference trainer.
     Only relevant for **full-parameter** training — LoRA runs use the
     shared-session reference (``policy.create_base_reference()``) on the
     policy trainer, so leave this ``None`` when ``lora_rank > 0``. For
     full-param, when set, a second trainer is provisioned; when not set,
     no reference is created. Can be the same value as ``training_shape_id``
-    — the control plane auto-appends ``--forward-only``."""
+    — the control plane auto-appends ``--forward-only`` so the trainer runs
+    as a frozen reference."""
 
     region: str | None = None
     custom_image_tag: str | None = None

--- a/training/utils/infra.py
+++ b/training/utils/infra.py
@@ -56,7 +56,6 @@ from fireworks.training.sdk.deployment import (
 
 from training.utils.client import DEFAULT_TIMEOUT_S, ReconnectableClient
 from training.utils.config import DeployConfig, InfraConfig, WeightSyncScope
-from training.utils.training_shapes import auto_select_training_shape
 
 TrainerHandle = CreatedTrainerJob | TrainerServiceEndpoint
 """Return type of :func:`request_trainer_job`.
@@ -76,6 +75,9 @@ _TRAINER_JOB_CONFIG_SUPPORTS_SKIP_VALIDATIONS = (
 )
 _TRAINER_JOB_CONFIG_SUPPORTS_TRAINING_SHAPE_REF = (
     "training_shape_ref" in inspect.signature(TrainerJobConfig).parameters
+)
+_TRAINER_JOB_CONFIG_SUPPORTS_AUTO_SELECT_SHAPE = (
+    "auto_select_training_shape" in inspect.signature(TrainerJobConfig).parameters
 )
 _TRAINER_JOB_CONFIG_SUPPORTS_TRAINER_REPLICA_COUNT = (
     "trainer_replica_count" in inspect.signature(TrainerJobConfig).parameters
@@ -122,6 +124,16 @@ def read_api_extra_headers_env() -> dict[str, str] | None:
         )
         return None
     return parsed or None
+
+
+def _uses_manual_training_infra(infra: InfraConfig) -> bool:
+    """Return True when caller-provided infra should bypass shape selection."""
+    return bool(
+        infra.skip_validations
+        or infra.accelerator_type
+        or infra.accelerator_count
+        or infra.node_count
+    )
 
 
 def _default_trainer_cancel_grace_period_s() -> float:
@@ -302,13 +314,16 @@ def request_trainer_job(
     ``TrainerServiceEndpoint`` for the reuse path (already polled by
     ``_reuse_or_resume_job``, so :func:`wait_trainer_job` is a no-op).
 
-    Two launch paths:
+    Three launch paths:
 
-    * **Shape path** (profile provided): sends ``training_shape_ref``
+    * **Explicit shape path** (profile provided): sends ``training_shape_ref``
       plus algorithm fields only.  The backend populates accelerator,
       image tag, node count, sharding, etc. from the validated shape.
-    * **Manual path** (no profile): sends all ``InfraConfig`` fields
-      as-is; the server skips shape validation.
+    * **Backend auto shape path** (no profile and no manual infra): the
+      backend chooses a validated shape from base model, context length,
+      LoRA rank, and ``forward_only``.
+    * **Manual path** (no profile with manual infra): sends all
+      ``InfraConfig`` fields as-is; the server skips shape validation.
 
     *cleanup*, when provided, registers the created job for cancellation
     on scope exit. Thread-safe: ``ResourceCleanup.trainer`` uses a lock.
@@ -326,11 +341,15 @@ def request_trainer_job(
         _emit(f"reusing existing {trainer_role} trainer {job_id}")
         return _reuse_or_resume_job(rlor_mgr, job_id)
 
+    auto_select_training_shape = profile is None and not _uses_manual_training_infra(infra)
+
     extra_trainer_args: dict[str, Any] = {}
     if _TRAINER_JOB_CONFIG_SUPPORTS_SKIP_VALIDATIONS:
         extra_trainer_args["skip_validations"] = infra.skip_validations
     if profile is not None and _TRAINER_JOB_CONFIG_SUPPORTS_TRAINING_SHAPE_REF:
         extra_trainer_args["training_shape_ref"] = profile.training_shape_version
+    if auto_select_training_shape and _TRAINER_JOB_CONFIG_SUPPORTS_AUTO_SELECT_SHAPE:
+        extra_trainer_args["auto_select_training_shape"] = True
     if infra.trainer_replica_count is not None:
         if infra.trainer_replica_count < 0:
             raise ValueError("trainer_replica_count must be non-negative")
@@ -359,16 +378,19 @@ def request_trainer_job(
             lora_rank=lora_rank,
             max_context_length=max_seq_len,
             learning_rate=learning_rate,
-            node_count=infra.node_count,
+            node_count=None if auto_select_training_shape else infra.node_count,
             display_name=display_name,
             hot_load_deployment_id=hot_load_deployment_id,
             region=infra.region,
             custom_image_tag=infra.custom_image_tag,
             extra_args=extra_args or infra.extra_args,
-            accelerator_type=infra.accelerator_type,
-            accelerator_count=infra.accelerator_count,
+            accelerator_type=None if auto_select_training_shape else infra.accelerator_type,
+            accelerator_count=None if auto_select_training_shape else infra.accelerator_count,
             forward_only=forward_only,
+            **extra_trainer_args,
         )
+        if auto_select_training_shape and not _TRAINER_JOB_CONFIG_SUPPORTS_AUTO_SELECT_SHAPE:
+            config.auto_select_training_shape = True
         if not _TRAINER_JOB_CONFIG_SUPPORTS_TRAINING_SHAPE_REF:
             config.training_shape_ref = None
 
@@ -929,11 +951,12 @@ def _create_trainer_job_with_replica_count(
         query_params.append(("deploymentId", config.hot_load_deployment_id))
 
     is_shape_path = bool(config.training_shape_ref)
+    is_auto_shape_path = bool(getattr(config, "auto_select_training_shape", False))
     if is_shape_path:
         query_params.append(("trainingShape", config.training_shape_ref))
         if config.skip_validations:
             query_params.append(("skipValidations", "true"))
-    else:
+    elif not is_auto_shape_path:
         query_params.append(("skipValidations", "true"))
 
     if query_params:
@@ -953,9 +976,10 @@ def _create_trainer_job_with_replica_count(
         "trainerReplicaCount": trainer_replica_count,
     }
 
-    if not is_shape_path:
-        if config.max_context_length is not None:
-            training_config["maxContextLength"] = config.max_context_length
+    if not is_shape_path and config.max_context_length is not None:
+        training_config["maxContextLength"] = config.max_context_length
+
+    if not is_shape_path and not is_auto_shape_path:
         payload["nodeCount"] = config.node_count if config.node_count is not None else 1
         if config.custom_image_tag:
             training_config["customImageTag"] = config.custom_image_tag
@@ -1086,7 +1110,9 @@ def setup_infra(
     """Build all training-side infrastructure in one call.
 
     Generic across loop types (RL, DPO, SFT). Neither ``infra_cfg`` nor
-    ``deploy_cfg`` is mutated; both are shape-resolved into local copies.
+    ``deploy_cfg`` is mutated; explicit shape IDs are resolved into local
+    copies, and omitted trainer shapes are selected by the backend when each
+    service-mode trainer is created.
 
     Args:
         rlor_mgr: Trainer job manager.
@@ -1095,7 +1121,9 @@ def setup_infra(
         infra_cfg: Infrastructure config (shape IDs, region, etc.).
         deploy_cfg: Deployment config. Required when ``needs_inference=True``.
         lora_rank: LoRA rank; 0 means full-parameter.
-        max_seq_len: Max sequence length. Auto-populated from shape when ``None``.
+        max_seq_len: Max sequence length. When no explicit training shape is
+            provided, this is sent to the backend shape selector as the
+            requested context length.
         learning_rate: Optimizer learning rate forwarded to trainer jobs.
         step_timeout: Per-step RPC timeout. Falls back to SDK default when ``None``.
         policy_job_id: Reuse an existing policy trainer job instead of creating one.
@@ -1172,7 +1200,8 @@ def setup_infra(
         lora_rank=lora_rank, max_seq_len=resolved_max_seq_len,
         learning_rate=learning_rate,
         policy_job_id=policy_job_id, reference_job_id=reference_job_id,
-        role_prefix=role_prefix, cleanup=cleanup, on_status=emit,
+        role_prefix=role_prefix, needs_reference=needs_reference,
+        cleanup=cleanup, on_status=emit,
     )
 
     dep_info: DeploymentInfo | _ReattachHandle | None = None
@@ -1287,14 +1316,15 @@ def _resolve_policy_shape(
 ) -> tuple[Any, int, str | None, str | None]:
     """Return (profile, resolved_max_seq_len, resolved_shape_id, resolved_deploy_shape)."""
     if training_shape_id is None:
-        training_shape_id = auto_select_training_shape(
-            rlor_mgr,
-            base_model=base_model,
-            trainer_role="policy",
-            lora_rank=lora_rank,
-            max_seq_len=max_seq_len,
-        )
-        logger.info("Auto-selected policy training shape: %s", training_shape_id)
+        if max_seq_len is None:
+            max_seq_len = 32768
+        if needs_inference and not deploy_shape:
+            raise ValueError(
+                "deployment.deployment_shape is required when training shapes "
+                "are selected by the backend. Set deployment_shape or provide "
+                "infra.training_shape_id."
+            )
+        return None, max_seq_len, None, deploy_shape
     profile = rlor_mgr.resolve_training_profile(training_shape_id)
 
     resolved_deploy_shape = deploy_shape
@@ -1331,17 +1361,7 @@ def _resolve_reference_shape(
                 ref_training_shape_id, lora_rank,
             )
         return rlor_mgr.resolve_training_profile(ref_training_shape_id), ref_training_shape_id
-    if not (needs_reference and lora_rank == 0):
-        return None, None
-    ref_training_shape_id = auto_select_training_shape(
-        rlor_mgr,
-        base_model=base_model,
-        trainer_role="reference",
-        lora_rank=lora_rank,
-        max_seq_len=max_seq_len,
-    )
-    logger.info("Auto-selected reference training shape: %s", ref_training_shape_id)
-    return rlor_mgr.resolve_training_profile(ref_training_shape_id), ref_training_shape_id
+    return None, None
 
 
 def _strip_args(infra: InfraConfig, flags: set[str]) -> InfraConfig:
@@ -1367,6 +1387,7 @@ def _request_trainers(
     policy_job_id: str | None,
     reference_job_id: str | None,
     role_prefix: str,
+    needs_reference: bool,
     hot_load_deployment_id: str | None,
     cleanup: ResourceCleanup | None,
     on_status: Callable[[str], None],
@@ -1389,7 +1410,8 @@ def _request_trainers(
     )
 
     ref_handle = None
-    if ref_profile is not None:
+    create_separate_reference = needs_reference and (lora_rank == 0 or ref_profile is not None)
+    if create_separate_reference:
         on_status("provisioning reference trainer")
         # Reference trainer runs forward-only: strip --full-oom-check, which
         # triggers a backward warmup that OOMs on smaller reference shapes.
@@ -1397,12 +1419,9 @@ def _request_trainers(
             _strip_args(infra, {"--full-oom-check"}),
             trainer_replica_count=None,
         )
-        # Propagate lora_rank so the gateway infers the correct trainer_mode:
-        #   lora_rank > 0  -> LORA_TRAINER (matches LoRA-capable ref shape)
-        #   lora_rank == 0 -> FORWARD_ONLY (full-param base-weight forward)
-        # A forward-only LoRA ref still loads the adapter on top of base
-        # weights; the adapter is configured upstream and only the forward
-        # pass runs here.
+        # Propagate lora_rank so client/server LoRA configuration stays aligned.
+        # The backend shape selector owns the mapping from forward_only + lora_rank
+        # to a validated service-mode shape.
         ref_handle = request_trainer_job(
             rlor_mgr,
             base_model=base_model,

--- a/training/utils/training_shapes.py
+++ b/training/utils/training_shapes.py
@@ -33,7 +33,6 @@ _TRAINING_SHAPE_VERSION_RE = re.compile(r"/versions/[^/]+$")
 
 _TRAINER_MODE_BY_CODE = {
     1: "POLICY_TRAINER",
-    2: "FORWARD_ONLY",
     3: "LORA_TRAINER",
 }
 
@@ -104,9 +103,7 @@ def auto_select_training_shape(
     if candidates:
         return _pick_best(candidates, max_seq_len)
 
-    mode_label = {"LORA_TRAINER": "LoRA", "FORWARD_ONLY": "reference"}.get(
-        expected_mode, "full-tune"
-    )
+    mode_label = "LoRA" if expected_mode == "LORA_TRAINER" else "full-tune"
     raise ValueError(
         f"No validated training shape matched base_model={base_model!r}, "
         f"mode={mode_label!r}, max_seq_len={max_seq_len!r}. "
@@ -126,7 +123,7 @@ def _expected_trainer_mode(
     if lora_rank > 0:
         return "LORA_TRAINER"
     if trainer_role == "reference":
-        return "FORWARD_ONLY"
+        return "LORA_TRAINER"
     return "POLICY_TRAINER"
 
 


### PR DESCRIPTION
## Summary
- Remove cookbook-side ad hoc managed shape resolution for SFT/ORPO/RFT flows.
- Let service-mode trainer creation own validated training shape selection from base model, context length, LoRA rank, custom image tag, and forward-only runtime mode.
- Treat reference trainers as forward-only runtime jobs on LoRA-capable shapes, not separate forward-only training shapes.
- Update docs, smoke defaults, and unit tests to avoid hard-coded forward-only shape assumptions.

## Validation
- `pytest -q training/tests/unit/test_infra_setup.py training/tests/unit/test_sft_loop.py training/tests/unit/test_orpo_loop.py training/tests/unit/test_shape_override_paths.py training/tests/unit/test_train_frozen_lake.py` -> 74 passed
- `git diff --check`

Draft because this coordinates with the root fireworks PR that updates control-plane trainer selection and submodule pointers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how trainers are provisioned when shape IDs are omitted; misalignment with the coordinating control-plane PR could cause job creation failures or wrong reference shapes until both sides deploy.
> 
> **Overview**
> **Trainer shape selection** moves from cookbook-side `auto_select_training_shape` (control-plane listing/filtering) to **service-mode trainer creation** via `auto_select_training_shape=True` on `TrainerJobConfig` when no explicit profile or manual infra is set.
> 
> SFT, ORPO, frozen_lake, and shared **`setup_infra`** no longer pre-resolve or mutate `training_shape_id` / `ref_training_shape_id`; they pass `profile=None`, default **`max_seq_len` to 32768** when unset, and require **`deployment.deployment_shape`** when inference runs without an explicit training shape. Reference trainers for full-param KL/DPO still provision separately with **`forward_only=True`**, but unset ref shapes are no longer auto-picked client-side—the backend selects a **LoRA-capable** validated shape.
> 
> Docs and config comments now describe references as **forward-only runtime on LoRA-capable shapes** (not dedicated `FORWARD_ONLY` training shapes). Smoke defaults reuse the same minimal policy shape for ref; **`training_shapes._expected_trainer_mode`** maps full-param reference to `LORA_TRAINER`. Unit tests assert delegation (`profile is None`, `auto_select_training_shape` on create) instead of mocked auto-select.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d29b521ff32c00ce5e25027109e154e7b19967a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->