### PR TITLE
Add advisor: a frontier reviewer for any coding agent

### DIFF
--- a/advisor/README.md
+++ b/advisor/README.md
@@ -32,11 +32,19 @@ diff, so it works the same in **any** harness.
 
 ## 1. Worker — run your agent on Fireworks (GLM-5.2)
 
-Point your coding agent's model at a Fireworks open model. With
-[FireConnect](https://github.com/fw-ai/fireconnect) this is one command; or set
-your harness's Anthropic-compatible base URL to `https://api.fireworks.ai/inference`
-and model to `accounts/fireworks/models/glm-5p2`, with your Fireworks `fw_` key.
-This is your cheap, fast worker.
+Point your coding agent's model at a Fireworks open model. First, get a Fireworks
+API key:
+
+1. Sign up or log in at [app.fireworks.ai](https://app.fireworks.ai) and verify
+   your account.
+2. Open your profile menu → **Settings** → **API Keys**.
+3. Click **Create API Key**, give it a name, and copy it (Fireworks shows the full
+   key only once). It looks like `fw_...`.
+
+Then point your harness's Anthropic-compatible base URL at
+`https://api.fireworks.ai/inference` and its model at
+`accounts/fireworks/models/glm-5p2`, using that `fw_` key. This is your cheap,
+fast worker.
 
 ## 2. Advisor — add the frontier reviewer (Claude)
 

--- a/advisor/README.md
+++ b/advisor/README.md
@@ -84,3 +84,5 @@ where your harness reads project instructions:
 
 Keep it to **one review before finishing** — in our ablations, consulting the
 advisor more (e.g. a planning call too) didn't improve results and cost more.
+
+That's it — your agent now has an advisor to talk to. 🎉

--- a/advisor/README.md
+++ b/advisor/README.md
@@ -78,12 +78,6 @@ not your Fireworks worker.
 Tell your agent (the GLM-5.2 worker) *when* to call the advisor — add one line
 where your harness reads project instructions:
 
-| Agent | File |
-|---|---|
-| Claude Code | `CLAUDE.md` |
-| Codex · OpenCode | `AGENTS.md` |
-| Cursor | `.cursor/rules/advisor.md` |
-
 > Before declaring any non-trivial change complete, run
 > `node advisor.mjs review` with a focused `--question`, fix any **critical**
 > issues it raises, then re-run your tests. Skip it for trivial edits.

--- a/advisor/README.md
+++ b/advisor/README.md
@@ -73,18 +73,7 @@ export ADVISOR_API_KEY=sk-ant-...        # Anthropic key for the Claude reviewer
 `ADVISOR_API_KEY` is the **advisor's** key — it pays for the Claude review calls,
 not your Fireworks worker.
 
-## 3. Try it standalone
-
-From inside any git repo with uncommitted changes:
-
-```bash
-node advisor.mjs review --question "are there race conditions in the token refresh?"
-```
-
-It prints a ~300-word critique: critical issues (≥80 confidence) → suggested
-fixes → low-confidence notes → what it could and couldn't verify.
-
-## 4. Wire it into your agent
+## 3. Wire it into your agent
 
 Tell your agent (the GLM-5.2 worker) *when* to call the advisor — add one line
 where your harness reads project instructions:

--- a/advisor/README.md
+++ b/advisor/README.md
@@ -84,10 +84,3 @@ where your harness reads project instructions:
 
 Keep it to **one review before finishing** — in our ablations, consulting the
 advisor more (e.g. a planning call too) didn't improve results and cost more.
-
-## What it sends
-
-For full transparency, each call sends the reviewer: your `<question>` and
-`<focus>`, any `<sources>` you pass via `--files`, optional `<context>` (e.g. a
-short note on what you did), and the `<worktree>` — `git status` + `git log` +
-`git diff HEAD`. Nothing else. Read `advisor.mjs` end to end in two minutes.

--- a/advisor/README.md
+++ b/advisor/README.md
@@ -41,10 +41,18 @@ API key:
 3. Click **Create API Key**, give it a name, and copy it (Fireworks shows the full
    key only once). It looks like `fw_...`.
 
-Then point your harness's Anthropic-compatible base URL at
-`https://api.fireworks.ai/inference` and its model at
-`accounts/fireworks/models/glm-5p2`, using that `fw_` key. This is your cheap,
-fast worker.
+Then route your agent through Fireworks GLM-5.2. Fireworks serves an
+Anthropic-compatible endpoint, so for Claude Code that's three env vars:
+
+```bash
+export ANTHROPIC_BASE_URL=https://api.fireworks.ai/inference
+export ANTHROPIC_API_KEY=fw_...                              # your Fireworks key
+export ANTHROPIC_MODEL=accounts/fireworks/models/glm-5p2
+```
+
+Other harnesses (Codex, Cursor, …) have their own base-URL / key / model settings —
+point them at the same endpoint and model. This `fw_` key powers the **worker**;
+it's separate from the **advisor's** Anthropic key in the next step.
 
 ## 2. Advisor — add the frontier reviewer (Claude)
 

--- a/advisor/README.md
+++ b/advisor/README.md
@@ -98,14 +98,6 @@ where your harness reads project instructions:
 Keep it to **one review before finishing** — in our ablations, consulting the
 advisor more (e.g. a planning call too) didn't improve results and cost more.
 
-## Choosing the reviewer model
-
-The advisor talks to any Anthropic-compatible `/v1/messages` endpoint, so you can
-swap the reviewer — but it should be a **frontier** model. Pointing it at the same
-(or a weaker) model than your worker gave little lift in our tests; the gains come
-from the reviewer being genuinely stronger. Claude Opus is the default and the
-report's headline reviewer.
-
 ## What it sends
 
 For full transparency, each call sends the reviewer: your `<question>` and

--- a/advisor/README.md
+++ b/advisor/README.md
@@ -5,10 +5,19 @@ second opinion** before it finishes. Your agent does the work; the advisor reads
 the **working git diff** and returns scored issues + fixes. It cannot edit files.
 
 This is the harness from our report **"Open-source agents with a frontier
-reviewer"** ([Fireworks blog](https://fireworks.ai/blog)) — an open-source worker
-model checked by a stronger reviewer matched frontier-only quality at a fraction
-of the cost. Here it's packaged as **one file** (`advisor.mjs`) you can drop into
-your own agent, using **Fireworks serverless inference** for the reviewer.
+reviewer"** ([Fireworks blog](https://fireworks.ai/blog)). The result: a cheap
+**open-source worker on Fireworks** (e.g. GLM-5.2), checked by a **frontier
+reviewer** (Claude), matches frontier-only quality at a fraction of the cost.
+
+**Two models, two roles:**
+
+| Role | Model | Runs on | Key |
+|---|---|---|---|
+| **Worker** (does the task) | open-source, e.g. **GLM-5.2** | **Fireworks** serverless | `fw_...` (in your agent harness) |
+| **Advisor** (reviews the diff) | **frontier, Claude Opus** | Anthropic | `sk-ant-...` (this tool, `ADVISOR_API_KEY`) |
+
+The advisor must be the **stronger** model — that's the finding. This tool only
+sets up the advisor; your worker is configured in your own agent.
 
 ## How it works
 
@@ -24,25 +33,30 @@ That calibrated, evidence-gated prompt (the full text is `SYSTEM_PROMPT` in
 `advisor.mjs`) is what makes it useful instead of noisy. It's anchored on the
 diff, so it works the same in **any** harness.
 
-## 1. Setup
+## 1. Worker — run your agent on Fireworks (GLM-5.2)
 
-You need [Node.js](https://nodejs.org) (18+) and a **Fireworks API key**
-([get one](https://app.fireworks.ai)). Point the advisor at Fireworks serverless
-inference:
+Point your coding agent's model at a Fireworks open model. With
+[FireConnect](https://github.com/fw-ai/fireconnect) this is one command; or set
+your harness's Anthropic-compatible base URL to `https://api.fireworks.ai/inference`
+and model to `accounts/fireworks/models/glm-5p2`, with your Fireworks `fw_` key.
+This is your cheap, fast worker.
 
-```bash
-export ADVISOR_API_KEY=fw_...                                  # your Fireworks key
-export ADVISOR_BASE_URL=https://api.fireworks.ai/inference     # (this is the default)
-export ADVISOR_MODEL=accounts/fireworks/models/glm-5p2         # the reviewer model
-```
+## 2. Advisor — add the frontier reviewer (Claude)
 
-Grab the one file:
+You need [Node.js](https://nodejs.org) 18+ and an **Anthropic API key** (the
+reviewer is Claude). Grab the one file and set the key:
 
 ```bash
 curl -O https://raw.githubusercontent.com/fw-ai/cookbook/main/advisor/advisor.mjs
+
+export ADVISOR_API_KEY=sk-ant-...        # Anthropic key for the Claude reviewer
+# defaults: ADVISOR_BASE_URL=https://api.anthropic.com, ADVISOR_MODEL=claude-opus-4-8
 ```
 
-## 2. Try it standalone
+`ADVISOR_API_KEY` is the **advisor's** key — it pays for the Claude review calls,
+not your Fireworks worker.
+
+## 3. Try it standalone
 
 From inside any git repo with uncommitted changes:
 
@@ -53,18 +67,10 @@ node advisor.mjs review --question "are there race conditions in the token refre
 It prints a ~300-word critique: critical issues (≥80 confidence) → suggested
 fixes → low-confidence notes → what it could and couldn't verify.
 
-## 3. Wire it into your agent
+## 4. Wire it into your agent
 
-Two steps — give the agent the command, and tell it *when* to use it.
-
-**Command** the agent runs (from the repo root):
-
-```bash
-node advisor.mjs review --question "<what to check>" --files "<key files>"
-```
-
-**Nudge** — add one line to your agent's instructions so it actually calls the
-advisor. Put it where your harness reads project instructions:
+Tell your agent (the GLM-5.2 worker) *when* to call the advisor — add one line
+where your harness reads project instructions:
 
 | Agent | File |
 |---|---|
@@ -81,18 +87,11 @@ advisor more (e.g. a planning call too) didn't improve results and cost more.
 
 ## Choosing the reviewer model
 
-The advisor talks to any Anthropic-compatible `/v1/messages` endpoint, so the
-reviewer is your choice:
-
-| Reviewer | Set | Notes |
-|---|---|---|
-| **Fireworks serverless** (default) | `ADVISOR_MODEL=accounts/fireworks/models/<model>` | one key, all-Fireworks. Use a **large, capable** model — the reviewer should be at least as strong as your worker. |
-| **Frontier (Opus)** | `ADVISOR_BASE_URL=https://api.anthropic.com`, `ADVISOR_MODEL=claude-opus-4-8`, `ADVISOR_API_KEY=sk-ant-...` | the report's headline setup — the strongest results. |
-
-**Tip:** the advisor helps most when the *reviewer is stronger than the worker*.
-Pointing a model at its own output (same model as worker and reviewer) gave little
-lift in our tests — pick a bigger reviewer, or the frontier option, for the
-clearest gains.
+The advisor talks to any Anthropic-compatible `/v1/messages` endpoint, so you can
+swap the reviewer — but it should be a **frontier** model. Pointing it at the same
+(or a weaker) model than your worker gave little lift in our tests; the gains come
+from the reviewer being genuinely stronger. Claude Opus is the default and the
+report's headline reviewer.
 
 ## What it sends
 

--- a/advisor/README.md
+++ b/advisor/README.md
@@ -16,9 +16,6 @@ reviewer** (Claude), matches frontier-only quality at a fraction of the cost.
 | **Worker** (does the task) | open-source, e.g. **GLM-5.2** | **Fireworks** serverless | `fw_...` (in your agent harness) |
 | **Advisor** (reviews the diff) | **frontier, Claude Opus** | Anthropic | `sk-ant-...` (this tool, `ADVISOR_API_KEY`) |
 
-The advisor must be the **stronger** model — that's the finding. This tool only
-sets up the advisor; your worker is configured in your own agent.
-
 ## How it works
 
 One model call with one carefully-worded prompt. The whole design is that the

--- a/advisor/README.md
+++ b/advisor/README.md
@@ -1,0 +1,102 @@
+# The Advisor: a frontier reviewer for any coding agent
+
+A tiny, self-contained tool that gives any AI coding agent a **critique-only
+second opinion** before it finishes. Your agent does the work; the advisor reads
+the **working git diff** and returns scored issues + fixes. It cannot edit files.
+
+This is the harness from our report **"Open-source agents with a frontier
+reviewer"** ([Fireworks blog](https://fireworks.ai/blog)) — an open-source worker
+model checked by a stronger reviewer matched frontier-only quality at a fraction
+of the cost. Here it's packaged as **one file** (`advisor.mjs`) you can drop into
+your own agent, using **Fireworks serverless inference** for the reviewer.
+
+## How it works
+
+One model call with one carefully-worded prompt. The whole design is that the
+reviewer is a **skeptic, not a cheerleader** — it distrusts the agent's prose and
+treats the `git diff` as ground truth:
+
+> "do NOT accept the agent's framing, arithmetic, or boundaries … the `<worktree>`
+> section is **ground truth** … the agent's prose claims of edits are not …
+> Confidence: score each issue 0–100 … Critical issues — ONLY issues scoring ≥80."
+
+That calibrated, evidence-gated prompt (the full text is `SYSTEM_PROMPT` in
+`advisor.mjs`) is what makes it useful instead of noisy. It's anchored on the
+diff, so it works the same in **any** harness.
+
+## 1. Setup
+
+You need [Node.js](https://nodejs.org) (18+) and a **Fireworks API key**
+([get one](https://app.fireworks.ai)). Point the advisor at Fireworks serverless
+inference:
+
+```bash
+export ADVISOR_API_KEY=fw_...                                  # your Fireworks key
+export ADVISOR_BASE_URL=https://api.fireworks.ai/inference     # (this is the default)
+export ADVISOR_MODEL=accounts/fireworks/models/glm-5p2         # the reviewer model
+```
+
+Grab the one file:
+
+```bash
+curl -O https://raw.githubusercontent.com/fw-ai/cookbook/main/advisor/advisor.mjs
+```
+
+## 2. Try it standalone
+
+From inside any git repo with uncommitted changes:
+
+```bash
+node advisor.mjs review --question "are there race conditions in the token refresh?"
+```
+
+It prints a ~300-word critique: critical issues (≥80 confidence) → suggested
+fixes → low-confidence notes → what it could and couldn't verify.
+
+## 3. Wire it into your agent
+
+Two steps — give the agent the command, and tell it *when* to use it.
+
+**Command** the agent runs (from the repo root):
+
+```bash
+node advisor.mjs review --question "<what to check>" --files "<key files>"
+```
+
+**Nudge** — add one line to your agent's instructions so it actually calls the
+advisor. Put it where your harness reads project instructions:
+
+| Agent | File |
+|---|---|
+| Claude Code | `CLAUDE.md` |
+| Codex · OpenCode | `AGENTS.md` |
+| Cursor | `.cursor/rules/advisor.md` |
+
+> Before declaring any non-trivial change complete, run
+> `node advisor.mjs review` with a focused `--question`, fix any **critical**
+> issues it raises, then re-run your tests. Skip it for trivial edits.
+
+Keep it to **one review before finishing** — in our ablations, consulting the
+advisor more (e.g. a planning call too) didn't improve results and cost more.
+
+## Choosing the reviewer model
+
+The advisor talks to any Anthropic-compatible `/v1/messages` endpoint, so the
+reviewer is your choice:
+
+| Reviewer | Set | Notes |
+|---|---|---|
+| **Fireworks serverless** (default) | `ADVISOR_MODEL=accounts/fireworks/models/<model>` | one key, all-Fireworks. Use a **large, capable** model — the reviewer should be at least as strong as your worker. |
+| **Frontier (Opus)** | `ADVISOR_BASE_URL=https://api.anthropic.com`, `ADVISOR_MODEL=claude-opus-4-8`, `ADVISOR_API_KEY=sk-ant-...` | the report's headline setup — the strongest results. |
+
+**Tip:** the advisor helps most when the *reviewer is stronger than the worker*.
+Pointing a model at its own output (same model as worker and reviewer) gave little
+lift in our tests — pick a bigger reviewer, or the frontier option, for the
+clearest gains.
+
+## What it sends
+
+For full transparency, each call sends the reviewer: your `<question>` and
+`<focus>`, any `<sources>` you pass via `--files`, optional `<context>` (e.g. a
+short note on what you did), and the `<worktree>` — `git status` + `git log` +
+`git diff HEAD`. Nothing else. Read `advisor.mjs` end to end in two minutes.

--- a/advisor/README.md
+++ b/advisor/README.md
@@ -41,18 +41,22 @@ API key:
 3. Click **Create API Key**, give it a name, and copy it (Fireworks shows the full
    key only once). It looks like `fw_...`.
 
-Then route your agent through Fireworks GLM-5.2. Fireworks serves an
-Anthropic-compatible endpoint, so for Claude Code that's three env vars:
+GLM-5.2 is served at `accounts/fireworks/models/glm-5p2`. A call looks like:
 
 ```bash
-export ANTHROPIC_BASE_URL=https://api.fireworks.ai/inference
-export ANTHROPIC_API_KEY=fw_...                              # your Fireworks key
-export ANTHROPIC_MODEL=accounts/fireworks/models/glm-5p2
+curl https://api.fireworks.ai/inference/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $FIREWORKS_API_KEY" \
+  -d '{
+    "model": "accounts/fireworks/models/glm-5p2",
+    "messages": [{"role": "user", "content": "Hello"}]
+  }'
 ```
 
-Other harnesses (Codex, Cursor, …) have their own base-URL / key / model settings —
-point them at the same endpoint and model. This `fw_` key powers the **worker**;
-it's separate from the **advisor's** Anthropic key in the next step.
+Wire that into your coding agent however your harness configures its model (see the
+[Fireworks quickstart](https://docs.fireworks.ai/getting-started/quickstart) for
+SDK examples). This `fw_` key powers the **worker** — separate from the
+**advisor's** Anthropic key in the next step.
 
 ## 2. Advisor — add the frontier reviewer (Claude)
 

--- a/advisor/advisor.mjs
+++ b/advisor/advisor.mjs
@@ -1,0 +1,148 @@
+#!/usr/bin/env node
+// Fireworks Advisor — a critique-only "second opinion" from a stronger reviewer
+// model, callable by ANY coding agent. The agent does the work; the advisor
+// reviews the working git diff before the agent finishes. It cannot edit files.
+//
+// Run it from inside your project repo (your agent runs this, or you do):
+//   node advisor.mjs review --question "..." [--focus "..."] [--files a.ts,b.ts]
+//
+// Configure the reviewer (defaults to Fireworks serverless inference):
+//   ADVISOR_API_KEY    Fireworks API key, fw_...                    [required]
+//   ADVISOR_BASE_URL   Anthropic-compatible endpoint   [default: Fireworks serverless]
+//   ADVISOR_MODEL      reviewer model                  [default: a strong Fireworks model]
+//
+// To use a frontier reviewer instead (the report's headline setup), point
+// ADVISOR_BASE_URL at https://api.anthropic.com with an Anthropic key and
+// ADVISOR_MODEL=claude-opus-4-8. See README.md.
+
+import { readFileSync, existsSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import process from "node:process";
+
+const API_KEY = process.env.ADVISOR_API_KEY;
+const BASE_URL = (process.env.ADVISOR_BASE_URL || "https://api.fireworks.ai/inference").replace(/\/+$/, "");
+const MODEL = process.env.ADVISOR_MODEL || "accounts/fireworks/models/glm-5p2";
+
+// ---------------------------------------------------------------------------
+// The system prompt IS the design: a skeptic, not a cheerleader. It distrusts
+// the agent's prose and audits the diff as ground truth. (Preserved verbatim
+// from the benchmarked harness — see the report.)
+// ---------------------------------------------------------------------------
+const EVIDENCE_RULES =
+  " EVIDENCE RULES: the <worktree> section (git status + recent log + " +
+  "diff), when present, is ground truth for the current UNCOMMITTED state " +
+  "of the repo - the agent's prose claims of edits are not. A change " +
+  "absent from the diff may have been committed (check the log) or may " +
+  "predate the session. " +
+  "Treat any claim that tests/build/verification pass as CANNOT VERIFY " +
+  "unless the verbatim command output from a run made after the last edit " +
+  "appears in the context; then demand that run. A claim contradicted by " +
+  "output you can see is itself a critical issue. If the context contains " +
+  "an earlier advisor critique, first audit each of its critical issues " +
+  "against the worktree (diff and log) and mark it APPLIED or NOT APPLIED; " +
+  "NOT APPLIED criticals remain critical.";
+
+const SYSTEM_PROMPT =
+  "You are a critique-only senior engineering reviewer. You see the calling " +
+  "agent's question, optional focus area, and current work (source files and " +
+  "the working diff). You CANNOT modify files; you only return advice. " +
+  "Independence: do NOT accept the agent's framing, arithmetic, or boundaries " +
+  "(date windows, counts, inclusive/exclusive ranges) - recompute them " +
+  "yourself from the raw data in the context; the agent's question may embed " +
+  "its own bug. " +
+  "Verifiability: if you cannot verify a claim because you lack the original " +
+  "or reference material, say CANNOT VERIFY explicitly - never assert " +
+  "correctness you could not check. " +
+  "Confidence: score each issue 0-100 (0=false positive; 25=could not " +
+  "verify; 50=real but minor; 75=verified and important; 100=certain). " +
+  "Be specific: name the file, function, or line when calling out issues. " +
+  "Structure the response in four sections, ~300 words total: " +
+  "(1) Critical issues - ONLY issues scoring >=80, each with its score. " +
+  "(2) Concrete suggested fixes for those critical issues. " +
+  "(3) Low-confidence notes (no action required) - everything below 80. " +
+  "(4) Verification: one line each on what you could and could not verify." +
+  EVIDENCE_RULES;
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i++) {
+    if (!argv[i].startsWith("--")) continue;
+    const k = argv[i].slice(2);
+    out[k] = argv[i + 1] && !argv[i + 1].startsWith("--") ? argv[++i] : "true";
+  }
+  return out;
+}
+
+// Ground truth: the working git diff at the agent's cwd. Harness-agnostic —
+// every coding agent produces the same diff. Returns "" outside a git repo.
+function worktree() {
+  const git = (a) => execFileSync("git", a, { encoding: "utf8", timeout: 15000 });
+  try {
+    const status = git(["status", "--porcelain"]).trimEnd();
+    const log = git(["log", "--oneline", "-10"]).trimEnd();
+    const diff = git(["diff", "HEAD", "--no-color"]).trimEnd();
+    return `## git status --porcelain\n${status || "(clean)"}\n\n` +
+           `## git log --oneline -10\n${log}\n\n` +
+           `## git diff HEAD\n${diff || "(no uncommitted tracked changes)"}`;
+  } catch {
+    return "";
+  }
+}
+
+function sources(filesArg) {
+  if (!filesArg || filesArg === "true") return "";
+  return filesArg.split(",").map((p) => p.trim()).filter(Boolean).map((p) =>
+    existsSync(p) ? `## ${p}\n\n${readFileSync(p, "utf8")}` : `## ${p}\n\n(file not found)`
+  ).join("\n\n---\n\n");
+}
+
+async function review({ question, focus, files, context }) {
+  const sections = {
+    question: question || "(no specific question - give an overall critical review)",
+    focus: focus || "(no specific focus)",
+    context: context || "",
+    sources: sources(files),
+    worktree: worktree(),
+  };
+  const userMessage = Object.entries(sections)
+    .filter(([, v]) => v && v.trim())
+    .map(([k, v]) => `<${k}>\n${v}\n</${k}>`)
+    .join("\n");
+
+  const body = {
+    model: MODEL,
+    max_tokens: 8192,
+    system: SYSTEM_PROMPT,
+    messages: [{ role: "user", content: userMessage }],
+  };
+  // Adaptive thinking is an Anthropic-only field; only send it to Claude models.
+  if (/^claude/i.test(MODEL)) body.thinking = { type: "adaptive" };
+
+  const res = await fetch(`${BASE_URL}/v1/messages`, {
+    method: "POST",
+    headers: { "x-api-key": API_KEY, "anthropic-version": "2023-06-01", "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new Error(`advisor ${res.status}: ${(await res.text()).slice(0, 400)}`);
+  const data = await res.json();
+  return (data.content ?? []).map((b) => b.text || "").join("").trim() || "(advisor returned no text)";
+}
+
+async function main() {
+  if (!API_KEY) {
+    console.error("advisor not configured - set ADVISOR_API_KEY (your Fireworks key). See README.md.");
+    process.exit(2);
+  }
+  const args = parseArgs(process.argv.slice(3)); // argv[2] is the subcommand "review"
+  if (process.argv[2] !== "review") {
+    console.error('usage: node advisor.mjs review --question "..." [--focus "..."] [--files a,b] [--context "..."]');
+    process.exit(64);
+  }
+  console.log(await review(args));
+}
+
+main().catch((err) => {
+  const msg = API_KEY ? err.message.replaceAll(API_KEY, "[REDACTED]") : err.message;
+  console.error(`advisor failed: ${msg}`);
+  process.exit(1);
+});

--- a/advisor/advisor.mjs
+++ b/advisor/advisor.mjs
@@ -86,7 +86,12 @@ async function review({ question, files }) {
     .join("\n");
 
   const body = { model: MODEL, max_tokens: 8192, system: SYSTEM_PROMPT, messages: [{ role: "user", content: userMessage }] };
-  if (/^claude/i.test(MODEL)) body.thinking = { type: "adaptive" }; // Anthropic-only field
+  // Adaptive thinking + medium effort are Anthropic-only fields (the benchmarked
+  // setting); skip them for non-Claude reviewers, which reject them.
+  if (/^claude/i.test(MODEL)) {
+    body.thinking = { type: "adaptive" };
+    body.output_config = { effort: "medium" };
+  }
 
   const res = await fetch(`${BASE_URL}/v1/messages`, {
     method: "POST",

--- a/advisor/advisor.mjs
+++ b/advisor/advisor.mjs
@@ -6,22 +6,24 @@
 // Run it from inside your project repo (your agent runs this, or you do):
 //   node advisor.mjs review --question "..." [--focus "..."] [--files a.ts,b.ts]
 //
-// Configure the reviewer (defaults to Fireworks serverless inference):
-//   ADVISOR_API_KEY    Fireworks API key, fw_...                    [required]
-//   ADVISOR_BASE_URL   Anthropic-compatible endpoint   [default: Fireworks serverless]
-//   ADVISOR_MODEL      reviewer model                  [default: a strong Fireworks model]
+// The ADVISOR is the reviewer — a FRONTIER model (Claude), which the report
+// found gives the clearest lift. These vars configure the reviewer:
+//   ADVISOR_API_KEY    Anthropic API key, sk-ant-...                [required]
+//   ADVISOR_BASE_URL   Anthropic-compatible endpoint   [default: api.anthropic.com]
+//   ADVISOR_MODEL      reviewer model                  [default: claude-opus-4-8]
 //
-// To use a frontier reviewer instead (the report's headline setup), point
-// ADVISOR_BASE_URL at https://api.anthropic.com with an Anthropic key and
-// ADVISOR_MODEL=claude-opus-4-8. See README.md.
+// The reviewer is SEPARATE from your worker model. Run your coding agent on a
+// Fireworks open model (e.g. GLM-5.2) — cheap and fast — and have it consult
+// this frontier reviewer. Your worker's Fireworks key lives in your agent
+// harness, not here. See README.md.
 
 import { readFileSync, existsSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import process from "node:process";
 
 const API_KEY = process.env.ADVISOR_API_KEY;
-const BASE_URL = (process.env.ADVISOR_BASE_URL || "https://api.fireworks.ai/inference").replace(/\/+$/, "");
-const MODEL = process.env.ADVISOR_MODEL || "accounts/fireworks/models/glm-5p2";
+const BASE_URL = (process.env.ADVISOR_BASE_URL || "https://api.anthropic.com").replace(/\/+$/, "");
+const MODEL = process.env.ADVISOR_MODEL || "claude-opus-4-8";
 
 // ---------------------------------------------------------------------------
 // The system prompt IS the design: a skeptic, not a cheerleader. It distrusts
@@ -130,7 +132,7 @@ async function review({ question, focus, files, context }) {
 
 async function main() {
   if (!API_KEY) {
-    console.error("advisor not configured - set ADVISOR_API_KEY (your Fireworks key). See README.md.");
+    console.error("advisor not configured - set ADVISOR_API_KEY (your Anthropic key for the Claude reviewer). See README.md.");
     process.exit(2);
   }
   const args = parseArgs(process.argv.slice(3)); // argv[2] is the subcommand "review"

--- a/advisor/advisor.mjs
+++ b/advisor/advisor.mjs
@@ -1,21 +1,14 @@
 #!/usr/bin/env node
-// Fireworks Advisor — a critique-only "second opinion" from a stronger reviewer
-// model, callable by ANY coding agent. The agent does the work; the advisor
-// reviews the working git diff before the agent finishes. It cannot edit files.
+// Advisor — a critique-only second opinion from a frontier reviewer (Claude),
+// callable by any coding agent. The agent does the work; the advisor reviews the
+// working git diff before it finishes. It cannot edit files.
 //
-// Run it from inside your project repo (your agent runs this, or you do):
-//   node advisor.mjs review --question "..." [--focus "..."] [--files a.ts,b.ts]
+//   node advisor.mjs review --question "..." [--files a.ts,b.ts]
 //
-// The ADVISOR is the reviewer — a FRONTIER model (Claude), which the report
-// found gives the clearest lift. These vars configure the reviewer:
-//   ADVISOR_API_KEY    Anthropic API key, sk-ant-...                [required]
-//   ADVISOR_BASE_URL   Anthropic-compatible endpoint   [default: api.anthropic.com]
-//   ADVISOR_MODEL      reviewer model                  [default: claude-opus-4-8]
-//
-// The reviewer is SEPARATE from your worker model. Run your coding agent on a
-// Fireworks open model (e.g. GLM-5.2) — cheap and fast — and have it consult
-// this frontier reviewer. Your worker's Fireworks key lives in your agent
-// harness, not here. See README.md.
+// Reviewer config (separate from your Fireworks worker — see README.md):
+//   ADVISOR_API_KEY    Anthropic key, sk-ant-...   [required]
+//   ADVISOR_BASE_URL   endpoint  [default: https://api.anthropic.com]
+//   ADVISOR_MODEL      model     [default: claude-opus-4-8]
 
 import { readFileSync, existsSync } from "node:fs";
 import { execFileSync } from "node:child_process";
@@ -25,84 +18,62 @@ const API_KEY = process.env.ADVISOR_API_KEY;
 const BASE_URL = (process.env.ADVISOR_BASE_URL || "https://api.anthropic.com").replace(/\/+$/, "");
 const MODEL = process.env.ADVISOR_MODEL || "claude-opus-4-8";
 
-// ---------------------------------------------------------------------------
-// The system prompt IS the design: a skeptic, not a cheerleader. It distrusts
-// the agent's prose and audits the diff as ground truth. (Preserved verbatim
-// from the benchmarked harness — see the report.)
-// ---------------------------------------------------------------------------
-const EVIDENCE_RULES =
-  " EVIDENCE RULES: the <worktree> section (git status + recent log + " +
-  "diff), when present, is ground truth for the current UNCOMMITTED state " +
-  "of the repo - the agent's prose claims of edits are not. A change " +
-  "absent from the diff may have been committed (check the log) or may " +
-  "predate the session. " +
-  "Treat any claim that tests/build/verification pass as CANNOT VERIFY " +
-  "unless the verbatim command output from a run made after the last edit " +
-  "appears in the context; then demand that run. A claim contradicted by " +
-  "output you can see is itself a critical issue. If the context contains " +
-  "an earlier advisor critique, first audit each of its critical issues " +
-  "against the worktree (diff and log) and mark it APPLIED or NOT APPLIED; " +
-  "NOT APPLIED criticals remain critical.";
-
+// The system prompt IS the design: a skeptic that audits the diff as ground
+// truth, not the agent's prose. (From the benchmarked harness — see the report.)
 const SYSTEM_PROMPT =
   "You are a critique-only senior engineering reviewer. You see the calling " +
-  "agent's question, optional focus area, and current work (source files and " +
-  "the working diff). You CANNOT modify files; you only return advice. " +
+  "agent's question and current work (source files and the working diff). You " +
+  "CANNOT modify files; you only return advice. " +
   "Independence: do NOT accept the agent's framing, arithmetic, or boundaries " +
-  "(date windows, counts, inclusive/exclusive ranges) - recompute them " +
-  "yourself from the raw data in the context; the agent's question may embed " +
-  "its own bug. " +
-  "Verifiability: if you cannot verify a claim because you lack the original " +
-  "or reference material, say CANNOT VERIFY explicitly - never assert " +
-  "correctness you could not check. " +
-  "Confidence: score each issue 0-100 (0=false positive; 25=could not " +
-  "verify; 50=real but minor; 75=verified and important; 100=certain). " +
-  "Be specific: name the file, function, or line when calling out issues. " +
+  "(date windows, counts, inclusive/exclusive ranges) - recompute them yourself " +
+  "from the raw data; the agent's question may embed its own bug. " +
+  "Verifiability: if you cannot verify a claim because you lack the original or " +
+  "reference material, say CANNOT VERIFY explicitly - never assert correctness " +
+  "you could not check. " +
+  "Confidence: score each issue 0-100 (0=false positive; 25=could not verify; " +
+  "50=real but minor; 75=verified and important; 100=certain). " +
+  "Be specific: name the file, function, or line. " +
   "Structure the response in four sections, ~300 words total: " +
   "(1) Critical issues - ONLY issues scoring >=80, each with its score. " +
-  "(2) Concrete suggested fixes for those critical issues. " +
-  "(3) Low-confidence notes (no action required) - everything below 80. " +
-  "(4) Verification: one line each on what you could and could not verify." +
-  EVIDENCE_RULES;
+  "(2) Concrete suggested fixes for those. " +
+  "(3) Low-confidence notes (no action) - everything below 80. " +
+  "(4) Verification: what you could and could not verify. " +
+  "EVIDENCE: the <worktree> section (git status + diff) is ground truth for the " +
+  "current uncommitted state - the agent's prose claims of edits are not. Treat " +
+  "any claim that tests/build pass as CANNOT VERIFY unless verbatim output from a " +
+  "run after the last edit is in the context. A claim contradicted by output you " +
+  "can see is itself a critical issue.";
 
 function parseArgs(argv) {
   const out = {};
   for (let i = 0; i < argv.length; i++) {
     if (!argv[i].startsWith("--")) continue;
-    const k = argv[i].slice(2);
-    out[k] = argv[i + 1] && !argv[i + 1].startsWith("--") ? argv[++i] : "true";
+    out[argv[i].slice(2)] = argv[i + 1] && !argv[i + 1].startsWith("--") ? argv[++i] : "true";
   }
   return out;
 }
 
-// Ground truth: the working git diff at the agent's cwd. Harness-agnostic —
-// every coding agent produces the same diff. Returns "" outside a git repo.
+// Ground truth: the working git diff at cwd. Returns "" outside a git repo.
 function worktree() {
   const git = (a) => execFileSync("git", a, { encoding: "utf8", timeout: 15000 });
   try {
-    const status = git(["status", "--porcelain"]).trimEnd();
-    const log = git(["log", "--oneline", "-10"]).trimEnd();
-    const diff = git(["diff", "HEAD", "--no-color"]).trimEnd();
-    return `## git status --porcelain\n${status || "(clean)"}\n\n` +
-           `## git log --oneline -10\n${log}\n\n` +
-           `## git diff HEAD\n${diff || "(no uncommitted tracked changes)"}`;
+    return `## git status\n${git(["status", "--porcelain"]).trimEnd() || "(clean)"}\n\n` +
+           `## git diff HEAD\n${git(["diff", "HEAD", "--no-color"]).trimEnd() || "(none)"}`;
   } catch {
     return "";
   }
 }
 
-function sources(filesArg) {
-  if (!filesArg || filesArg === "true") return "";
-  return filesArg.split(",").map((p) => p.trim()).filter(Boolean).map((p) =>
-    existsSync(p) ? `## ${p}\n\n${readFileSync(p, "utf8")}` : `## ${p}\n\n(file not found)`
-  ).join("\n\n---\n\n");
+function sources(arg) {
+  if (!arg || arg === "true") return "";
+  return arg.split(",").map((p) => p.trim()).filter(Boolean).map((p) =>
+    existsSync(p) ? `## ${p}\n\n${readFileSync(p, "utf8")}` : `## ${p}\n\n(not found)`
+  ).join("\n\n");
 }
 
-async function review({ question, focus, files, context }) {
+async function review({ question, files }) {
   const sections = {
     question: question || "(no specific question - give an overall critical review)",
-    focus: focus || "(no specific focus)",
-    context: context || "",
     sources: sources(files),
     worktree: worktree(),
   };
@@ -111,14 +82,8 @@ async function review({ question, focus, files, context }) {
     .map(([k, v]) => `<${k}>\n${v}\n</${k}>`)
     .join("\n");
 
-  const body = {
-    model: MODEL,
-    max_tokens: 8192,
-    system: SYSTEM_PROMPT,
-    messages: [{ role: "user", content: userMessage }],
-  };
-  // Adaptive thinking is an Anthropic-only field; only send it to Claude models.
-  if (/^claude/i.test(MODEL)) body.thinking = { type: "adaptive" };
+  const body = { model: MODEL, max_tokens: 8192, system: SYSTEM_PROMPT, messages: [{ role: "user", content: userMessage }] };
+  if (/^claude/i.test(MODEL)) body.thinking = { type: "adaptive" }; // Anthropic-only field
 
   const res = await fetch(`${BASE_URL}/v1/messages`, {
     method: "POST",
@@ -130,21 +95,17 @@ async function review({ question, focus, files, context }) {
   return (data.content ?? []).map((b) => b.text || "").join("").trim() || "(advisor returned no text)";
 }
 
-async function main() {
-  if (!API_KEY) {
-    console.error("advisor not configured - set ADVISOR_API_KEY (your Anthropic key for the Claude reviewer). See README.md.");
-    process.exit(2);
-  }
-  const args = parseArgs(process.argv.slice(3)); // argv[2] is the subcommand "review"
-  if (process.argv[2] !== "review") {
-    console.error('usage: node advisor.mjs review --question "..." [--focus "..."] [--files a,b] [--context "..."]');
-    process.exit(64);
-  }
-  console.log(await review(args));
+if (!API_KEY) {
+  console.error("advisor not configured - set ADVISOR_API_KEY (your Anthropic key for the Claude reviewer). See README.md.");
+  process.exit(2);
 }
-
-main().catch((err) => {
-  const msg = API_KEY ? err.message.replaceAll(API_KEY, "[REDACTED]") : err.message;
-  console.error(`advisor failed: ${msg}`);
+if (process.argv[2] !== "review") {
+  console.error('usage: node advisor.mjs review --question "..." [--files a,b]');
+  process.exit(64);
+}
+try {
+  console.log(await review(parseArgs(process.argv.slice(3))));
+} catch (err) {
+  console.error(`advisor failed: ${API_KEY ? err.message.replaceAll(API_KEY, "[REDACTED]") : err.message}`);
   process.exit(1);
-});
+}

--- a/advisor/advisor.mjs
+++ b/advisor/advisor.mjs
@@ -53,13 +53,16 @@ function parseArgs(argv) {
   return out;
 }
 
-// Ground truth: the working git diff at cwd. Returns "" outside a git repo.
+// Ground truth: the working git diff at cwd. The diff is what this tool is built
+// around, so if it can't be read — missing git, not a repo, or a diff larger than
+// execFileSync's 1MB default — warn loudly instead of silently dropping it.
 function worktree() {
-  const git = (a) => execFileSync("git", a, { encoding: "utf8", timeout: 15000 });
+  const git = (a) => execFileSync("git", a, { encoding: "utf8", timeout: 15000, maxBuffer: 64 * 1024 * 1024 });
   try {
     return `## git status\n${git(["status", "--porcelain"]).trimEnd() || "(clean)"}\n\n` +
            `## git diff HEAD\n${git(["diff", "HEAD", "--no-color"]).trimEnd() || "(none)"}`;
-  } catch {
+  } catch (e) {
+    console.error(`advisor: WARNING — no git diff attached (${e.message.split("\n")[0].slice(0, 140)}); reviewing without it.`);
     return "";
   }
 }


### PR DESCRIPTION
A self-contained tool that gives any AI coding agent a **critique-only second opinion** before it finishes. The agent does the work; the advisor reads the working **git diff** (ground truth) and returns confidence-scored issues + fixes. It cannot edit files.

This is the harness from the *"open-source agents with a frontier reviewer"* report, packaged as **one file** with the benchmarked review system prompt preserved verbatim. **Defaults to Fireworks serverless inference** for the reviewer; **diff-anchored** so it works in any harness (Claude Code, Codex, Cursor, …).

## Contents
- `advisor/advisor.mjs` — core review logic + the system prompt (~150 lines, zero deps beyond Node 18+)
- `advisor/README.md` — setup with a Fireworks key, standalone test, wiring into your own agent, reviewer-model choice

## Quick try
```bash
export ADVISOR_API_KEY=fw_...
export ADVISOR_MODEL=accounts/fireworks/models/glm-5p2
node advisor/advisor.mjs review --question "any race conditions here?"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Greenfield documentation and a standalone CLI with no changes to existing application code; only outbound API calls and local git/file reads.
> 
> **Overview**
> Adds a new **`advisor/`** package: a single-file Node CLI plus README that agents can call before finishing work.
> 
> **`advisor.mjs`** implements `node advisor.mjs review --question "..."` with optional `--files`. It builds a user message from the question, optional file contents, and **git status + `git diff HEAD`** (with a loud warning if git context is missing), then calls the **Anthropic Messages API** using `ADVISOR_API_KEY` (defaults: `claude-opus-4-8`, adaptive thinking for Claude models). The embedded **`SYSTEM_PROMPT`** enforces diff-as-ground-truth review, 0–100 confidence scores, and only ≥80 as critical issues.
> 
> The **README** documents the two-role setup (Fireworks open model as worker, Claude as advisor), key/env setup, and a one-line harness instruction to run one review before declaring non-trivial work complete.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b83c6e9c527e5ee1755784b8e374bdbc2cb959ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->