### PR TITLE
Add tool schema prefixes for cookbook renderers

### DIFF
--- a/training/renderer/deepseek_v4.py
+++ b/training/renderer/deepseek_v4.py
@@ -81,6 +81,7 @@ from tinker_cookbook.renderers.base import (
     Renderer,
     Role,
     ToolCall,
+    ToolSpec,
     TrainOnWhat,
     UnparsedToolCall,
 )
@@ -262,6 +263,20 @@ def _render_tools_section(tools: list[Mapping[str, Any]]) -> str:
         think_close=_THINK_CLOSE,
         tool_schemas="\n".join(_to_json(t) for t in function_dicts),
     )
+
+
+def _wrap_tool_specs(tools: list[ToolSpec]) -> list[dict[str, Any]]:
+    # render_messages_to_datums passes inner function specs; _render_tools_section
+    # expects OpenAI-wrapped {"type": "function", "function": ...} objects.
+    wrapped: list[dict[str, Any]] = []
+    for tool in tools:
+        if not isinstance(tool, Mapping):
+            raise TypeError(f"DeepseekV4Renderer expected tool mapping, got {type(tool)!r}")
+        if isinstance(tool.get("function"), Mapping):
+            wrapped.append(dict(tool))
+        else:
+            wrapped.append({"type": "function", "function": dict(tool)})
+    return wrapped
 
 
 def _has_any_tools(messages: list[Message]) -> bool:
@@ -568,6 +583,20 @@ class DeepseekV4Renderer(Renderer):
 
     def _encode(self, text: str) -> list[int]:
         return self.tokenizer.encode(text, add_special_tokens=False)
+
+    def create_conversation_prefix_with_tools(
+        self,
+        tools: list[ToolSpec],
+        system_prompt: str = "",
+    ) -> list[Message]:
+        """Attach top-level OpenAI tool schemas to the leading system message."""
+        return [
+            Message(
+                role="system",
+                content=system_prompt,
+                tools=_wrap_tool_specs(tools),
+            )
+        ]
 
     # ---- render_message branches ---------------------------------------------
 

--- a/training/renderer/glm5.py
+++ b/training/renderer/glm5.py
@@ -96,6 +96,7 @@ from tinker_cookbook.renderers.base import (
     Renderer,
     Role,
     ToolCall,
+    ToolSpec,
     TrainOnWhat,
     UnparsedToolCall,
     parse_think_blocks,
@@ -111,6 +112,25 @@ _TOOL_CALL_RE = re.compile(r"<tool_call>(.*?)</tool_call>", re.DOTALL)
 _TOOL_ARG_RE = re.compile(
     r"<arg_key>(.*?)</arg_key><arg_value>(.*?)</arg_value>",
     re.DOTALL,
+)
+# Mirrors the tools branch in zai-org/GLM-5.1's tokenizer chat_template.
+_TOOL_DECLARATION_PREFIX = """\
+
+# Tools
+
+You may call one or more functions to assist with the user query.
+
+You are provided with function signatures within <tools></tools> XML tags:
+<tools>
+"""
+_TOOL_DECLARATION_SUFFIX = """\
+</tools>
+
+For each function call, output the function name and arguments within the following XML format:
+""" + (
+    "<tool_call>{function-name}<arg_key>{arg-key-1}</arg_key>"
+    "<arg_value>{arg-value-1}</arg_value><arg_key>{arg-key-2}</arg_key>"
+    "<arg_value>{arg-value-2}</arg_value>...</tool_call>"
 )
 
 
@@ -155,6 +175,23 @@ def _format_tool_calls(tool_calls: list[ToolCall]) -> str:
         )
         parts.append(f"<tool_call>{tc.function.name}{kv}</tool_call>")
     return "".join(parts)
+
+
+def _format_tool_declarations(tools: list[ToolSpec]) -> str:
+    rendered_tools: list[str] = []
+    for tool in tools:
+        if not isinstance(tool, Mapping):
+            raise TypeError(f"GLM5Renderer expected tool mapping, got {type(tool)!r}")
+        tool_spec = tool.get("function") if isinstance(tool.get("function"), Mapping) else tool
+        if tool_spec.get("defer_loading"):
+            continue
+        filtered = {
+            key: value
+            for key, value in tool_spec.items()
+            if key not in {"defer_loading", "strict"}
+        }
+        rendered_tools.append(json.dumps(filtered, ensure_ascii=False))
+    return "\n".join(rendered_tools)
 
 
 def _parse_arg_value(value: str) -> Any:
@@ -659,6 +696,27 @@ class GLM5Renderer(DisaggregateMultiTurnMixin, Renderer):
         else:
             suffix_str = f"<|{role}|>"
         return self.tokenizer.encode(suffix_str, add_special_tokens=False)
+
+    def create_conversation_prefix_with_tools(
+        self,
+        tools: list[ToolSpec],
+        system_prompt: str = "",
+    ) -> list[Message]:
+        """Render top-level OpenAI tool schemas in GLM's system tool block."""
+        prefix_messages = [
+            Message(
+                role="system",
+                content=(
+                    _TOOL_DECLARATION_PREFIX
+                    + _format_tool_declarations(tools)
+                    + "\n"
+                    + _TOOL_DECLARATION_SUFFIX
+                ),
+            )
+        ]
+        if system_prompt:
+            prefix_messages.append(Message(role="system", content=system_prompt))
+        return prefix_messages
 
     def parse_response(self, response: list[int]) -> tuple[Message, bool]:
         end_idx = len(response)

--- a/training/renderer/kimi_k27_code.py
+++ b/training/renderer/kimi_k27_code.py
@@ -1,18 +1,24 @@
 """Renderer registration for Moonshot Kimi K2.7 Code.
 
-Kimi K2.7 Code keeps the K2.6 tokenizer, special tokens, and tool declaration
-format, but its official chat template differs in two important ways:
+Kimi K2.7 Code keeps the K2.6 tokenizer and special tokens, but its official
+chat template differs in three important ways:
 
 * historical thinking is preserved by default and cannot be disabled by the
   tokenizer's ``apply_chat_template`` wrapper;
 * no default system message is injected when the input starts with a user turn.
+* different tokenizer backends may either auto-populate the template-only
+  ``tools_ts_str`` variable or fall back to compact OpenAI JSON in
+  ``tool_declare``.
 
 This local renderer reuses the upstream K2.6 preserve-thinking implementation
-and only removes the default-system insertion so tokenization matches the
-official K2.7 Code template.
+and overrides those K2.7-specific pieces so tokenization matches the official
+K2.7 Code template.
 """
 
 from __future__ import annotations
+
+import json
+from typing import Any
 
 from tinker_cookbook.image_processing_utils import ImageProcessor
 from tinker_cookbook.renderers import register_renderer
@@ -22,6 +28,36 @@ from tinker_cookbook.renderers.kimi_k2_5_tool_declaration_ts import (
 )
 from tinker_cookbook.renderers.kimi_k26 import KimiK26PreserveThinkingRenderer
 from tinker_cookbook.tokenizer_utils import Tokenizer
+
+
+_KIMI_TOOL_STYLE_PROBE = [
+    {
+        "type": "function",
+        "function": {
+            "name": "probe",
+            "description": "probe",
+            "parameters": {"type": "object", "properties": {}, "required": []},
+        },
+    }
+]
+
+
+def _tokenizer_tools_branch_uses_typescript(tokenizer: Any) -> bool:
+    apply_chat_template = getattr(tokenizer, "apply_chat_template", None)
+    if apply_chat_template is None:
+        return False
+
+    try:
+        rendered = apply_chat_template(
+            [{"role": "user", "content": "probe"}],
+            tools=_KIMI_TOOL_STYLE_PROBE,
+            tokenize=False,
+            add_generation_prompt=False,
+        )
+    except Exception:
+        return False
+
+    return isinstance(rendered, str) and "namespace functions" in rendered
 
 
 class KimiK27CodeRenderer(KimiK26PreserveThinkingRenderer):
@@ -39,8 +75,15 @@ class KimiK27CodeRenderer(KimiK26PreserveThinkingRenderer):
 
         if tools:
             tools_payload = [{"type": "function", "function": tool} for tool in tools]
-            tools_ts_str = encode_tools_to_typescript_style(tools_payload)
-            messages.append(Message(role="tool_declare", content=tools_ts_str))
+            if _tokenizer_tools_branch_uses_typescript(self.tokenizer):
+                content = encode_tools_to_typescript_style(tools_payload)
+            else:
+                content = json.dumps(
+                    tools_payload,
+                    ensure_ascii=False,
+                    separators=(",", ":"),
+                )
+            messages.append(Message(role="tool_declare", content=content))
 
         if system_prompt:
             messages.append(Message(role="system", content=system_prompt))

--- a/training/renderer/mistral.py
+++ b/training/renderer/mistral.py
@@ -132,6 +132,18 @@ def _format_tools_block(tools: list[ToolSpec | Mapping[str, Any]]) -> str:
     return _AVAILABLE_TOOLS_OPEN + json.dumps(list(tools)) + _AVAILABLE_TOOLS_CLOSE
 
 
+def _wrap_tool_specs(tools: list[ToolSpec]) -> list[dict[str, Any]]:
+    wrapped: list[dict[str, Any]] = []
+    for tool in tools:
+        if not isinstance(tool, Mapping):
+            raise TypeError(f"MistralRenderer expected tool mapping, got {type(tool)!r}")
+        if isinstance(tool.get("function"), Mapping):
+            wrapped.append(dict(tool))
+        else:
+            wrapped.append({"type": "function", "function": dict(tool)})
+    return wrapped
+
+
 class MistralRenderer(Renderer):
     """Renderer for Mistral / Ministral Tekken-style chat models.
 
@@ -358,7 +370,7 @@ class MistralRenderer(Renderer):
         right position. This matches the Jinja template, where tools are
         rendered immediately after the system block and before any user turn.
         """
-        self._pending_tools = list(tools)
+        self._pending_tools = _wrap_tool_specs(tools)
         if system_prompt:
             return [Message(role="system", content=system_prompt)]
         return [Message(role="system", content=_DEFAULT_SYSTEM_SENTINEL)]

--- a/training/renderer/nemotron.py
+++ b/training/renderer/nemotron.py
@@ -15,6 +15,7 @@ but with different thinking-tag handling:
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping
 
 import tinker
 import torch
@@ -23,6 +24,7 @@ from tinker_cookbook.renderers.base import (
     RenderContext,
     RenderedMessage,
     Role,
+    ToolSpec,
     TrainOnWhat,
 )
 from tinker_cookbook.renderers import register_renderer
@@ -61,6 +63,61 @@ def _format_nemotron_tool_call(tool_call) -> str:
         parts.append(f"<parameter={key}>\n{formatted}\n</parameter>\n")
     parts.append("</function>\n</tool_call>\n")
     return "".join(parts)
+
+
+def _render_extra_keys(obj: Mapping[str, object], handled_keys: set[str]) -> list[str]:
+    """Render extra dict keys as XML, mirroring the HF template macro."""
+    lines: list[str] = []
+    for key, value in obj.items():
+        if key in handled_keys:
+            continue
+        if isinstance(value, (dict, list)):
+            lines.append(f"<{key}>{json.dumps(value)}</{key}>")
+        else:
+            lines.append(f"<{key}>{value!s}</{key}>")
+    return lines
+
+
+def _description_text(value: object) -> str:
+    if isinstance(value, str):
+        return value.strip()
+    return str(value)
+
+
+def _format_nemotron_tool_declaration(tool: ToolSpec) -> str:
+    """Format a single tool declaration in Nemotron's XML format."""
+    lines = [
+        "<function>",
+        f"<name>{tool['name']}</name>",
+    ]
+    if description := _description_text(tool.get("description", "")):
+        lines.append(f"<description>{description}</description>")
+    lines.append("<parameters>")
+    params = tool.get("parameters") or {}
+    if isinstance(params, dict) and "properties" in params:
+        for param_name, param_fields in params["properties"].items():
+            lines.append("<parameter>")
+            lines.append(f"<name>{param_name}</name>")
+            if "type" in param_fields:
+                lines.append(f"<type>{param_fields['type']!s}</type>")
+            if "description" in param_fields:
+                lines.append(
+                    f"<description>{_description_text(param_fields['description'])}</description>"
+                )
+            if "enum" in param_fields:
+                lines.append(f"<enum>{json.dumps(param_fields['enum'])}</enum>")
+            lines.extend(
+                _render_extra_keys(param_fields, {"name", "type", "description", "enum"})
+            )
+            lines.append("</parameter>")
+    if isinstance(params, dict):
+        lines.extend(_render_extra_keys(params, {"type", "properties", "required"}))
+    if isinstance(params, dict) and "required" in params:
+        lines.append(f"<required>{json.dumps(params['required'])}</required>")
+    lines.append("</parameters>")
+    lines.extend(_render_extra_keys(tool, {"type", "name", "description", "parameters"}))
+    lines.append("</function>")
+    return "\n".join(lines)
 
 
 def _truncate_thinking(content: str) -> str:
@@ -166,6 +223,57 @@ class NemotronRenderer(Qwen3Renderer):
         return super().build_supervised_example(
             self._preprocess_messages(messages), train_on_what=train_on_what,
         )
+
+    def create_conversation_prefix_with_tools(
+        self, tools: list[ToolSpec], system_prompt: str = ""
+    ) -> list[Message]:
+        """Create the Nemotron XML tool system block from top-level tools.
+
+        Mirrors the tools branch in the Nemotron HF tokenizer chat template.
+        """
+        tools_text = ""
+        if tools:
+            tool_declarations = "\n".join(
+                _format_nemotron_tool_declaration(tool) for tool in tools
+            )
+            tools_text = (
+                "# Tools\n\n"
+                "You have access to the following functions:\n\n"
+                "<tools>\n"
+                f"{tool_declarations}\n"
+                "</tools>\n\n"
+                "If you choose to call a function ONLY reply in the following format with NO suffix:\n\n"
+                "<tool_call>\n"
+                "<function=example_function_name>\n"
+                "<parameter=example_parameter_1>\n"
+                "value_1\n"
+                "</parameter>\n"
+                "<parameter=example_parameter_2>\n"
+                "This is the value for the second parameter\n"
+                "that can span\n"
+                "multiple lines\n"
+                "</parameter>\n"
+                "</function>\n"
+                "</tool_call>\n\n"
+                "<IMPORTANT>\n"
+                "Reminder:\n"
+                "- Function calls MUST follow the specified format: "
+                "an inner <function=...></function> block must be nested within "
+                "<tool_call></tool_call> XML tags\n"
+                "- Required parameters MUST be specified\n"
+                "- You may provide optional reasoning for your function call in natural language "
+                "BEFORE the function call, but NOT after\n"
+                "- If there is no function call available, answer the question like normal with "
+                "your current knowledge and do not tell the user about function calls\n"
+                "</IMPORTANT>"
+            )
+
+        if tools_text:
+            content = system_prompt + "\n\n" + tools_text if system_prompt else tools_text
+        else:
+            content = system_prompt
+
+        return [Message(role="system", content=content)]
 
     def _render_tool_message(self, message: Message, ctx: RenderContext) -> RenderedMessage:
         """Render a tool response, grouping consecutive tool messages.

--- a/training/tests/unit/test_deepseek_v4_renderer.py
+++ b/training/tests/unit/test_deepseek_v4_renderer.py
@@ -529,6 +529,43 @@ def test_system_with_tools_matches_oracle(tokenizer, renderer_thinking_keep):
     assert ours == expected_ids, tokenizer.decode(ours)
 
 
+def test_top_level_tool_prefix_matches_system_tools_oracle(
+    tokenizer,
+    renderer_thinking_keep,
+):
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Look up weather",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                    "required": ["city"],
+                },
+            },
+        }
+    ]
+    messages = [
+        {"role": "system", "content": "You are an assistant."},
+        {"role": "user", "content": "weather in SF?"},
+    ]
+    prefixed = renderer_thinking_keep.create_conversation_prefix_with_tools(
+        [tools[0]["function"]],
+        system_prompt="You are an assistant.",
+    ) + [messages[1]]
+
+    expected_ids = _oracle_ids(
+        tokenizer,
+        [{**messages[0], "tools": tools}, messages[1]],
+        thinking_mode="thinking",
+    )
+    ours = _renderer_generation(renderer_thinking_keep, prefixed)
+
+    assert ours == expected_ids, tokenizer.decode(ours)
+
+
 def test_drop_thinking_auto_disable_when_tools_present(
     tokenizer,
     renderer_thinking_strip,

--- a/training/tests/unit/test_glm5_renderer.py
+++ b/training/tests/unit/test_glm5_renderer.py
@@ -29,7 +29,7 @@ from training.tests.glm5_serverless_cases import (
     GLM5_SERVERLESS_PROMPT_TOKEN_CASES,
     GLM5_SERVERLESS_STOP_TOKEN_IDS,
 )
-from training.utils.supervised import normalize_messages
+from training.utils.supervised import normalize_messages, render_messages_to_datums
 from tinker_cookbook.renderers import get_renderer
 from tinker_cookbook.renderers.base import ToolCall, TrainOnWhat
 
@@ -213,6 +213,37 @@ def test_generation_prompt_system_user(tokenizer, renderer):
     ]
     hf = _hf_tokens(tokenizer, messages, add_generation_prompt=True)
     ours = _renderer_generation_tokens(renderer, messages)
+    assert ours == hf
+
+
+def test_generation_prompt_with_top_level_tools_matches_hf(tokenizer, renderer):
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Look up weather",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                    "required": ["city"],
+                },
+                "strict": True,
+            },
+        }
+    ]
+    messages = [
+        {"role": "system", "content": "You are helpful."},
+        {"role": "user", "content": "weather in SF?"},
+    ]
+    prefix = renderer.create_conversation_prefix_with_tools(
+        [tools[0]["function"]],
+        system_prompt="You are helpful.",
+    )
+
+    hf = _hf_tokens(tokenizer, messages, add_generation_prompt=True, tools=tools)
+    ours = _renderer_generation_tokens(renderer, prefix + messages[1:])
+
     assert ours == hf
 
 
@@ -716,6 +747,39 @@ def test_interleaved_tool_reasoning_and_params_are_trained(tokenizer, renderer):
     assert "Need current weather.</think>" in trained_text
     assert "<tool_call>get_weather" in trained_text
     assert "<arg_value>SF</arg_value>" in trained_text
+
+
+def test_render_messages_to_datums_accepts_top_level_tools(tokenizer, renderer):
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Look up weather",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                    "required": ["city"],
+                },
+            },
+        }
+    ]
+    rendered = render_messages_to_datums(
+        [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "weather in SF?"},
+            {"role": "assistant", "content": "I can check that."},
+        ],
+        renderer=renderer,
+        train_on_what="all_assistant_messages",
+        tools=tools,
+    )
+
+    decoded = tokenizer.decode(rendered[0].token_ids)
+
+    assert "# Tools" in decoded
+    assert "<tools>" in decoded
+    assert '"name": "get_weather"' in decoded
 
 
 # ── build_supervised_examples split behaviour ───────────────────────────────

--- a/training/tests/unit/test_kimi_k27_code_renderer.py
+++ b/training/tests/unit/test_kimi_k27_code_renderer.py
@@ -38,12 +38,15 @@ def _hf_tokens(
     messages: list[dict[str, Any]],
     *,
     add_generation_prompt: bool,
+    tools: list[dict[str, Any]] | None = None,
 ) -> list[int]:
-    result = tokenizer.apply_chat_template(
-        messages,
-        tokenize=True,
-        add_generation_prompt=add_generation_prompt,
-    )
+    kwargs: dict[str, Any] = {
+        "tokenize": True,
+        "add_generation_prompt": add_generation_prompt,
+    }
+    if tools is not None:
+        kwargs["tools"] = tools
+    result = tokenizer.apply_chat_template(messages, **kwargs)
     if hasattr(result, "input_ids"):
         return [int(t) for t in list(result.input_ids)]
     return [int(t) for t in list(result)]
@@ -126,6 +129,43 @@ _REASONING_CONTENT_MESSAGES = [
 def test_generation_prompt_matches_hf_chat_template(tokenizer, renderer, messages):
     expected = _hf_tokens(tokenizer, messages, add_generation_prompt=True)
     actual = _renderer_generation_tokens(renderer, messages)
+    _assert_tokens_match(tokenizer, expected, actual)
+
+
+@pytest.mark.timeout(180)
+def test_generation_prompt_with_top_level_tools_matches_hf(tokenizer, renderer):
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Look up weather for a city.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "city": {"type": "string", "description": "City name."},
+                    },
+                    "required": ["city"],
+                },
+            },
+        }
+    ]
+    messages = [
+        {"role": "system", "content": "You are helpful."},
+        {"role": "user", "content": "Weather in SF?"},
+    ]
+    prefix = renderer.create_conversation_prefix_with_tools(
+        [tools[0]["function"]],
+        system_prompt="You are helpful.",
+    )
+
+    expected = _hf_tokens(
+        tokenizer,
+        messages,
+        add_generation_prompt=True,
+        tools=tools,
+    )
+    actual = _renderer_generation_tokens(renderer, prefix + messages[1:])
     _assert_tokens_match(tokenizer, expected, actual)
 
 

--- a/training/tests/unit/test_mistral_renderer.py
+++ b/training/tests/unit/test_mistral_renderer.py
@@ -217,6 +217,43 @@ def test_generation_prompt_after_user(
     _assert_tokens_match(tokenizer, expected, actual)
 
 
+def test_generation_prompt_with_top_level_tools_matches_hf(
+    tokenizer: transformers.PreTrainedTokenizerBase, renderer: MistralRenderer
+) -> None:
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Look up weather",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                    "required": ["city"],
+                },
+            },
+        }
+    ]
+    messages = [
+        {"role": "system", "content": "Be terse."},
+        {"role": "user", "content": "weather in SF?"},
+    ]
+    prefix = renderer.create_conversation_prefix_with_tools(
+        [tools[0]["function"]],
+        system_prompt="Be terse.",
+    )
+
+    expected = _hf_tokens(
+        tokenizer,
+        messages,
+        add_generation_prompt=True,
+        tools=tools,
+    )
+    actual = _renderer_tokens(renderer, prefix + messages[1:])
+
+    _assert_tokens_match(tokenizer, expected, actual)
+
+
 # --- Tool calls / tool responses ------------------------------------
 
 

--- a/training/tests/unit/test_nemotron_renderer.py
+++ b/training/tests/unit/test_nemotron_renderer.py
@@ -118,6 +118,80 @@ def test_empty_system_message(tokenizer, renderer):
     assert hf == ours, f"Token mismatch:\nHF:   {hf}\nOurs: {ours}"
 
 
+@pytest.mark.parametrize(
+    "tool_function",
+    [
+        pytest.param(
+            {
+                "name": "get_weather",
+                "description": "Look up weather for a city.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "city": {
+                            "type": "string",
+                            "description": "City name.",
+                        },
+                        "unit": {
+                            "type": "string",
+                            "enum": ["celsius", "fahrenheit"],
+                        },
+                    },
+                    "required": ["city"],
+                },
+            },
+            id="string_descriptions",
+        ),
+        pytest.param(
+            {
+                "name": "get_weather",
+                "description": None,
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "city": {
+                            "type": "string",
+                            "description": None,
+                        },
+                    },
+                    "required": ["city"],
+                },
+            },
+            id="null_descriptions",
+        ),
+    ],
+)
+def test_generation_prompt_with_top_level_tools_matches_hf(
+    tokenizer,
+    renderer,
+    tool_function,
+):
+    """Top-level tools should render exactly like HF apply_chat_template(tools=...)."""
+    tools = [
+        {
+            "type": "function",
+            "function": tool_function,
+        }
+    ]
+    messages = [
+        {"role": "system", "content": "You are helpful."},
+        {"role": "user", "content": "Weather in SF?"},
+    ]
+    prefix = renderer.create_conversation_prefix_with_tools(
+        [tool_function],
+        system_prompt="You are helpful.",
+    )
+
+    hf = _hf_tokens(tokenizer, messages, enable_thinking=True, tools=tools)
+    ours = _renderer_tokens(renderer, prefix + messages[1:])
+
+    hf_text = tokenizer.decode(hf)
+    our_text = tokenizer.decode(ours)
+    print(f"\n--- HF ---\n{hf_text}")
+    print(f"\n--- Ours ---\n{our_text}")
+    assert hf == ours, f"Token mismatch:\nHF:   {hf}\nOurs: {ours}"
+
+
 # ── Multi-turn with history truncation ───────────────────────────────────────
 
 

--- a/training/tests/unit/test_supervised_rendering.py
+++ b/training/tests/unit/test_supervised_rendering.py
@@ -5,7 +5,14 @@ import os
 import pytest
 import torch
 import tinker
-from tinker_cookbook.renderers import TrainOnWhat
+from tinker_cookbook.renderers import (
+    Message,
+    ParseTermination,
+    RenderContext,
+    Renderer,
+    TrainOnWhat,
+)
+from tinker_cookbook.renderers.base import RenderedMessage
 
 from training.utils.losses import make_batch_weighted_sft_loss_fn
 from training.utils.data import prepare_sampling_messages
@@ -100,6 +107,30 @@ class SplitRenderer:
 
     def build_supervised_example(self, messages, train_on_what):
         raise AssertionError("render_messages_to_datums should use split examples")
+
+
+class BaseToolPrefixRenderer(Renderer):
+    def __init__(self):
+        super().__init__(tokenizer=None)
+        self.calls: list[tuple[list[dict], TrainOnWhat]] = []
+
+    def get_stop_sequences(self):
+        return []
+
+    def render_message(self, message: Message, ctx: RenderContext) -> RenderedMessage:
+        raise AssertionError("test uses build_supervised_example directly")
+
+    def parse_response(self, response: list[int]) -> tuple[Message, ParseTermination]:
+        return Message(role="assistant", content=""), ParseTermination.EOS
+
+    def build_supervised_example(
+        self, messages, train_on_what=TrainOnWhat.LAST_ASSISTANT_MESSAGE
+    ):
+        self.calls.append((messages, train_on_what))
+        return (
+            torch.tensor([10, 11, 12], dtype=torch.int64),
+            torch.tensor([0, 1, 1], dtype=torch.float32),
+        )
 
 
 def test_render_messages_to_datum_preserves_multi_turn_weights():
@@ -281,6 +312,38 @@ def test_render_messages_to_datums_fails_fast_without_split_implementation():
             renderer=UnimplementedSplitRenderer(),
             train_on_what="all_assistant_messages",
         )
+
+
+def test_render_messages_to_datums_skips_unimplemented_base_tool_prefix():
+    renderer = BaseToolPrefixRenderer()
+    messages = [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "u"},
+        {"role": "assistant", "content": "a"},
+    ]
+
+    rendered = render_messages_to_datums(
+        messages,
+        renderer=renderer,
+        train_on_what="all_assistant_messages",
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "lookup",
+                    "description": "lookup",
+                    "parameters": {"type": "object"},
+                },
+            }
+        ],
+    )
+
+    assert len(rendered) == 1
+    assert [m["role"] for m in renderer.calls[0][0]] == [
+        "system",
+        "user",
+        "assistant",
+    ]
 
 
 def test_normalize_messages_supports_openai_tool_call_shape():

--- a/training/utils/supervised.py
+++ b/training/utils/supervised.py
@@ -68,6 +68,17 @@ def parse_train_on_what(value: str | TrainOnWhat) -> TrainOnWhat:
     return TrainOnWhat(value.lower())
 
 
+def _tool_prefix_builder(renderer: Renderer):
+    """Return the renderer's tool-prefix hook if it is actually implemented."""
+    prefix_builder = getattr(renderer, "create_conversation_prefix_with_tools", None)
+    if prefix_builder is None:
+        return None
+    class_builder = getattr(type(renderer), "create_conversation_prefix_with_tools", None)
+    if class_builder is Renderer.create_conversation_prefix_with_tools:
+        return None
+    return prefix_builder
+
+
 def resolve_renderer_name(
     tokenizer_model: str,
     renderer_name: str = "",
@@ -918,16 +929,16 @@ def render_messages_to_datums(
 
     When ``tools`` is provided (top-level OpenAI function-calling array
     with ``{"type": "function", "function": {...}}`` items) and the
-    renderer exposes ``create_conversation_prefix_with_tools``, the tool
-    definitions are encoded as a ``tool_declare``-role message and
+    renderer implements ``create_conversation_prefix_with_tools``, the
+    tool definitions are encoded as renderer-specific prefix messages and
     prepended to the conversation. An existing leading system message's
     content is preserved as the system prompt passed to the renderer.
-    Renderers without tool support silently drop the field.
+    Renderers without tool-prefix support silently drop the field.
     """
     normalized_messages = list(normalize_messages(messages))
 
     if tools:
-        prefix_builder = getattr(renderer, "create_conversation_prefix_with_tools", None)
+        prefix_builder = _tool_prefix_builder(renderer)
         if prefix_builder is not None:
             tool_specs = [
                 t["function"]


### PR DESCRIPTION
## Summary

- add top-level tool schema prefix support for the cookbook training renderers
- cover DeepSeek V4, GLM5, Kimi K2.7 Code, Mistral, Nemotron, and supervised rendering tests
- preserve the existing public advisor files already on `main`

## Validation

- `python3 -m py_compile training/renderer/deepseek_v4.py training/renderer/glm5.py training/renderer/kimi_k27_code.py training/renderer/mistral.py training/renderer/nemotron.py training/utils/supervised.py training/tests/unit/test_deepseek_v4_renderer.py training/tests/unit/test_glm5_renderer.py training/tests/unit/test_kimi_k27_code_renderer.py training/tests/unit/test_mistral_renderer.py training/tests/unit/test_nemotron_renderer.py training/tests/unit/test_supervised_rendering.py`
- `git diff --check`
- Focused pytest collection was attempted locally, but this machine has mismatched cookbook deps / Python 3.14 (`fireworks` missing, `tinker_cookbook.renderers.kimi_k26` missing, `ParseTermination` export mismatch); leaving full test execution to CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect how tool-bearing training prompts are tokenized across multiple model families; mistakes would cause train/serve skew for function-calling SFT, though scope is limited to prefix encoding and guarded by parity tests.
> 
> **Overview**
> **Top-level OpenAI `tools` arrays** can now be turned into model-specific prefix messages before SFT/inference rendering, so training prompts align with each tokenizer’s `apply_chat_template(tools=...)` behavior.
> 
> **DeepSeek V4** wraps bare function specs into OpenAI envelopes on a leading system message (`tools` field). **GLM5** emits the official `<tools>` JSON block (honoring `defer_loading` / `strict`). **Mistral** normalizes specs before staging `[AVAILABLE_TOOLS]`. **Nemotron** builds the full XML tool-declaration system block. **Kimi K2.7 Code** probes the tokenizer and chooses TypeScript-style `tool_declare` vs compact JSON.
> 
> **`render_messages_to_datums`** uses `_tool_prefix_builder` so only renderers that override the base `Renderer.create_conversation_prefix_with_tools` prepend tools; others ignore the field unchanged.
> 
> Unit tests assert token parity with HF/oracle for generation prompts and cover the supervised path (e.g. GLM5 `render_messages_to_datums` with tools).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7078ec9c1ff6ff382c04faf6133a4b250c6eafe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->