### PR TITLE
Exclude synthesized end-of-turn close from trained completion span (frozen_lake / multihop_qa)

### DIFF
--- a/training/examples/multihop_qa/multihop_qa_rollout.py
+++ b/training/examples/multihop_qa/multihop_qa_rollout.py
@@ -102,12 +102,15 @@ def _strip_think_block(text: str) -> str:
 
 
 def _append_turn_suffix(core_ids: List[int], suffix_ids: List[int]) -> List[int]:
-    """Append the end-of-turn suffix, dropping any server-emitted trailing copy.
+    """Close an assistant turn for *framing* (next-prompt) purposes.
 
-    The model may finish a turn by emitting the end-of-turn marker itself, in
-    which case the server returns it inside ``core_ids``. Appending the suffix
+    Used to build the next turn's prompt, NOT the trained completion span. The
+    model may finish a turn by emitting the end-of-turn marker itself, in which
+    case the marker is already inside ``core_ids``. Appending the suffix
     unconditionally would duplicate it (e.g. ``<|im_end|><|im_end|>\\n``), so we
-    strip the longest tail of ``core_ids`` that overlaps the head of the suffix.
+    strip the longest tail of ``core_ids`` that overlaps the head of the suffix
+    before appending. The appended close lives in the next turn's prompt as
+    loss-masked context; it is never part of the loss-bearing completion span.
     """
     core = [int(x) for x in core_ids]
     suffix = [int(x) for x in suffix_ids]
@@ -397,7 +400,12 @@ class MultiHopQARolloutProcessor(RolloutProcessor):
                         int(x) for x in list(completion.get("completion_ids") or [])
                     ]
                     assistant_suffix_ids = text_client.encode_special_suffix()
-                    completion_ids = _append_turn_suffix(raw_completion_ids, assistant_suffix_ids)
+                    # Trained completion = engine tokens verbatim. The end-of-turn
+                    # close is NOT trained here: on a clean stop the model's own close
+                    # is already inside raw_completion_ids; on a length-truncated stop
+                    # nothing synthetic is added. The canonical close is re-attached
+                    # only as loss-masked framing when building the next prompt below.
+                    completion_ids = list(raw_completion_ids)
                     completion_text = shared_tokenizer.decode(
                         raw_completion_ids, skip_special_tokens=False,
                     ) if raw_completion_ids else str(completion.get("completion_text") or "")
@@ -479,9 +487,12 @@ class MultiHopQARolloutProcessor(RolloutProcessor):
                     clean_assistant_ids = shared_tokenizer.encode(
                         clean_completion_text, add_special_tokens=False
                     )
-                    clean_turn_ids = clean_assistant_ids + [
-                        int(x) for x in list(assistant_suffix_ids)
-                    ]
+                    # Framing bridge only (loss_mask=0 context for the next prompt):
+                    # dedup-append the canonical close to the (think-stripped) assistant
+                    # text so the turn is byte-exactly closed before the tool turn.
+                    clean_turn_ids = _append_turn_suffix(
+                        [int(x) for x in clean_assistant_ids], assistant_suffix_ids
+                    )
                     current_prompt_ids = (
                         list(prompt_ids)
                         + list(clean_turn_ids)

--- a/training/examples/multihop_qa/multihop_qa_rollout.py
+++ b/training/examples/multihop_qa/multihop_qa_rollout.py
@@ -101,6 +101,23 @@ def _strip_think_block(text: str) -> str:
     return text.strip()
 
 
+def _append_turn_suffix(core_ids: List[int], suffix_ids: List[int]) -> List[int]:
+    """Append the end-of-turn suffix, dropping any server-emitted trailing copy.
+
+    The model may finish a turn by emitting the end-of-turn marker itself, in
+    which case the server returns it inside ``core_ids``. Appending the suffix
+    unconditionally would duplicate it (e.g. ``<|im_end|><|im_end|>\\n``), so we
+    strip the longest tail of ``core_ids`` that overlaps the head of the suffix.
+    """
+    core = [int(x) for x in core_ids]
+    suffix = [int(x) for x in suffix_ids]
+    for overlap in range(min(len(core), len(suffix)), 0, -1):
+        if core[-overlap:] == suffix[:overlap]:
+            core = core[:-overlap]
+            break
+    return core + suffix
+
+
 def _build_tool_call_parser():
     """Build a tool call parser for search/submit_answer tools."""
     valid_names = {TOOL_NAME_SEARCH, TOOL_NAME_SUBMIT}
@@ -380,9 +397,7 @@ class MultiHopQARolloutProcessor(RolloutProcessor):
                         int(x) for x in list(completion.get("completion_ids") or [])
                     ]
                     assistant_suffix_ids = text_client.encode_special_suffix()
-                    completion_ids = list(raw_completion_ids) + [
-                        int(x) for x in list(assistant_suffix_ids)
-                    ]
+                    completion_ids = _append_turn_suffix(raw_completion_ids, assistant_suffix_ids)
                     completion_text = shared_tokenizer.decode(
                         raw_completion_ids, skip_special_tokens=False,
                     ) if raw_completion_ids else str(completion.get("completion_text") or "")

--- a/training/examples/rl/frozen_lake/frozen_lake_rollout.py
+++ b/training/examples/rl/frozen_lake/frozen_lake_rollout.py
@@ -212,12 +212,16 @@ def _strip_trailing_token_suffix(token_ids: List[int], suffix_ids: List[int]) ->
 
 
 def _append_turn_suffix(core_ids: List[int], suffix_ids: List[int]) -> List[int]:
-    """Append the end-of-turn suffix, dropping any server-emitted trailing copy.
+    """Close an assistant turn for *framing* (next-prompt) purposes.
 
-    The model may finish a turn by emitting the end-of-turn marker itself, in
-    which case the server returns it inside ``core_ids``. Appending the suffix
+    Used to build the next turn's prompt, NOT the trained completion span. The
+    model may finish a turn by emitting the end-of-turn marker itself, in which
+    case the server returns it inside ``core_ids``. Appending the suffix
     unconditionally would duplicate it (e.g. ``<|im_end|><|im_end|>\\n``), so we
-    strip the longest tail of ``core_ids`` that overlaps the head of the suffix.
+    strip the longest tail of ``core_ids`` that overlaps the head of the suffix
+    before appending. The appended close lives in the next turn's prompt as
+    loss-masked context; it is never part of the loss-bearing completion span
+    (see the rollout loop and ``masking.compute_model_output_spans``).
     """
     core = [int(x) for x in core_ids]
     suffix = [int(x) for x in suffix_ids]
@@ -1089,9 +1093,21 @@ class FrozenLakeToolRolloutProcessor(RolloutProcessor):
                         assistant_suffix_ids = image_client.encode_assistant_turn_suffix()
                     else:
                         assistant_suffix_ids = text_client.encode_special_suffix()
+                    # Trained completion = tool-call prefill + engine tokens verbatim.
+                    # The end-of-turn close is deliberately NOT part of the trained
+                    # span: on a clean stop the model's own close already sits inside
+                    # raw_completion_ids and stays trained with its real logprob; on a
+                    # length-truncated stop nothing synthetic is added, so we never
+                    # teach the model to stop at a forced cutoff. The canonical close is
+                    # re-attached below only as loss-masked framing for the next prompt.
                     completion_ids = [
                         int(x) for x in list(assistant_toolcall_prefill_ids)
-                    ] + _append_turn_suffix(raw_completion_ids, assistant_suffix_ids)
+                    ] + list(raw_completion_ids)
+                    # Framing bridge for the next turn's prompt (loss_mask=0 context):
+                    # dedup-append the canonical close so the assistant turn is
+                    # byte-exactly closed before the tool turn, without duplicating a
+                    # close the engine already emitted.
+                    assistant_turn_ids = _append_turn_suffix(completion_ids, assistant_suffix_ids)
                     completion_text = str(completion.get("completion_text") or "")
                     all_prompt_ids.extend(prompt_ids)
                     all_completion_ids.extend(completion_ids)
@@ -1168,7 +1184,6 @@ class FrozenLakeToolRolloutProcessor(RolloutProcessor):
                     if observation_mode == "image":
                         model_request_traces[-1]["assistant_turn_len"] = len(completion_ids)
                         if not done:
-                            assistant_turn_ids = list(completion_ids)
                             assistant_turn_text = (
                                 str(assistant_toolcall_prefill_text or "")
                                 + str(completion_text or "")
@@ -1198,7 +1213,6 @@ class FrozenLakeToolRolloutProcessor(RolloutProcessor):
                             current_prompt_ids = []
                             current_prompt_text = ""
                     else:
-                        assistant_turn_ids = list(completion_ids)
                         tool_suffix_ids = text_client.build_tool_response_suffix_token_ids(
                             tool_message=tool_message_payload
                         )

--- a/training/examples/rl/frozen_lake/frozen_lake_rollout.py
+++ b/training/examples/rl/frozen_lake/frozen_lake_rollout.py
@@ -211,6 +211,23 @@ def _strip_trailing_token_suffix(token_ids: List[int], suffix_ids: List[int]) ->
     return normalized_token_ids, 0
 
 
+def _append_turn_suffix(core_ids: List[int], suffix_ids: List[int]) -> List[int]:
+    """Append the end-of-turn suffix, dropping any server-emitted trailing copy.
+
+    The model may finish a turn by emitting the end-of-turn marker itself, in
+    which case the server returns it inside ``core_ids``. Appending the suffix
+    unconditionally would duplicate it (e.g. ``<|im_end|><|im_end|>\\n``), so we
+    strip the longest tail of ``core_ids`` that overlaps the head of the suffix.
+    """
+    core = [int(x) for x in core_ids]
+    suffix = [int(x) for x in suffix_ids]
+    for overlap in range(min(len(core), len(suffix)), 0, -1):
+        if core[-overlap:] == suffix[:overlap]:
+            core = core[:-overlap]
+            break
+    return core + suffix
+
+
 def _build_kimi_toolcall_generation_prefill_token_ids(tokenizer_name_or_path: str) -> List[int]:
     if not _is_kimi_tokenizer_name(tokenizer_name_or_path):
         return []
@@ -1072,11 +1089,9 @@ class FrozenLakeToolRolloutProcessor(RolloutProcessor):
                         assistant_suffix_ids = image_client.encode_assistant_turn_suffix()
                     else:
                         assistant_suffix_ids = text_client.encode_special_suffix()
-                    completion_ids = (
-                        [int(x) for x in list(assistant_toolcall_prefill_ids)]
-                        + list(raw_completion_ids)
-                        + [int(x) for x in list(assistant_suffix_ids)]
-                    )
+                    completion_ids = [
+                        int(x) for x in list(assistant_toolcall_prefill_ids)
+                    ] + _append_turn_suffix(raw_completion_ids, assistant_suffix_ids)
                     completion_text = str(completion.get("completion_text") or "")
                     all_prompt_ids.extend(prompt_ids)
                     all_completion_ids.extend(completion_ids)

--- a/training/examples/rl/frozen_lake/masking.py
+++ b/training/examples/rl/frozen_lake/masking.py
@@ -20,6 +20,17 @@ def compute_model_output_spans(
 
     Both the training loss mask and the UI visualization mask derive from
     this same set of spans so they stay aligned by construction.
+
+    Contract: ``length`` is the *trained* span — the tool-call prefill plus the
+    engine's completion tokens verbatim (``assistant_turn_len`` for intermediate
+    turns, ``len(completion_ids)`` for the last turn). It deliberately does NOT
+    include the synthesized end-of-turn close that bridges one turn to the next.
+    The rollout appends that close only into the *next* turn's prompt, so it sits
+    just after this span and is left unmasked (loss_mask=0). This implements the
+    TITO/renderer rule: never compute loss on a close token the model did not
+    actually emit (e.g. a synthesized close after a length-truncated turn). A
+    close the model *did* emit on a clean stop is part of ``completion_ids`` and
+    stays inside the span with its real logprob.
     """
     spans: List[Tuple[int, int, int]] = []
     num_turns = len(token_turn_traces)

--- a/training/examples/rl/frozen_lake/test_masking.py
+++ b/training/examples/rl/frozen_lake/test_masking.py
@@ -79,15 +79,19 @@ MULTI_TURN_3 = [
     },
 ]
 
+# Trained spans exclude the synthesized end-of-turn close. Turn 1's trained
+# completion is [prefill=99, raw tool-call token=10]; the close (90) is appended
+# only into turn 2's prompt as loss-masked framing and must NOT be trained.
 KIMI_STYLE_MULTI_TURN = [
     {
         "prompt_ids": [1, 2, 3],
-        "completion_ids": [99, 10, 90],  # prefill, raw tool call token(s), im_end
-        "assistant_turn_len": 3,
+        "completion_ids": [99, 10],  # prefill, raw tool call token(s) -- no close
+        "assistant_turn_len": 2,
     },
     {
+        # prompt = turn1 prompt + framed assistant turn [99, 10, 90] + tool [20, 21]
         "prompt_ids": [1, 2, 3, 99, 10, 90, 20, 21],
-        "completion_ids": [99, 30, 90],
+        "completion_ids": [99, 30],
     },
 ]
 
@@ -198,18 +202,24 @@ def test_fallback_when_assistant_turn_len_missing():
     assert spans_with_mrt[0] == spans_no_mrt[0]
 
 
-def test_kimi_style_mask_includes_prefill_and_im_end_tokens():
-    """Assistant framing tokens should be masked as model output too."""
+def test_kimi_style_prefill_trained_but_close_is_framing():
+    """Tool-call prefill is trained; the inter-turn close is framing (loss=0).
+
+    The synthesized end-of-turn close that bridges turn 1 to turn 2 (token 90 at
+    position 5) lives in turn 2's prompt and must be excluded from every span, so
+    neither the UI mask nor the training mask marks it as model output.
+    """
     ttt, mrt = _make_traces(KIMI_STYLE_MULTI_TURN)
     spans = compute_model_output_spans(ttt, mrt)
 
-    assert spans == [(3, 3, 1), (8, 3, 2)]
+    assert spans == [(3, 2, 1), (8, 2, 2)]
 
-    ui_mask = build_ui_token_mask(spans, 11)
-    assert ui_mask == [0, 0, 0, 1, 1, 1, 0, 0, 2, 2, 2]
+    ui_mask = build_ui_token_mask(spans, 10)
+    assert ui_mask == [0, 0, 0, 1, 1, 0, 0, 0, 2, 2]
+    assert ui_mask[5] == 0, "inter-turn close must not be trained as model output"
 
-    train_mask = build_training_loss_mask(spans, 10)
-    assert train_mask == [0.0, 0.0, 1.0, 1.0, 1.0, 0.0, 0.0, 1.0, 1.0, 1.0]
+    train_mask = build_training_loss_mask(spans, 9)
+    assert train_mask == [0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0]
 
 
 def test_shared_weighted_datum_matches_training_loss_mask():

--- a/training/tests/unit/test_frozen_lake_visual_rollout.py
+++ b/training/tests/unit/test_frozen_lake_visual_rollout.py
@@ -252,9 +252,13 @@ async def test_visual_rollout_preserves_prior_completion_tokens(monkeypatch):
 
     assert len(token_turn_traces) == 2
     assert token_turn_traces[0]["prompt_ids"] == [10, 11, 12]
-    assert token_turn_traces[0]["completion_ids"] == [tool_prefill_id, 101, 90]
+    # Trained completion = prefill + engine tokens, WITHOUT the end-of-turn close
+    # (90). The close is appended only into the next turn's prompt as loss-masked
+    # framing, which is why it appears in turn 1's prompt_ids but not its
+    # completion_ids.
+    assert token_turn_traces[0]["completion_ids"] == [tool_prefill_id, 101]
     assert token_turn_traces[1]["prompt_ids"] == [10, 11, 12, tool_prefill_id, 101, 90, 91, 92]
-    assert token_turn_traces[1]["completion_ids"] == [tool_prefill_id, 102, 90]
+    assert token_turn_traces[1]["completion_ids"] == [tool_prefill_id, 102]
 
     assert _FakeImageClient.requested_prompt_ids == [
         [10, 11, 12, tool_prefill_id],
@@ -265,8 +269,10 @@ async def test_visual_rollout_preserves_prior_completion_tokens(monkeypatch):
         "prompt:initial<|tool_calls_section_begin|>action:RIGHT<|im_end|>suffix:tool<|tool_calls_section_begin|>",
     ]
     assert _FakeImageClient.requested_image_counts == [1, 2]
-    assert extra["model_request_traces"][0]["assistant_turn_len"] == 3
-    assert extra["model_request_traces"][1]["assistant_turn_len"] == 3
+    # assistant_turn_len is the trained span length (prefill + engine tokens),
+    # excluding the framing close that bridges to the next turn.
+    assert extra["model_request_traces"][0]["assistant_turn_len"] == 2
+    assert extra["model_request_traces"][1]["assistant_turn_len"] == 2
     assert extra["observation_mode"] == "image"
     assert extra["tool_call_generation_mode"] == "prompt_only"
     assert [message.role for message in result.messages] == [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## TL;DR

`frozen_lake` and `multihop_qa` rollouts were folding a hardcoded `<|im_end|>\n` end-of-turn close into the **trained** completion span (loss=1, logprob 0.0). That (a) **duplicated** the close on clean stops and (b) **fabricated** a stop signal on length-truncated turns. This PR applies the principled rule used by the rest of the cookbook and by TITO/renderer frameworks: **never compute loss on a close token the model did not actually emit.** The canonical close is kept only as **loss-masked framing** for the next turn's prompt.

## Impact

The fabricated suffix tokens carry `loss_mask=1` but a placeholder inference logprob of `0.0`. That `inf=0.0` forces the per-token importance weight `≤ 1` (`tis = exp(old_policy − inf)` in GRPO/DAPO/GSPO/CISPO; `ratio = exp(pi − inf)` in REINFORCE/IS), so no single junk token blows up the gradient — but "≤ 1" is not "0", and several paths still move the weights. This is **not just a metrics issue**:

1. **Length-truncated turns — real, directionally-biased gradient (primary fix).** At a `max_tokens` cutoff the model did not want to stop, so it assigns the close only small/moderate probability (`old_policy ≈ −3…−6` → weight `≈ 0.05…0.002`). Small but nonzero, and it is a policy-gradient term reinforcing `<|im_end|>` at a forced cutoff. Across many truncated samples this is a *systematic* bias toward premature stopping (not random noise). The fix removes it.

2. **Sequence-level TIS — hits the good tokens too.** With `tis_config.level == "sequence"`, the weight is the geometric mean broadcast to all tokens. The junk tokens' very-negative `tis_log` (clamped to −20) drag that mean down, downweighting **every real token** in the trajectory. Removed by the fix.

3. **Token-count normalization dilution.** Fabricated tokens are counted in `num_tokens` / the weighted-token denominator used by grad-accumulation normalization; they add ~0 to the numerator but inflate the denominator, shrinking the effective per-token gradient/LR on real tokens. Config-dependent but real.

4. **Corrupted multi-turn model input → degraded rollout/reward (frozen_lake text path).** This is the most direct harm and is independent of the loss bookkeeping. The duplicate isn't only in the trained span — it's stapled into the next turn's prompt bridge (`assistant_turn_ids = completion_ids`), so on every clean stop the deployment samples the *next* turn from a malformed `...<|im_end|><|im_end|>\n...` context. Sampling is token-in (no re-render), so the double close goes straight into the model, which has essentially never seen two consecutive end tokens → worse actions / flakier tool-call formatting and a degraded **reward** signal. It corrupts the training **data**, not just the loss, and it **accumulates**: each clean-stop turn adds another stray close to the running prompt. It is also a train/serve skew (production prompts are well-formed). Scope: the image path strips the close inside its client and `multihop_qa` builds the bridge from re-encoded clean text, so both already had a single close — this item is specific to the frozen_lake text path.

5. **Metric contamination (secondary).** Because `inf=0.0` at `loss_mask=1` positions, `inference_diff`/`inference_kld` (k3 estimator over active tokens) inflate by `|pi|` and `rollout/entropy` (mean of `−inf` over active tokens) is biased toward 0 — so drift dashboards spike and entropy reads artificially low even where the gradient impact is muted.

Note: the clean-stop **duplicate's own gradient** is largely self-neutralized (the model strongly disfavors a second consecutive close → `old_policy ≈ −12` → weight `≈ 0`), so for that specific symptom the benefit is mostly hygiene + items 2–5. But that neutralization is an *accident* of `inf=0` clamping the ratio, not a correctness guarantee — and it is weakest exactly where it matters most (the truncated close). The fix makes the target correct by construction.

## Background / how we got here

This started as "is there a bug in `encode_special_suffix()`?" The investigation went through three stages; the full reasoning is preserved here so the next agent has the complete picture.

### Stage 1 — the duplication bug

The rollout loop built each turn's completion as:

```python
completion_ids = prefill + raw_completion_ids + encode_special_suffix()   # "<|im_end|>\n"
```

`encode_special_suffix()` (in `eval_protocol`'s `FireworksV1CompletionsClient`) always returns `<|im_end|>\n`. But when a turn ends because the model emitted the stop token (`finish_reason == "stop"`), the Fireworks `/v1/completions` client returns that `<|im_end|>` **inside** `completion_ids` (the text path passes it through untouched). So the suffix got stapled on a second time → `<|im_end|><|im_end|>\n`. (The image path was already safe: its local client strips the trailing suffix via `_strip_trailing_token_suffix` before re-appending.)

### Stage 2 — "should we gate on `finish_reason` instead of patching tokens?"

`finish_reason` is **not** a reliable gate:
- `finish_reason == "length"` → no close generated → you *would* need a close.
- `finish_reason == "stop"` → a stop token was hit, but whether the provider *includes* it in `token_ids` is config/provider-dependent.

So a `finish_reason`-only gate can both over- and under-append. A token-tail dedup is provider-agnostic and idempotent.

### Stage 3 — "should we even have `encode_special_suffix()` at all?" (this PR)

Comparing against the cookbook's first-party token-native rollouts:
- `single_turn_token_in/rollout.py`, `coding_agent/rollout.py` — use engine `output_tokens` **verbatim**, never append a literal close.
- `multi_turn_message_in/rollout.py` → `MessageTrajectoryAssembler` / `TrajectoryAssembler` — keep engine tokens verbatim and derive inter-turn scaffolding by diffing `apply_chat_template` outputs (`precompute_chat_suffix`), enforcing a prefix-equality invariant. The assembler module explicitly calls out hardcoding/re-tokenizing the boundary as the anti-pattern.

`frozen_lake`/`multihop_qa` are the outliers because they ride the `eval_protocol` SDK client and manually reconstruct the completion. But note they are **TITO-concat** rollouts: they build the *next* turn's prompt by concatenating tokens, and the close is the load-bearing bridge between the assistant turn and the tool turn (`build_tool_response_suffix_token_ids` renders only the tool turn, not the assistant's close). So we **cannot delete** `encode_special_suffix()` — deleting it produces a malformed chat template (`...assistant tokens<|im_start|>tool...` with no close).

The real defect is **conflation**: the same `completion_ids` (raw + close) was used both as the next-prompt bridge (legitimate, should be `loss=0` context) **and** as the trained span (`masking.compute_model_output_spans` marks the whole length `loss=1`, while the close positions carry logprob `0.0`). The worst case is `finish_reason == "length"`: the model never emitted a close, yet we synthesize one, mark it `loss=1` with logprob `0.0`, and teach the model to stop at a forced cutoff.

The TITO/renderers rule resolves it: **append for byte-exact framing, mask from loss.**

## What this PR changes

1. **Trained completion = tool-call prefill + engine tokens verbatim** (`frozen_lake_rollout.py`, `multihop_qa_rollout.py`).
   - On a clean stop, the model's own close is already inside the engine tokens and stays trained with its real logprob.
   - On a length-truncated stop, nothing synthetic is trained.

2. **Framing bridge** = `_append_turn_suffix(...)` appends the canonical close **only into the next turn's prompt** (loss-masked context). It dedups any engine-emitted close (longest tail-of-core / head-of-suffix overlap), handling both the single-token (`<|im_end|>`) and full (`<|im_end|>\n`) cases idempotently.

3. **`masking.py`** — spans already key off `assistant_turn_len` (intermediate) and `len(completion_ids)` (last), which now equal the trained engine-token length. The framing close lands in the next prompt and is left unmasked (`loss=0`). Added a docstring documenting this contract; no logic change needed.

4. **Tests** — updated `test_masking.py` (the `KIMI_STYLE_MULTI_TURN` case now asserts the inter-turn close at position 5 is `loss=0`) and `test_frozen_lake_visual_rollout.py` (completion spans exclude the close; `assistant_turn_len` is the trained length).

### Why masking needed no logic change (worked example)

```
turn0: prompt P0, trained completion C0 (raw), framed assistant turn = C0 + close S0
       next prompt P1 = P0 + (C0+S0) + tool_suffix T0
turn1: prompt P1, trained completion C1
full_tokens = P1 + C1 = P0 + C0 + S0 + T0 + C1
spans: (len P0, len C0, 1), (len P1, len C1, 2)
=> C0, C1 are loss=1; S0 (close) and T0 (tool) are loss=0
```

## Verification

- `training/examples/rl/frozen_lake/test_masking.py` + `training/tests/unit/test_frozen_lake_visual_rollout.py`: **19 passed**.
- `test_rollout_assembler.py` / `test_rollout_helpers.py` / `test_rollout_types.py`: **43 passed** (no regressions).
- Both rollout modules import cleanly; `_append_turn_suffix` edge cases (no overlap / single-token close / full close / empty) verified in both modules.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cb45b424-24fb-4f63-a459-8668ad16f9da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cb45b424-24fb-4f63-a459-8668ad16f9da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

