### PR TITLE
Default deployment cleanup to delete

### DIFF
--- a/skills/dev/SKILL.md
+++ b/skills/dev/SKILL.md
@@ -78,7 +78,8 @@ If the installed version doesn't satisfy the pin, upgrade first and retry. Only 
 1. **Shape first.** Prefer leaving `cfg.trainer.training_shape_id` unset so recipes auto-select the smallest validated shape that fits; set it only when you need an explicit override. The deployment shape comes from the profile. Manual infra fields are a mistake; the backend will reject or ignore them. See [`references/shapes.md`](references/shapes.md).
 2. **`WeightSyncScope.PER_TRAINER` is the default.** Set `DeployConfig(weight_sync_scope=WeightSyncScope.PER_TRAINER)` (the default). Do not combine it with `hot_load_deployment_id` — that field belongs to `PER_DEPLOYMENT`. Pick one bucket scope. See [`references/rl/hotload.md`](references/rl/hotload.md#weight-sync-scope-per_trainer-vs-per_deployment).
 3. **Fork, don't reinvent.** Training loop plumbing lives in `training/recipes/`. Fork the file that matches the task; do not rewire `FiretitanServiceClient` / `FiretitanTrainingClient` / deployment hotload from scratch.
-4. **Validate `output_model_id` before promote.** Server cap is 63 chars, charset `[a-z0-9-]`. A rejected promote orphans the sampler blob; the same `checkpoint_id` returns "not found in GCS" after GC. See [`references/checkpoints.md`](references/checkpoints.md#output_model_id-validation).
+4. **Cleanup deletes deployments by default.** Recipe `cleanup_on_exit=True` / distillation `cancel_on_exit=True` closes the trainer and deletes SDK-created deployments. Set cleanup off only when you deliberately want resources to survive. See [`references/recipes.md`](references/recipes.md#cleanup-lifecycle).
+5. **Validate `output_model_id` before promote.** Server cap is 63 chars, charset `[a-z0-9-]`. A rejected promote orphans the sampler blob; the same `checkpoint_id` returns "not found in GCS" after GC. See [`references/checkpoints.md`](references/checkpoints.md#output_model_id-validation).
 
 ---
 

--- a/skills/dev/references/recipes.md
+++ b/skills/dev/references/recipes.md
@@ -34,6 +34,10 @@ Distillation-specific: use `distillation_loop.py` for OPD/SDFT. Open [`distillat
 
 Auto-resume is scoped to one trainer. Pin both runs to the same trainer via `cfg.trainer.job_id` (all recipes; the reference trainer is SDK-managed, so there is no separate reference job id to pin), keep the same `log_path`, and rerun. `TrainingCheckpoints.resume()` lists the trainer's checkpoints on the control plane, picks the newest resumable row, and restores the rollout cursor from `dataloader.json`. See [`checkpoints.md`](checkpoints.md) for the full priority order and constraints.
 
+## Cleanup lifecycle
+
+Managed recipes that create a sampler deployment delete it when trainer cleanup is enabled. For RL/IGPO/async RL this is the default `Config.cleanup_on_exit=True`; for distillation it is `main(..., cancel_on_exit=True)` as used by the example entry points. Set cleanup off only when you deliberately want both trainer/deployment resources to survive for manual inspection or reuse.
+
 ## Init from another job
 
 ```python

--- a/skills/dev/references/rl/hotload.md
+++ b/skills/dev/references/rl/hotload.md
@@ -113,6 +113,8 @@ The structural / reachability errors (`invalid FW_HOSTED hot_load_bucket_url`, `
 
 `DeleteRlorTrainerJob` no longer hard-deletes the trainer row immediately — it transitions the row to `JOB_STATE_DELETED` and marks `DeletionTime`. A background GC hard-deletes rows after **30 days**, aligned with the RL-checkpoints GCS bucket lifecycle.
 
+Cookbook-managed RL recipes also request deployment deletion when `cleanup_on_exit=True` (the default), so sampler deployments created for a run are torn down with the trainer. Disable cleanup only when you intentionally want both resources left alive for inspection or reuse.
+
 During the 30-day retention window:
 - `list_checkpoints` on the deleted trainer keeps working.
 - `promote_checkpoint` keeps working — just pass `name` as usual.

--- a/training/README.md
+++ b/training/README.md
@@ -110,6 +110,9 @@ They do not require explicit trainer-job, deployment, or sampler setup.
 When `training_shape_id` is not set, the SDK selects validated runtime
 defaults. Explicit `training_shape_id`, `reference_training_shape_id`, and
 deployment-shape overrides still take precedence.
+When recipe cleanup is enabled (the default for RL-family recipes), the SDK
+closes the trainer and deletes SDK-created sampler deployments on exit. Disable
+cleanup only when you intentionally want resources to remain alive.
 
 To launch trainers with replicated HSDP, set the run-level replica count on
 `TrainerConfig`; it is not part of the validated training shape:

--- a/training/examples/manual/README.md
+++ b/training/examples/manual/README.md
@@ -27,8 +27,8 @@ Flags worth knowing:
 
 - `--deployment-id <id>` — reuse a warmed deployment across invocations
   (e.g. inspect the pod after the second run).
-- `--keep-resources` — skip trainer cancellation + deployment
-  scale-to-zero on exit. Default is to clean up.
+- `--keep-resources` — skip trainer cancellation + deployment cleanup on exit.
+  Default is to clean up.
 
 ## What to look for in the logs
 

--- a/training/examples/multihop_qa/train_multihop_qa_igpo.py
+++ b/training/examples/multihop_qa/train_multihop_qa_igpo.py
@@ -42,6 +42,7 @@ from training.examples.multihop_qa.multihop_qa_rollout import (
 from fireworks.training.sdk.client import GradAccNormalization
 
 from training.utils import (
+    CLEANUP_DEPLOYMENT_ON_CLOSE_DELETE,
     DEFAULT_ADAM,
     TrainerConfig,
     WandBConfig,
@@ -368,6 +369,9 @@ def main(cfg: MultiHopQAIGPOConfig | None = None) -> dict:
         deployment=deploy_cfg,
         hotload_timeout_s=WEIGHT_SYNC_TIMEOUT_S,
         cleanup_trainer_on_close=not cfg.policy_job_id,
+        cleanup_deployment_on_close=(
+            CLEANUP_DEPLOYMENT_ON_CLOSE_DELETE if not cfg.deployment_id else None
+        ),
         reference_required=use_reference,
     )
 

--- a/training/examples/rl/frozen_lake/train_frozen_lake.py
+++ b/training/examples/rl/frozen_lake/train_frozen_lake.py
@@ -43,6 +43,7 @@ from training.examples.rl.frozen_lake.masking import (
 from fireworks.training.sdk.client import GradAccNormalization
 
 from training.utils import (
+    CLEANUP_DEPLOYMENT_ON_CLOSE_DELETE,
     DEFAULT_ADAM,
     TrainerConfig,
     WandBConfig,
@@ -495,6 +496,9 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
         deployment=deploy_cfg,
         hotload_timeout_s=WEIGHT_SYNC_TIMEOUT_S,
         cleanup_trainer_on_close=not cfg.policy_job_id,
+        cleanup_deployment_on_close=(
+            CLEANUP_DEPLOYMENT_ON_CLOSE_DELETE if not cfg.deployment_id else None
+        ),
         reference_required=use_reference,
     )
 

--- a/training/examples/tools/verify_logprobs.py
+++ b/training/examples/tools/verify_logprobs.py
@@ -40,6 +40,7 @@ from fireworks.training.sdk import (
     DeploymentManager,
 )
 from training.utils import (
+    CLEANUP_DEPLOYMENT_ON_CLOSE_DELETE,
     TrainerConfig,
     DeployConfig,
     ReconnectableClient,
@@ -223,6 +224,9 @@ def main():
             tokenizer_model=args.tokenizer,
         ),
         cleanup_trainer_on_close=args.cleanup,
+        cleanup_deployment_on_close=(
+            CLEANUP_DEPLOYMENT_ON_CLOSE_DELETE if args.cleanup and not args.deployment_id else None
+        ),
         reference_required=use_reference,
     )
 
@@ -411,10 +415,8 @@ def main():
         else:
             logger.error("  No valid comparisons completed!")
 
-        # Trainers are deleted by service.close() (cleanup_trainer_on_close);
-        # scale the deployment we created to zero on cleanup.
-        if args.cleanup and not args.deployment_id:
-            deploy_mgr.scale_to_zero(dep_id)
+        # Trainers and generated deployments are deleted by service.close()
+        # when cleanup is enabled. User-supplied deployments are left alone.
 
 
 if __name__ == "__main__":

--- a/training/provision/README.md
+++ b/training/provision/README.md
@@ -99,8 +99,9 @@ uv run python provision.py --config /path/to/my_fireworks.yaml --recipe rl
 
 ### Lifecycle and flags
 
-- Resources the script creates are cleaned up on exit; resources you reattach to
-  (by setting `job_id` / `deployment_id` in the YAML) are left running.
+- Resources the script creates are cleaned up on exit; trainer jobs are closed
+  and SDK-created deployments are deleted. Resources you reattach to (by setting
+  `job_id` / `deployment_id` in the YAML) are left running.
 - `--cleanup-existing` also tears down reattached resources on exit.
 - `--progress-interval-s` (default 15) controls heartbeat cadence.
 - `--health-check-interval-s` (default 60) controls how often resources are

--- a/training/provision/provision.py
+++ b/training/provision/provision.py
@@ -27,6 +27,7 @@ from fireworks.training.sdk.client import FiretitanTrainingClient
 
 from training.utils import (
     AdaptiveConcurrencyController,
+    CLEANUP_DEPLOYMENT_ON_CLOSE_DELETE,
     ConcurrencyConfig,
     DeployConfig,
     ReconnectableClient,
@@ -456,7 +457,7 @@ def _build_managed_service(
     )
     resolved_deployment_cleanup = None
     if should_cleanup_deployment:
-        resolved_deployment_cleanup = cleanup_deployment_on_close or "scale_to_zero"
+        resolved_deployment_cleanup = cleanup_deployment_on_close or CLEANUP_DEPLOYMENT_ON_CLOSE_DELETE
     return build_service_client(
         api_key=api_key,
         base_url=base_url,

--- a/training/provision/tests/test_provision.py
+++ b/training/provision/tests/test_provision.py
@@ -97,7 +97,7 @@ def test_init_enables_cleanup_for_fresh_resources(monkeypatch: pytest.MonkeyPatc
     )
 
     assert calls[0]["cleanup_trainer_on_close"] is True
-    assert calls[0]["cleanup_deployment_on_close"] == "scale_to_zero"
+    assert calls[0]["cleanup_deployment_on_close"] == "delete"
 
 
 def test_init_does_not_cleanup_existing_resources_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -130,7 +130,7 @@ def test_init_can_cleanup_existing_resources_when_requested(monkeypatch: pytest.
     )
 
     assert calls[0]["cleanup_trainer_on_close"] is True
-    assert calls[0]["cleanup_deployment_on_close"] == "scale_to_zero"
+    assert calls[0]["cleanup_deployment_on_close"] == "delete"
 
 
 def test_progress_line_includes_resource_ids(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/training/recipes/async_rl_loop.py
+++ b/training/recipes/async_rl_loop.py
@@ -49,7 +49,7 @@ from fireworks.training.sdk.training_spec import (
 
 from training.utils.client import GradAccNormalization
 from training.utils import (
-    CLEANUP_DEPLOYMENT_ON_CLOSE_SCALE_TO_ZERO,
+    CLEANUP_DEPLOYMENT_ON_CLOSE_DELETE,
     DEFAULT_ADAM,
     DeployConfig,
     TrainerConfig,
@@ -388,7 +388,7 @@ def main(
             hotload_timeout_s=cfg.weight_sync_timeout,
             cleanup_trainer_on_close=cfg.cleanup_on_exit,
             cleanup_deployment_on_close=(
-                CLEANUP_DEPLOYMENT_ON_CLOSE_SCALE_TO_ZERO if cfg.cleanup_on_exit else None
+                CLEANUP_DEPLOYMENT_ON_CLOSE_DELETE if cfg.cleanup_on_exit else None
             ),
             reference_required=cfg.kl_beta > 0,
         )

--- a/training/recipes/distillation_loop.py
+++ b/training/recipes/distillation_loop.py
@@ -35,7 +35,7 @@ import tinker
 from fireworks.training.sdk.client import GradAccNormalization
 from fireworks.training.sdk.deployment import AdaptiveConcurrencyController, DeploymentConfig
 from training.utils import (
-    CLEANUP_DEPLOYMENT_ON_CLOSE_SCALE_TO_ZERO,
+    CLEANUP_DEPLOYMENT_ON_CLOSE_DELETE,
     DEFAULT_ADAM,
     ConcurrencyConfig,
     DeployConfig,
@@ -371,7 +371,7 @@ def _resolve_teacher_runtime(
                 for_training=True,
             ),
             timeout_s=cfg.teacher_deployment_timeout_s,
-            cleanup_on_close=CLEANUP_DEPLOYMENT_ON_CLOSE_SCALE_TO_ZERO if cancel_on_exit else None,
+            cleanup_on_close=CLEANUP_DEPLOYMENT_ON_CLOSE_DELETE if cancel_on_exit else None,
             tokenizer=tokenizer,
         )
         resolved_models[spec.model] = sampler.model
@@ -518,7 +518,7 @@ def main(
             hotload_timeout_s=cfg.weight_sync_timeout,
             cleanup_trainer_on_close=cancel_on_exit,
             cleanup_deployment_on_close=(
-                CLEANUP_DEPLOYMENT_ON_CLOSE_SCALE_TO_ZERO if cancel_on_exit else None
+                CLEANUP_DEPLOYMENT_ON_CLOSE_DELETE if cancel_on_exit else None
             ),
             reference_required=False,
         )

--- a/training/recipes/igpo_loop.py
+++ b/training/recipes/igpo_loop.py
@@ -35,7 +35,7 @@ import tinker
 
 from training.utils.client import GradAccNormalization
 from training.utils import (
-    CLEANUP_DEPLOYMENT_ON_CLOSE_SCALE_TO_ZERO,
+    CLEANUP_DEPLOYMENT_ON_CLOSE_DELETE,
     DEFAULT_ADAM,
     TrainerConfig,
     RunnerConfig,
@@ -296,7 +296,7 @@ def main(
             hotload_timeout_s=cfg.weight_sync_timeout,
             cleanup_trainer_on_close=cfg.cleanup_on_exit,
             cleanup_deployment_on_close=(
-                CLEANUP_DEPLOYMENT_ON_CLOSE_SCALE_TO_ZERO if cfg.cleanup_on_exit else None
+                CLEANUP_DEPLOYMENT_ON_CLOSE_DELETE if cfg.cleanup_on_exit else None
             ),
             reference_required=cfg.kl_beta > 0,
         )

--- a/training/recipes/rl_loop.py
+++ b/training/recipes/rl_loop.py
@@ -40,7 +40,7 @@ import tinker
 
 from training.utils.client import GradAccNormalization
 from training.utils import (
-    CLEANUP_DEPLOYMENT_ON_CLOSE_SCALE_TO_ZERO,
+    CLEANUP_DEPLOYMENT_ON_CLOSE_DELETE,
     DEFAULT_ADAM,
     AdaptiveConcurrencyController,
     ConcurrencyConfig,
@@ -415,7 +415,7 @@ def main(
             hotload_timeout_s=cfg.weight_sync_timeout,
             cleanup_trainer_on_close=cfg.cleanup_on_exit,
             cleanup_deployment_on_close=(
-                CLEANUP_DEPLOYMENT_ON_CLOSE_SCALE_TO_ZERO if cfg.cleanup_on_exit else None
+                CLEANUP_DEPLOYMENT_ON_CLOSE_DELETE if cfg.cleanup_on_exit else None
             ),
             reference_required=cfg.kl_beta > 0,
         )

--- a/training/tests/unit/test_async_rl_loop_runner.py
+++ b/training/tests/unit/test_async_rl_loop_runner.py
@@ -177,7 +177,7 @@ def test_main_requests_cleanup_for_sdk_created_resources(monkeypatch: pytest.Mon
     assert kwargs["cleanup_trainer_on_close"] is True
     assert (
         kwargs["cleanup_deployment_on_close"]
-        == async_rl_loop.CLEANUP_DEPLOYMENT_ON_CLOSE_SCALE_TO_ZERO
+        == async_rl_loop.CLEANUP_DEPLOYMENT_ON_CLOSE_DELETE
     )
 
 

--- a/training/tests/unit/test_distillation.py
+++ b/training/tests/unit/test_distillation.py
@@ -24,7 +24,7 @@ from training.recipes.distillation_loop import (
     main as run_opd_main,
 )
 from training.utils import (
-    CLEANUP_DEPLOYMENT_ON_CLOSE_SCALE_TO_ZERO,
+    CLEANUP_DEPLOYMENT_ON_CLOSE_DELETE,
     DeployConfig,
     RunnerConfig,
     TrainerConfig,
@@ -1190,7 +1190,7 @@ def test_resolve_teacher_runtime_reuses_duplicate_base_model_deployment() -> Non
     assert len(service.deployment_calls) == 1
     call = service.deployment_calls[0]
     assert call["timeout_s"] == 123
-    assert call["cleanup_on_close"] == CLEANUP_DEPLOYMENT_ON_CLOSE_SCALE_TO_ZERO
+    assert call["cleanup_on_close"] == CLEANUP_DEPLOYMENT_ON_CLOSE_DELETE
     assert call["tokenizer"] == "tok"
     assert call["config"].base_model == teacher_model
     assert call["config"].min_replica_count == 2

--- a/training/tests/unit/test_rl_loop.py
+++ b/training/tests/unit/test_rl_loop.py
@@ -179,7 +179,7 @@ def test_main_requests_cleanup_for_sdk_created_resources(monkeypatch):
     assert kwargs["cleanup_trainer_on_close"] is True
     assert (
         kwargs["cleanup_deployment_on_close"]
-        == module.CLEANUP_DEPLOYMENT_ON_CLOSE_SCALE_TO_ZERO
+        == module.CLEANUP_DEPLOYMENT_ON_CLOSE_DELETE
     )
 
 
@@ -228,7 +228,7 @@ def test_main_delegates_trainer_cleanup_for_existing_id_to_sdk(monkeypatch):
     assert kwargs["cleanup_trainer_on_close"] is True
     assert (
         kwargs["cleanup_deployment_on_close"]
-        == module.CLEANUP_DEPLOYMENT_ON_CLOSE_SCALE_TO_ZERO
+        == module.CLEANUP_DEPLOYMENT_ON_CLOSE_DELETE
     )
 
 

--- a/training/utils/__init__.py
+++ b/training/utils/__init__.py
@@ -36,6 +36,7 @@ del _warnings
 
 __all__ = [
     "AdaptiveConcurrencyController",
+    "CLEANUP_DEPLOYMENT_ON_CLOSE_DELETE",
     "CLEANUP_DEPLOYMENT_ON_CLOSE_SCALE_TO_ZERO",
     "GradAccNormalization",
     "AppendOnlyPickleLog",
@@ -112,6 +113,10 @@ __all__ = [
 
 from fireworks.training.sdk import CLEANUP_DEPLOYMENT_ON_CLOSE_SCALE_TO_ZERO
 from fireworks.training.sdk.deployment import AdaptiveConcurrencyController
+
+# The SDK accepts "delete" for deployment close cleanup. Keep the cookbook
+# default explicit so trainer cleanup tears down associated serving resources.
+CLEANUP_DEPLOYMENT_ON_CLOSE_DELETE = "delete"
 
 from training.utils.client import GradAccNormalization, ReconnectableClient
 from training.utils.config import (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Default cookbook-managed deployment cleanup to `delete` when trainer cleanup is enabled.
- Apply the same behavior to RL/distillation recipes, standalone provisioning, and direct example/tool entry points that create deployments.
- Update tests and lifecycle guidance in README/skill docs.

## Testing
- `python3 -m py_compile training/utils/__init__.py training/recipes/rl_loop.py training/recipes/async_rl_loop.py training/recipes/igpo_loop.py training/recipes/distillation_loop.py training/provision/provision.py training/examples/rl/frozen_lake/train_frozen_lake.py training/examples/multihop_qa/train_multihop_qa_igpo.py training/examples/tools/verify_logprobs.py training/tests/unit/test_rl_loop.py training/tests/unit/test_async_rl_loop_runner.py training/tests/unit/test_distillation.py training/provision/tests/test_provision.py`
- Attempted focused pytest cleanup tests; collection is blocked in this base environment because `tinker` and `fireworks` are not installed.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://fireworks-ai.slack.com/archives/C07JZTHEG95/p1782702777021419?thread_ts=1782702777.021419&cid=C07JZTHEG95)

<div><a href="https://cursor.com/agents/bc-7d7eb652-2cf3-5361-9ab4-6f0201ce8495"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d7eb652-2cf3-5361-9ab4-6f0201ce8495"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

