### PR TITLE
fix(renderer): add Qwen3.7 thinking support

### DIFF
--- a/training/renderer/_qwen3_split.py
+++ b/training/renderer/_qwen3_split.py
@@ -1,4 +1,4 @@
-"""Local Qwen3 / Qwen3.5 / Qwen3.6 renderers with multi-turn SFT disaggregate support.
+"""Local Qwen3 / Qwen3.5 / Qwen3.6 / Qwen3.7 renderers.
 
 Upstream ``tinker_cookbook.renderers.qwen3`` and
 ``tinker_cookbook.renderers.qwen3_5`` ship without a
@@ -16,7 +16,16 @@ override before any caller resolves a renderer via ``get_renderer``.
 
 from __future__ import annotations
 
+import dataclasses
+
+import tinker
 from tinker_cookbook.renderers import register_renderer
+from tinker_cookbook.renderers.base import (
+    Message,
+    RenderContext,
+    RenderedMessage,
+    TrainOnWhat,
+)
 from tinker_cookbook.renderers.qwen3 import (
     Qwen3DisableThinkingRenderer,
     Qwen3Renderer,
@@ -45,9 +54,7 @@ class Qwen3VLSplitRenderer(DisaggregateMultiTurnMixin, Qwen3VLRenderer):
     pass
 
 
-class Qwen3VLInstructSplitRenderer(
-    DisaggregateMultiTurnMixin, Qwen3VLInstructRenderer
-):
+class Qwen3VLInstructSplitRenderer(DisaggregateMultiTurnMixin, Qwen3VLInstructRenderer):
     pass
 
 
@@ -175,12 +182,201 @@ class Qwen3_6PreserveThinkingSplitRenderer(Qwen3_5SplitRenderer):
         has_think = False
         if isinstance(content, list):
             has_think = any(
-                isinstance(p, dict) and p.get("type") == "thinking"
-                for p in content
+                isinstance(p, dict) and p.get("type") == "thinking" for p in content
             )
         elif isinstance(content, str):
             has_think = "<think>" in content
         return "" if has_think else "<think>\n\n</think>\n\n"
+
+
+class _Qwen3_7TemplateMixin:
+    """Qwen3.7 template deltas on top of the Qwen3.6 renderer family.
+
+    Qwen3.7 keeps the Qwen3.6 vocabulary, special tokens, thinking blocks,
+    XML tool-call format, parser, and stop token. Its stock template differs
+    in three places that the upstream Qwen3.5 renderer does not model:
+
+    * An assistant remains in the active query/tool chain until the next real
+      user query, so its thinking stays visible while tool results are added.
+    * Consecutive tool results share one ``user`` envelope.
+    * Tool declarations retain their OpenAI
+      ``{"type":"function","function":...}`` wrapper.
+
+    Everything else deliberately delegates to Qwen3.6.
+    """
+
+    @staticmethod
+    def _visible_text(message: Message) -> str:
+        content = message.get("content", "")
+        if isinstance(content, str):
+            return content
+        return "".join(
+            part.get("text", "")
+            for part in content
+            if isinstance(part, dict) and part.get("type") == "text"
+        )
+
+    def _format_tool_calls_chunks(self, message: Message):
+        """Match Qwen3.7's conditional separator before the first tool call."""
+        assert "tool_calls" in message, "tool_calls are required to format tool calls"
+        separator = "\n\n" if self._visible_text(message).strip() else ""
+        return [
+            {
+                "type": "text",
+                "text": separator
+                + "\n".join(
+                    self._format_tool_call_xml(tool_call)
+                    for tool_call in message["tool_calls"]
+                ),
+            }
+        ]
+
+    def _render_tool_response(
+        self,
+        message: Message,
+        ctx: RenderContext,
+    ) -> RenderedMessage:
+        """Render consecutive tool results in one HF-compatible user turn.
+
+        ``RenderContext`` has the previous message but no look-ahead. A tool
+        group is opened by its first result, continued without another header,
+        and closed either at the conversation tail or by the following
+        non-tool message's header.
+        """
+        first_in_group = not (
+            ctx.prev_message is not None and ctx.prev_message.get("role") == "tool"
+        )
+        header_text = ""
+        if first_in_group:
+            maybe_newline = "\n" if ctx.idx > 0 else ""
+            header_text = f"{maybe_newline}<|im_start|>user"
+
+        content = self._visible_text(message).strip()
+        output_text = f"\n<tool_response>\n{content}\n</tool_response>"
+        if ctx.is_last:
+            output_text += "<|im_end|>"
+
+        header = None
+        if header_text:
+            header = tinker.types.EncodedTextChunk(
+                tokens=self.tokenizer.encode(
+                    header_text,
+                    add_special_tokens=False,
+                )
+            )
+        return RenderedMessage(
+            header=header,
+            output=[
+                tinker.types.EncodedTextChunk(
+                    tokens=self.tokenizer.encode(
+                        output_text,
+                        add_special_tokens=False,
+                    )
+                )
+            ],
+            stop_overlap=(
+                tinker.types.EncodedTextChunk(
+                    tokens=self.tokenizer.encode("\n", add_special_tokens=False)
+                )
+                if ctx.is_last
+                else None
+            ),
+        )
+
+    def render_message(
+        self,
+        message: Message,
+        ctx: RenderContext,
+    ) -> RenderedMessage:
+        if message["role"] == "tool":
+            return self._render_tool_response(message, ctx)
+
+        # HF's ``last_query_index`` is the last real user query, not the last
+        # message. Mark assistants in an active tool chain as current so the
+        # inherited renderer retains their thinking in default mode.
+        inherited_ctx = ctx
+        if message["role"] == "assistant":
+            inherited_ctx = dataclasses.replace(
+                ctx,
+                is_last=ctx.idx > ctx.last_user_index,
+            )
+        rendered = super().render_message(message, inherited_ctx)
+
+        # A non-tool message closes the preceding tool-result group. The
+        # inherited header already starts with the newline after <|im_end|>.
+        if ctx.prev_message is not None and ctx.prev_message.get("role") == "tool":
+            end_tokens = self.tokenizer.encode(
+                "<|im_end|>",
+                add_special_tokens=False,
+            )
+            old_header_tokens = list(rendered.header.tokens) if rendered.header else []
+            rendered = RenderedMessage(
+                header=tinker.types.EncodedTextChunk(
+                    tokens=end_tokens + old_header_tokens
+                ),
+                output=rendered.output,
+                stop_overlap=rendered.stop_overlap,
+            )
+        if ctx.is_last:
+            rendered = RenderedMessage(
+                header=rendered.header,
+                output=rendered.output,
+                stop_overlap=tinker.types.EncodedTextChunk(
+                    tokens=self.tokenizer.encode("\n", add_special_tokens=False)
+                ),
+            )
+        return rendered
+
+    def create_conversation_prefix_with_tools(
+        self,
+        tools,
+        system_prompt: str = "",
+    ):
+        """Keep OpenAI wrappers exactly as Qwen3.7's HF template serializes them."""
+        wrapped_tools = [{"type": "function", "function": tool} for tool in tools]
+        return super().create_conversation_prefix_with_tools(
+            wrapped_tools,
+            system_prompt=system_prompt,
+        )
+
+    def build_supervised_example(
+        self,
+        messages,
+        train_on_what=TrainOnWhat.LAST_ASSISTANT_MESSAGE,
+    ):
+        """Add HF's final newline as a masked, template-injected token.
+
+        Generation prompts get this newline from the following assistant
+        header. A closed conversation has no following header, while the HF
+        template still emits ``<|im_end|>\n``. Keep the extra token out of the
+        loss because it is not part of the model's ``<|im_end|>`` stop signal.
+        """
+        model_input, weights = super().build_supervised_example(
+            messages,
+            train_on_what=train_on_what,
+        )
+        newline_tokens = self.tokenizer.encode("\n", add_special_tokens=False)
+        if newline_tokens:
+            weights[-len(newline_tokens) :] = 0
+        return model_input, weights
+
+
+class Qwen3_7SplitRenderer(_Qwen3_7TemplateMixin, Qwen3_6SplitRenderer):
+    pass
+
+
+class Qwen3_7DisableThinkingSplitRenderer(
+    _Qwen3_7TemplateMixin,
+    Qwen3_6DisableThinkingSplitRenderer,
+):
+    pass
+
+
+class Qwen3_7PreserveThinkingSplitRenderer(
+    _Qwen3_7TemplateMixin,
+    Qwen3_6PreserveThinkingSplitRenderer,
+):
+    pass
 
 
 register_renderer("qwen3", lambda tok, ip=None: Qwen3SplitRenderer(tok))
@@ -202,9 +398,7 @@ register_renderer(
 )
 register_renderer(
     "qwen3_5_disable_thinking",
-    lambda tok, ip=None: Qwen3_5DisableThinkingSplitRenderer(
-        tok, image_processor=ip
-    ),
+    lambda tok, ip=None: Qwen3_5DisableThinkingSplitRenderer(tok, image_processor=ip),
 )
 register_renderer(
     "qwen3_6",
@@ -212,13 +406,27 @@ register_renderer(
 )
 register_renderer(
     "qwen3_6_disable_thinking",
-    lambda tok, ip=None: Qwen3_6DisableThinkingSplitRenderer(
-        tok, image_processor=ip
-    ),
+    lambda tok, ip=None: Qwen3_6DisableThinkingSplitRenderer(tok, image_processor=ip),
 )
 register_renderer(
     "qwen3_6_preserve_thinking",
-    lambda tok, ip=None: Qwen3_6PreserveThinkingSplitRenderer(
-        tok, image_processor=ip
+    lambda tok, ip=None: Qwen3_6PreserveThinkingSplitRenderer(tok, image_processor=ip),
+)
+register_renderer(
+    "qwen3_7",
+    lambda tok, ip=None: Qwen3_7SplitRenderer(tok, image_processor=ip),
+)
+register_renderer(
+    "qwen3_7_disable_thinking",
+    lambda tok, ip=None: Qwen3_7DisableThinkingSplitRenderer(
+        tok,
+        image_processor=ip,
+    ),
+)
+register_renderer(
+    "qwen3_7_preserve_thinking",
+    lambda tok, ip=None: Qwen3_7PreserveThinkingSplitRenderer(
+        tok,
+        image_processor=ip,
     ),
 )

--- a/training/renderer/_qwen3_split.py
+++ b/training/renderer/_qwen3_split.py
@@ -17,6 +17,7 @@ override before any caller resolves a renderer via ``get_renderer``.
 from __future__ import annotations
 
 import dataclasses
+from typing import cast
 
 import tinker
 from tinker_cookbook.renderers import register_renderer
@@ -27,10 +28,12 @@ from tinker_cookbook.renderers.base import (
     TrainOnWhat,
 )
 from tinker_cookbook.renderers.qwen3 import (
+    ImageProcessorProtocol,
     Qwen3DisableThinkingRenderer,
     Qwen3Renderer,
     Qwen3VLInstructRenderer,
     Qwen3VLRenderer,
+    image_to_chunk,
 )
 from tinker_cookbook.renderers.qwen3_5 import (
     Qwen3_5DisableThinkingRenderer,
@@ -251,10 +254,75 @@ class _Qwen3_7TemplateMixin:
             maybe_newline = "\n" if ctx.idx > 0 else ""
             header_text = f"{maybe_newline}<|im_start|>user"
 
-        content = self._visible_text(message).strip()
-        output_text = f"\n<tool_response>\n{content}\n</tool_response>"
+        content = message.get("content", "")
+        if isinstance(content, str):
+            trimmed_content: str | list[dict] = content.strip()
+        else:
+            # The HF template applies ``|trim`` after rendering the complete
+            # multimodal tool result. Preserve image boundaries while removing
+            # whitespace only from the outermost text parts.
+            trimmed_content = [dict(part) for part in content]
+            for part in trimmed_content:
+                if part.get("type") == "text":
+                    part["text"] = part.get("text", "").lstrip()
+                    if part["text"]:
+                        break
+                elif part.get("type") == "image":
+                    break
+            for part in reversed(trimmed_content):
+                if part.get("type") == "text":
+                    part["text"] = part.get("text", "").rstrip()
+                    if part["text"]:
+                        break
+                elif part.get("type") == "image":
+                    break
+
+        content_message = dict(message)
+        content_message["content"] = trimmed_content
+        content_parts = self._preprocess_message_parts(content_message)
+        output_parts = [
+            {"type": "text", "text": "\n<tool_response>\n"},
+            *content_parts,
+            {"type": "text", "text": "\n</tool_response>"},
+        ]
         if ctx.is_last:
-            output_text += "<|im_end|>"
+            output_parts.append({"type": "text", "text": "<|im_end|>"})
+
+        merged_output_parts: list[dict] = []
+        for part in output_parts:
+            if (
+                part["type"] == "text"
+                and merged_output_parts
+                and merged_output_parts[-1]["type"] == "text"
+            ):
+                merged_output_parts[-1]["text"] += part["text"]
+            else:
+                merged_output_parts.append(dict(part))
+
+        output: list[tinker.ModelInputChunk] = []
+        for part in merged_output_parts:
+            if part["type"] == "image":
+                assert self.image_processor is not None, (
+                    "image_processor is required to render image content"
+                )
+                output.append(
+                    image_to_chunk(
+                        image_or_str=part["image"],
+                        image_processor=cast(
+                            ImageProcessorProtocol,
+                            self.image_processor,
+                        ),
+                    )
+                )
+            else:
+                output.append(
+                    tinker.types.EncodedTextChunk(
+                        tokens=self.tokenizer.encode(
+                            part["text"],
+                            add_special_tokens=False,
+                        )
+                    )
+                )
 
         header = None
         if header_text:
@@ -266,14 +334,7 @@ class _Qwen3_7TemplateMixin:
             )
         return RenderedMessage(
             header=header,
-            output=[
-                tinker.types.EncodedTextChunk(
-                    tokens=self.tokenizer.encode(
-                        output_text,
-                        add_special_tokens=False,
-                    )
-                )
-            ],
+            output=output,
             stop_overlap=(
                 tinker.types.EncodedTextChunk(
                     tokens=self.tokenizer.encode("\n", add_special_tokens=False)
@@ -288,6 +349,13 @@ class _Qwen3_7TemplateMixin:
         message: Message,
         ctx: RenderContext,
     ) -> RenderedMessage:
+        if message["role"] == "system" and isinstance(message.get("content"), list):
+            if any(
+                isinstance(part, dict) and part.get("type") == "image"
+                for part in message["content"]
+            ):
+                raise ValueError("System message cannot contain images.")
+
         if message["role"] == "tool":
             return self._render_tool_response(message, ctx)
 
@@ -379,6 +447,23 @@ class Qwen3_7PreserveThinkingSplitRenderer(
     pass
 
 
+# Dedicated VL aliases keep model resolution explicit. The implementation is
+# intentionally shared with the text aliases: Qwen3.7 uses Qwen3.5's vision
+# tokens and image-chunk transport, while the Qwen3.7 mixin supplies the exact
+# thinking/tool-history template deltas. The separate names ensure only VL
+# checkpoints load an image processor.
+class Qwen3_7VLSplitRenderer(Qwen3_7SplitRenderer):
+    pass
+
+
+class Qwen3_7VLDisableThinkingSplitRenderer(Qwen3_7DisableThinkingSplitRenderer):
+    pass
+
+
+class Qwen3_7VLPreserveThinkingSplitRenderer(Qwen3_7PreserveThinkingSplitRenderer):
+    pass
+
+
 register_renderer("qwen3", lambda tok, ip=None: Qwen3SplitRenderer(tok))
 register_renderer(
     "qwen3_disable_thinking",
@@ -426,6 +511,24 @@ register_renderer(
 register_renderer(
     "qwen3_7_preserve_thinking",
     lambda tok, ip=None: Qwen3_7PreserveThinkingSplitRenderer(
+        tok,
+        image_processor=ip,
+    ),
+)
+register_renderer(
+    "qwen3_7_vl",
+    lambda tok, ip=None: Qwen3_7VLSplitRenderer(tok, image_processor=ip),
+)
+register_renderer(
+    "qwen3_7_vl_disable_thinking",
+    lambda tok, ip=None: Qwen3_7VLDisableThinkingSplitRenderer(
+        tok,
+        image_processor=ip,
+    ),
+)
+register_renderer(
+    "qwen3_7_vl_preserve_thinking",
+    lambda tok, ip=None: Qwen3_7VLPreserveThinkingSplitRenderer(
         tok,
         image_processor=ip,
     ),

--- a/training/renderer/verifier/utils/hf_parity.py
+++ b/training/renderer/verifier/utils/hf_parity.py
@@ -34,7 +34,7 @@ from tinker_cookbook.tokenizer_utils import get_tokenizer
 # renderer names (glm5, gemma4, minimax_m2, nemotron) under
 # ``tinker_cookbook.renderers.get_renderer``.
 import training.renderer  # noqa: F401
-from training.utils.supervised import normalize_messages
+from training.utils.supervised import prepare_messages_with_tools
 
 
 @dataclasses.dataclass
@@ -78,6 +78,7 @@ def compare_renderer_to_hf(
     renderer_name: str,
     tokenizer_model: str,
     messages: list[dict],
+    tools: list[dict] | None = None,
     add_generation_prompt: bool = True,
     apply_chat_template_kwargs: dict[str, Any] | None = None,
 ) -> HFParityResult:
@@ -95,7 +96,11 @@ def compare_renderer_to_hf(
         )
 
     renderer = get_renderer(renderer_name, tokenizer)
-    normalized = normalize_messages(messages)
+    normalized = prepare_messages_with_tools(
+        messages,
+        renderer=renderer,
+        tools=tools,
+    )
 
     if add_generation_prompt:
         renderer_input = renderer.build_generation_prompt(normalized, role="assistant")
@@ -107,6 +112,7 @@ def compare_renderer_to_hf(
     # ``BatchEncoding`` depending on the transformers version; normalize.
     hf_result = tokenizer.apply_chat_template(
         messages,
+        tools=tools,
         tokenize=True,
         add_generation_prompt=add_generation_prompt,
         **(apply_chat_template_kwargs or {}),

--- a/training/renderer/verifier/utils/probe.py
+++ b/training/renderer/verifier/utils/probe.py
@@ -37,7 +37,7 @@ from tinker_cookbook.renderers.base import (
 # renderers ("glm5", "gemma4", etc.) under the names exposed by
 # ``tinker_cookbook.renderers.get_renderer``.
 import training.renderer  # noqa: F401
-from training.utils.supervised import normalize_messages
+from training.utils.supervised import normalize_messages, prepare_messages_with_tools
 
 logger = logging.getLogger(__name__)
 
@@ -86,7 +86,9 @@ def resolve_dispatch(
 
         api_key = api_key or _os.environ.get("FIREWORKS_API_KEY")
         if not api_key:
-            raise DispatchError("FIREWORKS_API_KEY not set; cannot resolve deployment_id")
+            raise DispatchError(
+                "FIREWORKS_API_KEY not set; cannot resolve deployment_id"
+            )
         base_url = base_url or _os.environ.get(
             "FIREWORKS_BASE_URL", "https://api.fireworks.ai"
         )
@@ -373,7 +375,9 @@ def _call_completion(
         kwargs.update(extra_kwargs)
 
     response = client.chat.completions.create(**kwargs)
-    payload = response.model_dump() if hasattr(response, "model_dump") else dict(response)
+    payload = (
+        response.model_dump() if hasattr(response, "model_dump") else dict(response)
+    )
 
     prompt_ids = payload.get("prompt_token_ids")
     completion_ids: list[int] = []
@@ -437,7 +441,11 @@ def run_probe(
     The artifact is JSON-serialisable. The caller writes it to disk.
     """
     renderer = get_renderer(renderer_name, tokenizer)
-    normalized = normalize_messages(messages)
+    normalized = prepare_messages_with_tools(
+        messages,
+        renderer=renderer,
+        tools=tools,
+    )
 
     # 1) Local prompt render
     prompt_input = renderer.build_generation_prompt(normalized, role="assistant")
@@ -468,10 +476,8 @@ def run_probe(
         and len(completion_tokens) >= len(api_prompt_tokens)
         and completion_tokens[: len(api_prompt_tokens)] == api_prompt_tokens
     ):
-        completion_tokens = completion_tokens[len(api_prompt_tokens):]
-        completion_text = tokenizer.decode(
-            completion_tokens, skip_special_tokens=False
-        )
+        completion_tokens = completion_tokens[len(api_prompt_tokens) :]
+        completion_text = tokenizer.decode(completion_tokens, skip_special_tokens=False)
         echo_stripped = True
 
     # 3) Round-trip the completion through the renderer's parser so the
@@ -489,8 +495,7 @@ def run_probe(
         completion_message: Any = parsed_msg
     else:
         completion_message = {"role": "assistant", "content": completion_text}
-    full_messages_raw = list(messages) + [completion_message]
-    full_messages = normalize_messages(full_messages_raw)
+    full_messages = normalized + normalize_messages([completion_message])
 
     # Authoritative source for tokens AND per-token weights: the renderer's
     # own build_supervised_example. This honours per-renderer customization
@@ -517,7 +522,9 @@ def run_probe(
         # Pad span_refs so downstream indexing doesn't crash; the sanity flag
         # tells the human something is off and the audit table will look weird.
         if len(span_refs) < len(full_tokens):
-            span_refs = span_refs + [span_refs[-1]] * (len(full_tokens) - len(span_refs))
+            span_refs = span_refs + [span_refs[-1]] * (
+                len(full_tokens) - len(span_refs)
+            )
         else:
             span_refs = span_refs[: len(full_tokens)]
 
@@ -540,7 +547,9 @@ def run_probe(
         "full_render_prompt_prefix_matches_api": (
             full_tokens[: len(api_prompt_tokens)] == api_prompt_tokens
         ),
-        "tokenization_diverged_count": sum(1 for p in provenance if p == _PROV_DIVERGED),
+        "tokenization_diverged_count": sum(
+            1 for p in provenance if p == _PROV_DIVERGED
+        ),
         "echo_prompt_stripped": echo_stripped,
         "completion_token_count": len(completion_tokens),
         "completion_stop_reason": api.get("stop_reason"),

--- a/training/tests/unit/test_qwen3_7_renderer.py
+++ b/training/tests/unit/test_qwen3_7_renderer.py
@@ -1,0 +1,329 @@
+"""Focused Qwen3.7 thinking, multiturn, and tool-call renderer coverage."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import training.renderer  # noqa: F401 - registers cookbook-local renderers
+from tinker_cookbook.renderers import get_renderer
+from tinker_cookbook.renderers.base import TrainOnWhat
+from tinker_cookbook.tokenizer_utils import get_tokenizer
+from training.utils.supervised import (
+    normalize_messages,
+    prepare_messages_with_tools,
+)
+
+
+_TOKENIZER_MODEL = (
+    "/shared/qwen3p7-plus-llm-think/hf"
+    if Path("/shared/qwen3p7-plus-llm-think/hf/tokenizer_config.json").exists()
+    else "Qwen/Qwen3.6-27B"
+)
+_TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get weather for a city.",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+            },
+        },
+    }
+]
+
+
+def _tokenizer():
+    try:
+        tokenizer = get_tokenizer(_TOKENIZER_MODEL)
+    except (OSError, ValueError, RuntimeError) as exc:
+        pytest.skip(f"tokenizer unavailable for {_TOKENIZER_MODEL!r}: {exc}")
+    if not getattr(tokenizer, "chat_template", None):
+        pytest.skip(f"{_TOKENIZER_MODEL!r} has no chat_template")
+    return tokenizer
+
+
+def _assert_hf_parity(
+    *,
+    renderer_name: str,
+    messages: list[dict],
+    tools: list[dict] | None = None,
+    **template_kwargs,
+) -> None:
+    tokenizer = _tokenizer()
+    renderer = get_renderer(renderer_name, tokenizer)
+    normalized = prepare_messages_with_tools(
+        messages,
+        renderer=renderer,
+        tools=tools,
+    )
+    renderer_tokens = list(
+        renderer.build_generation_prompt(normalized, role="assistant").to_ints()
+    )
+    hf_result = tokenizer.apply_chat_template(
+        messages,
+        tools=tools,
+        tokenize=True,
+        add_generation_prompt=True,
+        **template_kwargs,
+    )
+    hf_tokens = list(
+        hf_result.input_ids if hasattr(hf_result, "input_ids") else hf_result
+    )
+    assert renderer_tokens == hf_tokens
+
+    renderer_text = tokenizer.decode(
+        renderer_tokens,
+        skip_special_tokens=False,
+        clean_up_tokenization_spaces=False,
+    )
+    hf_text = tokenizer.apply_chat_template(
+        messages,
+        tools=tools,
+        tokenize=False,
+        add_generation_prompt=True,
+        **template_kwargs,
+    )
+    assert renderer_text.encode("utf-8") == hf_text.encode("utf-8")
+
+
+def test_qwen3_7_variants_are_registered_with_expected_extension_property():
+    tokenizer = _tokenizer()
+
+    default = get_renderer("qwen3_7", tokenizer)
+    disabled = get_renderer("qwen3_7_disable_thinking", tokenizer)
+    preserved = get_renderer("qwen3_7_preserve_thinking", tokenizer)
+
+    assert default.has_extension_property is False
+    assert disabled.has_extension_property is False
+    assert preserved.has_extension_property is True
+
+
+@pytest.mark.parametrize(
+    ("renderer_name", "messages", "template_kwargs"),
+    [
+        (
+            "qwen3_7",
+            [{"role": "user", "content": "What is 2+2?"}],
+            {},
+        ),
+        (
+            "qwen3_7_disable_thinking",
+            [{"role": "user", "content": "What is 2+2?"}],
+            {"enable_thinking": False},
+        ),
+        (
+            "qwen3_7_preserve_thinking",
+            [
+                {"role": "user", "content": "What is 2+2?"},
+                {
+                    "role": "assistant",
+                    "reasoning_content": "Two plus two is four.",
+                    "content": "4",
+                },
+                {"role": "user", "content": "And 3+3?"},
+            ],
+            {"preserve_thinking": True},
+        ),
+    ],
+)
+@pytest.mark.timeout(180)
+def test_thinking_modes_are_byte_identical_to_hf_template(
+    renderer_name: str,
+    messages: list[dict],
+    template_kwargs: dict,
+):
+    _assert_hf_parity(
+        renderer_name=renderer_name,
+        messages=messages,
+        **template_kwargs,
+    )
+
+
+@pytest.mark.timeout(180)
+def test_empty_content_tool_call_keeps_exact_thinking_separator():
+    messages = [
+        {"role": "user", "content": "Check the weather in SF."},
+        {
+            "role": "assistant",
+            "reasoning_content": "I need current data.",
+            "content": "",
+            "tool_calls": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "arguments": {"city": "San Francisco"},
+                    },
+                }
+            ],
+        },
+        {"role": "tool", "content": "72F"},
+    ]
+
+    _assert_hf_parity(
+        renderer_name="qwen3_7",
+        messages=messages,
+        tools=_TOOLS,
+    )
+
+
+@pytest.mark.timeout(180)
+def test_parallel_tool_group_closes_before_following_user():
+    messages = [
+        {"role": "user", "content": "Compare SF and NYC weather."},
+        {
+            "role": "assistant",
+            "reasoning_content": "I need two calls.",
+            "content": "Checking.",
+            "tool_calls": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "arguments": {"city": "San Francisco"},
+                    },
+                },
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "arguments": {"city": "New York"},
+                    },
+                },
+            ],
+        },
+        {"role": "tool", "content": "SF: 72F"},
+        {"role": "tool", "content": "NYC: 68F"},
+        {"role": "user", "content": "Which is warmer?"},
+    ]
+
+    _assert_hf_parity(
+        renderer_name="qwen3_7_preserve_thinking",
+        messages=messages,
+        tools=_TOOLS,
+        preserve_thinking=True,
+    )
+
+
+@pytest.mark.timeout(180)
+def test_parser_round_trip_keeps_thinking_and_structured_tool_call():
+    tokenizer = _tokenizer()
+    renderer = get_renderer("qwen3_7", tokenizer)
+    response_text = (
+        "Need current data.\n</think>\n\n"
+        "<tool_call>\n"
+        "<function=get_weather>\n"
+        "<parameter=city>\nSan Francisco\n</parameter>\n"
+        "</function>\n"
+        "</tool_call><|im_end|>"
+    )
+    response_tokens = tokenizer.encode(response_text, add_special_tokens=False)
+
+    parsed, termination = renderer.parse_response(response_tokens)
+
+    assert termination.is_clean
+    assert parsed["content"][0] == {
+        "type": "thinking",
+        "thinking": "Need current data.",
+    }
+    assert parsed["tool_calls"][0].function.name == "get_weather"
+    assert parsed["tool_calls"][0].function.arguments == '{"city": "San Francisco"}'
+
+    # This is the verifier's parser -> normalizer hand-off that previously
+    # raised TypeError for tinker_cookbook.renderers.base.ToolCall.
+    normalized = normalize_messages([parsed])
+    assert normalized[0]["tool_calls"] == parsed["tool_calls"]
+
+
+@pytest.mark.timeout(180)
+def test_tool_trajectory_supervised_tokens_and_extension_property():
+    tokenizer = _tokenizer()
+    renderer = get_renderer("qwen3_7_preserve_thinking", tokenizer)
+    messages = [
+        {"role": "user", "content": "Compare SF and NYC weather."},
+        {
+            "role": "assistant",
+            "reasoning_content": "I need two calls.",
+            "content": "Checking.",
+            "tool_calls": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "arguments": {"city": "San Francisco"},
+                    },
+                },
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "arguments": {"city": "New York"},
+                    },
+                },
+            ],
+        },
+        {"role": "tool", "content": "SF: 72F"},
+        {"role": "tool", "content": "NYC: 68F"},
+        {
+            "role": "assistant",
+            "reasoning_content": "SF is four degrees warmer.",
+            "content": "San Francisco is warmer.",
+        },
+    ]
+    normalized = prepare_messages_with_tools(
+        messages,
+        renderer=renderer,
+        tools=_TOOLS,
+    )
+
+    model_input, weights = renderer.build_supervised_example(
+        normalized,
+        train_on_what=TrainOnWhat.LAST_ASSISTANT_TURN,
+    )
+    renderer_tokens = list(model_input.to_ints())
+    hf_result = tokenizer.apply_chat_template(
+        messages,
+        tools=_TOOLS,
+        tokenize=True,
+        add_generation_prompt=False,
+        preserve_thinking=True,
+    )
+    hf_tokens = list(
+        hf_result.input_ids if hasattr(hf_result, "input_ids") else hf_result
+    )
+
+    assert renderer_tokens == hf_tokens
+    renderer_text = tokenizer.decode(
+        renderer_tokens,
+        skip_special_tokens=False,
+        clean_up_tokenization_spaces=False,
+    )
+    hf_text = tokenizer.apply_chat_template(
+        messages,
+        tools=_TOOLS,
+        tokenize=False,
+        add_generation_prompt=False,
+        preserve_thinking=True,
+    )
+    assert renderer_text.encode("utf-8") == hf_text.encode("utf-8")
+    assert len(weights) == len(renderer_tokens)
+    assert weights.max().item() == 1
+    assert weights.min().item() == 0
+    newline_tokens = tokenizer.encode("\n", add_special_tokens=False)
+    assert renderer_tokens[-len(newline_tokens) :] == newline_tokens
+    assert weights[-len(newline_tokens) :].tolist() == [0] * len(newline_tokens)
+
+    # Sampling at each assistant turn must keep the previous prompt as an
+    # exact token prefix, including across a grouped parallel-tool response.
+    first_prompt = list(
+        renderer.build_generation_prompt(normalized[:2], role="assistant").to_ints()
+    )
+    second_prompt = list(
+        renderer.build_generation_prompt(normalized[:5], role="assistant").to_ints()
+    )
+    assert second_prompt[: len(first_prompt)] == first_prompt

--- a/training/tests/unit/test_qwen3_7_renderer.py
+++ b/training/tests/unit/test_qwen3_7_renderer.py
@@ -97,10 +97,16 @@ def test_qwen3_7_variants_are_registered_with_expected_extension_property():
     default = get_renderer("qwen3_7", tokenizer)
     disabled = get_renderer("qwen3_7_disable_thinking", tokenizer)
     preserved = get_renderer("qwen3_7_preserve_thinking", tokenizer)
+    vl_default = get_renderer("qwen3_7_vl", tokenizer)
+    vl_disabled = get_renderer("qwen3_7_vl_disable_thinking", tokenizer)
+    vl_preserved = get_renderer("qwen3_7_vl_preserve_thinking", tokenizer)
 
     assert default.has_extension_property is False
     assert disabled.has_extension_property is False
     assert preserved.has_extension_property is True
+    assert vl_default.has_extension_property is False
+    assert vl_disabled.has_extension_property is False
+    assert vl_preserved.has_extension_property is True
 
 
 @pytest.mark.parametrize(

--- a/training/tests/unit/test_qwen3_7_vl_renderer.py
+++ b/training/tests/unit/test_qwen3_7_vl_renderer.py
@@ -1,0 +1,316 @@
+"""Exact-checkpoint Qwen3.7 VL renderer parity and loss-mask coverage."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import tinker
+from PIL import Image
+from tinker_cookbook.image_processing_utils import get_image_processor
+from tinker_cookbook.renderers import get_renderer
+from tinker_cookbook.renderers.base import TrainOnWhat
+from tinker_cookbook.tokenizer_utils import get_tokenizer
+
+import training.renderer  # noqa: F401 - registers cookbook-local renderers
+from training.utils.supervised import normalize_messages, prepare_messages_with_tools
+
+
+_MODEL = Path("/shared/qwen3p7-plus-vl-think/hf")
+_TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "inspect_region",
+            "description": "Inspect a named region in the image.",
+            "parameters": {
+                "type": "object",
+                "properties": {"region": {"type": "string"}},
+                "required": ["region"],
+            },
+        },
+    }
+]
+
+
+pytestmark = pytest.mark.skipif(
+    not (_MODEL / "tokenizer_config.json").exists(),
+    reason="exact qwen3p7-plus-vl-think snapshot is not available",
+)
+
+
+@pytest.fixture(scope="module")
+def tokenizer():
+    return get_tokenizer(str(_MODEL))
+
+
+@pytest.fixture(scope="module")
+def image_processor():
+    return get_image_processor(str(_MODEL))
+
+
+@pytest.fixture(scope="module")
+def image() -> Image.Image:
+    return Image.new("RGB", (256, 192), color=(42, 117, 193))
+
+
+def _structural_tokens(model_input: tinker.ModelInput, tokenizer: Any) -> list[int]:
+    """Replace each binary image chunk with the template's one image-pad token."""
+    image_pad = tokenizer.encode("<|image_pad|>", add_special_tokens=False)
+    assert len(image_pad) == 1
+
+    tokens: list[int] = []
+    for chunk in model_input.chunks:
+        if isinstance(chunk, tinker.types.EncodedTextChunk):
+            tokens.extend(chunk.tokens)
+        else:
+            assert isinstance(chunk, tinker.types.ImageChunk)
+            assert chunk.expected_tokens > 0
+            tokens.extend(image_pad)
+    return tokens
+
+
+def _assert_generation_parity(
+    *,
+    renderer_name: str,
+    tokenizer: Any,
+    image_processor: Any,
+    messages: list[dict],
+    tools: list[dict] | None = None,
+    **template_kwargs: Any,
+) -> tinker.ModelInput:
+    renderer = get_renderer(
+        renderer_name,
+        tokenizer,
+        image_processor=image_processor,
+    )
+    normalized = prepare_messages_with_tools(
+        messages,
+        renderer=renderer,
+        tools=tools,
+    )
+    model_input = renderer.build_generation_prompt(normalized, role="assistant")
+    actual = _structural_tokens(model_input, tokenizer)
+    hf_result = tokenizer.apply_chat_template(
+        messages,
+        tools=tools,
+        tokenize=True,
+        add_generation_prompt=True,
+        **template_kwargs,
+    )
+    expected = list(
+        hf_result.input_ids if hasattr(hf_result, "input_ids") else hf_result
+    )
+    assert actual == expected
+    assert (
+        tokenizer.decode(
+            actual,
+            skip_special_tokens=False,
+            clean_up_tokenization_spaces=False,
+        ).encode()
+        == tokenizer.apply_chat_template(
+            messages,
+            tools=tools,
+            tokenize=False,
+            add_generation_prompt=True,
+            **template_kwargs,
+        ).encode()
+    )
+    return model_input
+
+
+@pytest.mark.parametrize(
+    ("renderer_name", "template_kwargs"),
+    [
+        ("qwen3_7_vl", {}),
+        ("qwen3_7_vl_disable_thinking", {"enable_thinking": False}),
+    ],
+)
+def test_vl_single_turn_thinking_modes_are_byte_identical(
+    renderer_name,
+    template_kwargs,
+    tokenizer,
+    image_processor,
+    image,
+):
+    model_input = _assert_generation_parity(
+        renderer_name=renderer_name,
+        tokenizer=tokenizer,
+        image_processor=image_processor,
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image", "image": image},
+                    {"type": "text", "text": "What is shown?"},
+                ],
+            }
+        ],
+        **template_kwargs,
+    )
+    image_chunks = [
+        chunk
+        for chunk in model_input.chunks
+        if isinstance(chunk, tinker.types.ImageChunk)
+    ]
+    assert len(image_chunks) == 1
+    assert image_chunks[0].expected_tokens > 0
+
+
+def test_vl_preserved_thinking_multiturn_and_two_images_are_byte_identical(
+    tokenizer,
+    image_processor,
+    image,
+):
+    _assert_generation_parity(
+        renderer_name="qwen3_7_vl_preserve_thinking",
+        tokenizer=tokenizer,
+        image_processor=image_processor,
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image", "image": image},
+                    {"type": "text", "text": "Describe the color."},
+                ],
+            },
+            {
+                "role": "assistant",
+                "reasoning_content": "The dominant color is blue.",
+                "content": "It is blue.",
+            },
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image", "image": image},
+                    {"type": "text", "text": "Is this the same image?"},
+                ],
+            },
+        ],
+        preserve_thinking=True,
+    )
+
+
+def test_vl_parallel_tool_calls_and_image_tool_result_are_byte_identical(
+    tokenizer,
+    image_processor,
+    image,
+):
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "image", "image": image},
+                {"type": "text", "text": "Inspect the top and bottom."},
+            ],
+        },
+        {
+            "role": "assistant",
+            "reasoning_content": "I need to inspect both regions.",
+            "content": "Checking both.",
+            "tool_calls": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "inspect_region",
+                        "arguments": {"region": "top"},
+                    },
+                },
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "inspect_region",
+                        "arguments": {"region": "bottom"},
+                    },
+                },
+            ],
+        },
+        {"role": "tool", "content": "Top: blue"},
+        {
+            "role": "tool",
+            "content": [
+                {"type": "text", "text": "  Bottom crop: "},
+                {"type": "image", "image": image},
+                {"type": "text", "text": "  "},
+            ],
+        },
+    ]
+    _assert_generation_parity(
+        renderer_name="qwen3_7_vl",
+        tokenizer=tokenizer,
+        image_processor=image_processor,
+        messages=messages,
+        tools=_TOOLS,
+    )
+
+
+def test_vl_supervised_chunks_weights_and_closed_template_align(
+    tokenizer,
+    image_processor,
+    image,
+):
+    renderer = get_renderer(
+        "qwen3_7_vl_preserve_thinking",
+        tokenizer,
+        image_processor=image_processor,
+    )
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "image", "image": image},
+                {"type": "text", "text": "Name the dominant color."},
+            ],
+        },
+        {
+            "role": "assistant",
+            "reasoning_content": "The pixels are mostly blue.",
+            "content": "Blue.",
+        },
+    ]
+    normalized = normalize_messages(messages)
+    model_input, weights = renderer.build_supervised_example(
+        normalized,
+        train_on_what=TrainOnWhat.LAST_ASSISTANT_TURN,
+    )
+    actual = _structural_tokens(model_input, tokenizer)
+    hf_result = tokenizer.apply_chat_template(
+        messages,
+        tokenize=True,
+        add_generation_prompt=False,
+        preserve_thinking=True,
+    )
+    expected = list(
+        hf_result.input_ids if hasattr(hf_result, "input_ids") else hf_result
+    )
+    assert actual == expected
+    assert len(weights) == sum(chunk.length for chunk in model_input.chunks)
+    assert weights.max().item() == 1
+    assert weights.min().item() == 0
+    assert any(
+        isinstance(chunk, tinker.types.ImageChunk) for chunk in model_input.chunks
+    )
+
+
+def test_vl_rejects_system_images_like_the_checkpoint_template(
+    tokenizer,
+    image_processor,
+    image,
+):
+    renderer = get_renderer(
+        "qwen3_7_vl",
+        tokenizer,
+        image_processor=image_processor,
+    )
+    messages = normalize_messages(
+        [
+            {
+                "role": "system",
+                "content": [{"type": "image", "image": image}],
+            },
+            {"role": "user", "content": "Describe it."},
+        ]
+    )
+    with pytest.raises(ValueError, match="System message cannot contain images"):
+        renderer.build_generation_prompt(messages)

--- a/training/tests/unit/test_renderer_hf_parity.py
+++ b/training/tests/unit/test_renderer_hf_parity.py
@@ -26,6 +26,7 @@ A renderer can pass one and still fail the other; both are needed.
 from __future__ import annotations
 
 import dataclasses
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -43,6 +44,7 @@ class _Case:
     renderer: str
     tokenizer_model: str
     messages: list[dict]
+    tools: list[dict] | None = None
     apply_chat_template_kwargs: dict[str, Any] = dataclasses.field(default_factory=dict)
     xfail_reason: str | None = None  # if set, mark the test xfail with this reason
 
@@ -64,6 +66,61 @@ _KIMI_REASONING_MSGS = [
         "role": "assistant",
         "reasoning_content": "2+2 is basic arithmetic.",
         "content": "4.",
+    },
+    {"role": "user", "content": "And 3+3?"},
+]
+
+_QWEN3_7_TOKENIZER = (
+    "/shared/qwen3p7-plus-llm-think/hf"
+    if Path("/shared/qwen3p7-plus-llm-think/hf/tokenizer_config.json").exists()
+    else "Qwen/Qwen3.6-27B"
+)
+_QWEN3_7_TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get weather for a city.",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+            },
+        },
+    }
+]
+_QWEN3_7_ACTIVE_PARALLEL_TOOL_MSGS = [
+    {"role": "user", "content": "Compare the weather in SF and NYC."},
+    {
+        "role": "assistant",
+        "reasoning_content": "I need current data for both cities.",
+        "content": "Checking both.",
+        "tool_calls": [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "arguments": {"city": "San Francisco"},
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "arguments": {"city": "New York"},
+                },
+            },
+        ],
+    },
+    {"role": "tool", "content": "San Francisco: 72F"},
+    {"role": "tool", "content": "NYC: 68F"},
+]
+_QWEN3_7_PRESERVED_MULTITURN_MSGS = [
+    {"role": "user", "content": "What is 2+2?"},
+    {
+        "role": "assistant",
+        "reasoning_content": "Two plus two is four.",
+        "content": "4",
     },
     {"role": "user", "content": "And 3+3?"},
 ]
@@ -155,6 +212,36 @@ _CASES: list[_Case] = [
         messages=_MULTI_TURN_MSGS,
         apply_chat_template_kwargs={"preserve_thinking": True},
     ),
+    # Qwen3.7 is a thin Qwen3.6 specialization. On developer machines this
+    # uses the exact downloaded qwen3p7-plus-llm-think tokenizer; CI falls
+    # back to the template-compatible public Qwen3.6 tokenizer.
+    _Case(
+        case_id="qwen3_7-thinking-single-turn",
+        renderer="qwen3_7",
+        tokenizer_model=_QWEN3_7_TOKENIZER,
+        messages=_SHORT_MSGS,
+    ),
+    _Case(
+        case_id="qwen3_7-disable-thinking",
+        renderer="qwen3_7_disable_thinking",
+        tokenizer_model=_QWEN3_7_TOKENIZER,
+        messages=_SHORT_MSGS,
+        apply_chat_template_kwargs={"enable_thinking": False},
+    ),
+    _Case(
+        case_id="qwen3_7-preserve-thinking-multi-turn",
+        renderer="qwen3_7_preserve_thinking",
+        tokenizer_model=_QWEN3_7_TOKENIZER,
+        messages=_QWEN3_7_PRESERVED_MULTITURN_MSGS,
+        apply_chat_template_kwargs={"preserve_thinking": True},
+    ),
+    _Case(
+        case_id="qwen3_7-active-parallel-tools",
+        renderer="qwen3_7",
+        tokenizer_model=_QWEN3_7_TOKENIZER,
+        messages=_QWEN3_7_ACTIVE_PARALLEL_TOOL_MSGS,
+        tools=_QWEN3_7_TOOLS,
+    ),
     _Case(
         case_id="kimi_k25-single-turn",
         renderer="kimi_k25",
@@ -196,6 +283,7 @@ def test_renderer_matches_hf_chat_template(case: _Case) -> None:
             renderer_name=case.renderer,
             tokenizer_model=case.tokenizer_model,
             messages=case.messages,
+            tools=case.tools,
             add_generation_prompt=True,
             apply_chat_template_kwargs=case.apply_chat_template_kwargs,
         )

--- a/training/tests/unit/test_supervised_rendering.py
+++ b/training/tests/unit/test_supervised_rendering.py
@@ -10,6 +10,7 @@ from tinker_cookbook.renderers import (
     ParseTermination,
     RenderContext,
     Renderer,
+    ToolCall,
     TrainOnWhat,
 )
 from tinker_cookbook.renderers.base import RenderedMessage
@@ -484,6 +485,28 @@ def test_normalize_messages_supports_openai_tool_call_shape():
     tool_call = normalized[0]["tool_calls"][0]
     assert tool_call.function.name == "lake_move"
     assert tool_call.function.arguments == '{"action": "RIGHT"}'
+
+
+def test_normalize_messages_accepts_renderer_parsed_tool_call() -> None:
+    """Verifier round trips pass the renderer's structured ToolCall back in."""
+    parsed_tool_call = ToolCall(
+        function=ToolCall.FunctionBody(
+            name="get_weather",
+            arguments='{"city": "San Francisco"}',
+        )
+    )
+
+    normalized = normalize_messages(
+        [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [parsed_tool_call],
+            }
+        ]
+    )
+
+    assert normalized[0]["tool_calls"] == [parsed_tool_call]
 
 
 def test_normalize_messages_keeps_tool_metadata_and_thinking_parts():
@@ -996,6 +1019,17 @@ def test_resolve_renderer_name_prefers_qwen3_6() -> None:
     assert resolve_renderer_name("Qwen/Qwen3.6-27B") == "qwen3_6"
     assert resolve_renderer_name("Qwen/Qwen3.6-9B") == "qwen3_6"
     assert resolve_renderer_name("custom/qwen3_6-finetune") == "qwen3_6"
+
+
+def test_resolve_renderer_name_prefers_qwen3_7() -> None:
+    """HF and Fireworks Qwen3.7 spellings use the dedicated thin alias."""
+    assert resolve_renderer_name("Qwen/Qwen3.7-Plus-LLM-Think") == "qwen3_7"
+    assert resolve_renderer_name("custom/qwen3_7-finetune") == "qwen3_7"
+    assert (
+        resolve_renderer_name("accounts/fireworks/models/qwen3p7-plus-llm-think")
+        == "qwen3_7"
+    )
+    assert resolve_renderer_name("/shared/qwen3p7-plus-llm-think/hf") == "qwen3_7"
 
 
 def test_resolve_renderer_name_prefers_gemma4() -> None:

--- a/training/tests/unit/test_supervised_rendering.py
+++ b/training/tests/unit/test_supervised_rendering.py
@@ -1032,6 +1032,40 @@ def test_resolve_renderer_name_prefers_qwen3_7() -> None:
     assert resolve_renderer_name("/shared/qwen3p7-plus-llm-think/hf") == "qwen3_7"
 
 
+def test_resolve_renderer_name_prefers_qwen3_7_vl() -> None:
+    assert resolve_renderer_name("Qwen/Qwen3.7-Plus-VL-Think") == "qwen3_7_vl"
+    assert (
+        resolve_renderer_name("accounts/fireworks/models/qwen3p7-plus-vl-think")
+        == "qwen3_7_vl"
+    )
+    assert resolve_renderer_name("/shared/qwen3p7-plus-vl-think/hf") == "qwen3_7_vl"
+
+
+def test_build_renderer_loads_image_processor_for_qwen3_7_vl(monkeypatch) -> None:
+    calls: list[tuple[str, object | None]] = []
+
+    def fake_get_image_processor(model_name):
+        assert model_name == "/shared/qwen3p7-plus-vl-think/hf"
+        return "qwen3.7-image-processor"
+
+    def fake_get_renderer(name, tokenizer, image_processor=None):
+        calls.append((name, image_processor))
+        return "renderer"
+
+    monkeypatch.setattr(
+        "training.utils.supervised.get_image_processor", fake_get_image_processor
+    )
+    monkeypatch.setattr("training.utils.supervised.get_renderer", fake_get_renderer)
+
+    renderer = build_renderer(
+        tokenizer="tok",
+        tokenizer_model="/shared/qwen3p7-plus-vl-think/hf",
+    )
+
+    assert renderer == "renderer"
+    assert calls == [("qwen3_7_vl", "qwen3.7-image-processor")]
+
+
 def test_resolve_renderer_name_prefers_gemma4() -> None:
     """Gemma 4 models should resolve to the gemma4 renderer."""
     assert resolve_renderer_name("google/gemma-4-12b-it") == "gemma4"

--- a/training/tests/unit/test_verifier_probe.py
+++ b/training/tests/unit/test_verifier_probe.py
@@ -23,7 +23,7 @@ from tinker_cookbook.renderers.base import (
     RenderContext,
     RenderedMessage,
     Renderer,
-    Role,
+    ToolCall,
     TrainOnWhat,
 )
 
@@ -99,6 +99,11 @@ class _ToyRenderer(Renderer):
     def get_stop_sequences(self) -> list[int]:
         return [_T["<eot>"]]
 
+    def create_conversation_prefix_with_tools(self, tools, system_prompt=""):
+        del tools
+        content = "hello" if not system_prompt else system_prompt
+        return [Message(role="system", content=content)]
+
     def render_message(self, message: Message, ctx: RenderContext) -> RenderedMessage:
         role = message["role"]
         content = message["content"] or ""
@@ -136,6 +141,25 @@ def _toy_factory(tokenizer, image_processor=None):
     return _ToyRenderer(tokenizer)
 
 
+class _ToolCallToyRenderer(_ToyRenderer):
+    def parse_response(self, response: list[int]):
+        message, termination = super().parse_response(response)
+        message["tool_calls"] = [
+            ToolCall(
+                function=ToolCall.FunctionBody(
+                    name="lookup",
+                    arguments='{"query": "weather"}',
+                )
+            )
+        ]
+        return message, termination
+
+
+def _tool_call_toy_factory(tokenizer, image_processor=None):
+    del image_processor
+    return _ToolCallToyRenderer(tokenizer)
+
+
 @pytest.fixture
 def toy_renderer():
     register_renderer("__verifier_test_toy", _toy_factory)
@@ -145,20 +169,32 @@ def toy_renderer():
         unregister_renderer("__verifier_test_toy")
 
 
+@pytest.fixture
+def tool_call_toy_renderer():
+    register_renderer("__verifier_test_tool_call", _tool_call_toy_factory)
+    try:
+        yield "__verifier_test_tool_call"
+    finally:
+        unregister_renderer("__verifier_test_tool_call")
+
+
 class _StubClient:
     """Returns prompt + completion token IDs that match the toy renderer's
     own render of the conversation, so the probe's alignment check
     classifies tokens cleanly."""
 
-    def __init__(self, prompt_token_ids: list[int], completion_token_ids: list[int], completion_text: str):
+    def __init__(
+        self,
+        prompt_token_ids: list[int],
+        completion_token_ids: list[int],
+        completion_text: str,
+    ):
         self._prompt_token_ids = prompt_token_ids
         self._completion_token_ids = completion_token_ids
         self._completion_text = completion_text
 
         # Mimic the .chat.completions.create surface
-        self.chat = SimpleNamespace(
-            completions=SimpleNamespace(create=self._create)
-        )
+        self.chat = SimpleNamespace(completions=SimpleNamespace(create=self._create))
 
     def _create(self, **kwargs: Any):
         # The probe sends echo=True, raw_output=True, return_token_ids=True
@@ -167,7 +203,10 @@ class _StubClient:
                 "prompt_token_ids": self._prompt_token_ids,
                 "choices": [
                     {
-                        "message": {"role": "assistant", "content": self._completion_text},
+                        "message": {
+                            "role": "assistant",
+                            "content": self._completion_text,
+                        },
                         "finish_reason": "stop",
                         "raw_output": {
                             "completion_token_ids": self._completion_token_ids,
@@ -189,8 +228,10 @@ def test_run_probe_artifact_shape_and_provenance(toy_renderer):
     # The toy renderer's prompt for these messages would be:
     #   <sys> hello <user> world <asst>
     expected_prompt_ids = [
-        _T["<sys>"], _T["hello"],
-        _T["<user>"], _T["world"],
+        _T["<sys>"],
+        _T["hello"],
+        _T["<user>"],
+        _T["world"],
         _T["<asst>"],
     ]
     completion_text = "fine thanks"
@@ -282,6 +323,64 @@ def test_run_probe_strips_echoed_prompt(toy_renderer):
     assert artifact["sanity"]["completion_token_count"] == len(actual_completion_ids)
     # No spurious divergence after stripping.
     assert artifact["sanity"]["tokenization_diverged_count"] == 0
+
+
+def test_run_probe_includes_tools_in_local_prompt(toy_renderer):
+    tokenizer = _StubTokenizer()
+    messages = [{"role": "user", "content": "world"}]
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "lookup",
+                "parameters": {"type": "object"},
+            },
+        }
+    ]
+    expected_prompt_ids = [
+        _T["<sys>"],
+        _T["hello"],
+        _T["<user>"],
+        _T["world"],
+        _T["<asst>"],
+    ]
+    client = _StubClient(
+        prompt_token_ids=expected_prompt_ids,
+        completion_token_ids=[_T["fine"]],
+        completion_text="fine",
+    )
+
+    artifact = run_probe(
+        renderer_name=toy_renderer,
+        tokenizer=tokenizer,
+        client=client,
+        model="test/model",
+        messages=messages,
+        tools=tools,
+    )
+
+    assert artifact["sanity"]["renderer_prompt_matches_api_prompt"] is True
+
+
+def test_run_probe_round_trips_renderer_tool_call(tool_call_toy_renderer):
+    tokenizer = _StubTokenizer()
+    messages = [{"role": "user", "content": "hello"}]
+    expected_prompt_ids = [_T["<user>"], _T["hello"], _T["<asst>"]]
+    client = _StubClient(
+        prompt_token_ids=expected_prompt_ids,
+        completion_token_ids=[_T["fine"], _T["thanks"]],
+        completion_text="fine thanks",
+    )
+
+    artifact = run_probe(
+        renderer_name=tool_call_toy_renderer,
+        tokenizer=tokenizer,
+        client=client,
+        model="test/model",
+        messages=messages,
+    )
+
+    assert artifact["sanity"]["renderer_prompt_matches_api_prompt"] is True
 
 
 def test_inspect_renders_structured_summary(toy_renderer):

--- a/training/utils/supervised.py
+++ b/training/utils/supervised.py
@@ -73,7 +73,9 @@ def _tool_prefix_builder(renderer: Renderer):
     prefix_builder = getattr(renderer, "create_conversation_prefix_with_tools", None)
     if prefix_builder is None:
         return None
-    class_builder = getattr(type(renderer), "create_conversation_prefix_with_tools", None)
+    class_builder = getattr(
+        type(renderer), "create_conversation_prefix_with_tools", None
+    )
     if class_builder is Renderer.create_conversation_prefix_with_tools:
         return None
     return prefix_builder
@@ -118,6 +120,13 @@ def resolve_renderer_name(
         return "minimax_m2"
     if "qwen3-vl" in normalized_model_name:
         return "qwen3_vl_instruct"
+    # Qwen3.7 text-only thinking checkpoints retain the Qwen3.6/Qwen3.5
+    # tokenizer and XML tool format. Match Fireworks' ``qwen3p7`` resource
+    # spelling as well as HF-style dotted/underscored names.
+    if any(
+        marker in normalized_model_name for marker in ("qwen3.7", "qwen3_7", "qwen3p7")
+    ):
+        return "qwen3_7"
     # Qwen3.6 reuses Qwen3.5's vocab + special tokens; the chat template only
     # adds an opt-in `preserve_thinking` flag (renders historical thinking
     # for ALL assistant turns when true). Default invocation produces output
@@ -286,6 +295,9 @@ def _normalize_tool_calls(tool_calls: Any) -> list[ToolCall]:
     """Normalize common tool-call shapes into Tinker's structured ToolCall form."""
     normalized: list[ToolCall] = []
     for tool_call in tool_calls or []:
+        if isinstance(tool_call, ToolCall):
+            normalized.append(tool_call)
+            continue
         if not isinstance(tool_call, Mapping):
             raise TypeError(f"Unsupported tool call type: {type(tool_call)!r}")
 
@@ -496,7 +508,9 @@ def normalize_messages(
         reasoning = message.get("reasoning")
         if thinking is None and reasoning is not None:
             if not isinstance(reasoning, str):
-                raise TypeError(f"Unsupported reasoning value type: {type(reasoning)!r}")
+                raise TypeError(
+                    f"Unsupported reasoning value type: {type(reasoning)!r}"
+                )
             if reasoning:
                 normalized_message["content"] = [
                     {"type": "thinking", "thinking": reasoning},
@@ -536,6 +550,52 @@ def normalize_messages(
         normalized.append(normalized_message)
 
     return normalized
+
+
+def prepare_messages_with_tools(
+    messages: Iterable[Mapping[str, Any]],
+    *,
+    renderer: Renderer,
+    tools: Sequence[Mapping[str, Any]] | None = None,
+) -> list[Message]:
+    """Normalize messages and prepend the renderer's canonical tool prefix.
+
+    Training and the live verifier both call this function so a local prompt
+    can never omit tool declarations that are present in the gateway request.
+    """
+    normalized_messages = list(normalize_messages(messages))
+    if not tools:
+        return normalized_messages
+
+    prefix_builder = _tool_prefix_builder(renderer)
+    if prefix_builder is None:
+        return normalized_messages
+
+    tool_specs = [
+        tool["function"]
+        for tool in tools
+        if isinstance(tool, Mapping) and isinstance(tool.get("function"), Mapping)
+    ]
+    if not tool_specs:
+        return normalized_messages
+
+    system_prompt = ""
+    if normalized_messages and normalized_messages[0].get("role") == "system":
+        system_content = normalized_messages.pop(0).get("content")
+        if isinstance(system_content, str):
+            system_prompt = system_content
+        elif isinstance(system_content, list):
+            system_prompt = "\n".join(
+                part.get("text", "")
+                for part in system_content
+                if isinstance(part, Mapping) and part.get("type") == "text"
+            )
+
+    prefix_messages = list(prefix_builder(tool_specs, system_prompt=system_prompt))
+    if any("trainable" in message for message in normalized_messages):
+        for prefix_message in prefix_messages:
+            prefix_message.setdefault("trainable", False)
+    return prefix_messages + normalized_messages
 
 
 def _stable_chunk_sentinel(chunk: Any) -> int:
@@ -936,9 +996,8 @@ def _equivalent_single_example_train_on_what(
     the false-positive warning while preserving true warnings for non-equivalent
     conversations.
     """
-    if (
-        train_on_what != TrainOnWhat.ALL_ASSISTANT_MESSAGES
-        or getattr(renderer, "has_extension_property", False)
+    if train_on_what != TrainOnWhat.ALL_ASSISTANT_MESSAGES or getattr(
+        renderer, "has_extension_property", False
     ):
         return train_on_what
 
@@ -1006,34 +1065,11 @@ def render_messages_to_datums(
     content is preserved as the system prompt passed to the renderer.
     Renderers without tool-prefix support silently drop the field.
     """
-    normalized_messages = list(normalize_messages(messages))
-
-    if tools:
-        prefix_builder = _tool_prefix_builder(renderer)
-        if prefix_builder is not None:
-            tool_specs = [
-                t["function"]
-                for t in tools
-                if isinstance(t, Mapping) and isinstance(t.get("function"), Mapping)
-            ]
-            if tool_specs:
-                system_prompt = ""
-                if normalized_messages and normalized_messages[0].get("role") == "system":
-                    sys_content = normalized_messages.pop(0).get("content")
-                    if isinstance(sys_content, str):
-                        system_prompt = sys_content
-                    elif isinstance(sys_content, list):
-                        system_prompt = "\n".join(
-                            part.get("text", "")
-                            for part in sys_content
-                            if isinstance(part, Mapping) and part.get("type") == "text"
-                        )
-                prefix = prefix_builder(tool_specs, system_prompt=system_prompt)
-                prefix_messages = list(prefix)
-                if any("trainable" in m for m in normalized_messages):
-                    for prefix_msg in prefix_messages:
-                        prefix_msg.setdefault("trainable", False)
-                normalized_messages = prefix_messages + normalized_messages
+    normalized_messages = prepare_messages_with_tools(
+        messages,
+        renderer=renderer,
+        tools=tools,
+    )
 
     effective_train_on_what = parse_train_on_what(train_on_what)
     if any("trainable" in m for m in normalized_messages):

--- a/training/utils/supervised.py
+++ b/training/utils/supervised.py
@@ -120,12 +120,18 @@ def resolve_renderer_name(
         return "minimax_m2"
     if "qwen3-vl" in normalized_model_name:
         return "qwen3_vl_instruct"
+    # Qwen3.7 VL thinking checkpoints use the same Qwen3.5 image-chunk
+    # transport plus Qwen3.7's thinking/tool template. Route these before the
+    # generic Qwen3.7 match so build_renderer loads the image processor.
+    is_qwen3_7 = any(
+        marker in normalized_model_name for marker in ("qwen3.7", "qwen3_7", "qwen3p7")
+    )
+    if is_qwen3_7 and "vl" in normalized_model_name:
+        return "qwen3_7_vl"
     # Qwen3.7 text-only thinking checkpoints retain the Qwen3.6/Qwen3.5
     # tokenizer and XML tool format. Match Fireworks' ``qwen3p7`` resource
     # spelling as well as HF-style dotted/underscored names.
-    if any(
-        marker in normalized_model_name for marker in ("qwen3.7", "qwen3_7", "qwen3p7")
-    ):
+    if is_qwen3_7:
         return "qwen3_7"
     # Qwen3.6 reuses Qwen3.5's vocab + special tokens; the chat template only
     # adds an opt-in `preserve_thinking` flag (renders historical thinking


### PR DESCRIPTION
## Summary

- register `qwen3_7`, `qwen3_7_disable_thinking`, and `qwen3_7_preserve_thinking`
- reuse the Qwen3.6 renderer family for shared vocabulary, thinking blocks, XML tool calls, parsing, stop tokens, and multiturn disaggregation
- implement only the Qwen3.7 chat-template deltas: active-chain thinking retention, OpenAI-wrapped tool declarations, grouped parallel tool responses, conditional empty-content separators, and the final closed-turn newline
- make supervised rendering and verifier probes use one tool-aware message-preparation path
- accept structured `ToolCall` values returned by renderer parsers during verifier round trips

## Why a dedicated Qwen3.7 renderer

Qwen3.7 is close enough to Qwen3.6 that copying the renderer would create unnecessary drift, so these classes subclass the Qwen3.6 variants through a thin template mixin. A plain alias is not token-equivalent, however: the official Qwen3.7 template changes how thinking is retained during tool chains, how consecutive tool results share a user envelope, how tool definitions are serialized, and how closed conversations terminate.

## Impact

Training and verification can select the text-only Qwen3.7 thinking model by its dotted, underscored, or Fireworks `qwen3p7` spelling while preserving exact Hugging Face template parity across thinking, preserved-thinking multiturn history, and tool-call trajectories.

## Validation

- exact local Qwen3.7 tokenizer/template parity for default thinking, disabled thinking, preserved thinking, multiturn history, empty-content tool calls, parallel tool results, and full supervised examples
- parser to normalizer round-trip for structured XML tool calls
- loss-mask and multiturn extension-property assertions
- focused and regression suite: 95 passed, 2 skipped, 1 expected xfail
- Ruff check and format check passed for all changed files

This PR intentionally contains cookbook-only changes. FireTitan checkpoint loading changes remain in fw-ai/fireworks#35025, and no `py/fireworks/` serving files are modified.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes chat-template tokenization and loss masks for Qwen3.7 SFT/tool trajectories; mistakes would cause train–inference drift, but scope is cookbook renderers with extensive HF byte-parity tests.
> 
> **Overview**
> Adds **Qwen3.7** (text + VL) renderers on top of the Qwen3.6 split family via `_Qwen3_7TemplateMixin`, registering `qwen3_7`, thinking variants, and `qwen3_7_vl*` aliases. The mixin implements only HF template deltas: thinking stays visible through active tool chains, parallel tool results share one user envelope, OpenAI-wrapped tool declarations, conditional tool-call separators, multimodal tool trimming, and a **masked trailing newline** on closed supervised conversations.
> 
> **Training and verifier alignment:** introduces `prepare_messages_with_tools` so SFT rendering, CPU HF parity, and live probes all prepend the same renderer tool prefix. HF parity and `run_probe` now pass `tools` through; probe round-trips reuse the tool-prepared prefix when building full conversations. `normalize_messages` / `_normalize_tool_calls` accept existing `ToolCall` objects from `parse_response` (fixes verifier hand-off). `resolve_renderer_name` routes Qwen3.7 / `qwen3p7` / VL spellings and loads image processors for VL builds.
> 
> **Tests:** new Qwen3.7 text/VL HF parity suites, regression cases in `test_renderer_hf_parity`, resolver/build_renderer tests, and probe tests for tools + structured tool calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 696ce6c15bee39786aa7279d7e15fb889d1d68ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->