### PR TITLE
refactor(training): make checkpoint resume explicit

### DIFF
--- a/skills/dev/references/checkpoints.md
+++ b/skills/dev/references/checkpoints.md
@@ -2,7 +2,7 @@
 
 `TrainingCheckpoints` in `training/utils/checkpoints.py` is the cookbook boundary for resume, promotion, and sampler weight sync. Checkpoint identity and metadata live on the Fireworks control plane. Recipes discover them through `list_checkpoints`; they do not maintain a second checkpoint registry.
 
-The only local checkpoint state is the dataset position that the trainer cannot infer:
+For supervised recipes, the only local checkpoint state is the dataset position that the trainer cannot infer:
 
 ```json
 {
@@ -15,13 +15,13 @@ This is `{log_path}/dataloader.json`, a bounded KV mapping from trainer job id a
 
 ## Save and sync APIs
 
-`TrainingCheckpoints.save(step, *, resumable, promotable, row_cursor)` keeps the two save capabilities independent:
+`TrainingCheckpoints.save(step, *, resumable, promotable, row_cursor=None)` keeps the two save capabilities independent:
 
-- `resumable=True` writes DCP weights and optimizer state and records `(trainer_job_id, actual_saved_step) -> row_cursor` locally.
+- `resumable=True` writes DCP weights and optimizer state. Supervised recipes may also record `(trainer_job_id, actual_saved_step) -> row_cursor` locally.
 - `promotable=True` writes a complete sampler export that can be promoted.
 - Both perform both writes under the same `step-N` logical name.
 
-Periodic saves use `resumable=True, promotable=False`; the final save usually uses both. `row_cursor` is required for every resumable save. If `dcp_save_interval=0` (the default), there are no intermediate resume points.
+Periodic saves use `resumable=True, promotable=False`; the final save usually uses both. If `dcp_save_interval=0` (the default), there are no intermediate resume points.
 
 RL recipes call `TrainingCheckpoints.sync_weights(step, hotload)`. They never pass `checkpoint_type` or branch on LoRA versus full-parameter training. The SDK saves a complete LoRA adapter for LoRA runs and manages the full/base/delta chain for full-parameter runs. The checkpoint manager also hides the complete-export choice required for promotion.
 
@@ -38,16 +38,24 @@ RL recipes call `TrainingCheckpoints.sync_weights(step, hotload)`. They never pa
 
 The checkpoint row determines the trainer state and step. The local KV mapping supplies only its row cursor. If the mapping has no entry, the cursor is `0`.
 
-Every recipe also exposes `dataloader_cursor`. When it is explicitly set, that exact cursor is used and the local mapping is not read. Use this for a deliberate data-position override or when resuming a remote checkpoint without its original `dataloader.json`.
+Supervised recipes expose `dataloader_cursor` as an override. When set, that exact cursor is used and the local mapping is not read.
 
-Resume priority is:
+`rl_loop` and `async_rl_loop` use a stricter explicit contract:
+
+- `dataloader_cursor` is always an integer and is the only dataset resume input;
+- no local cursor mapping is read or written;
+- no latest checkpoint is selected automatically;
+- `init_from_checkpoint`, when supplied, must explicitly identify the trainer checkpoint;
+- the returned `rows_trained` value is the cumulative row number to pass to the next run.
+
+Supervised resume priority is:
 
 1. `init_from_checkpoint` — load the explicit resumable checkpoint row/resource.
 2. Newest resumable RPC row for the current trainer — auto-resume.
 3. `warm_start_from_adapter` — load LoRA weights only and start at step/cursor zero.
 4. Fresh start.
 
-RPC list failures propagate instead of silently starting fresh.
+For supervised auto-resume, RPC list failures propagate instead of silently starting fresh. RL does not issue the auto-latest list call.
 
 ## Warm-start from a promoted adapter (LoRA only)
 
@@ -73,9 +81,9 @@ Supported in all recipe loops: `sft_loop`, `dpo_loop`, `orpo_loop`, `rl_loop`, `
 
 ## Cross-run resume
 
-Auto-resume is scoped to the current trainer job. To continue a prior trainer, pin `cfg.trainer.job_id`; its RPC rows and local row cursors will line up automatically.
+Supervised auto-resume is scoped to the current trainer job. To continue a prior trainer, pin `cfg.trainer.job_id`; its RPC rows and local row cursors will line up automatically.
 
-To resume into another trainer, pass the prior RPC row (preferred), its full resource name, or `f"{prior_job_id}:step-N"`. Cross-job resume preserves checkpoint step `N`. The cursor is looked up under the source trainer id, or taken directly from `dataloader_cursor` when provided.
+For RL, explicitly pass the prior RPC row (preferred), its full resource name, or `f"{prior_job_id}:step-N"`, plus `dataloader_cursor=<rows_trained from the prior run>`. Cross-job resume preserves checkpoint step `N`.
 
 ---
 

--- a/skills/dev/references/checkpoints.md
+++ b/skills/dev/references/checkpoints.md
@@ -1,47 +1,53 @@
-# Checkpoints — where state lives
+# Checkpoints — one remote source of truth
 
-The cookbook's checkpoint manager is `TrainingCheckpoints` in `training/utils/checkpoints.py`. The control plane is the source of truth for what checkpoints exist; the only cookbook-side state is `dataloader.json`, which maps each saved checkpoint name to a `data_consumed` counter (one int per row).
+`TrainingCheckpoints` in `training/utils/checkpoints.py` is the cookbook boundary for resume, promotion, and sampler weight sync. Checkpoint identity and metadata live on the Fireworks control plane. Recipes discover them through `list_checkpoints`; they do not maintain a second checkpoint registry.
 
-## Two axes
-
-`TrainingCheckpoints.save(name, *, resumable, promotable, data_consumed=None)` — pick capabilities independently:
-
-- `resumable=True` → DCP write (weights + optimizer). Training can continue from this.
-- `promotable=True` → sampler write (HF safetensors). Eligible for `promote_checkpoint`.
-- Both → DCP + sampler in one call.
-
-Periodic mid-training saves are usually `resumable=True, promotable=False`. The final save is `resumable=True, promotable=True`. RL weight sync saves sampler checkpoints with `save_weights_for_sampler_ext` and hotloads the returned snapshot identity; those sampler rows are separate from DCP resume saves.
-
-## `dataloader.json`
-
-Written to `{log_path}/dataloader.json`. Single int per checkpoint name:
+The only local checkpoint state is the dataset position that the trainer cannot infer:
 
 ```json
-{"step-10": 40, "step-50": 200}
+{
+  "trainer-job-a": {"10": 40, "50": 200},
+  "trainer-job-b": {"8": 32}
+}
 ```
 
-Bounded to the newest 20 entries. There is no `checkpoints.jsonl` — never has been, in the new model. The control plane (`FireworksClient.list_checkpoints(job_id)`) is queried at resume / promote time for everything else.
+This is `{log_path}/dataloader.json`, a bounded KV mapping from trainer job id and checkpoint step to the next raw row cursor. It contains no paths, checkpoint types, timestamps, or promotion metadata. Each trainer keeps its newest 20 cursor entries. The former flat `{"step-10": 40}` shape is migrated when it is read.
 
-## When each axis is used
+## Save and sync APIs
 
-- `cfg.dcp_save_interval` > 0 → recipe calls `ckpt.save(resumable=True, promotable=False, ...)` every N steps.
-- End of training → recipe calls `ckpt.save(resumable=True, promotable=True, ...)`.
-- `cfg.output_model_id` set → recipe also calls `ckpt.promote_latest(output_model_id, base_model)`.
+`TrainingCheckpoints.save(step, *, resumable, promotable, row_cursor)` keeps the two save capabilities independent:
 
-If `dcp_save_interval` is `0` (the default), mid-training saves are off — training cannot be resumed from intermediate steps. Set it in the recipe's `Config`.
+- `resumable=True` writes DCP weights and optimizer state and records `(trainer_job_id, actual_saved_step) -> row_cursor` locally.
+- `promotable=True` writes a complete sampler export that can be promoted.
+- Both perform both writes under the same `step-N` logical name.
 
-## Delta chain (sampler `checkpoint_type`)
+Periodic saves use `resumable=True, promotable=False`; the final save usually uses both. `row_cursor` is required for every resumable save. If `dcp_save_interval=0` (the default), there are no intermediate resume points.
 
-This is an SDK-level detail, surfaced when you call `save_weights_for_sampler_ext` directly. For full-parameter training, only `base` sampler saves are promotable; `delta` saves are not. LoRA always saves the full adapter, so every LoRA sampler checkpoint is promotable. The SDK-managed sampler backend records the base-then-delta chain for recipe hotload; recipe-level `ckpt.save(promotable=True)` always saves `base`.
+RL recipes call `TrainingCheckpoints.sync_weights(step, hotload)`. They never pass `checkpoint_type` or branch on LoRA versus full-parameter training. The SDK saves a complete LoRA adapter for LoRA runs and manages the full/base/delta chain for full-parameter runs. The checkpoint manager also hides the complete-export choice required for promotion.
 
-`checkpoint_type="merged_base"` is a third, LoRA-only value. Instead of saving the standalone adapter, the trainer folds the active adapter into the base weights (`W <- W + scaling*(B@A)`), strips the adapter metadata, and exports a full base checkpoint that promotes as `INFERENCE_BASE` / `HF_BASE_MODEL`. The session must have a non-trivial adapter — either trained in this run, or loaded via `load_adapter` / the recipe `warm_start_from_adapter`; a fresh LoRA session has zero-delta weights and would export base-identical output. It is a full standalone checkpoint, so — like `base` — it never participates in the delta chain. Note this client-side adapter load is the supported path; control-plane `warmStartFrom` of a LoRA addon is **not** effective and is rejected for service-mode RLOR jobs.
+`checkpoint_type="merged_base"` remains an explicit, specialized LoRA export operation: it folds an adapter into its base model to produce a standalone `HF_BASE_MODEL`. Use `training/examples/tools/merge_lora_and_promote.py` for that workflow; ordinary recipes should not choose checkpoint formats.
 
-Two ways to use it:
+## Resume
 
-- **During a LoRA training run** — to emit a full `HF_BASE_MODEL` instead of a `HF_PEFT_ADDON`, save the final promotable checkpoint directly with `client.save_weights_for_sampler("final-merged", checkpoint_type="merged_base")` rather than relying on `TrainingCheckpoints.save(promotable=True)` (which always saves `base`). The adapter is already loaded in-session, so no separate merge step is needed.
-- **Merge an existing adapter** (no further training) — the standalone `training/examples/tools/merge_lora_and_promote.py` script drives it end to end (provision → `load_adapter` → `merged_base` save → promote).
+`TrainingCheckpoints.list()` returns the authoritative RPC rows. A user may pass any of these forms as `init_from_checkpoint`:
 
----
+- the row dictionary returned by `ckpt.list()` or `FireworksClient.list_checkpoints(job_id)`;
+- the row's full checkpoint resource name;
+- `job_id:step-N`;
+- a bare `step-N` for the current trainer.
+
+The checkpoint row determines the trainer state and step. The local KV mapping supplies only its row cursor. If the mapping has no entry, the cursor is `0`.
+
+Every recipe also exposes `dataloader_cursor`. When it is explicitly set, that exact cursor is used and the local mapping is not read. Use this for a deliberate data-position override or when resuming a remote checkpoint without its original `dataloader.json`.
+
+Resume priority is:
+
+1. `init_from_checkpoint` — load the explicit resumable checkpoint row/resource.
+2. Newest resumable RPC row for the current trainer — auto-resume.
+3. `warm_start_from_adapter` — load LoRA weights only and start at step/cursor zero.
+4. Fresh start.
+
+RPC list failures propagate instead of silently starting fresh.
 
 ## Warm-start from a promoted adapter (LoRA only)
 
@@ -56,14 +62,7 @@ cfg = Config(
 )
 ```
 
-Semantics: weights-only load — LoRA A/B matrices initialize from the adapter; optimizer, LR schedule, and data cursor start fresh.
-
-Priority inside `TrainingCheckpoints.resume` (highest first):
-
-1. `init_from_checkpoint` — explicit cross-job DCP resume (weights + optimizer). Step counter resets.
-2. Newest resumable row on the control plane for the current trainer — auto-resume.
-3. `warm_start_from_adapter` — fresh start with adapter weights.
-4. None — fresh start from `base_model`.
+Semantics: weights-only load — LoRA A/B matrices initialize from the adapter; optimizer, LR schedule, step, and row cursor start fresh.
 
 **Constraints (enforced by `validate_warm_start_config`):**
 
@@ -74,12 +73,9 @@ Supported in all recipe loops: `sft_loop`, `dpo_loop`, `orpo_loop`, `rl_loop`, `
 
 ## Cross-run resume
 
-Auto-resume (priority 2) is **scoped to one trainer job**. If you re-run with the same `log_path` but provision a fresh trainer, the new trainer's `list_checkpoints` is empty and resume falls through to fresh start.
+Auto-resume is scoped to the current trainer job. To continue a prior trainer, pin `cfg.trainer.job_id`; its RPC rows and local row cursors will line up automatically.
 
-To resume across separate `main()` invocations, either:
-
-- Pin both runs to the same trainer via `cfg.trainer.job_id` (all recipes). The reference trainer is SDK-managed, so there is no separate reference job id to pin. The second run reattaches and the CP rows are visible.
-- Or use `init_from_checkpoint=f"{prior_job_id}:step-N"` for explicit cross-job DCP load. This resets the step counter to 0 — fine for warm-start scenarios, not for "continue training and skip to step N".
+To resume into another trainer, pass the prior RPC row (preferred), its full resource name, or `f"{prior_job_id}:step-N"`. Cross-job resume preserves checkpoint step `N`. The cursor is looked up under the source trainer id, or taken directly from `dataloader_cursor` when provided.
 
 ---
 

--- a/skills/dev/references/recipes.md
+++ b/skills/dev/references/recipes.md
@@ -40,7 +40,7 @@ Distillation-specific: use `distillation_loop.py` for OPD/SDFT. Open [`distillat
 
 ## Resume
 
-Auto-resume is scoped to one trainer. Pin both runs to the same trainer via `cfg.trainer.job_id`, keep the same `log_path`, and rerun. `TrainingCheckpoints.resume()` lists the trainer's authoritative RPC rows, picks the newest resumable row, and restores its exact row cursor from the local `trainer job -> step -> cursor` KV mapping. Set `cfg.dataloader_cursor` to override that lookup explicitly. See [`checkpoints.md`](checkpoints.md) for the full contract.
+SFT/DPO/ORPO retain trainer-scoped auto-resume through RPC rows and their local cursor mapping. Sync and async RL are explicit: pass the checkpoint through `init_from_checkpoint` and pass the prior run's returned `rows_trained` value through `dataloader_cursor`. RL neither reads/writes the local cursor mapping nor selects a latest checkpoint automatically. See [`checkpoints.md`](checkpoints.md) for the full contract.
 
 ## Init from another job
 
@@ -48,7 +48,7 @@ Auto-resume is scoped to one trainer. Pin both runs to the same trainer via `cfg
 config = Config(
     log_path="./new_run",
     init_from_checkpoint=checkpoint_row,  # row returned by list_checkpoints
-    dataloader_cursor=128,  # optional explicit override; bypasses local lookup
+    dataloader_cursor=128,  # required RL dataset position; no local lookup
     ...
 )
 ```

--- a/skills/dev/references/recipes.md
+++ b/skills/dev/references/recipes.md
@@ -40,19 +40,20 @@ Distillation-specific: use `distillation_loop.py` for OPD/SDFT. Open [`distillat
 
 ## Resume
 
-Auto-resume is scoped to one trainer. Pin both runs to the same trainer via `cfg.trainer.job_id` (all recipes; the reference trainer is SDK-managed, so there is no separate reference job id to pin), keep the same `log_path`, and rerun. `TrainingCheckpoints.resume()` lists the trainer's checkpoints on the control plane, picks the newest resumable row, and restores the rollout cursor from `dataloader.json`. See [`checkpoints.md`](checkpoints.md) for the full priority order and constraints.
+Auto-resume is scoped to one trainer. Pin both runs to the same trainer via `cfg.trainer.job_id`, keep the same `log_path`, and rerun. `TrainingCheckpoints.resume()` lists the trainer's authoritative RPC rows, picks the newest resumable row, and restores its exact row cursor from the local `trainer job -> step -> cursor` KV mapping. Set `cfg.dataloader_cursor` to override that lookup explicitly. See [`checkpoints.md`](checkpoints.md) for the full contract.
 
 ## Init from another job
 
 ```python
 config = Config(
     log_path="./new_run",
-    init_from_checkpoint="i44pvd4syzg8hjfk:step-4",  # job_id:checkpoint_name
+    init_from_checkpoint=checkpoint_row,  # row returned by list_checkpoints
+    dataloader_cursor=128,  # optional explicit override; bypasses local lookup
     ...
 )
 ```
 
-Loads weights from the other job; resets step to 0.
+You may also pass the row's full resource name or `"i44pvd4syzg8hjfk:step-4"`. Cross-job resume preserves the checkpoint step.
 
 ## RL specifics
 

--- a/skills/dev/references/rl/hotload.md
+++ b/skills/dev/references/rl/hotload.md
@@ -50,7 +50,6 @@ The two scopes are mutually exclusive for the same trainer ↔ deployment pair.
 | Field | Default | Meaning |
 |---|---|---|
 | `weight_sync_interval` | `1` | Sync every N optimizer steps. `1` = after every step (on-policy). `0` = no weight sync at all (rollouts always come from the initial policy — you almost never want this for RL). |
-| `first_checkpoint_type` | `"base"` | First sampler save is a full snapshot; subsequent saves can be deltas. Do not change. |
 | `weight_sync_timeout` | `600` | Per-hotload timeout in seconds. Bump if you see `Hotload did not complete within 600s` on large models. |
 | `weight_sync_before_training` | `False` | Push an initial base snapshot before step 0. Useful when the deployment starts from a different snapshot than the trainer's base. |
 | `dcp_save_interval` | `0` | DCP (optimizer + weights) save cadence for **resume**. Orthogonal to sampler hotload. `0` = off; no intermediate resume points. |
@@ -65,8 +64,10 @@ The two scopes are mutually exclusive for the same trainer ↔ deployment pair.
 
 For full-parameter training, the first sampler save is `base` (full weights, ~16 GB for 8B). Subsequent saves are `delta` (XOR diff, ~10× smaller). The SDK-managed sampler backend records this chain automatically — users don't pick per-step.
 
-- LoRA always saves the full adapter regardless of `checkpoint_type` — every LoRA sampler checkpoint is promotable.
+- LoRA always saves the full adapter; every LoRA sampler checkpoint is promotable.
 - Full-param `delta` saves are **not** promotable. Only `base` saves are. The cookbook's `TrainingCheckpoints.save(promotable=True)` always emits a `base` save, so periodic promotables stay promotable. Recipe weight sync switches to `delta` after the first call — those rows are still visible in `list_checkpoints`, while `promote_latest` picks the most-recent **promotable** row.
+
+This behavior is entirely behind `TrainingCheckpoints.sync_weights`: recipe code supplies a step and hotload callback, while the SDK chooses LoRA/full and full base/delta behavior.
 
 ## `dcp_save_interval` for resume
 
@@ -203,5 +204,5 @@ Agents sometimes copy old cookbook snippets that reference `hot_load_deployment_
 
 - [Hotload flows docs page](https://docs.fireworks.ai/fine-tuning/training-api/cookbook/hotload-flows) — user-facing overview (this skill is the deep reference)
 - Low-level `WeightSyncer` lifecycle: `fireworks.training.sdk.weight_syncer.WeightSyncer` (installed under `src/fireworks/training/sdk/weight_syncer.py`). Recipes use SDK-managed service hotload directly.
-- `save_weights_for_sampler_ext`, `save_state`, `list_checkpoints`: `fireworks.training.sdk.client.FiretitanTrainingClient`.
+- `save_weights_for_sampler`, `save_state`, `list_checkpoints`: `fireworks.training.sdk.client.FiretitanTrainingClient`.
 - Trainer + deployment managers this flow depends on: `fireworks.training.sdk.trainer.TrainerJobManager` and `fireworks.training.sdk.deployment.DeploymentManager`.

--- a/training/examples/multihop_qa/train_multihop_qa_igpo.py
+++ b/training/examples/multihop_qa/train_multihop_qa_igpo.py
@@ -114,6 +114,7 @@ class MultiHopQAIGPOConfig:
     epochs: int = 3
     max_rows: int = 200
     max_steps: int = 8
+    dataloader_cursor: int | None = None
     lora_rank: int = 0
     max_seq_len: int | None = None
 
@@ -407,14 +408,10 @@ def main(cfg: MultiHopQAIGPOConfig | None = None) -> dict:
             log_path=cfg.log_path,
             lora_rank=cfg.lora_rank,
         )
-        resume_info = ckpt.resume()
-        step_offset = resume_info.step if resume_info else 0
+        resume_info = ckpt.resume(dataloader_cursor=cfg.dataloader_cursor)
+        step_offset = resume_info.step
         if cfg.deployment_id:
-            name = (
-                f"resume-{step_offset}-base" if step_offset > 0 else "step-0-base"
-            )
-            saved = policy.save_weights_for_sampler_ext(name, checkpoint_type="base")
-            service.hotload_sampler_snapshot(saved.snapshot_name)
+            ckpt.sync_weights(step_offset, service.hotload_sampler_snapshot)
 
         # Rollout processor
         rollout_base_url = sampler.base_url.rstrip("/") + (
@@ -714,23 +711,22 @@ def main(cfg: MultiHopQAIGPOConfig | None = None) -> dict:
                     and step % WEIGHT_SYNC_INTERVAL == 0
                 ):
                     with timer("weight_sync"):
-                        saved = policy.save_weights_for_sampler_ext(f"step-{step}")
-                        service.hotload_sampler_snapshot(saved.snapshot_name)
+                        ckpt.sync_weights(step, service.hotload_sampler_snapshot)
 
                 if (
                     DCP_SAVE_INTERVAL > 0
                     and step % DCP_SAVE_INTERVAL == 0
                 ):
                     with timer("dcp_save"):
-                        _data_consumed = (
-                            (resume_info.data_consumed if resume_info else 0)
+                        row_cursor = (
+                            resume_info.row_cursor
                             + (step - step_offset) * prompt_groups_per_step
                         )
                         ckpt.save(
-                            f"step-{step}",
+                            step,
                             resumable=True,
                             promotable=False,
-                            data_consumed=_data_consumed,
+                            row_cursor=row_cursor,
                         )
 
                 metrics = compute_step_metrics(
@@ -810,15 +806,14 @@ def main(cfg: MultiHopQAIGPOConfig | None = None) -> dict:
 
             if global_step > step_offset:
                 try:
-                    cp_name = f"step-{global_step}"
-                    _data_consumed = (
-                        resume_info.data_consumed if resume_info else 0
-                    ) + (global_step - step_offset) * prompt_groups_per_step
+                    row_cursor = resume_info.row_cursor + (
+                        global_step - step_offset
+                    ) * prompt_groups_per_step
                     ckpt.save(
-                        cp_name,
+                        global_step,
                         resumable=True,
                         promotable=True,
-                        data_consumed=_data_consumed,
+                        row_cursor=row_cursor,
                     )
                     if getattr(cfg, "output_model_id", None):
                         ckpt.promote_latest(cfg.output_model_id, cfg.base_model)

--- a/training/examples/rl/frozen_lake/train_frozen_lake.py
+++ b/training/examples/rl/frozen_lake/train_frozen_lake.py
@@ -122,6 +122,7 @@ class FrozenLakeConfig:
     epochs: int = 3
     max_seeds: int = 20
     max_steps: int = 12
+    dataloader_cursor: int | None = None
     lora_rank: int = 0
     max_seq_len: int | None = None
 
@@ -532,13 +533,11 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
             log_path=cfg.log_path,
             lora_rank=cfg.lora_rank,
         )
-        resume_info = ckpt.resume()
-        step_offset = resume_info.step if resume_info else 0
-        prior_rows_consumed = resume_info.data_consumed if resume_info else 0
+        resume_info = ckpt.resume(dataloader_cursor=cfg.dataloader_cursor)
+        step_offset = resume_info.step
+        prior_rows_consumed = resume_info.row_cursor
         if cfg.deployment_id:
-            name = f"resume-{step_offset}-base" if step_offset > 0 else "step-0-base"
-            saved = policy.save_weights_for_sampler_ext(name, checkpoint_type="base")
-            service.hotload_sampler_snapshot(saved.snapshot_name)
+            ckpt.sync_weights(step_offset, service.hotload_sampler_snapshot)
 
         # -- Build rollout processor ----------------------------------------
         rollout_base_url = sampler.base_url.rstrip("/") + ("" if cfg.inference_base_url else "/inference")
@@ -716,10 +715,10 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
                     t0 = time.time()
                     with timer("dcp_save"):
                         ckpt.save(
-                            f"step-{step}",
+                            step,
                             resumable=True,
                             promotable=False,
-                            data_consumed=step - step_offset,
+                            row_cursor=prior_rows_consumed + step - step_offset,
                         )
                     logger.info("[step %d] dcp_save: done (%.1fs)", step, time.time() - t0)
 
@@ -759,8 +758,7 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
                 logger.info("[step %d] weight_sync: saving + loading...", step)
                 t0 = time.time()
                 with timer("weight_sync"):
-                    saved = policy.save_weights_for_sampler_ext(f"step-{step}")
-                    service.hotload_sampler_snapshot(saved.snapshot_name)
+                    ckpt.sync_weights(step, service.hotload_sampler_snapshot)
                 logger.info("[step %d] weight_sync: done (%.1fs)", step, time.time() - t0)
 
             def should_accept(pg: PromptGroup) -> bool:
@@ -834,13 +832,12 @@ def main(cfg: FrozenLakeConfig | None = None) -> dict:
 
             if global_step > step_offset:
                 try:
-                    cp_name = f"step-{global_step}"
-                    _data_consumed = int(final_stats["resolved_rows"])
+                    row_cursor = int(final_stats["resolved_rows"])
                     ckpt.save(
-                        cp_name,
+                        global_step,
                         resumable=True,
                         promotable=True,
-                        data_consumed=_data_consumed,
+                        row_cursor=row_cursor,
                     )
                     if getattr(cfg, "output_model_id", None):
                         ckpt.promote_latest(cfg.output_model_id, cfg.base_model)

--- a/training/recipes/async_rl_loop.py
+++ b/training/recipes/async_rl_loop.py
@@ -209,9 +209,10 @@ class Config:
 
     init_from_checkpoint: str | dict | None = None
     """Resume from prior checkpoint; bare name = this job, ``"job:name"``
-    = cross-job. Rows returned by ``list_checkpoints`` are also accepted."""
-    dataloader_cursor: int | None = None
-    """Explicit raw-row cursor. When set, local cursor resolution is skipped."""
+    = cross-job. Rows returned by ``list_checkpoints`` are also accepted.
+    When omitted, no latest checkpoint is selected automatically."""
+    dataloader_cursor: int = 0
+    """First raw dataset row to process. This is the only dataset resume input."""
     save_final_checkpoint: bool = True
     """Save a resumable+promotable checkpoint at the end of training."""
     output_model_id: str | None = None
@@ -269,7 +270,6 @@ def _save_checkpoint(
     ckpt: TrainingCheckpoints,
     *,
     step: int,
-    row_cursor: int,
     resumable: bool = True,
     promotable: bool = False,
 ) -> None:
@@ -280,7 +280,6 @@ def _save_checkpoint(
             step,
             resumable=resumable,
             promotable=promotable,
-            row_cursor=row_cursor,
         )
     logger.info("[%s] dcp_save: done (%.1fs)", name, span.elapsed)
 
@@ -304,6 +303,9 @@ def main(
     Remote trainer and sampler setup is owned by the SDK-managed Tinker path.
     """
     cfg = config
+    if cfg.dataloader_cursor < 0:
+        raise ValueError("dataloader_cursor must be >= 0")
+    logger.info("Dataset resume row: %d", cfg.dataloader_cursor)
     runner = RunnerIO(cfg.runner)
 
     logger.warning(
@@ -439,6 +441,7 @@ def main(
         resume_info = ckpt.resume(
             init_from_checkpoint=cfg.init_from_checkpoint,
             dataloader_cursor=cfg.dataloader_cursor,
+            auto_latest=False,
         )
         step_offset = resume_info.step
         if step_offset:
@@ -457,7 +460,7 @@ def main(
         else:
             rows = list(rows)
 
-        prior_rows_consumed = resume_info.row_cursor
+        prior_rows_consumed = cfg.dataloader_cursor
         row_loader = CursorDataLoader(
             rows,
             start_cursor=prior_rows_consumed,
@@ -852,7 +855,6 @@ def main(
                     _save_checkpoint(
                         ckpt,
                         step=step,
-                        row_cursor=int(loop_stats["resolved_rows"]),
                     )
                 except (OSError, RuntimeError) as e:
                     # Periodic save: surface the failure but keep training.
@@ -905,14 +907,12 @@ def main(
         # Promotion still requires at least one optimizer step.
         resume_row_cursor = int(final_stats["resolved_rows"])
         has_trained_steps = global_step > step_offset
-        has_advanced_dataset = resume_row_cursor > prior_rows_consumed
         promoted_checkpoint: str | None = None
-        if cfg.save_final_checkpoint and (has_trained_steps or has_advanced_dataset):
+        if cfg.save_final_checkpoint and has_trained_steps:
             ckpt.save(
                 global_step,
                 resumable=True,
                 promotable=has_trained_steps,
-                row_cursor=resume_row_cursor,
             )
             if cfg.output_model_id and has_trained_steps:
                 ckpt.promote_latest(cfg.output_model_id, cfg.base_model)
@@ -934,8 +934,10 @@ def main(
         )
 
         logger.info(
-            "Async RL training complete: %d steps (%d new in this run)",
-            global_step, global_step - step_offset,
+            "Async RL training complete: %d steps (%d new), rows trained: %d",
+            global_step,
+            global_step - step_offset,
+            resume_row_cursor,
         )
         wandb_finish()
         return {
@@ -943,4 +945,5 @@ def main(
             "policy_job_id": service.trainer_job_id,
             "reference_job_id": service.reference_trainer_job_id,
             "deployment_id": service.deployment_id,
+            "rows_trained": resume_row_cursor,
         }

--- a/training/recipes/async_rl_loop.py
+++ b/training/recipes/async_rl_loop.py
@@ -207,9 +207,11 @@ class Config:
     model). When unset the recipe still runs; the orchestration layer just
     won't receive progress updates. See ``training.utils.runner``."""
 
-    init_from_checkpoint: str | None = None
+    init_from_checkpoint: str | dict | None = None
     """Resume from prior checkpoint; bare name = this job, ``"job:name"``
-    = cross-job."""
+    = cross-job. Rows returned by ``list_checkpoints`` are also accepted."""
+    dataloader_cursor: int | None = None
+    """Explicit raw-row cursor. When set, local cursor resolution is skipped."""
     save_final_checkpoint: bool = True
     """Save a resumable+promotable checkpoint at the end of training."""
     output_model_id: str | None = None
@@ -266,18 +268,19 @@ def _rollout_fn_context_param_names(rollout_fn: RolloutFn) -> frozenset[str]:
 def _save_checkpoint(
     ckpt: TrainingCheckpoints,
     *,
-    name: str,
-    data_consumed: int,
+    step: int,
+    row_cursor: int,
     resumable: bool = True,
     promotable: bool = False,
 ) -> None:
+    name = f"step-{step}"
     logger.info("[%s] dcp_save...", name)
     with elapsed_timer("dcp_save") as span:
         ckpt.save(
-            name,
+            step,
             resumable=resumable,
             promotable=promotable,
-            data_consumed=data_consumed,
+            row_cursor=row_cursor,
         )
     logger.info("[%s] dcp_save: done (%.1fs)", name, span.elapsed)
 
@@ -435,8 +438,9 @@ def main(
 
         resume_info = ckpt.resume(
             init_from_checkpoint=cfg.init_from_checkpoint,
+            dataloader_cursor=cfg.dataloader_cursor,
         )
-        step_offset = resume_info.step if resume_info else 0
+        step_offset = resume_info.step
         if step_offset:
             logger.info("Resuming from step %d", step_offset)
             wandb_log(
@@ -445,11 +449,7 @@ def main(
 
         if cfg.weight_sync_before_training or service.requires_initial_sampler_sync():
             with elapsed_timer("weight_sync") as span:
-                saved = policy.save_weights_for_sampler(
-                    f"step-{step_offset}",
-                    checkpoint_type="base",
-                )
-                service.hotload_sampler_snapshot(saved.path)
+                ckpt.sync_weights(step_offset, service.hotload_sampler_snapshot)
             logger.info("[step %d] weight sync (%.1fs)", step_offset, span.elapsed)
 
         if rows is None:
@@ -457,7 +457,7 @@ def main(
         else:
             rows = list(rows)
 
-        prior_rows_consumed = resume_info.data_consumed if resume_info else 0
+        prior_rows_consumed = resume_info.row_cursor
         row_loader = CursorDataLoader(
             rows,
             start_cursor=prior_rows_consumed,
@@ -851,8 +851,8 @@ def main(
                 try:
                     _save_checkpoint(
                         ckpt,
-                        name=f"step-{step}",
-                        data_consumed=int(loop_stats["resolved_rows"]),
+                        step=step,
+                        row_cursor=int(loop_stats["resolved_rows"]),
                     )
                 except (OSError, RuntimeError) as e:
                     # Periodic save: surface the failure but keep training.
@@ -887,8 +887,8 @@ def main(
                 max_head_offpolicy_versions=cfg.max_head_offpolicy_versions,
                 with_reference=(reference is not None),
                 min_group_size=cfg.min_group_size,
-                weight_sync_fn=lambda step: service.hotload_sampler_snapshot(
-                    policy.save_weights_for_sampler(f"step-{step}").path
+                weight_sync_fn=lambda step: ckpt.sync_weights(
+                    step, service.hotload_sampler_snapshot
                 ),
                 weight_sync_interval=_WEIGHT_SYNC_INTERVAL,
                 max_concurrent=cfg.max_concurrency_rollout_sample,
@@ -896,7 +896,7 @@ def main(
                 pipeline_chunks_per_step=cfg.pipeline_chunks_per_step,
                 post_train_metrics_fn=log_post_train_metrics,
                 global_step=step_offset,
-                resolved_rows_fn=lambda: row_loader.data_consumed,
+                resolved_rows_fn=lambda: row_loader.row_cursor,
                 return_final_stats=True,
             )
         )
@@ -908,12 +908,11 @@ def main(
         has_advanced_dataset = resume_row_cursor > prior_rows_consumed
         promoted_checkpoint: str | None = None
         if cfg.save_final_checkpoint and (has_trained_steps or has_advanced_dataset):
-            cp_name = f"step-{global_step}"
             ckpt.save(
-                cp_name,
+                global_step,
                 resumable=True,
                 promotable=has_trained_steps,
-                data_consumed=resume_row_cursor,
+                row_cursor=resume_row_cursor,
             )
             if cfg.output_model_id and has_trained_steps:
                 ckpt.promote_latest(cfg.output_model_id, cfg.base_model)

--- a/training/recipes/async_rl_loop.py
+++ b/training/recipes/async_rl_loop.py
@@ -916,7 +916,7 @@ def main(
             )
             if cfg.output_model_id and has_trained_steps:
                 ckpt.promote_latest(cfg.output_model_id, cfg.base_model)
-                promoted_checkpoint = cp_name
+                promoted_checkpoint = f"step-{global_step}"
 
         if promoted_checkpoint is not None and cfg.output_model_id:
             runner.write_output_model(

--- a/training/recipes/distillation_loop.py
+++ b/training/recipes/distillation_loop.py
@@ -1043,7 +1043,7 @@ def main(
                     ckpt.promote_latest(cfg.output_model_id, cfg.base_model)
                     runner.write_output_model(
                         model_id=cfg.output_model_id,
-                        checkpoint=checkpoint_name,
+                        checkpoint=f"step-{global_step}",
                         job_id=policy_job_id,
                     )
             except Exception as exc:

--- a/training/recipes/distillation_loop.py
+++ b/training/recipes/distillation_loop.py
@@ -175,8 +175,11 @@ class Config:
     concurrency: ConcurrencyConfig = field(default_factory=ConcurrencyConfig)
     """Concurrency control for inference sampling."""
 
-    init_from_checkpoint: str | None = None
-    """Load pretrained DCP weights on a fresh dataset."""
+    init_from_checkpoint: str | dict | None = None
+    """Resume from a checkpoint name, resource, or ``list_checkpoints`` row."""
+
+    dataloader_cursor: int | None = None
+    """Explicit raw-row cursor. When set, local cursor resolution is skipped."""
 
     warm_start_from_adapter: str | None = None
     """GCS URI of an HF PEFT adapter directory for LoRA warm start."""
@@ -675,14 +678,13 @@ def main(
         resume_info = ckpt.resume(
             init_from_checkpoint=cfg.init_from_checkpoint,
             warm_start_from_adapter=cfg.warm_start_from_adapter,
+            dataloader_cursor=cfg.dataloader_cursor,
         )
-        step_offset = resume_info.step if resume_info else 0
+        step_offset = resume_info.step
         wandb_log({"train/step": step_offset}, step_offset)
 
         if cfg.weight_sync_before_training:
-            name = f"resume-{step_offset}-base" if step_offset > 0 else "step-0-base"
-            saved = policy.save_weights_for_sampler_ext(name, checkpoint_type="base")
-            service.hotload_sampler_snapshot(saved.snapshot_name)
+            ckpt.sync_weights(step_offset, service.hotload_sampler_snapshot)
 
         # -- Prepare sampling and training --------------------------------------
 
@@ -935,14 +937,14 @@ def main(
             rollouts_completed = step - step_offset
             dcp_interval = cfg.dcp_save_interval
             if dcp_interval > 0 and rollouts_completed > 0 and rollouts_completed % dcp_interval == 0:
-                data_consumed = (resume_info.data_consumed if resume_info else 0) + (
+                row_cursor = resume_info.row_cursor + (
                     rollouts_completed * prompt_groups_per_step
                 )
                 ckpt.save(
-                    f"step-{step}",
+                    step,
                     resumable=True,
                     promotable=False,
-                    data_consumed=data_consumed,
+                    row_cursor=row_cursor,
                 )
 
             metrics: dict[str, Any] = dict(flush_timing())
@@ -977,8 +979,7 @@ def main(
                 logger.info("[step %d] weight_sync: saving + loading...", step)
                 t0 = _time.time()
                 with timer("weight_sync"):
-                    saved = policy.save_weights_for_sampler_ext(f"step-{step}")
-                    service.hotload_sampler_snapshot(saved.snapshot_name)
+                    ckpt.sync_weights(step, service.hotload_sampler_snapshot)
                 logger.info("[step %d] weight_sync: done (%.1fs)", step, _time.time() - t0)
                 if (
                     cfg.step_eval is not None
@@ -1029,15 +1030,14 @@ def main(
 
         if cfg.save_final_checkpoint and global_step > step_offset:
             try:
-                checkpoint_name = f"step-{global_step}"
-                data_consumed = (resume_info.data_consumed if resume_info else 0) + (
+                row_cursor = resume_info.row_cursor + (
                     (global_step - step_offset) * prompt_groups_per_step
                 )
                 ckpt.save(
-                    checkpoint_name,
+                    global_step,
                     resumable=True,
                     promotable=True,
-                    data_consumed=data_consumed,
+                    row_cursor=row_cursor,
                 )
                 if cfg.output_model_id:
                     ckpt.promote_latest(cfg.output_model_id, cfg.base_model)

--- a/training/recipes/dpo_loop.py
+++ b/training/recipes/dpo_loop.py
@@ -159,7 +159,9 @@ class Config:
     dcp_save_interval: int = 0
     """Save DCP checkpoints every N steps. 0 disables."""
     wandb: WandBConfig = field(default_factory=lambda: WandBConfig(project="dpo-tinker"))
-    init_from_checkpoint: str | None = None
+    init_from_checkpoint: str | dict | None = None
+    dataloader_cursor: int | None = None
+    """Explicit raw-row cursor. When set, local cursor resolution is skipped."""
     warm_start_from_adapter: str | None = None
     """GCS URI of an HF PEFT adapter directory. When set, initializes LoRA
     weights from the adapter at training start (weights-only, fresh optimizer).
@@ -392,7 +394,7 @@ async def _train_loop(
         epoch: int,
         step_pairs: list[dict[str, Any]],
         *,
-        data_consumed: int | None = None,
+        row_cursor: int | None = None,
     ) -> None:
         nonlocal step
         step_t0 = time.monotonic()
@@ -424,11 +426,11 @@ async def _train_loop(
         if cfg.dcp_save_interval > 0 and step % cfg.dcp_save_interval == 0:
             with timer("dcp_save"):
                 ckpt.save(
-                    f"step-{step}",
+                    step,
                     resumable=True,
                     promotable=False,
-                    data_consumed=(
-                        cursor.value if data_consumed is None else data_consumed
+                    row_cursor=(
+                        cursor.value if row_cursor is None else row_cursor
                     ),
                 )
 
@@ -508,7 +510,7 @@ async def _train_loop(
         async def _emit_enriched(
             chunk: list[dict[str, Any]],
             *,
-            data_consumed: int,
+            row_cursor: int,
         ) -> None:
             nonlocal pairs_per_epoch
             enriched = await _ref_forward_batch(
@@ -518,7 +520,7 @@ async def _train_loop(
             if multi_epoch:
                 for pair in enriched:
                     ref_cache_log.append(pair)
-            await pipe.put((enriched, data_consumed))
+            await pipe.put((enriched, row_cursor))
 
         while True:
             batch = await asyncio.to_thread(next, loader_iter, sentinel)
@@ -554,13 +556,13 @@ async def _train_loop(
             while len(pending_pairs) >= batch_size:
                 await _emit_enriched(
                     pending_pairs[:batch_size],
-                    data_consumed=cursor.value,
+                    row_cursor=cursor.value,
                 )
                 pending_pairs = pending_pairs[batch_size:]
             if cfg.max_pairs is not None and pairs_per_epoch + len(pending_pairs) >= cfg.max_pairs:
                 break
         if pending_pairs:
-            await _emit_enriched(pending_pairs, data_consumed=cursor.value)
+            await _emit_enriched(pending_pairs, row_cursor=cursor.value)
         await pipe.put(_DONE)
 
     async def _trainer() -> None:
@@ -568,12 +570,12 @@ async def _train_loop(
             item = await pipe.get()
             if item is _DONE:
                 break
-            step_pairs, data_consumed = item
+            step_pairs, row_cursor = item
             await asyncio.to_thread(
                 _run_train_step,
                 0,
                 step_pairs,
-                data_consumed=data_consumed,
+                row_cursor=row_cursor,
             )
             pbar.update(1)
 
@@ -740,8 +742,9 @@ def main(
         resume_info = ckpt.resume(
             init_from_checkpoint=cfg.init_from_checkpoint,
             warm_start_from_adapter=cfg.warm_start_from_adapter,
+            dataloader_cursor=cfg.dataloader_cursor,
         )
-        step_offset = resume_info.step if resume_info else 0
+        step_offset = resume_info.step
         wandb_log({"train/step": step_offset}, step_offset)
         adam_kwargs = dict(DEFAULT_ADAM)
         adam_kwargs["weight_decay"] = cfg.weight_decay
@@ -801,7 +804,7 @@ def main(
             reference_job_id = None
 
         cursor = RawRowCursor(max_rows=len(pair_dataset) * cfg.epochs)
-        cursor.resume(resume_info.data_consumed if resume_info else None)
+        cursor.resume(resume_info.row_cursor)
         runner.start_training()
         step = asyncio.run(
             _train_loop(
@@ -819,12 +822,11 @@ def main(
         # -- Final checkpoint --------------------------------------------------
 
         if cfg.save_final_checkpoint and step > step_offset:
-            cp_name = f"step-{step}"
             ckpt.save(
-                cp_name,
+                step,
                 resumable=True,
                 promotable=True,
-                data_consumed=cursor.value,
+                row_cursor=cursor.value,
             )
 
             if getattr(cfg, "output_model_id", None):

--- a/training/recipes/dpo_loop.py
+++ b/training/recipes/dpo_loop.py
@@ -832,7 +832,9 @@ def main(
             if getattr(cfg, "output_model_id", None):
                 ckpt.promote_latest(cfg.output_model_id, cfg.base_model)
                 runner.write_output_model(
-                    model_id=cfg.output_model_id, checkpoint=cp_name, job_id=policy_job_id,
+                    model_id=cfg.output_model_id,
+                    checkpoint=f"step-{step}",
+                    job_id=policy_job_id,
                 )
 
         total_steps = step

--- a/training/recipes/igpo_loop.py
+++ b/training/recipes/igpo_loop.py
@@ -758,7 +758,11 @@ def main(
                 )
                 if getattr(cfg, "output_model_id", None):
                     ckpt.promote_latest(cfg.output_model_id, cfg.base_model)
-                    runner.write_output_model(model_id=cfg.output_model_id, checkpoint=cp_name, job_id=policy_job_id)
+                    runner.write_output_model(
+                        model_id=cfg.output_model_id,
+                        checkpoint=f"step-{global_step}",
+                        job_id=policy_job_id,
+                    )
             except Exception as e:
                 logger.warning("Final checkpoint failed: %s", e)
 

--- a/training/recipes/igpo_loop.py
+++ b/training/recipes/igpo_loop.py
@@ -131,7 +131,9 @@ class Config:
     scoring_workers: int = 8
     """ThreadPoolExecutor max_workers for async IG scoring."""
 
-    init_from_checkpoint: str | None = None
+    init_from_checkpoint: str | dict | None = None
+    dataloader_cursor: int | None = None
+    """Explicit raw-row cursor. When set, local cursor resolution is skipped."""
     warm_start_from_adapter: str | None = None
     """GCS URI of an HF PEFT adapter directory. When set, initializes LoRA
     weights from the adapter at training start (weights-only, fresh optimizer).
@@ -362,16 +364,13 @@ def main(
         resume_info = ckpt.resume(
             init_from_checkpoint=cfg.init_from_checkpoint,
             warm_start_from_adapter=cfg.warm_start_from_adapter,
+            dataloader_cursor=cfg.dataloader_cursor,
         )
-        step_offset = resume_info.step if resume_info else 0
+        step_offset = resume_info.step
 
         if cfg.weight_sync_before_training:
             with timer("weight_sync"):
-                saved = policy.save_weights_for_sampler_ext(
-                    f"step-{step_offset}",
-                    checkpoint_type="base",
-                )
-                service.hotload_sampler_snapshot(saved.snapshot_name)
+                ckpt.sync_weights(step_offset, service.hotload_sampler_snapshot)
 
         # Dataset
         raw_dataset = load_jsonl_dataset(cfg.dataset, cfg.max_rows)
@@ -678,14 +677,13 @@ def main(
             # 5. Sync weights
             if cfg.weight_sync_interval > 0 and step % cfg.weight_sync_interval == 0:
                 with timer("weight_sync"):
-                    saved = policy.save_weights_for_sampler_ext(f"step-{step}")
-                    service.hotload_sampler_snapshot(saved.snapshot_name)
+                    ckpt.sync_weights(step, service.hotload_sampler_snapshot)
             if cfg.dcp_save_interval > 0 and step % cfg.dcp_save_interval == 0:
                 ckpt.save(
-                    f"step-{step}",
+                    step,
                     resumable=True,
                     promotable=False,
-                    data_consumed=cursor.value,
+                    row_cursor=cursor.value,
                 )
 
             # 6. Metrics
@@ -732,12 +730,7 @@ def main(
 
         train_fns = TrainStepFns(train_step=train_step)
 
-        # Prefer the persisted raw-row cursor; fall back to step-derived
-        # progress for older checkpoints.
-        cursor.resume(
-            resume_info.data_consumed if resume_info else None,
-            fallback=step_offset * prompt_groups_per_step,
-        )
+        cursor.resume(resume_info.row_cursor)
         remaining_rows = all_rows[cursor.value:]
 
         total_rl_steps = len(rl_dataset) - step_offset
@@ -757,12 +750,11 @@ def main(
         # Final checkpoint
         if global_step > step_offset:
             try:
-                cp_name = f"step-{global_step}"
                 ckpt.save(
-                    cp_name,
+                    global_step,
                     resumable=True,
                     promotable=True,
-                    data_consumed=cursor.value,
+                    row_cursor=cursor.value,
                 )
                 if getattr(cfg, "output_model_id", None):
                     ckpt.promote_latest(cfg.output_model_id, cfg.base_model)

--- a/training/recipes/orpo_loop.py
+++ b/training/recipes/orpo_loop.py
@@ -54,6 +54,7 @@ from fireworks.training.sdk.training_spec import (
 
 from training.utils import (
     DEFAULT_ADAM,
+    RawRowCursor,
     TrainerConfig,
     ReconnectableClient,
     RunnerConfig,
@@ -158,7 +159,9 @@ class Config:
     """Timeout in seconds for forward_backward / optim_step calls.
     0 = use DEFAULT_TIMEOUT_S from training.utils.client."""
 
-    init_from_checkpoint: str | None = None
+    init_from_checkpoint: str | dict | None = None
+    dataloader_cursor: int | None = None
+    """Explicit prepared-row cursor. When set, local cursor resolution is skipped."""
     warm_start_from_adapter: str | None = None
     """GCS URI of an HF PEFT adapter directory. When set, initializes LoRA
     weights from the adapter at training start (weights-only, fresh optimizer).
@@ -327,8 +330,9 @@ def main(
         resume_info = ckpt.resume(
             init_from_checkpoint=cfg.init_from_checkpoint,
             warm_start_from_adapter=cfg.warm_start_from_adapter,
+            dataloader_cursor=cfg.dataloader_cursor,
         )
-        step_offset = resume_info.step if resume_info else 0
+        step_offset = resume_info.step
 
         # -- Data ----------------------------------------------------------------
 
@@ -392,6 +396,8 @@ def main(
 
         step = step_offset
         total_steps = ((len(pair_cache) + cfg.batch_size - 1) // cfg.batch_size) * cfg.epochs
+        cursor = RawRowCursor(max_rows=len(pair_cache) * cfg.epochs)
+        cursor.resume(resume_info.row_cursor)
 
         logger.info(
             "LR schedule: %s | warmup_steps=%s | warmup_ratio=%s | peak_lr=%g",
@@ -436,14 +442,15 @@ def main(
             result = client.forward_backward_custom(datums, loss_fn)
             client.optim_step(adam_params)
             step += 1
+            cursor.record(len(step_pairs))
 
             if cfg.dcp_save_interval > 0 and step % cfg.dcp_save_interval == 0:
                 logger.info("Saving DCP checkpoint at step %d", step)
                 ckpt.save(
-                    f"step-{step}",
+                    step,
                     resumable=True,
                     promotable=False,
-                    data_consumed=(step - step_offset) * cfg.batch_size,
+                    row_cursor=cursor.value,
                 )
 
             step_elapsed = time.monotonic() - step_started_at
@@ -491,10 +498,14 @@ def main(
         start_running(runner, total_steps=total_steps)
 
         for epoch in range(cfg.epochs):
+            epoch_start = epoch * len(pair_cache)
+            skip_in_epoch = max(0, cursor.value - epoch_start)
+            if skip_in_epoch >= len(pair_cache):
+                continue
             epoch_pairs = _shuffled_pair_cache(pair_cache, cfg.seed, epoch)
             step_t0 = time.monotonic()
             batch_buffer: list[dict] = []
-            for pair in epoch_pairs:
+            for pair in epoch_pairs[skip_in_epoch:]:
                 batch_buffer.append(pair)
                 if len(batch_buffer) >= cfg.batch_size:
                     step_t0 = _run_train_step(epoch, batch_buffer, step_t0)
@@ -507,12 +518,11 @@ def main(
 
         if cfg.save_final_checkpoint and step > step_offset:
             logger.info("Saving final checkpoint (step %d)...", step)
-            cp_name = f"step-{step}"
             ckpt.save(
-                cp_name,
+                step,
                 resumable=True,
                 promotable=True,
-                data_consumed=(step - step_offset) * cfg.batch_size,
+                row_cursor=cursor.value,
             )
             if getattr(cfg, "output_model_id", None):
                 ckpt.promote_latest(cfg.output_model_id, cfg.base_model)

--- a/training/recipes/orpo_loop.py
+++ b/training/recipes/orpo_loop.py
@@ -527,7 +527,9 @@ def main(
             if getattr(cfg, "output_model_id", None):
                 ckpt.promote_latest(cfg.output_model_id, cfg.base_model)
                 runner.write_output_model(
-                    model_id=cfg.output_model_id, checkpoint=cp_name, job_id=job_id,
+                    model_id=cfg.output_model_id,
+                    checkpoint=f"step-{step}",
+                    job_id=job_id,
                 )
 
         write_completed(runner, step=step, total_steps=total_steps)

--- a/training/recipes/rl_loop.py
+++ b/training/recipes/rl_loop.py
@@ -1024,7 +1024,9 @@ def main(
                 if getattr(cfg, "output_model_id", None):
                     ckpt.promote_latest(cfg.output_model_id, cfg.base_model)
                     runner.write_output_model(
-                        model_id=cfg.output_model_id, checkpoint=cp_name, job_id=policy_job_id,
+                        model_id=cfg.output_model_id,
+                        checkpoint=f"step-{global_step}",
+                        job_id=policy_job_id,
                     )
             except Exception as e:
                 logger.warning("Failed to save final checkpoint: %s", e)

--- a/training/recipes/rl_loop.py
+++ b/training/recipes/rl_loop.py
@@ -232,9 +232,12 @@ class Config:
     """Directory to save per-step trajectory JSONL files.  Each file contains
     prompts, completions, and rewards for every prompt group in that step."""
 
-    init_from_checkpoint: str | None = None
+    init_from_checkpoint: str | dict | None = None
     """Load pretrained DCP weights on a fresh dataset. Supports cross-job
-    format ``"job_id:checkpoint_name"``."""
+    format ``"job_id:checkpoint_name"`` and rows from ``list_checkpoints``."""
+
+    dataloader_cursor: int | None = None
+    """Explicit raw-row cursor. When set, local cursor resolution is skipped."""
 
     warm_start_from_adapter: str | None = None
     """GCS URI of an HF PEFT adapter directory. When set, initializes LoRA
@@ -570,19 +573,16 @@ def main(
         resume_info = ckpt.resume(
             init_from_checkpoint=cfg.init_from_checkpoint,
             warm_start_from_adapter=cfg.warm_start_from_adapter,
+            dataloader_cursor=cfg.dataloader_cursor,
         )
-        step_offset = resume_info.step if resume_info else 0
+        step_offset = resume_info.step
         wandb_log({"train/step": step_offset}, step_offset)
 
         if cfg.weight_sync_before_training or service.requires_initial_sampler_sync():
             logger.info("[step %d] weight sync: saving + loading...", step_offset)
             t0 = _time.time()
             with timer("weight_sync"):
-                saved = policy.save_weights_for_sampler(
-                    f"step-{step_offset}",
-                    checkpoint_type="base",
-                )
-                service.hotload_sampler_snapshot(saved.path)
+                ckpt.sync_weights(step_offset, service.hotload_sampler_snapshot)
             logger.info("[step %d] weight sync: done (%.1fs)", step_offset, _time.time() - t0)
 
         # -- Prepare sampling and training --------------------------------------
@@ -916,10 +916,10 @@ def main(
                 logger.info("[step %d] dcp_save...", step)
                 t0 = _time.time()
                 ckpt.save(
-                    f"step-{step}",
+                    step,
                     resumable=True,
                     promotable=False,
-                    data_consumed=cursor.value,
+                    row_cursor=cursor.value,
                 )
                 logger.info("[step %d] dcp_save: done (%.1fs)", step, _time.time() - t0)
 
@@ -982,13 +982,7 @@ def main(
 
         train_fns = TrainStepFns(train_step=train_step)
 
-        # Prefer the persisted raw-row cursor; fall back to step-derived
-        # progress for older checkpoints.
-        rollouts_done = step_offset // max(1, cfg.ppo_n_minibatches)
-        cursor.resume(
-            resume_info.data_consumed if resume_info else None,
-            fallback=rollouts_done * prompt_groups_per_step,
-        )
+        cursor.resume(resume_info.row_cursor)
         remaining_rows = all_rows[cursor.value:]
 
         total_rl_steps = len(rl_dataset) * max(1, cfg.ppo_n_minibatches) - step_offset
@@ -1006,8 +1000,8 @@ def main(
                 global_step=step_offset,
                 metrics_callback=_loop_metrics_callback,
                 weight_sync_fn=(
-                    lambda step: service.hotload_sampler_snapshot(
-                        policy.save_weights_for_sampler(f"step-{step}").path
+                    lambda step: ckpt.sync_weights(
+                        step, service.hotload_sampler_snapshot
                     )
                     if cfg.weight_sync_interval > 0
                     else None
@@ -1020,12 +1014,11 @@ def main(
 
         if cfg.save_final_checkpoint and global_step > step_offset:
             try:
-                cp_name = f"step-{global_step}"
                 ckpt.save(
-                    cp_name,
+                    global_step,
                     resumable=True,
                     promotable=True,
-                    data_consumed=cursor.value,
+                    row_cursor=cursor.value,
                 )
 
                 if getattr(cfg, "output_model_id", None):

--- a/training/recipes/rl_loop.py
+++ b/training/recipes/rl_loop.py
@@ -234,10 +234,11 @@ class Config:
 
     init_from_checkpoint: str | dict | None = None
     """Load pretrained DCP weights on a fresh dataset. Supports cross-job
-    format ``"job_id:checkpoint_name"`` and rows from ``list_checkpoints``."""
+    format ``"job_id:checkpoint_name"`` and rows from ``list_checkpoints``.
+    When omitted, no latest checkpoint is selected automatically."""
 
-    dataloader_cursor: int | None = None
-    """Explicit raw-row cursor. When set, local cursor resolution is skipped."""
+    dataloader_cursor: int = 0
+    """First raw dataset row to process. This is the only dataset resume input."""
 
     warm_start_from_adapter: str | None = None
     """GCS URI of an HF PEFT adapter directory. When set, initializes LoRA
@@ -381,6 +382,9 @@ def main(
     sample_prompt_fn: Callable[..., Awaitable[PromptGroup | None]] | None = None,
 ):
     cfg = config
+    if cfg.dataloader_cursor < 0:
+        raise ValueError("dataloader_cursor must be >= 0")
+    logger.info("Dataset resume row: %d", cfg.dataloader_cursor)
     runner = RunnerIO(cfg.runner)
     uses_recipe_sampler = sample_prompt_fn is None
 
@@ -574,6 +578,7 @@ def main(
             init_from_checkpoint=cfg.init_from_checkpoint,
             warm_start_from_adapter=cfg.warm_start_from_adapter,
             dataloader_cursor=cfg.dataloader_cursor,
+            auto_latest=False,
         )
         step_offset = resume_info.step
         wandb_log({"train/step": step_offset}, step_offset)
@@ -919,7 +924,6 @@ def main(
                     step,
                     resumable=True,
                     promotable=False,
-                    row_cursor=cursor.value,
                 )
                 logger.info("[step %d] dcp_save: done (%.1fs)", step, _time.time() - t0)
 
@@ -982,7 +986,7 @@ def main(
 
         train_fns = TrainStepFns(train_step=train_step)
 
-        cursor.resume(resume_info.row_cursor)
+        cursor.resume(cfg.dataloader_cursor)
         remaining_rows = all_rows[cursor.value:]
 
         total_rl_steps = len(rl_dataset) * max(1, cfg.ppo_n_minibatches) - step_offset
@@ -1018,7 +1022,6 @@ def main(
                     global_step,
                     resumable=True,
                     promotable=True,
-                    row_cursor=cursor.value,
                 )
 
                 if getattr(cfg, "output_model_id", None):
@@ -1032,13 +1035,18 @@ def main(
                 logger.warning("Failed to save final checkpoint: %s", e)
 
         write_completed(runner, step=global_step, total_steps=total_rl_steps)
-        logger.info("Training complete: %d steps", global_step)
+        logger.info(
+            "Training complete: %d steps, rows trained: %d",
+            global_step,
+            cursor.value,
+        )
         wandb_finish()
         return {
             "steps": global_step,
             "policy_job_id": policy_job_id,
             "reference_job_id": reference_job_id,
             "deployment_id": deployment_id,
+            "rows_trained": cursor.value,
         }
 
 

--- a/training/recipes/sft_loop.py
+++ b/training/recipes/sft_loop.py
@@ -1097,7 +1097,9 @@ def main(
             if getattr(cfg, "output_model_id", None):
                 ckpt.promote_latest(cfg.output_model_id, cfg.base_model)
                 runner.write_output_model(
-                    model_id=cfg.output_model_id, checkpoint=cp_name, job_id=job_id,
+                    model_id=cfg.output_model_id,
+                    checkpoint=f"step-{step}",
+                    job_id=job_id,
                 )
 
         write_completed(runner, step=step, total_steps=step)

--- a/training/recipes/sft_loop.py
+++ b/training/recipes/sft_loop.py
@@ -514,9 +514,11 @@ class Config:
 
     dcp_save_interval: int = 0  # save DCP checkpoint every N steps (0 = off)
 
-    init_from_checkpoint: str | None = None
-    """Load pretrained DCP weights on a fresh dataset. Supports cross-job
-    format ``"job_id:checkpoint_name"``."""
+    init_from_checkpoint: str | dict | None = None
+    """Resume from a checkpoint name, resource, or ``list_checkpoints`` row."""
+
+    dataloader_cursor: int | None = None
+    """Explicit raw-row cursor. When set, local cursor resolution is skipped."""
 
     warm_start_from_adapter: str | None = None
     """GCS URI of an HF PEFT adapter directory. When set, initializes LoRA
@@ -878,11 +880,12 @@ def main(
         resume_info = ckpt.resume(
             init_from_checkpoint=cfg.init_from_checkpoint,
             warm_start_from_adapter=cfg.warm_start_from_adapter,
+            dataloader_cursor=cfg.dataloader_cursor,
         )
-        step = resume_info.step if resume_info else 0
+        step = resume_info.step
         total_raw_rows = training_count * cfg.epochs
         cursor = RawRowCursor(max_rows=total_raw_rows)
-        cursor.resume(resume_info.data_consumed if resume_info else None)
+        cursor.resume(resume_info.row_cursor)
         wandb_log({"train/step": step}, step)
 
         adam_kwargs = dict(DEFAULT_ADAM)
@@ -951,7 +954,12 @@ def main(
             if cfg.dcp_save_interval > 0 and s % cfg.dcp_save_interval == 0:
                 with timer("dcp_save"):
                     logger.info("Saving DCP checkpoint at step %d", s)
-                    ckpt.save(f"step-{s}", resumable=True, promotable=False, data_consumed=cursor.value)
+                    ckpt.save(
+                        s,
+                        resumable=True,
+                        promotable=False,
+                        row_cursor=cursor.value,
+                    )
 
             # Metrics logging
             step_metrics: Dict[str, Any] = flush_timing()
@@ -1077,15 +1085,14 @@ def main(
 
         # -- Final checkpoint --------------------------------------------------
 
-        start_step = resume_info.step if resume_info else 0
+        start_step = resume_info.step
         if cfg.save_final_checkpoint and step > start_step:
             logger.info("Saving final checkpoint (step %d)...", step)
-            cp_name = f"step-{step}"
             ckpt.save(
-                cp_name,
+                step,
                 resumable=True,
                 promotable=True,
-                data_consumed=cursor.value,
+                row_cursor=cursor.value,
             )
             if getattr(cfg, "output_model_id", None):
                 ckpt.promote_latest(cfg.output_model_id, cfg.base_model)

--- a/training/tests/e2e/test_dpo_resume_e2e.py
+++ b/training/tests/e2e/test_dpo_resume_e2e.py
@@ -45,6 +45,10 @@ def _make_preference_dataset(path: str, num_pairs: int = 8) -> None:
             f.write(json.dumps(row) + "\n")
 
 
+def _max_row_cursor(mapping: dict[str, dict[str, int]]) -> int:
+    return max(int(cursor) for steps in mapping.values() for cursor in steps.values())
+
+
 @pytest.mark.e2e
 @pytest.mark.timeout(5400)
 class TestDPOResumeE2E:
@@ -151,7 +155,7 @@ class TestDPOResumeE2E:
             with open(dataloader_path) as f:
                 phase1_dataloader = json.load(f)
             assert phase1_dataloader, "dataloader.json should be non-empty after phase 1"
-            phase1_data_consumed = max(int(v) for v in phase1_dataloader.values())
+            phase1_row_cursor = _max_row_cursor(phase1_dataloader)
 
             phase1_rows = rlor_mgr.list_checkpoints(phase1_job_id)
             phase1_resumable = [
@@ -197,10 +201,10 @@ class TestDPOResumeE2E:
 
             with open(dataloader_path) as f:
                 phase2_dataloader = json.load(f)
-            phase2_data_consumed = max(int(v) for v in phase2_dataloader.values())
-            assert phase2_data_consumed >= phase1_data_consumed, (
-                f"Phase 2 data_consumed ({phase2_data_consumed}) should not regress "
-                f"from phase 1's ({phase1_data_consumed}); dataloader cursor should remain aligned."
+            phase2_row_cursor = _max_row_cursor(phase2_dataloader)
+            assert phase2_row_cursor >= phase1_row_cursor, (
+                f"Phase 2 row cursor ({phase2_row_cursor}) should not regress "
+                f"from phase 1's ({phase1_row_cursor}); dataloader cursor should remain aligned."
             )
 
             logger.info("Resume verified: phase1=%d, phase2=%d", phase1_steps, phase2_steps)

--- a/training/tests/e2e/test_grpo_resume_e2e.py
+++ b/training/tests/e2e/test_grpo_resume_e2e.py
@@ -4,10 +4,8 @@ Two-phase test on the SDK-managed single-shape trainer:
 
   Phase 1: Create an RL trainer/deployment, train a few steps, and save DCP
            checkpoints. Capture the policy, reference, and deployment IDs.
-  Phase 2: Reattach to the same trainer and deployment with the same ``log_path``.
-           ``TrainingCheckpoints.resume()`` lists the policy trainer's
-           checkpoints on the control plane, picks the newest resumable
-           row, and restores the rollout cursor from ``dataloader.json``.
+  Phase 2: Reattach to the same trainer and deployment, explicitly passing the
+           chosen RPC checkpoint row and phase 1's returned dataset row cursor.
 
 Requires:
   FIREWORKS_API_KEY     -- API key with training/deployment access
@@ -17,9 +15,8 @@ Requires:
 
 from __future__ import annotations
 
-import json
-import os
 import logging
+import os
 import tempfile
 import time
 from dataclasses import replace
@@ -28,7 +25,6 @@ import httpx
 import pytest
 
 from training.utils import DeployConfig, TrainerConfig
-from training.utils.checkpoints import DATALOADER_BASE_NAME
 from training.tests.e2e.conftest import GSM8K_SAMPLE_URL
 from training.recipes.async_rl_loop import Config, main
 from training.tests.async_grpo_helpers import (
@@ -38,14 +34,6 @@ from training.tests.async_grpo_helpers import (
 )
 
 logger = logging.getLogger(__name__)
-
-
-def _max_row_cursor(mapping: dict[str, dict[str, int]]) -> int:
-    return max(
-        int(cursor)
-        for job_rows in mapping.values()
-        for cursor in job_rows.values()
-    )
 
 
 _TRAINER_CLEANUP_STATES = {
@@ -186,16 +174,11 @@ class TestGRPOResumeE2E:
                 phase1_deployment_id,
             )
 
-            # Read the persisted rollout cursor from dataloader.json — the only
-            # cookbook-side state in the new model (job id -> step -> row cursor).
-            dataloader_path = os.path.join(log_dir, DATALOADER_BASE_NAME)
-            assert os.path.exists(dataloader_path), (
-                f"Phase 1 should have written {DATALOADER_BASE_NAME} under {log_dir}"
+            phase1_row_cursor = phase1_metrics["rows_trained"]
+            assert phase1_row_cursor > 0
+            assert not os.path.exists(os.path.join(log_dir, "dataloader.json")), (
+                "RL must not persist a client-side cursor registry"
             )
-            with open(dataloader_path) as f:
-                phase1_dataloader = json.load(f)
-            assert phase1_dataloader, "dataloader.json should be non-empty after phase 1"
-            phase1_row_cursor = _max_row_cursor(phase1_dataloader)
 
             # Verify the control plane has at least one resumable row for the
             # phase-1 policy trainer — phase 2's resume reads from there.
@@ -208,14 +191,17 @@ class TestGRPOResumeE2E:
                 f"Expected phase 1 to leave a resumable row on the control plane "
                 f"for policy job {phase1_policy_job_id}; got rows: {phase1_rows}"
             )
+            phase1_checkpoint = max(
+                phase1_resumable,
+                key=lambda row: row.get("createTime", ""),
+            )
             logger.info(
                 "Phase 1 CP rows: %d resumable (row_cursor=%d)",
                 len(phase1_resumable), phase1_row_cursor,
             )
 
-            # Phase 2: reattach to the same policy + reference trainers so resume
-            # can find the phase-1 CP rows. Auto-resume across separate trainer
-            # jobs is not supported in the new model.
+            # Phase 2 explicitly selects both pieces of resume state: the RPC
+            # checkpoint row and the first dataset row to process.
             logger.info(
                 "PHASE 2: reattach to policy=%s, reference=%s",
                 phase1_policy_job_id, phase1_reference_job_id,
@@ -243,6 +229,8 @@ class TestGRPOResumeE2E:
                 ),
                 weight_sync_before_training=True,
                 weight_sync_timeout=600,
+                init_from_checkpoint=phase1_checkpoint,
+                dataloader_cursor=phase1_row_cursor,
             )
 
             phase2_metrics = main(
@@ -263,9 +251,7 @@ class TestGRPOResumeE2E:
                 f"({phase1_steps}); resume probably did not pick up phase 1's CP rows."
             )
 
-            with open(dataloader_path) as f:
-                phase2_dataloader = json.load(f)
-            phase2_row_cursor = _max_row_cursor(phase2_dataloader)
+            phase2_row_cursor = phase2_metrics["rows_trained"]
             assert phase2_row_cursor >= phase1_row_cursor, (
                 f"Phase 2 row cursor ({phase2_row_cursor}) should not regress "
                 f"from phase 1's ({phase1_row_cursor}); rollout cursor should remain aligned."

--- a/training/tests/e2e/test_grpo_resume_e2e.py
+++ b/training/tests/e2e/test_grpo_resume_e2e.py
@@ -39,6 +39,15 @@ from training.tests.async_grpo_helpers import (
 
 logger = logging.getLogger(__name__)
 
+
+def _max_row_cursor(mapping: dict[str, dict[str, int]]) -> int:
+    return max(
+        int(cursor)
+        for job_rows in mapping.values()
+        for cursor in job_rows.values()
+    )
+
+
 _TRAINER_CLEANUP_STATES = {
     "JOB_STATE_ARCHIVED",
     "JOB_STATE_DELETING",
@@ -178,7 +187,7 @@ class TestGRPOResumeE2E:
             )
 
             # Read the persisted rollout cursor from dataloader.json — the only
-            # cookbook-side state in the new model (one int per checkpoint name).
+            # cookbook-side state in the new model (job id -> step -> row cursor).
             dataloader_path = os.path.join(log_dir, DATALOADER_BASE_NAME)
             assert os.path.exists(dataloader_path), (
                 f"Phase 1 should have written {DATALOADER_BASE_NAME} under {log_dir}"
@@ -186,7 +195,7 @@ class TestGRPOResumeE2E:
             with open(dataloader_path) as f:
                 phase1_dataloader = json.load(f)
             assert phase1_dataloader, "dataloader.json should be non-empty after phase 1"
-            phase1_data_consumed = max(int(v) for v in phase1_dataloader.values())
+            phase1_row_cursor = _max_row_cursor(phase1_dataloader)
 
             # Verify the control plane has at least one resumable row for the
             # phase-1 policy trainer — phase 2's resume reads from there.
@@ -200,8 +209,8 @@ class TestGRPOResumeE2E:
                 f"for policy job {phase1_policy_job_id}; got rows: {phase1_rows}"
             )
             logger.info(
-                "Phase 1 CP rows: %d resumable (data_consumed=%d)",
-                len(phase1_resumable), phase1_data_consumed,
+                "Phase 1 CP rows: %d resumable (row_cursor=%d)",
+                len(phase1_resumable), phase1_row_cursor,
             )
 
             # Phase 2: reattach to the same policy + reference trainers so resume
@@ -256,15 +265,15 @@ class TestGRPOResumeE2E:
 
             with open(dataloader_path) as f:
                 phase2_dataloader = json.load(f)
-            phase2_data_consumed = max(int(v) for v in phase2_dataloader.values())
-            assert phase2_data_consumed >= phase1_data_consumed, (
-                f"Phase 2 data_consumed ({phase2_data_consumed}) should not regress "
-                f"from phase 1's ({phase1_data_consumed}); rollout cursor should remain aligned."
+            phase2_row_cursor = _max_row_cursor(phase2_dataloader)
+            assert phase2_row_cursor >= phase1_row_cursor, (
+                f"Phase 2 row cursor ({phase2_row_cursor}) should not regress "
+                f"from phase 1's ({phase1_row_cursor}); rollout cursor should remain aligned."
             )
             logger.info(
-                "Resume verified: phase1=%d steps (data_consumed=%d), "
-                "phase2=%d steps (data_consumed=%d)",
-                phase1_steps, phase1_data_consumed, phase2_steps, phase2_data_consumed,
+                "Resume verified: phase1=%d steps (row_cursor=%d), "
+                "phase2=%d steps (row_cursor=%d)",
+                phase1_steps, phase1_row_cursor, phase2_steps, phase2_row_cursor,
             )
             verified = True
         finally:

--- a/training/tests/e2e/test_sft_resume_e2e.py
+++ b/training/tests/e2e/test_sft_resume_e2e.py
@@ -54,6 +54,10 @@ def _make_chat_dataset(path: str, num_examples: int = 10) -> None:
             f.write(json.dumps(row) + "\n")
 
 
+def _max_row_cursor(mapping: dict[str, dict[str, int]]) -> int:
+    return max(int(cursor) for steps in mapping.values() for cursor in steps.values())
+
+
 @pytest.mark.e2e
 @pytest.mark.timeout(5400)
 class TestSFTResumeE2E:
@@ -108,7 +112,7 @@ class TestSFTResumeE2E:
 
             # Read the persisted raw_rows_consumed from dataloader.json.
             # In the new model, dataloader.json holds the only cookbook-side
-            # state — one int per checkpoint name.
+            # state — a trainer job -> checkpoint step -> row cursor KV mapping.
             dataloader_path = os.path.join(log_dir, DATALOADER_BASE_NAME)
             assert os.path.exists(dataloader_path), (
                 f"Phase 1 should have written {DATALOADER_BASE_NAME} under {log_dir}"
@@ -116,7 +120,7 @@ class TestSFTResumeE2E:
             with open(dataloader_path) as f:
                 phase1_dataloader = json.load(f)
             assert phase1_dataloader, "dataloader.json should be non-empty after phase 1"
-            phase1_raw_rows = max(int(v) for v in phase1_dataloader.values())
+            phase1_raw_rows = _max_row_cursor(phase1_dataloader)
 
             # Verify the control plane has at least one resumable row for the
             # phase-1 trainer — that is what phase 2's resume will read.
@@ -165,7 +169,7 @@ class TestSFTResumeE2E:
 
             with open(dataloader_path) as f:
                 phase2_dataloader = json.load(f)
-            phase2_raw_rows = max(int(v) for v in phase2_dataloader.values())
+            phase2_raw_rows = _max_row_cursor(phase2_dataloader)
             assert phase2_raw_rows > phase1_raw_rows, (
                 f"Phase 2 raw_rows_consumed ({phase2_raw_rows}) should exceed "
                 f"phase 1's ({phase1_raw_rows}); dataloader cursor should advance."

--- a/training/tests/smoke_test/test_checkpoints_smoke.py
+++ b/training/tests/smoke_test/test_checkpoints_smoke.py
@@ -200,21 +200,25 @@ class TestCheckpointsSmoke:
         dataloader_path = os.path.join(log_dir, DATALOADER_BASE_NAME)
         assert os.path.exists(dataloader_path), (
             f"Expected {DATALOADER_BASE_NAME} under {log_dir} "
-            "(written by ckpt.save when data_consumed is supplied)"
+            "(written by ckpt.save when row_cursor is supplied)"
         )
         with open(dataloader_path) as f:
             dataloader_state = json.load(f)
         assert dataloader_state, (
             f"{DATALOADER_BASE_NAME} should be non-empty after a resumable save"
         )
-        max_data_consumed = max(int(v) for v in dataloader_state.values())
-        assert max_data_consumed > 0, (
+        max_row_cursor = max(
+            int(cursor)
+            for job_rows in dataloader_state.values()
+            for cursor in job_rows.values()
+        )
+        assert max_row_cursor > 0, (
             f"Expected positive raw_rows_consumed in {DATALOADER_BASE_NAME}, "
             f"got {dataloader_state}"
         )
         logger.info(
-            "dataloader.json: %d entries, max=%d",
-            len(dataloader_state), max_data_consumed,
+            "dataloader.json: %d trainer jobs, max row cursor=%d",
+            len(dataloader_state), max_row_cursor,
         )
 
         # ---- Confirm trainer cleanup ---------------------------------------

--- a/training/tests/test_dataloader_cursor.py
+++ b/training/tests/test_dataloader_cursor.py
@@ -23,59 +23,32 @@ TrainStepFns, run_rl_loop = load_rl_train("dataloader_cursor", prompt_group_cls=
 
 
 # ---------------------------------------------------------------------------
-# RawRowCursor: resume() — clamping, ambiguity, fallback
+# RawRowCursor: resume() — exact cursor and clamping
 # ---------------------------------------------------------------------------
 
 
-def test_resume_with_persisted_value_sets_cursor():
+def test_resume_sets_exact_cursor():
     cursor = RawRowCursor(max_rows=10)
     cursor.resume(5)
     assert cursor.value == 5
 
 
-def test_resume_clamps_persisted_past_max():
+def test_resume_clamps_cursor_past_max():
     cursor = RawRowCursor(max_rows=3)
     cursor.resume(99)
     assert cursor.value == 3
 
 
-def test_resume_clamps_negative_persisted_to_zero():
+def test_resume_clamps_negative_cursor_to_zero():
     cursor = RawRowCursor(max_rows=10)
     cursor.resume(-5)
     assert cursor.value == 0
 
 
-def test_resume_with_none_uses_fallback():
-    """``persisted=None`` (no dataloader.json) → cursor takes ``fallback``."""
+def test_resume_zero_is_fresh_start():
     cursor = RawRowCursor(max_rows=10)
-    cursor.resume(None, fallback=4)
-    assert cursor.value == 4
-
-
-def test_resume_with_zero_persisted_and_zero_fallback_trusts_zero():
-    """Fresh start (both 0) is trusted, not routed through fallback."""
-    cursor = RawRowCursor(max_rows=10)
-    cursor.resume(0, fallback=0)
+    cursor.resume(0)
     assert cursor.value == 0
-
-
-def test_resume_with_zero_persisted_and_nonzero_fallback_takes_fallback():
-    """Legacy ckpt signal: ``persisted=0`` with non-zero fallback → step-derived path."""
-    cursor = RawRowCursor(max_rows=10)
-    cursor.resume(0, fallback=4)
-    assert cursor.value == 4
-
-
-def test_resume_prefers_persisted_over_fallback_when_both_nonzero():
-    cursor = RawRowCursor(max_rows=10)
-    cursor.resume(7, fallback=4)
-    assert cursor.value == 7
-
-
-def test_resume_clamps_fallback_past_max():
-    cursor = RawRowCursor(max_rows=3)
-    cursor.resume(None, fallback=10)
-    assert cursor.value == 3
 
 
 def test_resume_without_max_rows_does_not_clamp():
@@ -170,7 +143,7 @@ def test_pipeline_clean_run_advances_cursor_to_dataset_length():
     """No drops, no fails: cursor at end equals dataset length."""
     rows = [{"id": i, "reward": 1.0} for i in range(8)]
     cursor = RawRowCursor(max_rows=len(rows))
-    cursor.resume(None, fallback=0)
+    cursor.resume(0)
     from training.tests._dataloader_test_helpers import _load_module
     m = _load_module("rl_train_for_int", "utils/rl/train.py")
 
@@ -209,7 +182,7 @@ def test_pipeline_with_drops_advances_cursor_by_raw_rows_not_accepted():
         {"id": 5, "reward": 1.0},
     ]
     cursor = RawRowCursor(max_rows=len(rows))
-    cursor.resume(None, fallback=0)
+    cursor.resume(0)
     from training.tests._dataloader_test_helpers import _load_module
     m = _load_module("rl_train_for_drops", "utils/rl/train.py")
 
@@ -280,7 +253,7 @@ def test_tail_drops_in_window_are_unaccounted():
         {"id": 3, "reward": 0.0},   # tail drop after dispatch
     ]
     cursor = RawRowCursor(max_rows=len(rows))
-    cursor.resume(None, fallback=0)
+    cursor.resume(0)
     from training.tests._dataloader_test_helpers import _load_module
     m = _load_module("rl_train_for_tail", "utils/rl/train.py")
 

--- a/training/tests/unit/test_async_rl_loop_runner.py
+++ b/training/tests/unit/test_async_rl_loop_runner.py
@@ -10,7 +10,9 @@ SDK, or a deployment:
 
 from __future__ import annotations
 
+import logging
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -139,6 +141,11 @@ class TestConfigRunnerField:
 
         assert cfg.pipeline_chunks_per_step == 1
 
+    def test_dataset_resume_row_defaults_to_zero(self) -> None:
+        cfg = async_rl_loop.Config(log_path="gs://logs")
+
+        assert cfg.dataloader_cursor == 0
+
     def test_config_uses_conservative_loss_defaults(self) -> None:
         cfg = async_rl_loop.Config(log_path="gs://logs")
 
@@ -183,6 +190,45 @@ def test_main_requests_cleanup_for_sdk_created_resources(monkeypatch: pytest.Mon
     assert (
         kwargs["cleanup_deployment_on_close"]
         == async_rl_loop.CLEANUP_DEPLOYMENT_ON_CLOSE_SCALE_TO_ZERO
+    )
+
+
+def test_main_logs_dataset_resume_row_first(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    cfg = async_rl_loop.Config(
+        log_path="/tmp/async_rl_test_logs",
+        dataloader_cursor=23,
+        deployment=async_rl_loop.DeployConfig(tokenizer_model="Qwen/Qwen3-1.7B"),
+    )
+
+    with caplog.at_level(logging.INFO):
+        _build_service_kwargs(monkeypatch, cfg)
+
+    assert "Dataset resume row: 23" in caplog.text
+
+
+def test_main_rejects_negative_dataset_resume_row() -> None:
+    cfg = async_rl_loop.Config(log_path="/tmp/logs", dataloader_cursor=-1)
+
+    with pytest.raises(ValueError, match="dataloader_cursor"):
+        async_rl_loop.main(
+            cfg,
+            rows=[],
+            rollout_fn_factory=lambda _setup: (lambda _sample: None),
+        )
+
+
+def test_checkpoint_save_has_no_client_cursor_payload() -> None:
+    checkpoints = MagicMock()
+
+    async_rl_loop._save_checkpoint(checkpoints, step=7)
+
+    checkpoints.save.assert_called_once_with(
+        7,
+        resumable=True,
+        promotable=False,
     )
 
 

--- a/training/tests/unit/test_checkpoints.py
+++ b/training/tests/unit/test_checkpoints.py
@@ -240,6 +240,25 @@ class TestResume:
             checkpoints.resume()
         client.load_state_with_optimizer.assert_not_called()
 
+    def test_auto_latest_can_be_disabled_without_listing_or_local_lookup(
+        self, tmp_path, monkeypatch
+    ):
+        checkpoints, client, fw = _make(str(tmp_path), rows=[_row("step-3")])
+        monkeypatch.setattr(
+            checkpoints,
+            "_read_row_cursor",
+            lambda *_args: pytest.fail("local cursor lookup must not run"),
+        )
+
+        info = checkpoints.resume(
+            dataloader_cursor=11,
+            auto_latest=False,
+        )
+
+        assert info == ResumeInfo(row_cursor=11)
+        fw.list_checkpoints.assert_not_called()
+        client.load_state_with_optimizer.assert_not_called()
+
     def test_warm_start_loads_adapter_and_honors_explicit_cursor(self, tmp_path):
         checkpoints, client, _ = _make(str(tmp_path), lora_rank=8)
 
@@ -273,11 +292,14 @@ class TestSave:
         }
         fw.list_checkpoints.assert_not_called()
 
-    def test_resumable_save_requires_cursor(self, tmp_path):
-        checkpoints, _, _ = _make(str(tmp_path))
+    def test_resumable_save_without_cursor_writes_no_local_state(self, tmp_path):
+        checkpoints, client, fw = _make(str(tmp_path))
 
-        with pytest.raises(ValueError, match="row_cursor"):
-            checkpoints.save(1, resumable=True, promotable=False)
+        checkpoints.save(1, resumable=True, promotable=False)
+
+        client.save_state.assert_called_once_with("step-1")
+        fw.list_checkpoints.assert_not_called()
+        assert not (tmp_path / DATALOADER_BASE_NAME).exists()
 
     def test_promotable_save_forces_complete_export_behind_boundary(self, tmp_path):
         checkpoints, client, _ = _make(str(tmp_path))

--- a/training/tests/unit/test_checkpoints.py
+++ b/training/tests/unit/test_checkpoints.py
@@ -1,796 +1,437 @@
-"""Unit tests for ``training.utils.checkpoints``."""
+"""Unit tests for the cookbook checkpoint boundary."""
+
+from __future__ import annotations
 
 import json
-import os
-import tempfile
+from datetime import datetime, timezone
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
 
 from training.utils.checkpoints import (
     DATALOADER_BASE_NAME,
+    DATALOADER_HISTORY_KEEP,
     ResumeInfo,
     TrainingCheckpoints,
     _logical_name,
-    _newest_first,
     _logical_name_for_run,
+    _newest_first,
     _public_logical_name,
     validate_warm_start_config,
 )
 
 
-@pytest.fixture
-def log_dir():
-    with tempfile.TemporaryDirectory() as d:
-        yield d
-
-
-def _mock_fw_client(rows=None):
-    """``fw._rows`` is the mutable source of truth; ``list_checkpoints`` returns
-    a snapshot of it. This lets the client mock append a new row on
-    ``save_state``/``save_weights_for_sampler``, exercising the polling
-    codepath in ``TrainingCheckpoints``."""
-    fw = MagicMock()
-    fw._rows = list(rows or [])
-    fw.list_checkpoints = MagicMock(side_effect=lambda job_id, **kw: list(fw._rows))
-    fw.promote_checkpoint.return_value = {"state": "READY", "kind": "HF_BASE_MODEL"}
-    return fw
-
-
-def _mock_client(fw=None, save_state_renames_to: str | None = None):
-    """Build a fake ReconnectableClient.
-
-    ``save_state_renames_to`` simulates the service-mode trainer renaming the
-    DCP checkpoint to its internal step counter: when set, the fake appends a
-    CP row named ``save_state_renames_to`` (instead of the caller name) so that
-    ``TrainingCheckpoints._resolve_cp_name_after_save`` polls and finds the
-    renamed row. Default (None) honors the caller name.
-    """
-    client = MagicMock()
-    client.resolve_checkpoint_path.side_effect = lambda name, source_job_id=None: (
-        f"path://{source_job_id or 'self'}/{name}"
-    )
-
-    # Use a counter so appended rows have monotonically-increasing createTime
-    # (the poll picks newest-first, so this matters for multi-save tests).
-    counter = {"n": 0}
-
-    def _save_state(name):
-        cp_name = save_state_renames_to or name
-        if fw is not None:
-            counter["n"] += 1
-            fw._rows.append(
-                {
-                    "name": f"accounts/a/rlorTrainerJobs/job-1/checkpoints/{cp_name}",
-                    "createTime": f"2099-01-01T00:00:{counter['n']:02d}Z",
-                    "checkpointType": "CHECKPOINT_TYPE_TRAINING",
-                    "promotable": False,
-                }
-            )
-        result = MagicMock()
-        result.path = f"tinker://policy/{cp_name}"
-        return result
-
-    client.save_state.side_effect = _save_state
-    client.save_weights_for_sampler.side_effect = lambda name, checkpoint_type="base": (
-        MagicMock(snapshot_name=f"{name}-snap")
-    )
-    return client
-
-
-def _row(short_name, *, ctype, promotable, create_time):
+def _row(
+    short_name: str,
+    *,
+    checkpoint_type: str = "CHECKPOINT_TYPE_TRAINING",
+    promotable: bool = False,
+    create_time: str = "2026-07-01T00:00:00Z",
+    job_id: str = "job-1",
+) -> dict:
     return {
-        "name": f"accounts/a/rlorTrainerJobs/job-1/checkpoints/{short_name}",
+        "name": f"accounts/a/rlorTrainerJobs/{job_id}/checkpoints/{short_name}",
         "createTime": create_time,
-        "checkpointType": ctype,
+        "checkpointType": checkpoint_type,
         "promotable": promotable,
     }
 
 
 def _make(
-    log_dir,
+    log_dir: str,
     *,
-    fw_rows=None,
-    lora_rank=0,
-    save_state_renames_to: str | None = None,
-    serverless=False,
+    rows: list[dict] | None = None,
+    lora_rank: int = 0,
+    saved_name: str | None = None,
+    serverless: bool = False,
     current_run_id: str | None = None,
-):
-    fw = _mock_fw_client(rows=fw_rows)
-    client = _mock_client(fw=fw, save_state_renames_to=save_state_renames_to)
-    ckpt = TrainingCheckpoints(
+) -> tuple[TrainingCheckpoints, MagicMock, MagicMock]:
+    fw = MagicMock()
+    fw.rows = list(rows or [])
+    fw.list_checkpoints.side_effect = lambda _job_id, **_kwargs: list(fw.rows)
+    fw.promote_checkpoint.return_value = {"state": "READY"}
+
+    client = MagicMock()
+    client.resolve_checkpoint_path.side_effect = (
+        lambda name, source_job_id=None: f"path://{source_job_id or 'self'}/{name}"
+    )
+    client.save_state.side_effect = lambda name: SimpleNamespace(
+        path=f"tinker://run/state/{saved_name or name}"
+    )
+
+    def _save_sampler(name: str, *args, checkpoint_type=None, **kwargs):
+        if checkpoint_type == "base":
+            suffix = "LORA" if lora_rank else "BASE"
+            public_name = (
+                f"{current_run_id}-{name}" if serverless and current_run_id else name
+            )
+            fw.rows.append(
+                _row(
+                    public_name,
+                    checkpoint_type=f"CHECKPOINT_TYPE_INFERENCE_{suffix}",
+                    promotable=True,
+                    create_time=datetime.now(timezone.utc).isoformat(),
+                )
+            )
+        return SimpleNamespace(path=f"snapshot://{name}")
+
+    client.save_weights_for_sampler.side_effect = _save_sampler
+    checkpoints = TrainingCheckpoints(
         client,
         fw,
         trainer_id="job-1",
         log_path=log_dir,
         lora_rank=lora_rank,
         serverless=serverless,
-        # Disable stabilization + tighten timeouts so unit tests run instantly.
-        save_appear_timeout_s=5.0,
-        save_stabilize_s=0.0,
-        save_poll_s=0.01,
         current_run_id=current_run_id,
+        save_appear_timeout_s=0.1,
+        save_poll_s=0.001,
     )
-    return ckpt, client, fw
+    return checkpoints, client, fw
 
 
-# -- validate_warm_start_config ------------------------------------------------
-
-
-class TestValidateWarmStartConfig:
+class TestWarmStartValidation:
     def test_mutually_exclusive(self):
         with pytest.raises(ValueError, match="mutually exclusive"):
             validate_warm_start_config(
-                warm_start_from_adapter="some/adapter",
+                warm_start_from_adapter="adapter",
                 init_from_checkpoint="job:step-5",
                 lora_rank=8,
             )
 
-    def test_warm_start_requires_lora(self):
+    def test_adapter_requires_lora(self):
         with pytest.raises(ValueError, match="cfg.base_model"):
             validate_warm_start_config(
-                warm_start_from_adapter="some/adapter",
+                warm_start_from_adapter="adapter",
                 init_from_checkpoint=None,
                 lora_rank=0,
             )
 
-    def test_ok(self):
-        validate_warm_start_config(
-            warm_start_from_adapter=None,
-            init_from_checkpoint=None,
-            lora_rank=0,
-        )
-        validate_warm_start_config(
-            warm_start_from_adapter="a",
-            init_from_checkpoint=None,
-            lora_rank=8,
-        )
-
-
-# -- resume --------------------------------------------------------------------
-
 
 class TestResume:
-    def test_fresh_start_when_empty(self, log_dir):
-        ckpt, client, _ = _make(log_dir, fw_rows=[])
-        assert ckpt.resume() is None
+    def test_fresh_start_is_explicit_zero_state(self, tmp_path):
+        checkpoints, client, _ = _make(str(tmp_path))
+
+        assert checkpoints.resume() == ResumeInfo()
         client.load_state_with_optimizer.assert_not_called()
 
-    def test_resume_newest_training_row(self, log_dir):
+    def test_newest_resumable_rpc_row_drives_resume(self, tmp_path):
         rows = [
+            _row("step-5", create_time="2026-07-01T00:00:00Z"),
+            _row("step-10", create_time="2026-07-02T00:00:00Z"),
             _row(
-                "step-5",
-                ctype="CHECKPOINT_TYPE_TRAINING",
-                promotable=False,
-                create_time="2026-04-01T00:00:00Z",
-            ),
-            _row(
-                "step-10",
-                ctype="CHECKPOINT_TYPE_TRAINING",
-                promotable=False,
-                create_time="2026-04-02T00:00:00Z",
-            ),
-            _row(
-                "step-7-sampler",
-                ctype="CHECKPOINT_TYPE_INFERENCE_BASE",
+                "step-20-abcd1234",
+                checkpoint_type="CHECKPOINT_TYPE_INFERENCE_BASE",
                 promotable=True,
-                create_time="2026-04-03T00:00:00Z",
+                create_time="2026-07-03T00:00:00Z",
             ),
         ]
-        # Pre-populate dataloader.json so resume can recover data_consumed.
-        os.makedirs(log_dir, exist_ok=True)
-        with open(os.path.join(log_dir, DATALOADER_BASE_NAME), "w") as f:
-            json.dump({"step-5": 40, "step-10": 80}, f)
+        (tmp_path / DATALOADER_BASE_NAME).write_text(
+            json.dumps({"job-1": {"5": 40, "10": 80}})
+        )
+        checkpoints, client, _ = _make(str(tmp_path), rows=rows)
 
-        ckpt, client, _ = _make(log_dir, fw_rows=rows)
-        info = ckpt.resume()
-        assert info == ResumeInfo(step=10, data_consumed=80, source_job_id="job-1")
+        info = checkpoints.resume()
+
+        assert info == ResumeInfo(step=10, row_cursor=80, source_job_id="job-1")
+        client.resolve_checkpoint_path.assert_called_once_with(
+            "step-10", source_job_id=None
+        )
         client.load_state_with_optimizer.assert_called_once_with("path://self/step-10")
 
-    def test_resume_picks_training_lora_too(self, log_dir):
-        rows = [
-            _row(
-                "step-5",
-                ctype="CHECKPOINT_TYPE_TRAINING_LORA",
-                promotable=False,
-                create_time="2026-04-01T00:00:00Z",
-            ),
-            _row(
-                "step-5-hotload",
-                ctype="CHECKPOINT_TYPE_INFERENCE_LORA",
-                promotable=True,
-                create_time="2026-04-01T00:05:00Z",
-            ),
-        ]
-        ckpt, client, _ = _make(log_dir, fw_rows=rows, lora_rank=8)
-        info = ckpt.resume()
-        assert info is not None
-        assert info.step == 5
-        client.load_state_with_optimizer.assert_called_once_with("path://self/step-5")
+    def test_list_row_can_be_passed_directly_for_cross_job_resume(self, tmp_path):
+        row = _row("step-7", job_id="source-job")
+        (tmp_path / DATALOADER_BASE_NAME).write_text(
+            json.dumps({"source-job": {"7": 91}})
+        )
+        checkpoints, client, _ = _make(str(tmp_path))
 
-    def test_resume_serverless_uses_bare_name(self, log_dir):
-        # Serverless: trainer_id is the TrainingSession id, not a job. Auto-resume
-        # must NOT build cross_job://<session_id>/<name> — the pooled trainer
-        # rejects that (the name must already be session-scoped and session_id is
-        # not a source job). It must resume from the bare logical name
-        # (source_job_id=None) so the trainer prepends sessions/<sid>/ itself.
-        rows = [
-            _row(
-                "step-5",
-                ctype="CHECKPOINT_TYPE_TRAINING_LORA",
-                promotable=False,
-                create_time="2026-04-01T00:00:00Z",
-            ),
-        ]
-        ckpt, client, _ = _make(log_dir, fw_rows=rows, lora_rank=8, serverless=True)
-        info = ckpt.resume()
-        assert info is not None
-        assert info.step == 5
-        assert info.source_job_id is None
+        info = checkpoints.resume(init_from_checkpoint=row)
+
+        assert info == ResumeInfo(step=7, row_cursor=91, source_job_id="source-job")
         client.resolve_checkpoint_path.assert_called_once_with(
-            "step-5", source_job_id=None
+            "step-7", source_job_id="source-job"
         )
-        # source_job_id=None => bare name (mock renders the absent job as 'self').
-        client.load_state_with_optimizer.assert_called_once_with("path://self/step-5")
 
-    def test_resume_serverless_strips_current_run_prefix(self, log_dir):
-        current_run_id = "run-abcdef"
+    def test_full_resource_name_can_be_passed_directly(self, tmp_path):
+        checkpoints, _, _ = _make(str(tmp_path))
+
+        info = checkpoints.resume(
+            init_from_checkpoint=(
+                "accounts/a/rlorTrainerJobs/source-job/checkpoints/step-4"
+            ),
+            dataloader_cursor=33,
+        )
+
+        assert info == ResumeInfo(step=4, row_cursor=33, source_job_id="source-job")
+
+    def test_explicit_cursor_bypasses_local_lookup(self, tmp_path, monkeypatch):
+        checkpoints, _, _ = _make(str(tmp_path), rows=[_row("step-3")])
+
+        monkeypatch.setattr(
+            checkpoints,
+            "_read_row_cursor",
+            lambda *_args: pytest.fail("local cursor lookup must be bypassed"),
+        )
+
+        assert checkpoints.resume(dataloader_cursor=17).row_cursor == 17
+
+    def test_cross_job_resume_preserves_step_with_missing_local_cursor(self, tmp_path):
+        checkpoints, _, _ = _make(str(tmp_path))
+
+        info = checkpoints.resume(init_from_checkpoint="source-job:step-12")
+
+        assert info == ResumeInfo(step=12, row_cursor=0, source_job_id="source-job")
+
+    def test_non_resumable_rpc_row_is_rejected(self, tmp_path):
+        checkpoints, _, _ = _make(str(tmp_path))
+        row = _row(
+            "step-5",
+            checkpoint_type="CHECKPOINT_TYPE_INFERENCE_BASE",
+            promotable=True,
+        )
+
+        with pytest.raises(ValueError, match="resumable"):
+            checkpoints.resume(init_from_checkpoint=row)
+
+    def test_invalid_checkpoint_name_is_rejected(self, tmp_path):
+        checkpoints, _, _ = _make(str(tmp_path))
+
+        with pytest.raises(ValueError, match="step-N"):
+            checkpoints.resume(init_from_checkpoint="job-1:final")
+
+    def test_serverless_resume_uses_current_run_only(self, tmp_path):
+        run_id = "run-0123456789abcdef0123456789abcdef"
         rows = [
             _row(
-                "run-oldrun-step-9",
-                ctype="CHECKPOINT_TYPE_TRAINING_LORA",
-                promotable=False,
-                create_time="2026-04-03T00:00:00Z",
-            ),
-            _row(
-                f"{current_run_id}-step-5",
-                ctype="CHECKPOINT_TYPE_TRAINING_LORA",
-                promotable=False,
-                create_time="2026-04-01T00:00:00Z",
-            ),
-        ]
-        os.makedirs(log_dir, exist_ok=True)
-        with open(os.path.join(log_dir, DATALOADER_BASE_NAME), "w") as f:
-            json.dump({"step-5": 40, "run-abcdef-step-5": 999}, f)
-
-        ckpt, client, _ = _make(
-            log_dir,
-            fw_rows=rows,
-            lora_rank=8,
-            serverless=True,
-            current_run_id=current_run_id,
-        )
-        info = ckpt.resume()
-
-        assert info == ResumeInfo(step=5, data_consumed=40, source_job_id=None)
-        client.resolve_checkpoint_path.assert_called_once_with(
-            "step-5", source_job_id=None
-        )
-        client.load_state_with_optimizer.assert_called_once_with("path://self/step-5")
-
-    def test_resume_serverless_without_run_id_ignores_run_scoped_rows(self, log_dir):
-        rows = [
-            _row(
-                "run-0123456789abcdef0123456789abcdef-step-99",
-                ctype="CHECKPOINT_TYPE_TRAINING_LORA",
-                promotable=False,
+                "run-fedcba9876543210fedcba9876543210-step-99",
+                checkpoint_type="CHECKPOINT_TYPE_TRAINING_LORA",
                 create_time="2099-01-01T00:00:00Z",
             ),
             _row(
-                "step-5",
-                ctype="CHECKPOINT_TYPE_TRAINING_LORA",
-                promotable=False,
-                create_time="2026-04-01T00:00:00Z",
+                f"{run_id}-step-5",
+                checkpoint_type="CHECKPOINT_TYPE_TRAINING_LORA",
             ),
         ]
-        ckpt, client, _ = _make(
-            log_dir,
-            fw_rows=rows,
+        (tmp_path / DATALOADER_BASE_NAME).write_text(
+            json.dumps({"job-1": {"5": 44}})
+        )
+        checkpoints, client, _ = _make(
+            str(tmp_path),
+            rows=rows,
             lora_rank=8,
             serverless=True,
+            current_run_id=run_id,
         )
-        info = ckpt.resume()
 
-        assert info == ResumeInfo(step=5, data_consumed=0, source_job_id=None)
+        info = checkpoints.resume()
+
+        assert info == ResumeInfo(step=5, row_cursor=44, source_job_id="job-1")
         client.resolve_checkpoint_path.assert_called_once_with(
             "step-5", source_job_id=None
         )
-        client.load_state_with_optimizer.assert_called_once_with("path://self/step-5")
 
-    def test_init_from_checkpoint_takes_priority(self, log_dir):
-        rows = [
-            _row(
-                "step-50",
-                ctype="CHECKPOINT_TYPE_TRAINING",
-                promotable=False,
-                create_time="2026-04-02T00:00:00Z",
-            ),
-        ]
-        ckpt, client, _ = _make(log_dir, fw_rows=rows)
-        info = ckpt.resume(init_from_checkpoint="other-job:step-3")
-        assert info == ResumeInfo(step=0, data_consumed=0, source_job_id="other-job")
-        client.load_state_with_optimizer.assert_called_once_with(
-            "path://other-job/step-3"
-        )
+    def test_list_failure_does_not_silently_start_fresh(self, tmp_path):
+        checkpoints, client, fw = _make(str(tmp_path))
+        fw.list_checkpoints.side_effect = RuntimeError("503")
 
-    def test_same_trainer_init_from_checkpoint_resumes_cursor(self, log_dir):
-        os.makedirs(log_dir, exist_ok=True)
-        with open(os.path.join(log_dir, DATALOADER_BASE_NAME), "w") as f:
-            json.dump({"step-3": 24}, f)
-
-        ckpt, client, _ = _make(log_dir, fw_rows=[])
-        info = ckpt.resume(init_from_checkpoint="job-1:step-3")
-        assert info == ResumeInfo(step=3, data_consumed=24, source_job_id="job-1")
-        client.resolve_checkpoint_path.assert_called_once_with("step-3")
-        client.load_state_with_optimizer.assert_called_once_with("path://self/step-3")
-
-    def test_init_from_checkpoint_serverless_uses_bare_name(self, log_dir):
-        # Serverless: init_from_checkpoint must resume from the bare name, not
-        # cross_job://<session>/<name> (the pool trainer rejects that). A spec
-        # naming THIS session is accepted with its prefix stripped.
-        ckpt, client, _ = _make(
-            log_dir, serverless=True
-        )  # trainer_id/session == "job-1"
-        info = ckpt.resume(init_from_checkpoint="job-1:step-5")
-        assert info == ResumeInfo(step=0, data_consumed=0, source_job_id=None)
-        client.resolve_checkpoint_path.assert_called_once_with(
-            "step-5", source_job_id=None
-        )
-        client.load_state_with_optimizer.assert_called_once_with("path://self/step-5")
-
-    def test_init_from_checkpoint_serverless_rejects_cross_session(self, log_dir):
-        # Cross-session warm-start is unsupported on the shared pool (isolation).
-        ckpt, _, _ = _make(log_dir, serverless=True)  # session == "job-1"
-        with pytest.raises(ValueError, match="another session"):
-            ckpt.resume(init_from_checkpoint="other-session:step-5")
-
-    def test_warm_start_adapter_when_no_resume(self, log_dir):
-        ckpt, client, _ = _make(log_dir, fw_rows=[], lora_rank=8)
-        info = ckpt.resume(warm_start_from_adapter="hf/adapter")
-        assert info == ResumeInfo(step=0, data_consumed=0, source_job_id=None)
-        client.load_adapter.assert_called_once_with("hf/adapter")
-
-    def test_list_failure_treated_as_fresh_start(self, log_dir):
-        ckpt, client, fw = _make(log_dir)
-        fw.list_checkpoints.side_effect = RuntimeError("503 Service Unavailable")
-        info = ckpt.resume()
-        assert info is None
+        with pytest.raises(RuntimeError, match="503"):
+            checkpoints.resume()
         client.load_state_with_optimizer.assert_not_called()
 
+    def test_warm_start_loads_adapter_and_honors_explicit_cursor(self, tmp_path):
+        checkpoints, client, _ = _make(str(tmp_path), lora_rank=8)
 
-# -- save ----------------------------------------------------------------------
+        info = checkpoints.resume(
+            warm_start_from_adapter="gs://bucket/adapter",
+            dataloader_cursor=6,
+        )
+
+        assert info == ResumeInfo(row_cursor=6)
+        client.load_adapter.assert_called_once_with("gs://bucket/adapter")
 
 
 class TestSave:
-    def test_resumable_only_writes_dcp_and_dataloader(self, log_dir):
-        ckpt, client, fw = _make(log_dir)
-        ckpt.save("step-1", resumable=True, promotable=False, data_consumed=100)
+    def test_resumable_save_writes_only_job_step_cursor_mapping(self, tmp_path):
+        checkpoints, client, _ = _make(str(tmp_path))
 
-        client.save_state.assert_called_once_with("step-1")
+        checkpoints.save(3, resumable=True, promotable=False, row_cursor=24)
+
+        client.save_state.assert_called_once_with("step-3")
+        assert json.loads((tmp_path / DATALOADER_BASE_NAME).read_text()) == {
+            "job-1": {"3": 24}
+        }
+
+    def test_rpc_result_step_is_used_without_control_plane_poll(self, tmp_path):
+        checkpoints, _, fw = _make(str(tmp_path), saved_name="step-2")
+
+        checkpoints.save(42, resumable=True, promotable=False, row_cursor=777)
+
+        assert json.loads((tmp_path / DATALOADER_BASE_NAME).read_text()) == {
+            "job-1": {"2": 777}
+        }
+        fw.list_checkpoints.assert_not_called()
+
+    def test_resumable_save_requires_cursor(self, tmp_path):
+        checkpoints, _, _ = _make(str(tmp_path))
+
+        with pytest.raises(ValueError, match="row_cursor"):
+            checkpoints.save(1, resumable=True, promotable=False)
+
+    def test_promotable_save_forces_complete_export_behind_boundary(self, tmp_path):
+        checkpoints, client, _ = _make(str(tmp_path))
+
+        checkpoints.save(4, resumable=False, promotable=True)
+
+        client.save_weights_for_sampler.assert_called_once_with(
+            "step-4", checkpoint_type="base"
+        )
+        assert not (tmp_path / DATALOADER_BASE_NAME).exists()
+
+    def test_existing_promotable_row_skips_duplicate_export(self, tmp_path):
+        rows = [
+            _row(
+                "step-4-abcd1234",
+                checkpoint_type="CHECKPOINT_TYPE_INFERENCE_LORA",
+                promotable=True,
+            )
+        ]
+        checkpoints, client, _ = _make(str(tmp_path), rows=rows, lora_rank=8)
+
+        checkpoints.save(4, resumable=False, promotable=True)
+
         client.save_weights_for_sampler.assert_not_called()
 
-        with open(os.path.join(log_dir, DATALOADER_BASE_NAME)) as f:
-            assert json.load(f) == {"step-1": 100}
+    def test_invalid_save_arguments_are_rejected(self, tmp_path):
+        checkpoints, _, _ = _make(str(tmp_path))
 
-    def test_promotable_only_writes_sampler_no_dataloader(self, log_dir):
-        ckpt, client, fw = _make(log_dir)
-        ckpt.save("step-1", resumable=False, promotable=True)
-        client.save_state.assert_not_called()
-        client.save_weights_for_sampler.assert_called_once_with(
-            "step-1", checkpoint_type="base"
-        )
-        assert not os.path.exists(os.path.join(log_dir, DATALOADER_BASE_NAME))
-
-    def test_both_writes_both(self, log_dir):
-        ckpt, client, _ = _make(log_dir)
-        ckpt.save("step-1", resumable=True, promotable=True, data_consumed=42)
-        client.save_state.assert_called_once_with("step-1")
-        client.save_weights_for_sampler.assert_called_once()
-
-    def test_neither_raises(self, log_dir):
-        ckpt, _, _ = _make(log_dir)
         with pytest.raises(ValueError, match="at least one"):
-            ckpt.save("step-1", resumable=False, promotable=False)
+            checkpoints.save(1, resumable=False, promotable=False)
+        with pytest.raises(ValueError, match="step"):
+            checkpoints.save(-1, resumable=True, promotable=False, row_cursor=0)
+        with pytest.raises(ValueError, match="row_cursor"):
+            checkpoints.save(1, resumable=True, promotable=False, row_cursor=-1)
 
-    def test_skip_if_promotable_already_exists(self, log_dir):
-        existing = [
-            _row(
-                "step-1",
-                ctype="CHECKPOINT_TYPE_INFERENCE_LORA",
-                promotable=True,
-                create_time="2026-04-01T00:00:00Z",
-            ),
-        ]
-        ckpt, client, _ = _make(log_dir, fw_rows=existing, lora_rank=8)
-        ckpt.save("step-1", resumable=True, promotable=True, data_consumed=10)
-        client.save_state.assert_called_once()
-        client.save_weights_for_sampler.assert_not_called()
 
-    def test_no_skip_when_existing_not_promotable(self, log_dir):
-        existing = [
-            _row(
-                "step-1",
-                ctype="CHECKPOINT_TYPE_TRAINING",
-                promotable=False,
-                create_time="2026-04-01T00:00:00Z",
-            ),
-        ]
-        ckpt, client, _ = _make(log_dir, fw_rows=existing)
-        ckpt.save("step-1", resumable=False, promotable=True)
-        client.save_weights_for_sampler.assert_called_once()
-
-    def test_skip_check_failure_falls_back_to_save(self, log_dir):
-        ckpt, client, fw = _make(log_dir)
-        fw.list_checkpoints.side_effect = RuntimeError("503")
-        ckpt.save("step-1", resumable=False, promotable=True)
-        client.save_weights_for_sampler.assert_called_once()
-
-    def test_skip_matches_suffixed_server_name(self, log_dir):
-        """The trainer appends ``-<8 hex>`` to sampler names server-side.
-        Skip should match on the logical name (pre-suffix) so callers passing
-        ``step-1`` match a stored row ``step-1-abcd1234``."""
-        existing = [
-            _row(
-                "step-1-abcd1234",
-                ctype="CHECKPOINT_TYPE_INFERENCE_LORA",
-                promotable=True,
-                create_time="2026-04-01T00:00:00Z",
-            ),
-        ]
-        ckpt, client, _ = _make(log_dir, fw_rows=existing, lora_rank=8)
-        ckpt.save("step-1", resumable=False, promotable=True)
-        client.save_weights_for_sampler.assert_not_called()
-
-    def test_skip_matches_run_scoped_suffixed_server_name(self, log_dir):
-        """Serverless session checkpoints surface as ``run-id-checkpoint``.
-
-        The cookbook caller only knows the checkpoint leaf it passed to the
-        trainer, so skip matching must ignore the public run prefix and the
-        trainer's 8-hex sampler suffix.
-        """
-        current_run_id = "run-0123456789abcdef0123456789abcdef"
-        existing = [
-            _row(
-                f"{current_run_id}-step-1-abcd1234",
-                ctype="CHECKPOINT_TYPE_INFERENCE_LORA",
-                promotable=True,
-                create_time="2026-04-01T00:00:00Z",
-            ),
-        ]
-        ckpt, client, _ = _make(
-            log_dir,
-            fw_rows=existing,
-            lora_rank=8,
-            serverless=True,
-            current_run_id=current_run_id,
-        )
-        ckpt.save("step-1", resumable=False, promotable=True)
-        client.save_weights_for_sampler.assert_not_called()
-
-    def test_skip_without_run_id_ignores_run_scoped_promotable_checkpoint(
-        self, log_dir
+class TestWeightSync:
+    @pytest.mark.parametrize("lora_rank", [0, 8])
+    def test_sdk_selects_lora_full_and_full_base_delta_modes(
+        self, tmp_path, lora_rank
     ):
-        existing = [
+        checkpoints, client, _ = _make(str(tmp_path), lora_rank=lora_rank)
+        hotload = MagicMock()
+
+        path = checkpoints.sync_weights(9, hotload)
+
+        assert path == "snapshot://step-9"
+        client.save_weights_for_sampler.assert_called_once_with("step-9")
+        hotload.assert_called_once_with("snapshot://step-9")
+
+    def test_missing_snapshot_path_is_an_error(self, tmp_path):
+        checkpoints, client, _ = _make(str(tmp_path))
+        client.save_weights_for_sampler.side_effect = None
+        client.save_weights_for_sampler.return_value = SimpleNamespace(path=None)
+
+        with pytest.raises(RuntimeError, match="returned no snapshot path"):
+            checkpoints.sync_weights(2, MagicMock())
+
+
+class TestCursorStore:
+    def test_legacy_flat_mapping_migrates_on_write(self, tmp_path):
+        (tmp_path / DATALOADER_BASE_NAME).write_text(
+            json.dumps({"step-2": 20, "step-4": 40})
+        )
+        checkpoints, _, _ = _make(str(tmp_path))
+
+        assert checkpoints.resume(
+            init_from_checkpoint="job-1:step-4"
+        ).row_cursor == 40
+        checkpoints.save(6, resumable=True, promotable=False, row_cursor=60)
+
+        assert json.loads((tmp_path / DATALOADER_BASE_NAME).read_text()) == {
+            "job-1": {"2": 20, "4": 40, "6": 60}
+        }
+
+    def test_history_is_bounded_per_job(self, tmp_path):
+        checkpoints, _, _ = _make(str(tmp_path))
+
+        for step in range(DATALOADER_HISTORY_KEEP + 3):
+            checkpoints.save(
+                step,
+                resumable=True,
+                promotable=False,
+                row_cursor=step * 2,
+            )
+
+        mapping = json.loads((tmp_path / DATALOADER_BASE_NAME).read_text())["job-1"]
+        assert len(mapping) == DATALOADER_HISTORY_KEEP
+        assert min(map(int, mapping)) == 3
+
+    def test_corrupt_mapping_is_treated_as_empty(self, tmp_path):
+        (tmp_path / DATALOADER_BASE_NAME).write_text("{bad json")
+        checkpoints, _, _ = _make(str(tmp_path))
+
+        assert checkpoints.resume(
+            init_from_checkpoint="job-1:step-2"
+        ).row_cursor == 0
+
+
+class TestPromote:
+    def test_latest_promotable_resource_is_passed_to_sdk(self, tmp_path):
+        rows = [
             _row(
-                "run-0123456789abcdef0123456789abcdef-step-1-abcd1234",
-                ctype="CHECKPOINT_TYPE_INFERENCE_LORA",
+                "step-5",
+                checkpoint_type="CHECKPOINT_TYPE_INFERENCE_BASE",
                 promotable=True,
-                create_time="2099-01-01T00:00:00Z",
+                create_time="2026-07-01T00:00:00Z",
+            ),
+            _row(
+                "step-10",
+                checkpoint_type="CHECKPOINT_TYPE_INFERENCE_BASE",
+                promotable=True,
+                create_time="2026-07-02T00:00:00Z",
             ),
         ]
-        ckpt, client, _ = _make(
-            log_dir,
-            fw_rows=existing,
-            lora_rank=8,
-            serverless=True,
-        )
-        ckpt.save("step-1", resumable=False, promotable=True)
-        client.save_weights_for_sampler.assert_called_once_with(
-            "step-1", checkpoint_type="base"
-        )
+        checkpoints, _, fw = _make(str(tmp_path), rows=rows)
 
-    def test_skip_ignores_other_run_promotable_checkpoint(self, log_dir):
-        current_run_id = "run-current"
-        existing = [
-            _row(
-                "run-previous-step-1-abcd1234",
-                ctype="CHECKPOINT_TYPE_INFERENCE_LORA",
-                promotable=True,
-                create_time="2099-01-01T00:00:00Z",
-            ),
-            _row(
-                f"{current_run_id}-step-2-abcd1234",
-                ctype="CHECKPOINT_TYPE_INFERENCE_LORA",
-                promotable=True,
-                create_time="2099-01-01T00:00:01Z",
-            ),
-        ]
-        ckpt, client, _ = _make(
-            log_dir,
-            fw_rows=existing,
-            lora_rank=8,
-            serverless=True,
-            current_run_id=current_run_id,
-        )
-        ckpt.save("step-1", resumable=False, promotable=True)
-        client.save_weights_for_sampler.assert_called_once_with(
-            "step-1", checkpoint_type="base"
+        checkpoints.promote_latest("output", "accounts/a/models/base")
+
+        fw.promote_checkpoint.assert_called_once_with(
+            name="accounts/a/rlorTrainerJobs/job-1/checkpoints/step-10",
+            output_model_id="output",
+            base_model="accounts/a/models/base",
+            hot_load_deployment_id=None,
         )
 
-    def test_skip_does_not_match_different_step(self, log_dir):
-        existing = [
-            _row(
-                "step-1-abcd1234",
-                ctype="CHECKPOINT_TYPE_INFERENCE_LORA",
-                promotable=True,
-                create_time="2026-04-01T00:00:00Z",
-            ),
-        ]
-        ckpt, client, _ = _make(log_dir, fw_rows=existing, lora_rank=8)
-        ckpt.save("step-2", resumable=False, promotable=True)
-        client.save_weights_for_sampler.assert_called_once()
+    def test_missing_promotable_row_is_an_error(self, tmp_path):
+        checkpoints, _, _ = _make(str(tmp_path), rows=[_row("step-1")])
 
-    def test_dataloader_keyed_on_server_name_when_trainer_renames(self, log_dir):
-        """Trainer service-mode may rename DCP saves to its internal step
-        counter: caller passes "step-42" but the service writes "step-0".
-        ``dataloader.json`` must be keyed on the server-returned name so the
-        resume lookup (which reads names from the control plane) matches."""
-        ckpt, client, _ = _make(log_dir, save_state_renames_to="step-0")
-        ckpt.save("step-42", resumable=True, promotable=False, data_consumed=777)
-        client.save_state.assert_called_once_with("step-42")
-
-        with open(os.path.join(log_dir, DATALOADER_BASE_NAME)) as f:
-            data = json.load(f)
-        assert data == {"step-0": 777}, f"expected server name keyed, got {data}"
-
-    def test_dataloader_keyed_on_caller_name_when_no_rename(self, log_dir):
-        """When the server honors the caller name, ``dataloader.json`` keys
-        by the same string (no regression vs prior behavior)."""
-        ckpt, client, _ = _make(log_dir)  # default: no rename
-        ckpt.save("step-5", resumable=True, promotable=False, data_consumed=50)
-        with open(os.path.join(log_dir, DATALOADER_BASE_NAME)) as f:
-            assert json.load(f) == {"step-5": 50}
-
-    def test_promotable_save_waits_for_run_scoped_cp_row(self, log_dir):
-        current_run_id = "run-f7bd5935b27b46d2ac21c90ac7a19cd5"
-        row = _row(
-            f"{current_run_id}-step-8-c42a35e8",
-            ctype="CHECKPOINT_TYPE_INFERENCE_LORA",
-            promotable=True,
-            create_time="2099-01-01T00:00:05Z",
-        )
-        old_row = _row(
-            "run-oldrun-step-8-c42a35e8",
-            ctype="CHECKPOINT_TYPE_INFERENCE_LORA",
-            promotable=True,
-            create_time="2099-01-01T00:00:10Z",
-        )
-        ckpt, client, fw = _make(
-            log_dir,
-            lora_rank=8,
-            serverless=True,
-            current_run_id=current_run_id,
-        )
-
-        calls = {"n": 0}
-
-        def _list_after_delay(job_id, **kwargs):
-            calls["n"] += 1
-            if calls["n"] >= 3:
-                return [old_row, row]
-            return [old_row]
-
-        fw.list_checkpoints.side_effect = _list_after_delay
-
-        ckpt.save("step-8", resumable=False, promotable=True)
-
-        client.save_weights_for_sampler.assert_called_once_with(
-            "step-8", checkpoint_type="base"
-        )
-        assert calls["n"] >= 3
+        with pytest.raises(RuntimeError, match="No promotable"):
+            checkpoints.promote_latest("output", "base")
 
 
-class TestLogicalName:
+class TestHelpers:
     @pytest.mark.parametrize(
-        "stored,logical",
+        ("stored", "logical"),
         [
             ("step-3", "step-3"),
             ("step-3-abcd1234", "step-3"),
             ("resume-3-base-45dda197", "resume-3-base"),
-            ("step-11-45dda197", "step-11"),
-            ("step-3-ABCD1234", "step-3-ABCD1234"),  # uppercase — not the pattern
-            ("step-3-12345", "step-3-12345"),  # 5 chars — not 8
-            ("step-3-abcdefghi", "step-3-abcdefghi"),  # 9 chars — not 8
         ],
     )
-    def test_strip_session_suffix(self, stored, logical):
+    def test_logical_name(self, stored, logical):
         assert _logical_name(stored) == logical
 
-    @pytest.mark.parametrize(
-        "stored,logical",
-        [
-            ("step-3-abcd1234", "step-3"),
-            ("run-0123456789abcdef0123456789abcdef-step-3-abcd1234", "step-3"),
-            (
-                "run-0123456789abcdef0123456789abcdef-resume-3-base-45dda197",
-                "resume-3-base",
-            ),
-            ("run-0123456789abcdef0123456789abcdef:step-3-abcd1234", "step-3"),
-        ],
-    )
-    def test_public_logical_name_ignores_run_prefix(self, stored, logical):
-        assert _public_logical_name(stored) == logical
+    def test_public_and_current_run_logical_names(self):
+        run_id = "run-0123456789abcdef0123456789abcdef"
+        stored = f"{run_id}-step-3-abcd1234"
+        assert _public_logical_name(stored) == "step-3"
+        assert _logical_name_for_run(stored, run_id) == "step-3"
 
-    def test_logical_name_for_current_run_accepts_short_run_id(self):
-        assert (
-            _logical_name_for_run("run-abcdef-step-3-abcd1234", "run-abcdef")
-            == "step-3"
-        )
-        assert (
-            _logical_name_for_run("run-other-step-3-abcd1234", "run-abcdef")
-            == "run-other-step-3"
-        )
-
-
-# -- promote_latest ------------------------------------------------------------
-
-
-class TestPromoteLatest:
-    """``promote_latest`` hands the row's 4-segment ``name`` to the SDK
-    verbatim. The cookbook does not disassemble into
-    ``(job_id, checkpoint_id)``."""
-
-    def test_picks_newest_promotable_and_passes_full_name(self, log_dir):
+    def test_newest_first_parses_mixed_timestamp_precision(self):
         rows = [
-            _row(
-                "step-5",
-                ctype="CHECKPOINT_TYPE_INFERENCE_BASE",
-                promotable=True,
-                create_time="2026-04-01T00:00:00Z",
-            ),
-            _row(
-                "step-10",
-                ctype="CHECKPOINT_TYPE_INFERENCE_BASE",
-                promotable=True,
-                create_time="2026-04-02T00:00:00Z",
-            ),
-            _row(
-                "step-10-dcp",
-                ctype="CHECKPOINT_TYPE_TRAINING",
-                promotable=False,
-                create_time="2026-04-02T00:05:00Z",
-            ),
+            _row("step-1", create_time="2026-07-01T00:00:13Z"),
+            _row("step-2", create_time="2026-07-01T00:00:13.123456Z"),
         ]
-        ckpt, _, fw = _make(log_dir, fw_rows=rows)
-        ckpt.promote_latest("my-model", "accounts/a/models/qwen3-1p7b-bf16")
-        fw.promote_checkpoint.assert_called_once_with(
-            name="accounts/a/rlorTrainerJobs/job-1/checkpoints/step-10",
-            output_model_id="my-model",
-            base_model="accounts/a/models/qwen3-1p7b-bf16",
-            hot_load_deployment_id=None,
-        )
-
-    def test_serverless_promote_latest_uses_current_run_only(self, log_dir):
-        current_run_id = "run-current"
-        rows = [
-            _row(
-                "run-previous-step-99",
-                ctype="CHECKPOINT_TYPE_INFERENCE_LORA",
-                promotable=True,
-                create_time="2099-01-01T00:00:00Z",
-            ),
-            _row(
-                f"{current_run_id}-step-5",
-                ctype="CHECKPOINT_TYPE_INFERENCE_LORA",
-                promotable=True,
-                create_time="2026-04-01T00:00:00Z",
-            ),
-        ]
-        ckpt, _, fw = _make(
-            log_dir,
-            fw_rows=rows,
-            lora_rank=8,
-            serverless=True,
-            current_run_id=current_run_id,
-        )
-        ckpt.promote_latest("my-model", "accounts/a/models/qwen3-1p7b-bf16")
-        fw.promote_checkpoint.assert_called_once()
-        _, kwargs = fw.promote_checkpoint.call_args
-        assert kwargs["name"].endswith(f"/checkpoints/{current_run_id}-step-5")
-
-    def test_serverless_promote_latest_without_run_id_ignores_run_scoped_rows(
-        self, log_dir
-    ):
-        rows = [
-            _row(
-                "run-0123456789abcdef0123456789abcdef-step-99",
-                ctype="CHECKPOINT_TYPE_INFERENCE_LORA",
-                promotable=True,
-                create_time="2099-01-01T00:00:00Z",
-            ),
-        ]
-        ckpt, _, fw = _make(log_dir, fw_rows=rows, lora_rank=8, serverless=True)
-        with pytest.raises(RuntimeError, match="No promotable"):
-            ckpt.promote_latest("my-model", "accounts/a/models/qwen3-1p7b-bf16")
-        fw.promote_checkpoint.assert_not_called()
-
-    def test_skips_arc_v2_because_not_promotable(self, log_dir):
-        rows = [
-            _row(
-                "step-5-arc",
-                ctype="CHECKPOINT_TYPE_INFERENCE_ARC_V2",
-                promotable=False,
-                create_time="2026-04-02T00:00:00Z",
-            ),
-            _row(
-                "step-5-lora",
-                ctype="CHECKPOINT_TYPE_INFERENCE_LORA",
-                promotable=True,
-                create_time="2026-04-01T00:00:00Z",
-            ),
-        ]
-        ckpt, _, fw = _make(log_dir, fw_rows=rows)
-        ckpt.promote_latest("out", "base")
-        fw.promote_checkpoint.assert_called_once()
-        _, kwargs = fw.promote_checkpoint.call_args
-        assert kwargs["name"].endswith("/checkpoints/step-5-lora")
-
-    def test_errors_when_no_promotable(self, log_dir):
-        rows = [
-            _row(
-                "step-1",
-                ctype="CHECKPOINT_TYPE_TRAINING",
-                promotable=False,
-                create_time="2026-04-01T00:00:00Z",
-            ),
-        ]
-        ckpt, _, _ = _make(log_dir, fw_rows=rows)
-        with pytest.raises(RuntimeError, match="No promotable"):
-            ckpt.promote_latest("out", "base")
-
-
-# -- dataloader.json bookkeeping -----------------------------------------------
-
-
-class TestNewestFirstMixedPrecision:
-    """The control plane mixes ``...:13Z`` (second precision) and
-    ``...:13.123456Z`` (microsecond precision) ``createTime`` strings.
-    A lexicographic sort would put the older second-precision row
-    ahead of the newer microsecond-precision one because
-    ``'Z' (90) > '.' (46)``, silently picking a stale checkpoint in
-    ``_latest_resumable`` / ``promote_latest``.
-    """
-
-    def test_microsecond_row_beats_second_row_at_later_wall_time(self):
-        # Newer row uses microsecond precision; older row uses
-        # second precision.  Newer must win.
-        newer = {"name": "step-20", "createTime": "2026-04-29T10:00:13.500000Z"}
-        older = {"name": "step-10", "createTime": "2026-04-29T10:00:12Z"}
-        assert _newest_first([older, newer])[0] is newer
-
-    def test_microsecond_row_beats_same_second_row_with_lex_inversion(self):
-        # Same wall-second; ``...:13Z`` lex-sorts AFTER ``...:13.500Z``
-        # because ``'Z' (90) > '.' (46)``.  Datetime sort must put
-        # the microsecond row first.
-        newer = {"name": "step-20", "createTime": "2026-04-29T10:00:13.500000Z"}
-        older = {"name": "step-10", "createTime": "2026-04-29T10:00:13Z"}
-        assert _newest_first([older, newer])[0] is newer
-
-    def test_unparseable_createtime_sorts_to_end(self):
-        valid = {"name": "step-1", "createTime": "2026-04-29T10:00:13.500000Z"}
-        broken = {"name": "step-2", "createTime": "not-a-timestamp"}
-        missing = {"name": "step-3"}
-        ordered = _newest_first([broken, missing, valid])
-        assert ordered[0] is valid
-
-
-class TestDataloaderJson:
-    def test_bounded_history(self, log_dir):
-        ckpt, _, _ = _make(log_dir)
-        for i in range(1, 26):
-            ckpt.save(f"step-{i}", resumable=True, promotable=False, data_consumed=i)
-        with open(os.path.join(log_dir, DATALOADER_BASE_NAME)) as f:
-            data = json.load(f)
-        # Keep only the newest 20.
-        assert len(data) == 20
-        assert set(data.keys()) == {f"step-{i}" for i in range(6, 26)}
+        assert _newest_first(rows)[0]["name"].endswith("/step-2")

--- a/training/tests/unit/test_cursor_dataloader.py
+++ b/training/tests/unit/test_cursor_dataloader.py
@@ -5,33 +5,33 @@ def test_cursor_starts_from_resume_point():
     loader = CursorDataLoader(["a", "b", "c"], start_cursor=1)
 
     assert next(loader).value == "b"
-    assert loader.data_consumed == 1
+    assert loader.row_cursor == 1
 
 
 def test_cursor_advances_in_order_only():
     loader = CursorDataLoader(["a", "b", "c"])
 
     loader.mark_resolved(1)
-    assert loader.data_consumed == 0
+    assert loader.row_cursor == 0
 
     loader.mark_resolved(0)
-    assert loader.data_consumed == 2
+    assert loader.row_cursor == 2
 
     loader.mark_resolved(2)
-    assert loader.data_consumed == 3
+    assert loader.row_cursor == 3
 
 
 def test_cursor_ignores_already_resolved_indices():
     loader = CursorDataLoader(["a", "b"], start_cursor=1)
 
     loader.mark_resolved(0)
-    assert loader.data_consumed == 1
+    assert loader.row_cursor == 1
 
 
 def test_cursor_can_resume_past_available_rows():
     loader = CursorDataLoader(["a"], start_cursor=3)
 
-    assert loader.data_consumed == 3
+    assert loader.row_cursor == 3
     assert list(loader) == []
 
 

--- a/training/tests/unit/test_dpo_loop.py
+++ b/training/tests/unit/test_dpo_loop.py
@@ -473,8 +473,8 @@ class TestTrainLoop:
             def __init__(self):
                 self.saves = []
 
-            def save(self, name, **kwargs):
-                self.saves.append((name, kwargs))
+            def save(self, step, **kwargs):
+                self.saves.append((step, kwargs))
 
         ds = _make_pair_dataset(tmp_path, n=4)
         cfg = module.Config(
@@ -497,8 +497,8 @@ class TestTrainLoop:
 
         assert step == 2
         assert ckpt.saves == [
-            ("step-1", {"resumable": True, "promotable": False, "data_consumed": 2}),
-            ("step-2", {"resumable": True, "promotable": False, "data_consumed": 4}),
+            (1, {"resumable": True, "promotable": False, "row_cursor": 2}),
+            (2, {"resumable": True, "promotable": False, "row_cursor": 4}),
         ]
 
     def test_multi_epoch_uses_ref_cache_log(self, tmp_path, monkeypatch):
@@ -797,8 +797,8 @@ class TestTrainLoop:
         assert call["metrics"]["train/ref_tokens"] == 12
         assert call["metrics"]["train/total_tokens"] == 24
 
-    def test_data_consumed_includes_render_drops(self, tmp_path, monkeypatch):
-        """``data_consumed`` reflects raw rows pulled (incl. render drops), not post-filter pairs."""
+    def test_row_cursor_includes_render_drops(self, tmp_path, monkeypatch):
+        """The cursor reflects raw rows pulled, not post-filter pairs."""
         events: dict = {}
         _stub_train_step_deps(monkeypatch, events)
 
@@ -822,8 +822,8 @@ class TestTrainLoop:
         saves: list[dict] = []
 
         class _CapturingCkpt:
-            def save(self, name, *, resumable, promotable, data_consumed):
-                saves.append({"name": name, "data_consumed": data_consumed})
+            def save(self, step, *, resumable, promotable, row_cursor):
+                saves.append({"step": step, "row_cursor": row_cursor})
 
         cursor = _new_cursor(max_rows=6)
         step = asyncio.run(
@@ -840,9 +840,9 @@ class TestTrainLoop:
         assert step == 2
         assert cursor.value == 6
         # Final DCP save records raw rows (incl. drops), not just the 4 trained pairs.
-        assert saves[-1]["data_consumed"] == 6
+        assert saves[-1]["row_cursor"] == 6
 
-    def test_data_consumed_threads_prior_value_on_resume(self, tmp_path, monkeypatch):
+    def test_row_cursor_threads_prior_value_on_resume(self, tmp_path, monkeypatch):
         """Cursor pre-resumed to ``persisted=100`` accumulates new raw rows on top."""
         events: dict = {}
         _stub_train_step_deps(monkeypatch, events)
@@ -856,8 +856,8 @@ class TestTrainLoop:
         saves: list[int] = []
 
         class _CapturingCkpt:
-            def save(self, name, *, resumable, promotable, data_consumed):
-                saves.append(data_consumed)
+            def save(self, step, *, resumable, promotable, row_cursor):
+                saves.append(row_cursor)
 
         # max_rows=None: pretend a larger source where 100 prior rows were consumed.
         cursor = _new_cursor(persisted=100)
@@ -875,8 +875,8 @@ class TestTrainLoop:
         assert cursor.value == 104
         assert saves[-1] == 104
 
-    def test_data_consumed_grows_per_epoch_in_multi_epoch(self, tmp_path, monkeypatch):
-        """Multi-epoch replay advances ``data_consumed`` by ``total_raw_rows`` per epoch."""
+    def test_row_cursor_grows_per_epoch_in_multi_epoch(self, tmp_path, monkeypatch):
+        """Multi-epoch replay advances the cursor by total raw rows per epoch."""
         events: dict = {}
         _stub_train_step_deps(monkeypatch, events)
 

--- a/training/tests/unit/test_rl_loop.py
+++ b/training/tests/unit/test_rl_loop.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib
 import inspect
 import json
+import logging
 import pkgutil
 from types import SimpleNamespace
 
@@ -156,6 +157,33 @@ def test_main_requires_deployment_tokenizer_model(monkeypatch):
 
     with pytest.raises(ValueError, match="deployment.tokenizer_model"):
         module.main(cfg)
+
+
+def test_dataset_resume_row_defaults_to_zero():
+    cfg = module.Config(log_path="/tmp/rl_test_logs")
+
+    assert cfg.dataloader_cursor == 0
+
+
+def test_main_rejects_negative_dataset_resume_row():
+    cfg = module.Config(log_path="/tmp/rl_test_logs", dataloader_cursor=-1)
+
+    with pytest.raises(ValueError, match="dataloader_cursor"):
+        module.main(cfg)
+
+
+def test_main_logs_dataset_resume_row_first(monkeypatch, caplog):
+    cfg = module.Config(
+        log_path="/tmp/rl_test_logs",
+        dataset="/tmp/prompts.jsonl",
+        dataloader_cursor=23,
+        deployment=module.DeployConfig(tokenizer_model="Qwen/Qwen3-1.7B"),
+    )
+
+    with caplog.at_level(logging.INFO):
+        _build_service_kwargs(monkeypatch, cfg)
+
+    assert "Dataset resume row: 23" in caplog.text
 
 
 async def _external_sample_prompt_fn(_row, *, cursor_index: int):

--- a/training/tests/unit/test_sft_loop.py
+++ b/training/tests/unit/test_sft_loop.py
@@ -13,10 +13,7 @@ from training.utils.checkpoints import TrainingCheckpoints
 def _patch_resume(monkeypatch, resume_info):
     """Replace TrainingCheckpoints.resume on the class for unit tests.
 
-    ``resume_info`` is what ``ckpt.resume()`` should return: ``None`` for
-    a fresh start, or a SimpleNamespace with ``step`` / ``data_consumed``
-    fields. After PR #385 ``data_consumed`` carries SFT's
-    ``raw_rows_consumed`` semantically (single load-bearing counter).
+    ``resume_info`` carries the resolved trainer step and raw-row cursor.
     """
     monkeypatch.setattr(
         TrainingCheckpoints, "resume", lambda self, **kwargs: resume_info,

--- a/training/utils/checkpoints.py
+++ b/training/utils/checkpoints.py
@@ -1,35 +1,14 @@
-"""Unified checkpoint API for cookbook training loops.
+"""Checkpoint, resume, and sampler weight-sync plumbing for cookbook loops.
 
-Collapses the old three-way split (DCP / sampler-full / sampler-LoRA) behind
-two user-facing axes: ``resumable`` and ``promotable``. The control plane
-(``FireworksClient.list_checkpoints(job_id)``) is the source of truth for
-what checkpoints exist, their type, and promotability. The only
-locally-persisted file is ``dataloader.json``, which maps checkpoint name
-to the cookbook's ``data_consumed`` counter (no server-side
-representation).
+Remote checkpoint rows are authoritative. The cookbook only persists the one
+piece of client state the trainer cannot know: a mapping from trainer job and
+checkpoint step to the next raw dataset row::
 
-The helpers centralize checkpoint naming and resume metadata handling.
+    {"trainer-job-id": {"10": 80, "20": 160}}
 
-Usage::
-
-    ckpt = TrainingCheckpoints(client, rlor_mgr,
-                               trainer_id=job_id, log_path=cfg.log_path,
-                               lora_rank=cfg.lora_rank)
-
-    resume_info = ckpt.resume(
-        init_from_checkpoint=cfg.init_from_checkpoint,
-        warm_start_from_adapter=cfg.warm_start_from_adapter,
-    )
-
-    # periodic (RL / SFT)
-    ckpt.save(f"step-{step}", resumable=True, promotable=False,
-              data_consumed=data_consumed)
-
-    # final
-    ckpt.save(f"step-{step}", resumable=True, promotable=True,
-              data_consumed=data_consumed)
-    if cfg.output_model_id:
-        ckpt.promote_latest(cfg.output_model_id, cfg.base_model)
+Recipes never choose LoRA/full or base/delta sampler formats. ``sync_weights``
+delegates that choice to the SDK, while final promotable saves force a complete
+export behind this boundary.
 """
 
 from __future__ import annotations
@@ -40,60 +19,62 @@ import re
 import time
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import Any, Protocol
+from typing import Any, Callable, Mapping, Protocol
 
 import training.utils.fileio as fileio
 
-DATALOADER_BASE_NAME = "dataloader.json"
+DATALOADER_CURSOR_BASE_NAME = "dataloader.json"
+# Compatibility for callers that imported the old constant.
+DATALOADER_BASE_NAME = DATALOADER_CURSOR_BASE_NAME
 DATALOADER_HISTORY_KEEP = 20
 
 _RESUMABLE_TYPE_SUFFIXES = ("TRAINING", "TRAINING_LORA")
+_SESSION_SUFFIX_RE = re.compile(r"-[0-9a-f]{8}$")
+_RUN_SCOPED_NAME_RE = re.compile(r"^run-[0-9a-f]{32}[:-](.+)$")
+_CHECKPOINT_RESOURCE_RE = re.compile(
+    r"(?:^|/)(?:rlorTrainerJobs|trainingSessions)/([^/]+)/checkpoints/([^/]+)$"
+)
+_STEP_NAME_RE = re.compile(r"^step-(\d+)$")
+_PROMOTABLE_FRESHNESS_TOLERANCE_S = 10.0
 
 logger = logging.getLogger(__name__)
 
 
-# -- Public types --------------------------------------------------------------
-
-
-@dataclass
+@dataclass(frozen=True)
 class ResumeInfo:
-    """Resolved resume state returned by :meth:`TrainingCheckpoints.resume`."""
+    """The resolved trainer step and raw-row cursor for a run."""
 
     step: int = 0
-    #: Cumulative raw rows from the source dataset (incl. drops / sample failures), across all runs.
-    data_consumed: int = 0
+    row_cursor: int = 0
     source_job_id: str | None = None
 
+    @property
+    def data_consumed(self) -> int:
+        """Backward-compatible name for :attr:`row_cursor`."""
+        return self.row_cursor
 
-class _CheckpointLister(Protocol):
+
+class _CheckpointControlPlane(Protocol):
     def list_checkpoints(self, job_id: str, *, page_size: int = 200) -> list[dict]: ...
 
     def promote_checkpoint(
         self,
-        job_id: str,
-        checkpoint_id: str,
+        *,
+        name: str,
         output_model_id: str,
         base_model: str,
-        *,
         hot_load_deployment_id: str | None = None,
     ) -> dict: ...
-
-
-# -- Helpers -------------------------------------------------------------------
 
 
 def validate_warm_start_config(
     *,
     warm_start_from_adapter: str | None,
-    init_from_checkpoint: str | None,
+    init_from_checkpoint: str | Mapping[str, Any] | None,
     lora_rank: int,
 ) -> None:
-    """Validate cross-field constraints on warm-start inputs.
-
-    Full-param warm-start is handled via ``cfg.base_model`` at session init,
-    not via this API — this helper only checks the LoRA adapter path.
-    """
-    if warm_start_from_adapter and init_from_checkpoint:
+    """Validate cross-field constraints on weights-only warm starts."""
+    if warm_start_from_adapter and init_from_checkpoint is not None:
         raise ValueError(
             "warm_start_from_adapter and init_from_checkpoint are mutually exclusive"
         )
@@ -101,51 +82,31 @@ def validate_warm_start_config(
         raise ValueError(
             "warm_start_from_adapter requires lora_rank > 0. "
             "For full-param warm-start, set cfg.base_model to the promoted model "
-            "resource name — the training session will initialize from it directly."
+            "resource name; the training session initializes from it directly."
         )
 
 
 def _short_name(resource_name: str) -> str:
-    """Extract the trailing checkpoint id from a full resource name."""
     return resource_name.rstrip("/").rsplit("/", 1)[-1]
 
 
-_SESSION_SUFFIX_RE = re.compile(r"-[0-9a-f]{8}$")
-_RUN_SCOPED_NAME_RE = re.compile(r"^run-[0-9a-f]{32}[:-](.+)$")
-_PROMOTABLE_FRESHNESS_TOLERANCE_S = 10.0
-
-
 def _logical_name(short: str) -> str:
-    """Strip the server-appended session suffix from a sampler checkpoint id.
-
-    Sampler writes (``INFERENCE_*`` rows) get an 8-hex-char session id
-    appended by the trainer (e.g. ``"step-5"`` -> ``"step-5-45dda197"``).
-    DCP (``TRAINING*``) rows keep the original caller-supplied name. For
-    skip-if-exists the caller's logical name is what should match.
-    """
+    """Strip the trainer's sampler-session suffix from a checkpoint id."""
     return _SESSION_SUFFIX_RE.sub("", short)
 
 
 def _public_logical_name(short: str) -> str:
-    """Return the caller-visible logical name for a CP checkpoint id.
-
-    Serverless training-session checkpoints are surfaced as
-    ``<run_id>-<checkpoint_id>`` to keep multiple source runs unique. The
-    cookbook caller only knows the trainer-side ``<checkpoint_id>`` it passed
-    to ``save()``, so skip/wait checks compare against the suffix after the
-    public run prefix. Accept the legacy ``<run_id>:<checkpoint_id>`` form too
-    so in-flight jobs from older control planes still skip duplicate saves.
-    """
-    m = _RUN_SCOPED_NAME_RE.match(short)
-    if m:
-        short = m.group(1)
+    """Strip a public serverless run prefix and sampler-session suffix."""
+    match = _RUN_SCOPED_NAME_RE.match(short)
+    if match:
+        short = match.group(1)
     return _logical_name(short)
 
 
 def _logical_name_for_run(short: str, current_run_id: str | None = None) -> str:
     if current_run_id:
-        for sep in ("-", ":"):
-            prefix = f"{current_run_id}{sep}"
+        for separator in ("-", ":"):
+            prefix = f"{current_run_id}{separator}"
             if short.startswith(prefix):
                 return _logical_name(short[len(prefix) :])
     return _public_logical_name(short)
@@ -157,296 +118,246 @@ def _is_run_scoped_name(short: str) -> bool:
 
 def _belongs_to_run(short: str, current_run_id: str | None = None) -> bool:
     if current_run_id is None:
-        # Without the owning run id, only legacy unscoped rows are safe to use.
-        # A run-scoped row belongs to a specific source run under the shared
-        # TrainingSession; treating it as eligible would let resume/promote/skip
-        # pick another run's checkpoint.
         return not _is_run_scoped_name(short)
     return short.startswith(f"{current_run_id}-") or short.startswith(
         f"{current_run_id}:"
     )
 
 
-def _is_resumable_row(row: dict) -> bool:
-    ctype = row.get("checkpointType", "") or ""
-    return any(ctype.endswith(suffix) for suffix in _RESUMABLE_TYPE_SUFFIXES)
+def _is_resumable_row(row: Mapping[str, Any]) -> bool:
+    checkpoint_type = row.get("checkpointType", "") or ""
+    return any(checkpoint_type.endswith(suffix) for suffix in _RESUMABLE_TYPE_SUFFIXES)
 
 
 def _parse_iso_time(value: str | None) -> datetime | None:
-    """Parse an RFC3339 timestamp into an aware ``datetime``.
-
-    Handles both microsecond-precision (``...123456Z``) and
-    second-precision (``...Z``) forms used by the control plane.
-    Returns ``None`` on missing / malformed input so callers can
-    fall back without crashing.
-    """
     if not value:
         return None
-    s = value.strip()
-    if not s:
+    value = value.strip()
+    if not value:
         return None
-    if s.endswith("Z"):
-        s = s[:-1] + "+00:00"
+    if value.endswith("Z"):
+        value = value[:-1] + "+00:00"
     try:
-        dt = datetime.fromisoformat(s)
+        parsed = datetime.fromisoformat(value)
     except ValueError:
         return None
-    if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=timezone.utc)
-    return dt
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
 
 
 def _newest_first(rows: list[dict]) -> list[dict]:
-    """Sort rows newest-first by parsed ``createTime``.
-
-    Lexicographic sort is wrong because the control plane mixes
-    second-precision (``...:13Z``) and microsecond-precision
-    (``...:13.123456Z``) timestamps in the same response: ``'Z' (90)
-    > '.' (46)`` makes the older second-precision row sort newer than
-    the newer microsecond-precision one, silently picking a stale
-    checkpoint in :meth:`_latest_resumable` and :meth:`promote_latest`.
-    Sort by parsed datetime instead (epoch fallback for unparseable
-    values so they sort to the end).
-    """
-    NEG_INF = datetime.min.replace(tzinfo=timezone.utc)
+    """Sort CP rows by parsed ``createTime`` rather than RFC3339 text."""
+    epoch = datetime.min.replace(tzinfo=timezone.utc)
     return sorted(
         rows,
-        key=lambda r: _parse_iso_time(r.get("createTime")) or NEG_INF,
+        key=lambda row: _parse_iso_time(row.get("createTime")) or epoch,
         reverse=True,
     )
 
 
-def _parse_cross_job(spec: str) -> tuple[str | None, str]:
-    """Parse ``"job_id:checkpoint_name"`` or a plain path/name."""
-    if ":" in spec and not spec.startswith(("gs://", "/")):
+def _checkpoint_step(name: str) -> int:
+    match = _STEP_NAME_RE.fullmatch(name)
+    if match is None:
+        raise ValueError(
+            f"Checkpoint {name!r} does not use the cookbook step-N naming contract"
+        )
+    return int(match.group(1))
+
+
+def _checkpoint_ref(
+    spec: str | Mapping[str, Any],
+    *,
+    default_job_id: str,
+) -> tuple[str, str]:
+    """Resolve a list-checkpoints row, resource name, ``job:name``, or name."""
+    if isinstance(spec, Mapping):
+        if not _is_resumable_row(spec):
+            raise ValueError("init_from_checkpoint must reference a resumable checkpoint")
+        value = spec.get("name")
+        if not isinstance(value, str) or not value:
+            raise ValueError("Checkpoint row is missing its resource name")
+        spec = value
+
+    resource_match = _CHECKPOINT_RESOURCE_RE.search(spec)
+    if resource_match:
+        return resource_match.group(1), resource_match.group(2)
+
+    if ":" in spec and not spec.startswith(("gs://", "tinker://", "/")):
         job_id, name = spec.split(":", 1)
-        return job_id, name
-    return None, spec
-
-
-# -- Main class ----------------------------------------------------------------
+        if job_id and name:
+            return job_id, name
+    return default_job_id, _short_name(spec)
 
 
 class TrainingCheckpoints:
-    """Single cookbook-side checkpoint manager.
-
-    Holds a reference to the live training client (for save / load RPCs on
-    the trainer pod) and a control-plane client (for the authoritative list
-    of checkpoints and for ``:promote``).
-    """
+    """One cookbook boundary for checkpoint RPCs and sampler weight sync."""
 
     def __init__(
         self,
         client: Any,
-        fw_client: _CheckpointLister,
+        fw_client: _CheckpointControlPlane,
         *,
         trainer_id: str,
         log_path: str,
         lora_rank: int = 0,
         serverless: bool = False,
         save_appear_timeout_s: float = 90.0,
-        save_stabilize_s: float = 15.0,
         save_poll_s: float = 3.0,
         current_run_id: str | None = None,
+        **legacy_options: Any,
     ) -> None:
+        # ``save_stabilize_s`` used to control a CP poll after DCP saves. DCP
+        # results now give us the stored checkpoint name directly.
+        legacy_options.pop("save_stabilize_s", None)
+        if legacy_options:
+            unexpected = ", ".join(sorted(legacy_options))
+            raise TypeError(f"Unexpected checkpoint options: {unexpected}")
         self._client = client
         self._fw_client = fw_client
         self._trainer_id = trainer_id
         self._log_path = log_path
         self._lora_rank = lora_rank
-        # In serverless mode trainer_id is the TrainingSession id (not a job),
-        # which changes how resume refs are built — see resume().
         self._serverless = serverless
         self._current_run_id = current_run_id if serverless else None
         self._save_appear_timeout_s = save_appear_timeout_s
-        self._save_stabilize_s = save_stabilize_s
         self._save_poll_s = save_poll_s
 
-    # -- Save --------------------------------------------------------------
+    def list(self) -> list[dict]:
+        """Return the control plane's authoritative checkpoint rows."""
+        return self._fw_client.list_checkpoints(self._trainer_id)
 
     def save(
         self,
-        name: str,
+        step: int,
         *,
         resumable: bool,
         promotable: bool,
-        data_consumed: int | None = None,
+        row_cursor: int | None = None,
     ) -> None:
-        """Save a checkpoint with the requested capabilities.
+        """Save trainer state and/or a complete promotable export.
 
-        ``resumable=True`` writes a DCP checkpoint (weights + optimizer).
-        ``promotable=True`` writes a sampler checkpoint. The sampler write is
-        skipped if a row with the same name already exists on the control
-        plane with ``promotable=True`` (e.g. produced earlier by
-        RL weight sync in the same loop).
-
-        ``data_consumed`` is persisted to ``dataloader.json`` keyed on
-        ``name`` so the corresponding resume call can recover the cookbook's
-        rollouts-consumed counter. Ignored when ``resumable=False``.
+        The cursor is recorded only for a resumable save. The step stored in
+        the trainer RPC result is used as the key, so server-side normalization
+        never requires a second control-plane lookup.
         """
+        if step < 0:
+            raise ValueError("step must be >= 0")
         if not (resumable or promotable):
             raise ValueError("save() requires at least one of resumable/promotable")
+        if resumable and row_cursor is None:
+            raise ValueError("row_cursor is required for resumable checkpoints")
+        if row_cursor is not None and row_cursor < 0:
+            raise ValueError("row_cursor must be >= 0")
 
-        t0 = time.time()
+        name = f"step-{step}"
         if resumable:
-            # Record save start time so we can wait for the control plane to
-            # reflect a row newer than this save. The trainer may rename to its
-            # internal step counter (caller passes "step-42", service stores
-            # as "step-0") — and resume reads names from the control plane —
-            # so ``dataloader.json`` must be keyed on whatever name ends up as
-            # the newest resumable row (which is exactly what resume will pick).
-            t_save_iso = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
-            logger.info("Saving DCP checkpoint '%s'...", name)
-            self._client.save_state(name)
-            logger.info("DCP checkpoint '%s' saved (%.1fs)", name, time.time() - t0)
-            if data_consumed is not None:
-                actual_name = self._resolve_cp_name_after_save(
-                    fallback=name,
-                    save_started_iso=t_save_iso,
-                    appear_timeout_s=self._save_appear_timeout_s,
-                    stabilize_s=self._save_stabilize_s,
-                    poll_s=self._save_poll_s,
-                )
-                self._write_dataloader(actual_name, data_consumed)
-                if actual_name != name:
-                    logger.info(
-                        "DCP server-stored name %r differs from caller name %r; "
-                        "dataloader.json keyed on server name for resume alignment.",
-                        actual_name,
-                        name,
-                    )
+            started = time.time()
+            logger.info("Saving resumable checkpoint %r...", name)
+            result = self._client.save_state(name)
+            actual_name = self._saved_checkpoint_name(result, fallback=name)
+            actual_step = _checkpoint_step(actual_name)
+            self._write_row_cursor(self._trainer_id, actual_step, int(row_cursor))
+            logger.info(
+                "Resumable checkpoint %r saved (%.1fs, row cursor %d)",
+                actual_name,
+                time.time() - started,
+                row_cursor,
+            )
 
         if promotable:
-            if self._promotable_exists(name):
-                logger.info(
-                    "Sampler checkpoint '%s' already promotable on control plane — "
-                    "skipping redundant save.",
-                    name,
-                )
-            else:
-                t1 = time.time()
-                sampler_save_started = datetime.now(timezone.utc)
-                logger.info("Saving sampler checkpoint '%s'...", name)
-                self._client.save_weights_for_sampler(name, checkpoint_type="base")
-                logger.info(
-                    "Sampler checkpoint '%s' saved (%.1fs)", name, time.time() - t1
-                )
-                actual_name = self._wait_for_promotable_after_save(
-                    name=name,
-                    save_started=sampler_save_started,
-                    appear_timeout_s=self._save_appear_timeout_s,
-                    poll_s=self._save_poll_s,
-                )
-                if actual_name and actual_name != name:
-                    logger.info(
-                        "Sampler server-stored name %r differs from caller name %r; "
-                        "using control-plane row for subsequent promotion.",
-                        actual_name,
-                        name,
-                    )
+            self._save_promotable(name)
 
-    # -- Resume ------------------------------------------------------------
+    def sync_weights(
+        self,
+        step: int,
+        hotload: Callable[[str], Any],
+    ) -> str:
+        """Save and hot-load the current sampler weights.
+
+        No checkpoint format is supplied: the SDK selects a full LoRA adapter
+        for LoRA runs and manages the base/delta chain for full-parameter runs.
+        """
+        if step < 0:
+            raise ValueError("step must be >= 0")
+        name = f"step-{step}"
+        started = time.time()
+        saved = self._client.save_weights_for_sampler(name)
+        path = getattr(saved, "path", None)
+        if not isinstance(path, str) or not path:
+            raise RuntimeError(f"Weight sync {name!r} returned no snapshot path")
+        hotload(path)
+        logger.info("Weights synced at step %d (%.1fs)", step, time.time() - started)
+        return path
 
     def resume(
         self,
         *,
-        init_from_checkpoint: str | None = None,
+        init_from_checkpoint: str | Mapping[str, Any] | None = None,
         warm_start_from_adapter: str | None = None,
-    ) -> ResumeInfo | None:
-        """Determine resume state and load weights into the live client.
+        dataloader_cursor: int | None = None,
+    ) -> ResumeInfo:
+        """Resolve and load a checkpoint, returning step and raw-row cursor.
 
-        Priority:
-
-        1. ``init_from_checkpoint`` — explicit DCP load. Same-trainer loads
-           resume the step/cursor; cross-job loads reset the step counter.
-        2. Newest resumable row on the control plane — auto-resume.
-        3. ``warm_start_from_adapter`` — HF PEFT adapter (weights only).
-        4. Fresh start (returns ``None``).
+        ``init_from_checkpoint`` accepts a row returned by :meth:`list`, its
+        full resource name, ``job_id:step-N``, or a bare ``step-N``. When
+        ``dataloader_cursor`` is supplied, local cursor state is not read.
         """
         validate_warm_start_config(
             warm_start_from_adapter=warm_start_from_adapter,
             init_from_checkpoint=init_from_checkpoint,
             lora_rank=self._lora_rank,
         )
+        if dataloader_cursor is not None and dataloader_cursor < 0:
+            raise ValueError("dataloader_cursor must be >= 0")
 
-        if init_from_checkpoint:
-            source_job_id, dcp_name = _parse_cross_job(init_from_checkpoint)
-            if self._serverless:
-                # The pooled trainer namespaces checkpoints under
-                # sessions/<session_id>/ and rejects cross_job://<id>/<name> refs
-                # (a session id is not a source job). Cross-session warm-start is
-                # not supported on the shared pool (checkpoints are session
-                # isolated), so a spec naming a different session is an error;
-                # otherwise resume from the bare name and let the trainer prepend
-                # the session prefix, mirroring the auto-resume path below.
-                if source_job_id and source_job_id != self._trainer_id:
-                    raise ValueError(
-                        f"serverless init_from_checkpoint cannot reference another "
-                        f"session ({source_job_id!r}); checkpoints on the shared pool "
-                        f"are isolated to session {self._trainer_id!r}. Use a bare "
-                        f"checkpoint name to resume within this session."
-                    )
-                source_job_id = None
-            elif source_job_id == self._trainer_id:
-                path = self._client.resolve_checkpoint_path(dcp_name)
-                logger.info(
-                    "Resuming from explicit same-trainer checkpoint: %s", dcp_name
-                )
-                t0 = time.time()
-                self._client.load_state_with_optimizer(path)
-                logger.info("Checkpoint loaded: %s (%.1fs)", path, time.time() - t0)
-                return ResumeInfo(
-                    step=_step_from_name(dcp_name),
-                    data_consumed=self._read_dataloader(dcp_name),
-                    source_job_id=source_job_id,
-                )
-            path = self._client.resolve_checkpoint_path(
-                dcp_name, source_job_id=source_job_id
+        if init_from_checkpoint is not None:
+            source_job_id, stored_name = _checkpoint_ref(
+                init_from_checkpoint,
+                default_job_id=self._trainer_id,
             )
-            logger.info(
-                "Starting at step 0 with weights loaded from %s "
-                "(no resume — step counter resets)",
-                path,
+            if self._serverless and source_job_id != self._trainer_id:
+                raise ValueError(
+                    "serverless init_from_checkpoint cannot reference another "
+                    f"session ({source_job_id!r}); checkpoints on the shared pool "
+                    "are isolated"
+                )
+            logical_name = self._trainer_logical_name(stored_name)
+            step = _checkpoint_step(logical_name)
+            load_source = None if source_job_id == self._trainer_id else source_job_id
+            self._load_checkpoint(logical_name, source_job_id=load_source)
+            return ResumeInfo(
+                step=step,
+                row_cursor=self._resolve_row_cursor(
+                    source_job_id,
+                    step,
+                    override=dataloader_cursor,
+                ),
+                source_job_id=source_job_id,
             )
-            t0 = time.time()
-            self._client.load_state_with_optimizer(path)
-            logger.info("Checkpoint loaded (%.1fs)", time.time() - t0)
-            return ResumeInfo(step=0, data_consumed=0, source_job_id=source_job_id)
 
         latest = self._latest_resumable()
-        if latest:
-            short = _short_name(latest["name"])
-            logical = self._trainer_logical_name(short)
-            # In serverless mode the pooled multi-session trainer namespaces
-            # checkpoints under the current run/session itself and rejects a
-            # cross_job://<session_id>/<name> ref (session_id is not a source
-            # job, and CP rows are public run-scoped ids). Resume from the
-            # trainer-side logical name so the trainer prepends its current run
-            # prefix; the dedicated path also uses the local trainer namespace
-            # because cross_job://<same-trainer>/<name> points at the global
-            # durable checkpoint prefix and can miss still-local trainer state.
-            path = self._client.resolve_checkpoint_path(logical, source_job_id=None)
-            logger.info("Resuming from control-plane row: %s", short)
-            t0 = time.time()
-            self._client.load_state_with_optimizer(path)
-            logger.info("Checkpoint loaded: %s (%.1fs)", path, time.time() - t0)
+        if latest is not None:
+            logical_name = self._trainer_logical_name(_short_name(latest["name"]))
+            step = _checkpoint_step(logical_name)
+            self._load_checkpoint(logical_name, source_job_id=None)
             return ResumeInfo(
-                step=_step_from_name(logical),
-                data_consumed=self._read_dataloader(logical),
-                source_job_id=None if self._serverless else self._trainer_id,
+                step=step,
+                row_cursor=self._resolve_row_cursor(
+                    self._trainer_id,
+                    step,
+                    override=dataloader_cursor,
+                ),
+                source_job_id=self._trainer_id,
             )
 
         if warm_start_from_adapter:
-            logger.info("Fresh start with HF adapter: %s", warm_start_from_adapter)
-            t0 = time.time()
+            logger.info("Starting with an explicit HF adapter")
+            started = time.time()
             self._client.load_adapter(warm_start_from_adapter)
-            logger.info("Adapter loaded (%.1fs)", time.time() - t0)
-            return ResumeInfo(step=0, data_consumed=0, source_job_id=None)
+            logger.info("Adapter loaded (%.1fs)", time.time() - started)
 
-        logger.info("Starting at step 0 from base model (no checkpoint)")
-        return None
-
-    # -- Promote -----------------------------------------------------------
+        return ResumeInfo(row_cursor=dataloader_cursor or 0)
 
     def promote_latest(
         self,
@@ -455,33 +366,22 @@ class TrainingCheckpoints:
         *,
         hot_load_deployment_id: str | None = None,
     ) -> dict:
-        """Promote the newest promotable row on the control plane.
-
-        No local lookup. Works identically for full and LoRA runs; in LoRA
-        runs this transparently picks up the most recent
-        weight-sync sampler row without requiring an explicit final
-        sampler save.
-        """
+        """Promote the newest promotable row returned by the control plane."""
         rows = _newest_first(
             [
-                r
-                for r in self._list_checkpoints()
-                if r.get("promotable") and self._row_matches_current_run(r)
+                row
+                for row in self.list()
+                if row.get("promotable") and self._row_matches_current_run(row)
             ]
         )
         if not rows:
             raise RuntimeError(
-                f"No promotable checkpoints found for trainer job '{self._trainer_id}'. "
-                "Call save(promotable=True) or run a promotable weight sync first."
+                f"No promotable checkpoints found for trainer job {self._trainer_id!r}. "
+                "Save a promotable checkpoint first."
             )
-        # Use the 4-segment resource name end-to-end: the SDK accepts
-        # ``name=`` directly, so we hand the row's ``name`` field through
-        # without disassembly. See the public docs page on saving and
-        # loading (``/fine-tuning/training-api/saving-and-loading``) for
-        # the full promote API contract.
         full_name = rows[0]["name"]
         logger.info(
-            "Promoting newest promotable checkpoint: %s -> %s",
+            "Promoting checkpoint %s -> %s",
             _short_name(full_name),
             output_model_id,
         )
@@ -492,181 +392,51 @@ class TrainingCheckpoints:
             hot_load_deployment_id=hot_load_deployment_id,
         )
 
-    # -- Internal ----------------------------------------------------------
-
-    def _list_checkpoints(self) -> list[dict]:
-        return self._fw_client.list_checkpoints(self._trainer_id)
-
-    def _resolve_cp_name_after_save(
-        self,
-        *,
-        fallback: str,
-        save_started_iso: str,
-        appear_timeout_s: float,
-        stabilize_s: float,
-        poll_s: float,
-    ) -> str:
-        """Wait for the save to surface, let the CP state stabilize, then
-        return the short name of the row resume would pick (newest resumable).
-
-        The control plane can show a transient row name mid-save before the
-        trainer's internal bookkeeping consolidates (e.g. caller writes
-        ``step-2`` but the service later collapses it into ``step-0``). Picking
-        the "first new name" would race with that consolidation and store a
-        dataloader key that resume never sees. Instead we mirror
-        :meth:`_latest_resumable` exactly: after a brief stabilization window,
-        pick the newest resumable row.
-        """
-        deadline = time.time() + appear_timeout_s
-        while time.time() < deadline:
-            try:
-                rows = self._list_checkpoints()
-            except AttributeError as e:
-                # Permanent: the control-plane client doesn't implement
-                # ``list_checkpoints`` (e.g. a unit-test fake). Don't burn
-                # the appear_timeout — fall back to the caller name now.
-                logger.warning(
-                    "list_checkpoints not implemented on control-plane client (%s); "
-                    "falling back to caller name %r for dataloader.json.",
-                    e,
-                    fallback,
-                )
-                return fallback
-            except Exception as e:
-                logger.debug(
-                    "list_checkpoints during save-resolution failed: %s; retrying.",
-                    e,
-                )
-                time.sleep(poll_s)
-                continue
-            surfaced = any(
-                _is_resumable_row(r)
-                and self._row_matches_current_run(r)
-                and r.get("createTime", "") >= save_started_iso
-                for r in rows
-            )
-            if surfaced:
-                break
-            time.sleep(poll_s)
-        else:
-            logger.warning(
-                "Timed out after %.0fs waiting for CP to surface save (>= %s); "
-                "falling back to caller name %r for dataloader.json.",
-                appear_timeout_s,
-                save_started_iso,
-                fallback,
-            )
-            return fallback
-
-        time.sleep(stabilize_s)
-
-        try:
-            rows = self._list_checkpoints()
-        except Exception as e:
-            logger.warning(
-                "list_checkpoints after stabilize failed (%s); falling back to %r.",
-                e,
-                fallback,
-            )
-            return fallback
-        resumable = [
-            r for r in rows if _is_resumable_row(r) and self._row_matches_current_run(r)
-        ]
-        if not resumable:
-            return fallback
-        newest = _newest_first(resumable)[0]
-        return self._trainer_logical_name(_short_name(newest["name"]))
-
-    def _wait_for_promotable_after_save(
-        self,
-        *,
-        name: str,
-        save_started: datetime,
-        appear_timeout_s: float,
-        poll_s: float,
-    ) -> str | None:
-        """Wait until a freshly-saved sampler row is visible on the CP.
-
-        Fast-checkpoint sampler saves are discovered through a regional scan,
-        which can lag the trainer RPC return briefly. Without this wait the
-        next ``promote_latest`` call can observe an empty checkpoint list even
-        though the sampler bytes were written successfully.
-        """
-        deadline = time.time() + appear_timeout_s
-        while time.time() < deadline:
-            try:
-                row = self._promotable_row(name, min_create_time=save_started)
-            except AttributeError as e:
-                logger.warning(
-                    "list_checkpoints not implemented on control-plane client (%s); "
-                    "cannot confirm sampler checkpoint %r surfaced.",
-                    e,
-                    name,
-                )
-                return None
-            except Exception as e:
-                logger.debug(
-                    "list_checkpoints during sampler save-resolution failed: %s; retrying.",
-                    e,
-                )
-                time.sleep(poll_s)
-                continue
-            if row:
-                return _short_name(row["name"])
-            time.sleep(poll_s)
-
-        logger.warning(
-            "Timed out after %.0fs waiting for sampler checkpoint %r to surface "
-            "as promotable; continuing and letting promote_latest perform the "
-            "final control-plane check.",
-            appear_timeout_s,
+    def _load_checkpoint(self, name: str, *, source_job_id: str | None) -> None:
+        path = self._client.resolve_checkpoint_path(
             name,
+            source_job_id=source_job_id,
         )
-        return None
+        logger.info("Resuming from checkpoint %s", path)
+        started = time.time()
+        self._client.load_state_with_optimizer(path)
+        logger.info("Checkpoint loaded (%.1fs)", time.time() - started)
 
     def _latest_resumable(self) -> dict | None:
-        try:
-            rows = [
-                r
-                for r in self._list_checkpoints()
-                if _is_resumable_row(r) and self._row_matches_current_run(r)
-            ]
-        except Exception as e:
-            logger.warning(
-                "Control-plane list_checkpoints failed (%s); treating as fresh start. "
-                "Override with init_from_checkpoint if this is wrong.",
-                e,
-            )
-            return None
+        rows = [
+            row
+            for row in self.list()
+            if _is_resumable_row(row) and self._row_matches_current_run(row)
+        ]
         rows = _newest_first(rows)
         return rows[0] if rows else None
 
-    def _row_matches_current_run(self, row: dict) -> bool:
-        if not self._serverless:
-            return True
-        return _belongs_to_run(_short_name(row.get("name", "")), self._current_run_id)
+    def _save_promotable(self, name: str) -> None:
+        if self._promotable_row(name) is not None:
+            logger.info("Promotable checkpoint %r already exists", name)
+            return
+        started_at = datetime.now(timezone.utc)
+        started = time.time()
+        # A complete export is required for promotion. This is intentionally
+        # hidden here; ordinary weight sync delegates base/delta selection.
+        self._client.save_weights_for_sampler(name, checkpoint_type="base")
+        logger.info("Promotable checkpoint %r saved (%.1fs)", name, time.time() - started)
+        self._wait_for_promotable(name=name, save_started=started_at)
 
-    def _trainer_logical_name(self, short: str) -> str:
-        if self._serverless:
-            return _logical_name_for_run(short, self._current_run_id)
-        return _logical_name(short)
-
-    def _promotable_exists(self, name: str) -> bool:
-        """Check if ``name`` is already on the control plane as promotable.
-
-        Failures are non-fatal: on error we proceed with the save (GCS
-        overwrite is safe), trading dedup for forward progress.
-        """
-        try:
-            row = self._promotable_row(name)
-        except Exception as e:
-            logger.warning(
-                "Control-plane list_checkpoints failed during skip-check (%s); "
-                "proceeding with sampler write.",
-                e,
-            )
-            return False
-        return row is not None
+    def _wait_for_promotable(self, *, name: str, save_started: datetime) -> None:
+        deadline = time.time() + self._save_appear_timeout_s
+        while time.time() < deadline:
+            try:
+                if self._promotable_row(name, min_create_time=save_started) is not None:
+                    return
+            except Exception as error:
+                logger.debug("Checkpoint list failed while waiting for %r: %s", name, error)
+            time.sleep(self._save_poll_s)
+        logger.warning(
+            "Timed out after %.0fs waiting for promotable checkpoint %r to surface",
+            self._save_appear_timeout_s,
+            name,
+        )
 
     def _promotable_row(
         self,
@@ -674,9 +444,7 @@ class TrainingCheckpoints:
         *,
         min_create_time: datetime | None = None,
     ) -> dict | None:
-        rows = _newest_first(
-            [r for r in self._list_checkpoints() if r.get("promotable")]
-        )
+        rows = _newest_first([row for row in self.list() if row.get("promotable")])
         freshness_floor = None
         if min_create_time is not None:
             freshness_floor = min_create_time - timedelta(
@@ -687,46 +455,94 @@ class TrainingCheckpoints:
                 continue
             if self._trainer_logical_name(_short_name(row.get("name", ""))) != name:
                 continue
-            if freshness_floor is not None:
-                create_time = _parse_iso_time(row.get("createTime"))
-                if create_time is not None and create_time < freshness_floor:
-                    continue
+            create_time = _parse_iso_time(row.get("createTime"))
+            if (
+                freshness_floor is not None
+                and create_time is not None
+                and create_time < freshness_floor
+            ):
+                continue
             return row
         return None
 
-    def _dataloader_path(self) -> str:
-        return fileio.join(self._log_path, DATALOADER_BASE_NAME)
+    def _row_matches_current_run(self, row: Mapping[str, Any]) -> bool:
+        if not self._serverless:
+            return True
+        return _belongs_to_run(_short_name(row.get("name", "")), self._current_run_id)
 
-    def _read_all_dataloader(self) -> dict[str, int]:
+    def _trainer_logical_name(self, short: str) -> str:
+        if self._serverless:
+            return _logical_name_for_run(short, self._current_run_id)
+        return _logical_name(short)
+
+    @staticmethod
+    def _saved_checkpoint_name(result: Any, *, fallback: str) -> str:
+        path = getattr(result, "path", None)
+        if not isinstance(path, str) or not path:
+            return fallback
+        short = _short_name(path)
+        return short if _STEP_NAME_RE.fullmatch(short) else fallback
+
+    def _resolve_row_cursor(
+        self,
+        job_id: str,
+        step: int,
+        *,
+        override: int | None,
+    ) -> int:
+        if override is not None:
+            return override
+        return self._read_row_cursor(job_id, step)
+
+    def _dataloader_path(self) -> str:
+        return fileio.join(self._log_path, DATALOADER_CURSOR_BASE_NAME)
+
+    def _read_cursor_store(self) -> dict[str, dict[str, int]]:
         path = self._dataloader_path()
         raw = fileio.read_text(path)
         if not raw:
             return {}
         try:
             data = json.loads(raw)
-        except json.JSONDecodeError as e:
-            logger.warning("Corrupt %s (%s); treating as empty.", path, e)
+        except json.JSONDecodeError as error:
+            logger.warning("Corrupt %s (%s); treating as empty", path, error)
             return {}
-        return {k: int(v) for k, v in data.items()}
+        if not isinstance(data, dict):
+            logger.warning("Invalid cursor mapping in %s; treating as empty", path)
+            return {}
 
-    def _write_dataloader(self, name: str, data_consumed: int) -> None:
-        data = self._read_all_dataloader()
-        data[name] = data_consumed
-        if len(data) > DATALOADER_HISTORY_KEEP:
-            ordered = sorted(data.items(), key=lambda kv: _step_from_name(kv[0]))
-            data = dict(ordered[-DATALOADER_HISTORY_KEEP:])
+        # Migrate the former {"step-N": cursor} shape into the only local
+        # state shape supported now: {job_id: {step: cursor}}.
+        if all(not isinstance(value, dict) for value in data.values()):
+            migrated: dict[str, int] = {}
+            for name, cursor in data.items():
+                try:
+                    migrated[str(_checkpoint_step(str(name)))] = int(cursor)
+                except (TypeError, ValueError):
+                    continue
+            return {self._trainer_id: migrated} if migrated else {}
+
+        normalized: dict[str, dict[str, int]] = {}
+        try:
+            for job_id, steps in data.items():
+                if not isinstance(steps, dict):
+                    raise TypeError
+                normalized[str(job_id)] = {
+                    str(int(step)): int(cursor) for step, cursor in steps.items()
+                }
+        except (TypeError, ValueError):
+            logger.warning("Invalid cursor mapping in %s; treating as empty", path)
+            return {}
+        return normalized
+
+    def _write_row_cursor(self, job_id: str, step: int, row_cursor: int) -> None:
+        data = self._read_cursor_store()
+        job_steps = data.setdefault(job_id, {})
+        job_steps[str(step)] = row_cursor
+        ordered = sorted(job_steps.items(), key=lambda item: int(item[0]))
+        data[job_id] = dict(ordered[-DATALOADER_HISTORY_KEEP:])
         fileio.makedirs(self._log_path)
         fileio.write_json(self._dataloader_path(), data)
 
-    def _read_dataloader(self, name: str) -> int:
-        return self._read_all_dataloader().get(name, 0)
-
-
-def _step_from_name(name: str) -> int:
-    """Parse an integer step from a ``"step-N"`` checkpoint name."""
-    if name.startswith("step-"):
-        try:
-            return int(name.removeprefix("step-"))
-        except ValueError:
-            pass
-    return 0
+    def _read_row_cursor(self, job_id: str, step: int) -> int:
+        return self._read_cursor_store().get(job_id, {}).get(str(step), 0)

--- a/training/utils/checkpoints.py
+++ b/training/utils/checkpoints.py
@@ -237,16 +237,14 @@ class TrainingCheckpoints:
     ) -> None:
         """Save trainer state and/or a complete promotable export.
 
-        The cursor is recorded only for a resumable save. The step stored in
-        the trainer RPC result is used as the key, so server-side normalization
-        never requires a second control-plane lookup.
+        When ``row_cursor`` is supplied for a resumable save, it is recorded
+        under the step returned by the trainer. Omitting it performs no local
+        cursor I/O, which is the sync/async RL contract.
         """
         if step < 0:
             raise ValueError("step must be >= 0")
         if not (resumable or promotable):
             raise ValueError("save() requires at least one of resumable/promotable")
-        if resumable and row_cursor is None:
-            raise ValueError("row_cursor is required for resumable checkpoints")
         if row_cursor is not None and row_cursor < 0:
             raise ValueError("row_cursor must be >= 0")
 
@@ -256,14 +254,21 @@ class TrainingCheckpoints:
             logger.info("Saving resumable checkpoint %r...", name)
             result = self._client.save_state(name)
             actual_name = self._saved_checkpoint_name(result, fallback=name)
-            actual_step = _checkpoint_step(actual_name)
-            self._write_row_cursor(self._trainer_id, actual_step, int(row_cursor))
-            logger.info(
-                "Resumable checkpoint %r saved (%.1fs, row cursor %d)",
-                actual_name,
-                time.time() - started,
-                row_cursor,
-            )
+            if row_cursor is None:
+                logger.info(
+                    "Resumable checkpoint %r saved (%.1fs)",
+                    actual_name,
+                    time.time() - started,
+                )
+            else:
+                actual_step = _checkpoint_step(actual_name)
+                self._write_row_cursor(self._trainer_id, actual_step, row_cursor)
+                logger.info(
+                    "Resumable checkpoint %r saved (%.1fs, row cursor %d)",
+                    actual_name,
+                    time.time() - started,
+                    row_cursor,
+                )
 
         if promotable:
             self._save_promotable(name)
@@ -296,12 +301,14 @@ class TrainingCheckpoints:
         init_from_checkpoint: str | Mapping[str, Any] | None = None,
         warm_start_from_adapter: str | None = None,
         dataloader_cursor: int | None = None,
+        auto_latest: bool = True,
     ) -> ResumeInfo:
         """Resolve and load a checkpoint, returning step and raw-row cursor.
 
         ``init_from_checkpoint`` accepts a row returned by :meth:`list`, its
         full resource name, ``job_id:step-N``, or a bare ``step-N``. When
         ``dataloader_cursor`` is supplied, local cursor state is not read.
+        Set ``auto_latest=False`` when the caller owns checkpoint selection.
         """
         validate_warm_start_config(
             warm_start_from_adapter=warm_start_from_adapter,
@@ -336,7 +343,7 @@ class TrainingCheckpoints:
                 source_job_id=source_job_id,
             )
 
-        latest = self._latest_resumable()
+        latest = self._latest_resumable() if auto_latest else None
         if latest is not None:
             logical_name = self._trainer_logical_name(_short_name(latest["name"]))
             step = _checkpoint_step(logical_name)

--- a/training/utils/config.py
+++ b/training/utils/config.py
@@ -280,7 +280,6 @@ class WeightSyncConfig:
     dcp_save_interval: int = 0
     dcp_timeout: int = 2700
     """Timeout in seconds for DCP save_state / load_state_with_optimizer (default 45 min)."""
-    first_checkpoint_type: str = "base"
     weight_sync_before_training: bool = False
     weight_sync_timeout: int = 600
 

--- a/training/utils/dataloader.py
+++ b/training/utils/dataloader.py
@@ -50,8 +50,13 @@ class CursorDataLoader(Generic[T]):
         return CursorItem(index=idx, value=copy.deepcopy(self.items[self._row_index(idx)]))
 
     @property
-    def data_consumed(self) -> int:
+    def row_cursor(self) -> int:
         return self.cursor
+
+    @property
+    def data_consumed(self) -> int:
+        """Backward-compatible alias for :attr:`row_cursor`."""
+        return self.row_cursor
 
     @property
     def total_items(self) -> int:

--- a/training/utils/dataloader_cursor.py
+++ b/training/utils/dataloader_cursor.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 
 class RawRowCursor:
-    """Cumulative count of raw source rows consumed across all runs.
+    """Cumulative raw source-row cursor shared across training runs.
 
-    Same accounting unit ``ResumeInfo.data_consumed`` carries: raw rows
-    pulled from the source dataset, including drops / sample failures.
+    This is the same accounting unit as ``ResumeInfo.row_cursor``: raw rows
+    pulled from the source dataset, including drops and sample failures.
     Set ``max_rows`` to clamp (e.g. RL's pre-multiplied row list); leave
     ``None`` for cursors that grow across epochs (SFT/DPO multi-epoch).
     """
@@ -20,18 +20,9 @@ class RawRowCursor:
     def value(self) -> int:
         return self._value
 
-    def resume(self, persisted: int | None, *, fallback: int = 0) -> None:
-        """Set cursor from a checkpoint's ``data_consumed``, falling back to a
-        step-derived count when persisted is missing or zero on a non-fresh resume.
-
-        ``persisted=0`` with ``fallback>0`` is the legacy-checkpoint signal
-        (``dataloader.json`` not yet written): take the step-derived path.
-        ``persisted=0`` with ``fallback=0`` is a fresh start: trust the 0.
-        """
-        if persisted is not None and (persisted > 0 or fallback == 0):
-            self._value = self._clamp(persisted)
-            return
-        self._value = self._clamp(fallback)
+    def resume(self, row_cursor: int) -> None:
+        """Set the exact cursor resolved by ``TrainingCheckpoints.resume``."""
+        self._value = self._clamp(row_cursor)
 
     def record(self, raw_rows: int) -> None:
         """Advance cursor by ``raw_rows`` (clamped). Negative is a no-op."""


### PR DESCRIPTION
## Summary

- make control-plane `list_checkpoints` rows the authoritative checkpoint registry
- accept RPC rows, resource names, or `job_id:step-N` for explicit checkpoint loading
- route recipe weight sync through `TrainingCheckpoints.sync_weights`, leaving LoRA/full and full base/delta selection behind the cookbook/SDK boundary
- keep the supervised SFT/DPO/ORPO cursor mapping as `trainer job id -> checkpoint step -> row cursor`
- give sync and async RL a stricter contract:
  - `dataloader_cursor: int = 0` is the only dataset resume input
  - no client-side cursor mapping is read or written
  - no latest checkpoint is selected automatically
  - the starting row is logged before setup
  - the returned `rows_trained` value is the cumulative row number for the next run
- update recipes, examples, resume E2E fixtures, unit coverage, and checkpoint documentation

## Why

Checkpoint discovery, dataset progress, and sampler export modes had leaked across recipe loops. This change gives those concerns a clear boundary: remote RPC rows describe checkpoints, the SDK owns snapshot format selection, and RL callers explicitly own their dataset row.

The async/sync RL flow is intentionally simple:

```
init_from_checkpoint=<explicit RPC row/resource>
dataloader_cursor=<prior rows_trained>
    -> train
    -> {"rows_trained": <next cumulative row>}
```

## Behavior changes

- sync/async RL no longer auto-resume from the newest checkpoint
- sync/async RL DCP saves carry no client cursor payload and create no `dataloader.json`
- a fresh RL run starts at row zero unless `dataloader_cursor` is supplied
- supervised recipes retain their existing trainer-scoped auto-resume behavior
- legacy flat supervised cursor files are migrated when read
- control-plane list failures still propagate on supervised auto-resume
- ordinary recipes do not pass checkpoint modes; the specialized LoRA merged-base tool remains explicit

## Managed orchestration impact

Managed SFT/DPO/ORPO keep their current periodic DCP and local-cursor retry path. Managed async RL now needs its caller to provide both an explicit checkpoint and `dataloader_cursor` for cold resume. The current Go managed config does not yet expose `dataloader_cursor`; that integration must be handled before relying on managed async-RL cold resume.

## Validation

```
training/.venv/bin/python -m pytest -q   training/tests/unit/test_async_rl_loop_runner.py   training/tests/unit/test_async_rl_train.py   training/tests/unit/test_distillation.py   training/tests/unit/test_dpo_loop.py   training/tests/unit/test_orpo_loop.py   training/tests/unit/test_rl_loop.py   training/tests/unit/test_sft_loop.py   training/tests/unit/test_text2sql_train_sft.py   training/tests/unit/test_train_frozen_lake.py   training/tests/unit/test_checkpoints.py   training/tests/unit/test_cursor_dataloader.py   training/tests/test_dataloader_cursor.py   training/tests/test_smoke_imports.py
```

364 passed. The resource-backed async resume E2E test was updated to pass an explicit RPC row plus the returned row number and to assert that no local cursor registry is created; it was collected but not run locally.