### PR TITLE
fix(training): propagate tokenizer hub failures

### DIFF
--- a/training/tests/unit/test_tokenizers.py
+++ b/training/tests/unit/test_tokenizers.py
@@ -1,26 +1,47 @@
 from __future__ import annotations
 
+import socket
+import threading
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from types import SimpleNamespace
 
+import httpx
 import pytest
+from huggingface_hub.errors import HfHubHTTPError
+from huggingface_hub.utils import hf_raise_for_status
 
 import training.utils.tokenizers as tokenizers
 import training.utils.runner as runner
 from training.utils.runner import RunnerConfig, RunnerIO
 
 
-class FakeHuggingFaceHTTPError(Exception):
-    def __init__(self, status_code: int, model: str = "Qwen/Qwen3-8B"):
-        super().__init__(
-            f"Server error '{status_code}' for url 'https://huggingface.co/{model}'"
-        )
-        self.response = SimpleNamespace(status_code=status_code)
+@contextmanager
+def local_status_server(status_code: int):
+    class StatusHandler(BaseHTTPRequestHandler):
+        def do_HEAD(self):
+            self.send_response(status_code)
+            self.end_headers()
 
+        def log_message(self, format, *args):
+            pass
 
-def wrapped_tokenizer_error(status_code: int, model: str = "Qwen/Qwen3-8B") -> OSError:
+    server = ThreadingHTTPServer(("127.0.0.1", 0), StatusHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
     try:
-        raise FakeHuggingFaceHTTPError(status_code, model)
-    except FakeHuggingFaceHTTPError as exc:
+        yield f"http://127.0.0.1:{server.server_port}/model"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join()
+
+
+def real_wrapped_tokenizer_http_error(url: str) -> OSError:
+    response = httpx.head(url)
+    try:
+        hf_raise_for_status(response)
+    except HfHubHTTPError as exc:
         try:
             raise OSError(
                 "Unable to load vocabulary from file. Please check that the "
@@ -84,111 +105,81 @@ def test_load_deployment_tokenizer_uses_generic_deploy_config_fields(monkeypatch
     assert captured == {"model": "model/name", "revision": "abc123"}
 
 
-def test_load_tokenizer_retries_transient_huggingface_failure(monkeypatch):
-    calls = 0
-    sleeps: list[float] = []
-    fake_tokenizer = object()
+@pytest.mark.parametrize("status_code", [404, 504])
+def test_load_tokenizer_propagates_real_huggingface_http_status(
+    monkeypatch, status_code
+):
+    with local_status_server(status_code) as url:
 
-    def fake_from_pretrained(model, **kwargs):
-        nonlocal calls
-        calls += 1
-        if calls < 3:
-            raise wrapped_tokenizer_error(504)
-        return fake_tokenizer
+        def from_pretrained(model, **kwargs):
+            raise real_wrapped_tokenizer_http_error(url)
+
+        monkeypatch.setattr(
+            tokenizers.transformers.AutoTokenizer, "from_pretrained", from_pretrained
+        )
+
+        with pytest.raises(RuntimeError) as exc_info:
+            tokenizers.load_tokenizer("org/model-504")
+
+    assert str(exc_info.value) == (
+        "Hugging Face Hub request failed while loading tokenizer "
+        f"'org/model-504' (HTTP {status_code})."
+    )
+    tokenizer_error = exc_info.value.__cause__
+    assert isinstance(tokenizer_error, OSError)
+    hub_error = tokenizer_error.__cause__
+    assert isinstance(hub_error, HfHubHTTPError)
+    assert hub_error.response.status_code == status_code
+    assert isinstance(hub_error.__cause__, httpx.HTTPStatusError)
+
+
+def test_load_tokenizer_does_not_misclassify_connection_refused_as_http(monkeypatch):
+    socket_handle = socket.socket()
+    socket_handle.bind(("127.0.0.1", 0))
+    port = socket_handle.getsockname()[1]
+    socket_handle.close()
+    url = f"http://127.0.0.1:{port}/model"
+
+    def from_pretrained(model, **kwargs):
+        try:
+            httpx.head(url)
+        except httpx.ConnectError as exc:
+            raise OSError("Unable to reach tokenizer endpoint") from exc
+        raise AssertionError("expected connection refusal")
 
     monkeypatch.setattr(
-        tokenizers.transformers.AutoTokenizer, "from_pretrained", fake_from_pretrained
-    )
-    monkeypatch.setattr(tokenizers.time, "sleep", sleeps.append)
-
-    result = tokenizers.load_tokenizer("Qwen/Qwen3-8B")
-
-    assert result is fake_tokenizer
-    assert calls == 3
-    assert sleeps == [2.0, 4.0]
-
-
-def test_load_tokenizer_reports_huggingface_unavailability_after_retries(monkeypatch):
-    sleeps: list[float] = []
-
-    def fake_from_pretrained(model, **kwargs):
-        raise wrapped_tokenizer_error(504)
-
-    monkeypatch.setattr(
-        tokenizers.transformers.AutoTokenizer, "from_pretrained", fake_from_pretrained
-    )
-    monkeypatch.setattr(tokenizers.time, "sleep", sleeps.append)
-
-    with pytest.raises(RuntimeError) as exc_info:
-        tokenizers.load_tokenizer("Qwen/Qwen3-8B")
-
-    assert "Hugging Face Hub is unavailable" in str(exc_info.value)
-    assert "HTTP 504" in str(exc_info.value)
-    assert "exhausted 3 attempts" in str(exc_info.value)
-    assert sleeps == [2.0, 4.0]
-    assert isinstance(exc_info.value.__cause__, OSError)
-
-
-def test_load_tokenizer_does_not_retry_non_transient_failure(monkeypatch):
-    calls = 0
-    sleeps: list[float] = []
-
-    def fake_from_pretrained(model, **kwargs):
-        nonlocal calls
-        calls += 1
-        raise wrapped_tokenizer_error(404)
-
-    monkeypatch.setattr(
-        tokenizers.transformers.AutoTokenizer, "from_pretrained", fake_from_pretrained
-    )
-    monkeypatch.setattr(tokenizers.time, "sleep", sleeps.append)
-
-    with pytest.raises(OSError, match="Unable to load vocabulary"):
-        tokenizers.load_tokenizer("missing/model")
-
-    assert calls == 1
-    assert sleeps == []
-
-
-def test_load_tokenizer_trusts_explicit_non_transient_status(monkeypatch):
-    calls = 0
-
-    def fake_from_pretrained(model, **kwargs):
-        nonlocal calls
-        calls += 1
-        raise wrapped_tokenizer_error(404, model="org/model-504")
-
-    monkeypatch.setattr(
-        tokenizers.transformers.AutoTokenizer, "from_pretrained", fake_from_pretrained
+        tokenizers.transformers.AutoTokenizer, "from_pretrained", from_pretrained
     )
 
-    with pytest.raises(OSError, match="Unable to load vocabulary"):
-        tokenizers.load_tokenizer("org/model-504")
+    with pytest.raises(OSError, match="Unable to reach tokenizer endpoint") as exc_info:
+        tokenizers.load_tokenizer("offline/model")
 
-    assert calls == 1
+    assert isinstance(exc_info.value.__cause__, httpx.ConnectError)
+    assert tokenizers._huggingface_http_status_code(exc_info.value) is None
 
 
 def test_huggingface_unavailability_propagates_to_runner_status(monkeypatch):
     status_writes: list[tuple[str, dict]] = []
 
-    def fake_from_pretrained(model, **kwargs):
-        raise wrapped_tokenizer_error(503)
+    with local_status_server(503) as url:
 
-    monkeypatch.setattr(
-        tokenizers.transformers.AutoTokenizer, "from_pretrained", fake_from_pretrained
-    )
-    monkeypatch.setattr(tokenizers.time, "sleep", lambda _: None)
-    monkeypatch.setattr(
-        runner.fileio,
-        "write_json",
-        lambda path, payload: status_writes.append((path, payload)),
-    )
+        def from_pretrained(model, **kwargs):
+            raise real_wrapped_tokenizer_http_error(url)
 
-    with pytest.raises(RuntimeError):
-        with RunnerIO(RunnerConfig(status_file="status.json")):
-            tokenizers.load_tokenizer("Qwen/Qwen3-8B")
+        monkeypatch.setattr(
+            tokenizers.transformers.AutoTokenizer, "from_pretrained", from_pretrained
+        )
+        monkeypatch.setattr(
+            runner.fileio,
+            "write_json",
+            lambda path, payload: status_writes.append((path, payload)),
+        )
+
+        with pytest.raises(RuntimeError):
+            with RunnerIO(RunnerConfig(status_file="status.json")):
+                tokenizers.load_tokenizer("Qwen/Qwen3-8B")
 
     assert status_writes[-1][0] == "status.json"
     assert status_writes[-1][1]["code"] == 9
-    assert "Hugging Face Hub is unavailable" in status_writes[-1][1]["message"]
+    assert "Hugging Face Hub request failed" in status_writes[-1][1]["message"]
     assert "HTTP 503" in status_writes[-1][1]["message"]

--- a/training/tests/unit/test_tokenizers.py
+++ b/training/tests/unit/test_tokenizers.py
@@ -10,17 +10,16 @@ from training.utils.runner import RunnerConfig, RunnerIO
 
 
 class FakeHuggingFaceHTTPError(Exception):
-    def __init__(self, status_code: int):
+    def __init__(self, status_code: int, model: str = "Qwen/Qwen3-8B"):
         super().__init__(
-            f"Server error '{status_code}' for url "
-            "'https://huggingface.co/Qwen/Qwen3-8B'"
+            f"Server error '{status_code}' for url 'https://huggingface.co/{model}'"
         )
         self.response = SimpleNamespace(status_code=status_code)
 
 
-def wrapped_tokenizer_error(status_code: int) -> OSError:
+def wrapped_tokenizer_error(status_code: int, model: str = "Qwen/Qwen3-8B") -> OSError:
     try:
-        raise FakeHuggingFaceHTTPError(status_code)
+        raise FakeHuggingFaceHTTPError(status_code, model)
     except FakeHuggingFaceHTTPError as exc:
         try:
             raise OSError(
@@ -149,6 +148,24 @@ def test_load_tokenizer_does_not_retry_non_transient_failure(monkeypatch):
 
     assert calls == 1
     assert sleeps == []
+
+
+def test_load_tokenizer_trusts_explicit_non_transient_status(monkeypatch):
+    calls = 0
+
+    def fake_from_pretrained(model, **kwargs):
+        nonlocal calls
+        calls += 1
+        raise wrapped_tokenizer_error(404, model="org/model-504")
+
+    monkeypatch.setattr(
+        tokenizers.transformers.AutoTokenizer, "from_pretrained", fake_from_pretrained
+    )
+
+    with pytest.raises(OSError, match="Unable to load vocabulary"):
+        tokenizers.load_tokenizer("org/model-504")
+
+    assert calls == 1
 
 
 def test_huggingface_unavailability_propagates_to_runner_status(monkeypatch):

--- a/training/tests/unit/test_tokenizers.py
+++ b/training/tests/unit/test_tokenizers.py
@@ -2,7 +2,33 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import pytest
+
 import training.utils.tokenizers as tokenizers
+import training.utils.runner as runner
+from training.utils.runner import RunnerConfig, RunnerIO
+
+
+class FakeHuggingFaceHTTPError(Exception):
+    def __init__(self, status_code: int):
+        super().__init__(
+            f"Server error '{status_code}' for url "
+            "'https://huggingface.co/Qwen/Qwen3-8B'"
+        )
+        self.response = SimpleNamespace(status_code=status_code)
+
+
+def wrapped_tokenizer_error(status_code: int) -> OSError:
+    try:
+        raise FakeHuggingFaceHTTPError(status_code)
+    except FakeHuggingFaceHTTPError as exc:
+        try:
+            raise OSError(
+                "Unable to load vocabulary from file. Please check that the "
+                "provided vocabulary is accessible and not corrupted."
+            ) from exc
+        except OSError as wrapped:
+            return wrapped
 
 
 def test_load_tokenizer_forwards_optional_revision(monkeypatch):
@@ -57,3 +83,95 @@ def test_load_deployment_tokenizer_uses_generic_deploy_config_fields(monkeypatch
     )
 
     assert captured == {"model": "model/name", "revision": "abc123"}
+
+
+def test_load_tokenizer_retries_transient_huggingface_failure(monkeypatch):
+    calls = 0
+    sleeps: list[float] = []
+    fake_tokenizer = object()
+
+    def fake_from_pretrained(model, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls < 3:
+            raise wrapped_tokenizer_error(504)
+        return fake_tokenizer
+
+    monkeypatch.setattr(
+        tokenizers.transformers.AutoTokenizer, "from_pretrained", fake_from_pretrained
+    )
+    monkeypatch.setattr(tokenizers.time, "sleep", sleeps.append)
+
+    result = tokenizers.load_tokenizer("Qwen/Qwen3-8B")
+
+    assert result is fake_tokenizer
+    assert calls == 3
+    assert sleeps == [2.0, 4.0]
+
+
+def test_load_tokenizer_reports_huggingface_unavailability_after_retries(monkeypatch):
+    sleeps: list[float] = []
+
+    def fake_from_pretrained(model, **kwargs):
+        raise wrapped_tokenizer_error(504)
+
+    monkeypatch.setattr(
+        tokenizers.transformers.AutoTokenizer, "from_pretrained", fake_from_pretrained
+    )
+    monkeypatch.setattr(tokenizers.time, "sleep", sleeps.append)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        tokenizers.load_tokenizer("Qwen/Qwen3-8B")
+
+    assert "Hugging Face Hub is unavailable" in str(exc_info.value)
+    assert "HTTP 504" in str(exc_info.value)
+    assert "exhausted 3 attempts" in str(exc_info.value)
+    assert sleeps == [2.0, 4.0]
+    assert isinstance(exc_info.value.__cause__, OSError)
+
+
+def test_load_tokenizer_does_not_retry_non_transient_failure(monkeypatch):
+    calls = 0
+    sleeps: list[float] = []
+
+    def fake_from_pretrained(model, **kwargs):
+        nonlocal calls
+        calls += 1
+        raise wrapped_tokenizer_error(404)
+
+    monkeypatch.setattr(
+        tokenizers.transformers.AutoTokenizer, "from_pretrained", fake_from_pretrained
+    )
+    monkeypatch.setattr(tokenizers.time, "sleep", sleeps.append)
+
+    with pytest.raises(OSError, match="Unable to load vocabulary"):
+        tokenizers.load_tokenizer("missing/model")
+
+    assert calls == 1
+    assert sleeps == []
+
+
+def test_huggingface_unavailability_propagates_to_runner_status(monkeypatch):
+    status_writes: list[tuple[str, dict]] = []
+
+    def fake_from_pretrained(model, **kwargs):
+        raise wrapped_tokenizer_error(503)
+
+    monkeypatch.setattr(
+        tokenizers.transformers.AutoTokenizer, "from_pretrained", fake_from_pretrained
+    )
+    monkeypatch.setattr(tokenizers.time, "sleep", lambda _: None)
+    monkeypatch.setattr(
+        runner.fileio,
+        "write_json",
+        lambda path, payload: status_writes.append((path, payload)),
+    )
+
+    with pytest.raises(RuntimeError):
+        with RunnerIO(RunnerConfig(status_file="status.json")):
+            tokenizers.load_tokenizer("Qwen/Qwen3-8B")
+
+    assert status_writes[-1][0] == "status.json"
+    assert status_writes[-1][1]["code"] == 9
+    assert "Hugging Face Hub is unavailable" in status_writes[-1][1]["message"]
+    assert "HTTP 503" in status_writes[-1][1]["message"]

--- a/training/utils/tokenizers.py
+++ b/training/utils/tokenizers.py
@@ -76,7 +76,7 @@ def load_tokenizer(
                     "Hugging Face Hub is unavailable while loading tokenizer "
                     f"{tokenizer_model!r} (HTTP {status_code}); exhausted "
                     f"{_TOKENIZER_LOAD_ATTEMPTS} attempts. Retry the training job "
-                    "when Hugging Face is available or use a staged tokenizer artifact."
+                    "when Hugging Face is available."
                 ) from exc
 
             backoff_seconds = _TOKENIZER_RETRY_INITIAL_BACKOFF_SECONDS * 2 ** (

--- a/training/utils/tokenizers.py
+++ b/training/utils/tokenizers.py
@@ -26,8 +26,15 @@ def _transient_huggingface_status_code(exc: BaseException) -> int | None:
         seen.add(id(current))
         response = getattr(current, "response", None)
         status_code = getattr(response, "status_code", None)
-        if status_code in _TRANSIENT_HTTP_STATUS_CODES:
-            return int(status_code)
+        if status_code is not None:
+            try:
+                parsed_status_code = int(status_code)
+            except (TypeError, ValueError):
+                pass
+            else:
+                if parsed_status_code in _TRANSIENT_HTTP_STATUS_CODES:
+                    return parsed_status_code
+                return None
 
         message = str(current)
         normalized_message = message.lower()

--- a/training/utils/tokenizers.py
+++ b/training/utils/tokenizers.py
@@ -2,27 +2,23 @@
 
 from __future__ import annotations
 
-import logging
 import re
-import time
 from typing import Any
 
 import transformers
 
 
-logger = logging.getLogger(__name__)
-
-_TRANSIENT_HTTP_STATUS_CODES = frozenset({408, 429, 500, 502, 503, 504})
-_TOKENIZER_LOAD_ATTEMPTS = 3
-_TOKENIZER_RETRY_INITIAL_BACKOFF_SECONDS = 2.0
-_HTTP_STATUS_PATTERN = re.compile(r"\b(408|429|500|502|503|504)\b")
+_HTTP_STATUS_PATTERN = re.compile(r"\b([45]\d\d)\b")
 
 
-def _transient_huggingface_status_code(exc: BaseException) -> int | None:
-    """Find a retryable Hugging Face HTTP status in a wrapped exception chain."""
-    current: BaseException | None = exc
+def _huggingface_http_status_code(exc: BaseException) -> int | None:
+    """Find a Hugging Face HTTP status in a wrapped exception graph."""
+    pending: list[BaseException] = [exc]
     seen: set[int] = set()
-    while current is not None and id(current) not in seen:
+    while pending:
+        current = pending.pop()
+        if id(current) in seen:
+            continue
         seen.add(id(current))
         response = getattr(current, "response", None)
         status_code = getattr(response, "status_code", None)
@@ -32,9 +28,8 @@ def _transient_huggingface_status_code(exc: BaseException) -> int | None:
             except (TypeError, ValueError):
                 pass
             else:
-                if parsed_status_code in _TRANSIENT_HTTP_STATUS_CODES:
+                if 400 <= parsed_status_code <= 599:
                     return parsed_status_code
-                return None
 
         message = str(current)
         normalized_message = message.lower()
@@ -47,7 +42,10 @@ def _transient_huggingface_status_code(exc: BaseException) -> int | None:
             if match is not None:
                 return int(match.group(1))
 
-        current = current.__cause__ or current.__context__
+        if current.__cause__ is not None:
+            pending.append(current.__cause__)
+        if current.__context__ is not None:
+            pending.append(current.__context__)
     return None
 
 
@@ -60,40 +58,20 @@ def load_tokenizer(
     ``tokenizer_revision`` is optional; empty strings are treated as unset so
     existing configs keep resolving HuggingFace ``main``.
     """
-    for attempt in range(1, _TOKENIZER_LOAD_ATTEMPTS + 1):
-        try:
-            return transformers.AutoTokenizer.from_pretrained(
-                tokenizer_model,
-                revision=tokenizer_revision or None,
-                trust_remote_code=True,
-            )
-        except Exception as exc:
-            status_code = _transient_huggingface_status_code(exc)
-            if status_code is None:
-                raise
-            if attempt == _TOKENIZER_LOAD_ATTEMPTS:
-                raise RuntimeError(
-                    "Hugging Face Hub is unavailable while loading tokenizer "
-                    f"{tokenizer_model!r} (HTTP {status_code}); exhausted "
-                    f"{_TOKENIZER_LOAD_ATTEMPTS} attempts. Retry the training job "
-                    "when Hugging Face is available."
-                ) from exc
-
-            backoff_seconds = _TOKENIZER_RETRY_INITIAL_BACKOFF_SECONDS * 2 ** (
-                attempt - 1
-            )
-            logger.warning(
-                "Transient Hugging Face tokenizer load failure for %r (HTTP %d); "
-                "retrying attempt %d/%d in %.1fs",
-                tokenizer_model,
-                status_code,
-                attempt + 1,
-                _TOKENIZER_LOAD_ATTEMPTS,
-                backoff_seconds,
-            )
-            time.sleep(backoff_seconds)
-
-    raise AssertionError("unreachable")
+    try:
+        return transformers.AutoTokenizer.from_pretrained(
+            tokenizer_model,
+            revision=tokenizer_revision or None,
+            trust_remote_code=True,
+        )
+    except Exception as exc:
+        status_code = _huggingface_http_status_code(exc)
+        if status_code is None:
+            raise
+        raise RuntimeError(
+            "Hugging Face Hub request failed while loading tokenizer "
+            f"{tokenizer_model!r} (HTTP {status_code})."
+        ) from exc
 
 
 def load_deployment_tokenizer(deployment: Any) -> Any:

--- a/training/utils/tokenizers.py
+++ b/training/utils/tokenizers.py
@@ -2,9 +2,46 @@
 
 from __future__ import annotations
 
+import logging
+import re
+import time
 from typing import Any
 
 import transformers
+
+
+logger = logging.getLogger(__name__)
+
+_TRANSIENT_HTTP_STATUS_CODES = frozenset({408, 429, 500, 502, 503, 504})
+_TOKENIZER_LOAD_ATTEMPTS = 3
+_TOKENIZER_RETRY_INITIAL_BACKOFF_SECONDS = 2.0
+_HTTP_STATUS_PATTERN = re.compile(r"\b(408|429|500|502|503|504)\b")
+
+
+def _transient_huggingface_status_code(exc: BaseException) -> int | None:
+    """Find a retryable Hugging Face HTTP status in a wrapped exception chain."""
+    current: BaseException | None = exc
+    seen: set[int] = set()
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        response = getattr(current, "response", None)
+        status_code = getattr(response, "status_code", None)
+        if status_code in _TRANSIENT_HTTP_STATUS_CODES:
+            return int(status_code)
+
+        message = str(current)
+        normalized_message = message.lower()
+        if (
+            "huggingface" in normalized_message
+            or "huggingface.co" in normalized_message
+            or "hf hub" in normalized_message
+        ):
+            match = _HTTP_STATUS_PATTERN.search(message)
+            if match is not None:
+                return int(match.group(1))
+
+        current = current.__cause__ or current.__context__
+    return None
 
 
 def load_tokenizer(
@@ -16,11 +53,40 @@ def load_tokenizer(
     ``tokenizer_revision`` is optional; empty strings are treated as unset so
     existing configs keep resolving HuggingFace ``main``.
     """
-    return transformers.AutoTokenizer.from_pretrained(
-        tokenizer_model,
-        revision=tokenizer_revision or None,
-        trust_remote_code=True,
-    )
+    for attempt in range(1, _TOKENIZER_LOAD_ATTEMPTS + 1):
+        try:
+            return transformers.AutoTokenizer.from_pretrained(
+                tokenizer_model,
+                revision=tokenizer_revision or None,
+                trust_remote_code=True,
+            )
+        except Exception as exc:
+            status_code = _transient_huggingface_status_code(exc)
+            if status_code is None:
+                raise
+            if attempt == _TOKENIZER_LOAD_ATTEMPTS:
+                raise RuntimeError(
+                    "Hugging Face Hub is unavailable while loading tokenizer "
+                    f"{tokenizer_model!r} (HTTP {status_code}); exhausted "
+                    f"{_TOKENIZER_LOAD_ATTEMPTS} attempts. Retry the training job "
+                    "when Hugging Face is available or use a staged tokenizer artifact."
+                ) from exc
+
+            backoff_seconds = _TOKENIZER_RETRY_INITIAL_BACKOFF_SECONDS * 2 ** (
+                attempt - 1
+            )
+            logger.warning(
+                "Transient Hugging Face tokenizer load failure for %r (HTTP %d); "
+                "retrying attempt %d/%d in %.1fs",
+                tokenizer_model,
+                status_code,
+                attempt + 1,
+                _TOKENIZER_LOAD_ATTEMPTS,
+                backoff_seconds,
+            )
+            time.sleep(backoff_seconds)
+
+    raise AssertionError("unreachable")
 
 
 def load_deployment_tokenizer(deployment: Any) -> Any:


### PR DESCRIPTION
## Summary
- preserve the actual Hugging Face HTTP status hidden beneath Transformers' generic tokenizer `OSError`
- rely on `huggingface_hub`'s existing retry/backoff instead of multiplying it with another full-tokenizer retry loop
- traverse both cause and context edges because Transformers/Hugging Face wrappers can retain multiple exception paths
- leave status-less connection/offline failures unchanged rather than incorrectly labeling them HTTP 504

## Evidence
Production `hcpt6h6y` showed:
`httpx.HTTPStatusError(504)` → `HfHubHTTPError(504)` → Transformers `OSError: Unable to load vocabulary`.

Executable real-path checks using `AutoTokenizer.from_pretrained`:
- local HTTP server returning 504: 14 real requests; Hub backoff calls `1,2,4,8,8` twice; final `RuntimeError` and Runner status are `Hugging Face Hub request failed ... (HTTP 504)`
- deterministic closed localhost port: connection refused; final class is status-less `OSError` with the original configuration message, not 504
- `unshare -n` was attempted but unavailable (`Operation not permitted`), so no host firewall/network changes were used

## Flow
```mermaid
flowchart LR
    A[AutoTokenizer / Hub built-in retry] --> B{Wrapped HTTP status?}
    B -- yes --> C[Propagate HF + HTTP status]
    B -- no --> D[Preserve original exception]
    C --> E[Runner managed-job status]
```

## Test plan
- [x] focused tokenizer suite — 7 passed
- [x] real local HTTP responses create `HTTPStatusError` → `HfHubHTTPError` → `OSError` regression chains
- [x] real localhost connection refusal is not misclassified as HTTP
- [x] Runner status preserves HTTP 503
- [x] Ruff lint/format and IDE diagnostics clean

## Risk
Low. This does not change tokenizer source or add a retry layer. HTTP failures become explicit; status-less failures preserve existing behavior.

Related: fw-ai/fireworks#35974 and INC-808.