### PR TITLE
fix(training): surface W&B auth failures as user-actionable errors

### DIFF
--- a/training/tests/unit/test_logging.py
+++ b/training/tests/unit/test_logging.py
@@ -1,0 +1,79 @@
+"""Tests for W&B setup error handling (training.utils.logging)."""
+
+from __future__ import annotations
+
+import os
+import sys
+import types
+
+import pytest
+
+from training.utils.config import WandBConfig
+from training.utils.logging import setup_wandb
+from training.utils.runner import WandbConfigError
+
+
+def _install_fake_wandb(monkeypatch, *, init_exc: Exception | None = None) -> types.ModuleType:
+    """Install a minimal fake ``wandb`` module so setup_wandb runs without the dep."""
+    fake = types.ModuleType("wandb")
+    errors_mod = types.ModuleType("wandb.errors")
+
+    class AuthenticationError(Exception):
+        pass
+
+    class UsageError(Exception):
+        pass
+
+    class CommError(Exception):
+        pass
+
+    errors_mod.AuthenticationError = AuthenticationError
+    errors_mod.UsageError = UsageError
+    errors_mod.CommError = CommError
+    fake.errors = errors_mod
+    fake.run = None
+
+    def _init(**_kwargs):
+        if init_exc is not None:
+            raise init_exc
+        fake.run = None
+
+    fake.init = _init
+    fake.define_metric = lambda *_a, **_k: None
+    monkeypatch.setitem(sys.modules, "wandb", fake)
+    monkeypatch.setitem(sys.modules, "wandb.errors", errors_mod)
+    return fake
+
+
+class TestSetupWandb:
+    def test_no_entity_returns_false(self):
+        assert setup_wandb(WandBConfig(), {}) is False
+
+    def test_message_based_auth_error_raises_wandb_config_error(self, monkeypatch):
+        monkeypatch.setenv("WANDB_API_KEY", "bad-key")
+        _install_fake_wandb(monkeypatch, init_exc=Exception("401 Unauthorized"))
+        with pytest.raises(WandbConfigError, match="authentication/configuration failed"):
+            setup_wandb(WandBConfig(entity="acme", project="proj"), {})
+
+    def test_typed_auth_error_raises_wandb_config_error(self, monkeypatch):
+        monkeypatch.setenv("WANDB_API_KEY", "bad-key")
+        fake = _install_fake_wandb(monkeypatch)
+
+        def _init(**_kwargs):
+            raise fake.errors.AuthenticationError("nope")
+
+        fake.init = _init
+        with pytest.raises(WandbConfigError):
+            setup_wandb(WandBConfig(entity="acme"), {})
+
+    def test_non_auth_error_propagates_unchanged(self, monkeypatch):
+        monkeypatch.setenv("WANDB_API_KEY", "key")
+        _install_fake_wandb(monkeypatch, init_exc=RuntimeError("disk full"))
+        with pytest.raises(RuntimeError, match="disk full"):
+            setup_wandb(WandBConfig(entity="acme"), {})
+
+    def test_missing_key_uses_offline_mode(self, monkeypatch):
+        monkeypatch.delenv("WANDB_API_KEY", raising=False)
+        _install_fake_wandb(monkeypatch)
+        assert setup_wandb(WandBConfig(entity="acme"), {}) is True
+        assert os.environ.get("WANDB_MODE") == "offline"

--- a/training/tests/unit/test_runner.py
+++ b/training/tests/unit/test_runner.py
@@ -101,6 +101,16 @@ class TestRunnerIOStatus:
         assert data["message"] == "OOM"
         assert "details" not in data
 
+    def test_write_status_error_code_override(self, tmp_path):
+        path = str(tmp_path / "status.json")
+        runner = RunnerIO(RunnerConfig(status_file=path))
+
+        runner.write_status(RunStatus.FAILED, error="bad config", error_code=3)
+
+        data = json.loads(open(path).read())
+        assert data["code"] == 3  # INVALID_ARGUMENT overrides the FAILED default (9)
+        assert data["message"] == "bad config"
+
     def test_write_status_overwrites(self, tmp_path):
         path = str(tmp_path / "status.json")
         runner = RunnerIO(RunnerConfig(status_file=path))
@@ -356,6 +366,34 @@ class TestRunnerIOContextManager:
         assert data["code"] == 9
         assert data["message"] == "boom"
         assert data["details"][0]["percent"] == 50
+
+    def test_user_config_error_writes_invalid_argument(self, tmp_path):
+        """User-actionable errors raised inside the context surface as INVALID_ARGUMENT."""
+        from training.utils.runner import WandbConfigError
+
+        path = str(tmp_path / "status.json")
+        runner = RunnerIO(RunnerConfig(status_file=path))
+
+        with pytest.raises(WandbConfigError, match="bad key"):
+            with runner:
+                raise WandbConfigError("bad key")
+
+        data = json.loads(open(path).read())
+        assert data["code"] == 3  # INVALID_ARGUMENT, not the generic FAILED_PRECONDITION
+        assert data["message"] == "bad key"
+
+    def test_generic_exception_writes_failed_precondition(self, tmp_path):
+        """Non-user-config errors keep the default FAILED_PRECONDITION code."""
+        path = str(tmp_path / "status.json")
+        runner = RunnerIO(RunnerConfig(status_file=path))
+
+        with pytest.raises(RuntimeError):
+            with runner:
+                raise RuntimeError("boom")
+
+        data = json.loads(open(path).read())
+        assert data["code"] == 9  # FAILED_PRECONDITION
+        assert data["message"] == "boom"
 
     def test_exception_flushes_metadata(self, tmp_path):
         meta = str(tmp_path / "meta.json")

--- a/training/utils/logging.py
+++ b/training/utils/logging.py
@@ -8,43 +8,80 @@ from math import comb
 from typing import Any
 
 from training.utils.config import WandBConfig
+from training.utils.runner import WandbConfigError
 
 logger = logging.getLogger(__name__)
+
+
+def _is_wandb_auth_error(exc: BaseException) -> bool:
+    """Heuristically classify a W&B exception as an auth/permission/config error.
+
+    Recognizes ``wandb.errors`` auth/usage types when available, and falls back
+    to message inspection (401 / unauthorized / api key / permission) so the
+    classification is robust across wandb versions.
+    """
+    try:
+        import wandb
+
+        auth_types = tuple(
+            t
+            for t in (
+                getattr(wandb.errors, "AuthenticationError", None),
+                getattr(wandb.errors, "UsageError", None),
+            )
+            if isinstance(t, type)
+        )
+        if auth_types and isinstance(exc, auth_types):
+            return True
+    except Exception:
+        pass
+    msg = str(exc).lower()
+    return any(token in msg for token in ("401", "unauthorized", "permission", "api key", "api_key", "authentication"))
 
 
 def setup_wandb(wb: WandBConfig, config: dict[str, Any]) -> bool:
     """Initialize WandB if entity is provided. Returns True if active.
 
     If ``WANDB_API_KEY`` is not set, falls back to offline mode so runs
-    are logged locally without requiring authentication.
+    are logged locally without requiring authentication. Auth/permission/config
+    failures from ``wandb.init`` are re-raised as :class:`WandbConfigError` so
+    the orchestration layer surfaces them as a user-actionable error
+    (FIR2-1774).
     """
     if not wb.entity:
         return False
     try:
         import os
         import wandb
-
-        if not os.environ.get("WANDB_API_KEY"):
-            logger.warning(
-                "WANDB_API_KEY not set; running wandb in offline mode. "
-                "Set the key to sync runs to the dashboard."
-            )
-            os.environ["WANDB_MODE"] = "offline"
-
-        wandb.init(entity=wb.entity, project=wb.project, name=wb.run_name, config=config)
-        if wandb.run is not None:
-            wandb.define_metric("train/step")
-            wandb.define_metric("train/*", step_metric="train/step")
-            wandb.define_metric("perf/*", step_metric="train/step")
-            wandb.define_metric("rollout/*", step_metric="train/step")
-            wandb.define_metric("batch/*", step_metric="train/step")
-            wandb.define_metric("infra/*", step_metric="train/step")
-            wandb.define_metric("ctx/*", step_metric="train/step")
-            logger.info("WandB: %s", wandb.run.url)
-        return True
     except ImportError:
         logger.warning("wandb not installed; metrics will only be logged to console")
         return False
+
+    if not os.environ.get("WANDB_API_KEY"):
+        logger.warning(
+            "WANDB_API_KEY not set; running wandb in offline mode. " "Set the key to sync runs to the dashboard."
+        )
+        os.environ["WANDB_MODE"] = "offline"
+
+    try:
+        wandb.init(entity=wb.entity, project=wb.project, name=wb.run_name, config=config)
+    except Exception as exc:
+        if _is_wandb_auth_error(exc):
+            raise WandbConfigError(
+                f"Weights & Biases authentication/configuration failed: {exc}. "
+                "Check your W&B API key, entity, and project."
+            ) from exc
+        raise
+    if wandb.run is not None:
+        wandb.define_metric("train/step")
+        wandb.define_metric("train/*", step_metric="train/step")
+        wandb.define_metric("perf/*", step_metric="train/step")
+        wandb.define_metric("rollout/*", step_metric="train/step")
+        wandb.define_metric("batch/*", step_metric="train/step")
+        wandb.define_metric("infra/*", step_metric="train/step")
+        wandb.define_metric("ctx/*", step_metric="train/step")
+        logger.info("WandB: %s", wandb.run.url)
+    return True
 
 
 def compute_pass_at_k(

--- a/training/utils/runner.py
+++ b/training/utils/runner.py
@@ -53,6 +53,7 @@ class RunStatus(str, Enum):
 
 
 _GRPC_OK = 0
+_GRPC_INVALID_ARGUMENT = 3
 _GRPC_FAILED_PRECONDITION = 9
 _JOB_PROGRESS_TYPE_URL = "type.googleapis.com/gateway.JobProgress"
 
@@ -62,6 +63,20 @@ _STATUS_TO_GRPC_CODE: dict[RunStatus, int] = {
     RunStatus.COMPLETED: _GRPC_OK,
     RunStatus.FAILED: _GRPC_FAILED_PRECONDITION,
 }
+
+
+class UserConfigError(Exception):
+    """Base class for user-actionable configuration errors raised inside a recipe.
+
+    When a recipe raises one of these inside a ``RunnerIO`` context, the runner
+    records the failure as ``INVALID_ARGUMENT`` (user-fixable) instead of the
+    generic ``FAILED_PRECONDITION``, so the control plane preserves the
+    actionable message and category (FIR2-1774).
+    """
+
+
+class WandbConfigError(UserConfigError):
+    """Raised when Weights & Biases auth/config is invalid (bad key, entity, or project)."""
 
 
 @dataclass
@@ -124,11 +139,17 @@ class RunnerIO:
 
     def __exit__(self, exc_type: object, exc_val: object, tb: object) -> bool:
         if exc_type is not None:
+            # User-config errors (bad W&B credentials, etc.) are user-actionable;
+            # surface them as INVALID_ARGUMENT instead of the generic
+            # FAILED_PRECONDITION so the control plane preserves the actionable
+            # message and category (FIR2-1774).
+            error_code = _GRPC_INVALID_ARGUMENT if isinstance(exc_val, UserConfigError) else None
             self.write_status(
                 RunStatus.FAILED,
                 step=self._last_step,
                 total_steps=self._last_total_steps,
                 error=str(exc_val),
+                error_code=error_code,
             )
             self.write_metadata()
         return False  # never suppress the exception
@@ -143,12 +164,13 @@ class RunnerIO:
         total_steps: int = 0,
         message: str = "",
         error: str | None = None,
+        error_code: int | None = None,
     ) -> None:
         self._last_step = step
         self._last_total_steps = total_steps
         if not self._status_file:
             return
-        grpc_code = _STATUS_TO_GRPC_CODE.get(status, _GRPC_OK)
+        grpc_code = error_code if error_code is not None else _STATUS_TO_GRPC_CODE.get(status, _GRPC_OK)
         status_message = error or message or status.value
         payload: dict[str, Any] = {
             "code": grpc_code,


### PR DESCRIPTION
## Summary

Mirror of the cookbook helper changes in [fw-ai/fireworks#31723](https://github.com/fw-ai/fireworks/pull/31723) (FIR2-1774), so the two cookbook copies (`public-repos/cookbook` in the fireworks repo and this `fw-ai/cookbook` repo, vendored as a submodule) stay in sync.

Managed SFT/DPO training failures can bypass customer-visible status propagation. W&B auth/permission errors in particular surfaced only as a generic `FAILED_PRECONDITION`, giving the customer no actionable message.

## What changed

- **`setup_wandb`** (`training/utils/logging.py`): re-raises auth/permission/401 failures from `wandb.init` as a new user-actionable `WandbConfigError` ("check your W&B API key, entity, and project") instead of letting them propagate as a generic exception. Offline-mode fallback when no key is set is preserved. Classification (`_is_wandb_auth_error`) recognizes `wandb.errors` auth/usage types when available and falls back to message inspection so it is robust across wandb versions.
- **`RunnerIO`** (`training/utils/runner.py`): new `UserConfigError` / `WandbConfigError` types; `write_status` gains an `error_code` override; `__exit__` maps `UserConfigError` to `INVALID_ARGUMENT` (gRPC code 3) instead of the generic `FAILED_PRECONDITION` (9), so the control plane preserves the actionable message and category.

```mermaid
flowchart LR
    W["wandb.init auth failure"] -->|"setup_wandb"| E[WandbConfigError]
    E -->|"raised inside recipe"| RIO["RunnerIO.__exit__"]
    RIO -->|"UserConfigError -> code 3"| S["status file (INVALID_ARGUMENT)"]
    S --> CP["control plane: user-actionable message"]
```

## Test plan

- [x] `training/tests/unit/test_runner.py`: `error_code` override + `UserConfigError` -> INVALID_ARGUMENT in `RunnerIO.__exit__`; generic exception keeps FAILED_PRECONDITION.
- [x] `training/tests/unit/test_logging.py` (new): `setup_wandb` raises `WandbConfigError` on typed/message-based auth errors, propagates non-auth errors unchanged, and falls back to offline mode with no key.
- [ ] CI runs the cookbook unit suite.

Made with [Cursor](https://cursor.com)