### PR TITLE
Add MiniMax M3 renderer parity

### DIFF
--- a/training/renderer/__init__.py
+++ b/training/renderer/__init__.py
@@ -22,6 +22,8 @@ from training.renderer import gemma4 as _gemma4  # noqa: F401  (registers "gemma
 from training.renderer import glm5 as _glm5  # noqa: F401  (registers "glm5")
 from training.renderer import kimi_k27_code as _kimi_k27_code  # noqa: F401  (registers "kimi_k27_code")
 from training.renderer import minimax_m2 as _minimax_m2  # noqa: F401  (registers "minimax_m2")
+from training.renderer import minimax_m3 as _minimax_m3  # noqa: F401  (registers "minimax_m3")
+
 # Local overrides for upstream renderers that need disaggregate-per-user-turn
 # multi-turn SFT support (no upstream ``build_supervised_examples`` override).
 from training.renderer import _qwen3_split as _qwen3_split  # noqa: F401

--- a/training/renderer/minimax_m3.py
+++ b/training/renderer/minimax_m3.py
@@ -431,15 +431,21 @@ class MiniMaxM3Renderer(Renderer):
 
     def _normalize_response_tokens(self, response: list[int]) -> list[int]:
         if self.thinking_mode == "enabled":
-            return (
-                list(self.tokenizer.encode(_THINK_BEGIN, add_special_tokens=False))
-                + response
+            prefix = list(
+                self.tokenizer.encode(_THINK_BEGIN, add_special_tokens=False)
             )
+            if response[: len(prefix)] == prefix:
+                return response
+            if _THINK_END in str(self.tokenizer.decode(response)):
+                return prefix + response
+            return response
         if self.thinking_mode == "disabled":
-            return (
-                list(self.tokenizer.encode(_THINK_END, add_special_tokens=False))
-                + response
+            prefix = list(
+                self.tokenizer.encode(_THINK_END, add_special_tokens=False)
             )
+            if response[: len(prefix)] == prefix:
+                return response
+            return prefix + response
         return response
 
     def parse_response(self, response: list[int]) -> tuple[Message, ParseTermination]:

--- a/training/renderer/minimax_m3.py
+++ b/training/renderer/minimax_m3.py
@@ -1,0 +1,507 @@
+"""Renderer for the MiniMax M3 chat protocol."""
+
+from __future__ import annotations
+
+import json
+import re
+import xml.etree.ElementTree as ET
+from collections.abc import Mapping
+from typing import Any, Literal
+
+import tinker
+import torch
+from tinker_cookbook.renderers import register_renderer
+from tinker_cookbook.renderers.base import (
+    Message,
+    ParseTermination,
+    RenderContext,
+    RenderedMessage,
+    Renderer,
+    Role,
+    ToolCall,
+    ToolSpec,
+    TrainOnWhat,
+    UnparsedToolCall,
+    parse_response_for_stop_token,
+)
+from tinker_cookbook.tokenizer_utils import Tokenizer
+
+ThinkingMode = Literal["enabled", "disabled", "adaptive"]
+
+_NS = "]<]minimax[>["
+_BOD = "]~!b["
+_BOS = "]~b]"
+_EOS = "[e~["
+_THINK_BEGIN = "<mm:think>"
+_THINK_END = "</mm:think>"
+_TOOL_CALL_BEGIN = _NS + "<tool_call>"
+_TOOL_CALL_END = _NS + "</tool_call>"
+_IMAGE = "]<]image[>["
+_VIDEO = "]<]video[>["
+
+_DEFAULT_SYSTEM = (
+    "Your model version is MiniMax-M3, developed by MiniMax. Knowledge cutoff: January 2026. "
+    "Founded in early 2022, MiniMax is a global AI foundation model company committed to "
+    "advancing the frontiers of AI towards AGI."
+)
+_DEFAULT_DEVELOPER = "You are a helpful assistant."
+_DEFAULT_ROOT_SENTINEL = "__MINIMAX_M3_DEFAULT_ROOT__"
+_DEFAULT_DEVELOPER_SENTINEL = "__MINIMAX_M3_DEFAULT_DEVELOPER__"
+
+_TOOL_CALL_RE = re.compile(
+    re.escape(_TOOL_CALL_BEGIN) + r"\n?(.*?)" + re.escape(_TOOL_CALL_END),
+    re.DOTALL,
+)
+
+
+def _visible_text(content: Any) -> str:
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, str):
+                parts.append(item)
+            elif isinstance(item, Mapping) and item.get("type") == "text":
+                parts.append(str(item.get("text", "")))
+            elif isinstance(item, Mapping) and item.get("type") == "image":
+                parts.append(_IMAGE)
+            elif isinstance(item, Mapping) and item.get("type") == "video":
+                parts.append(_VIDEO)
+            elif isinstance(item, Mapping) and isinstance(item.get("output"), str):
+                parts.append(item["output"])
+        return "".join(parts)
+    return str(content)
+
+
+def _assistant_parts(content: Any) -> tuple[str, str]:
+    if isinstance(content, str):
+        for begin, end in ((_THINK_BEGIN, _THINK_END), ("<think>", "</think>")):
+            if end in content:
+                reasoning = content.split(end, 1)[0].split(begin)[-1].strip("\n")
+                visible = content.split(end, 1)[1].strip("\n")
+                return reasoning, visible
+        return "", content
+    reasoning: list[str] = []
+    visible: list[str] = []
+    if isinstance(content, list):
+        for part in content:
+            if not isinstance(part, Mapping):
+                continue
+            if part.get("type") == "thinking":
+                reasoning.append(str(part.get("thinking", "")))
+            elif part.get("type") == "text":
+                visible.append(str(part.get("text", "")))
+    return "".join(reasoning), "".join(visible)
+
+
+def _xml_scalar(value: Any) -> str:
+    if isinstance(value, bool):
+        return json.dumps(value)
+    return str(value)
+
+
+def _to_xml(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, Mapping):
+        return "".join(
+            f"{_NS}<{key}>{_to_xml(item)}{_NS}</{key}>"
+            for key, item in value.items()
+            if item is not None
+        )
+    if isinstance(value, list):
+        return "".join(f"{_NS}<item>{_to_xml(item)}{_NS}</item>" for item in value)
+    return _xml_scalar(value)
+
+
+def _tool_arguments(tool_call: ToolCall) -> dict[str, Any]:
+    arguments = json.loads(tool_call.function.arguments or "{}")
+    if not isinstance(arguments, dict):
+        raise TypeError("MiniMax M3 tool arguments must be a JSON object.")
+    return arguments
+
+
+def _format_tool_calls(tool_calls: list[ToolCall]) -> str:
+    calls: list[str] = []
+    for tool_call in tool_calls:
+        body = [f'{_NS}<invoke name="{tool_call.function.name}">']
+        for key, value in _tool_arguments(tool_call).items():
+            if value is None:
+                continue
+            body.append(f"{_NS}<{key}>{_to_xml(value)}{_NS}</{key}>")
+        body.append(f"{_NS}</invoke>\n")
+        calls.append("".join(body))
+    return f"{_TOOL_CALL_BEGIN}\n{''.join(calls)}{_TOOL_CALL_END}"
+
+
+def _tool_function(tool: ToolSpec | Mapping[str, Any]) -> Mapping[str, Any]:
+    raw = dict(tool)
+    function = raw.get("function")
+    return function if isinstance(function, Mapping) else raw
+
+
+def _format_tools(tools: list[ToolSpec | Mapping[str, Any]]) -> str:
+    rendered = "".join(
+        f"<tool>{json.dumps(_tool_function(tool), ensure_ascii=False)}</tool>\n"
+        for tool in tools
+    )
+    example = (
+        f"{_TOOL_CALL_BEGIN}\n"
+        f'{_NS}<invoke name="tool-name-1">'
+        f"{_NS}<param-1>value-1{_NS}</param-1>"
+        f"{_NS}<param-2>{_NS}<item>{_NS}<key-a>val-a{_NS}</key-a>"
+        f"{_NS}<key-b>val-b{_NS}</key-b>{_NS}</item>{_NS}</param-2>"
+        f"{_NS}</invoke>\n"
+        f'{_NS}<invoke name="tool-name-2">'
+        f"{_NS}<param-1>value-1{_NS}</param-1>{_NS}</invoke>\n"
+        f"{_TOOL_CALL_END}"
+    )
+    return (
+        "\n\n# Tools\nYou may call one or more tools to assist with the user query.\n"
+        "Here are the tools available in JSONSchema format:\n\n<tools>\n"
+        f"{rendered}</tools>\n\n"
+        f"To call tools, wrap all invocations in a single {_TOOL_CALL_BEGIN}{_TOOL_CALL_END} block. "
+        "Parameter values containing nested objects or arrays are recursively expanded into XML elements. "
+        f"Example:\n\n{example}"
+    )
+
+
+def _thinking_instructions(mode: ThinkingMode) -> str:
+    mode_text = {
+        "enabled": (
+            "Current thinking mode: enabled. You MUST think step by step before every response, "
+            "including after receiving function/tool results.\n"
+        ),
+        "disabled": "Current thinking mode: disabled. Do not output any thinking process.\n",
+        "adaptive": (
+            "Current thinking mode: adaptive. You are encouraged to think for complex decision-making, "
+            "multi-step reasoning, or when analyzing function/tool results.\n"
+        ),
+    }[mode]
+    return (
+        "\n\n<thinking_instructions>\n"
+        f"You have a thinking capability that allows you to reason step by step before responding. "
+        f"When thinking is enabled, wrap your reasoning in {_THINK_BEGIN}{_THINK_END} tags before your response. "
+        f"When thinking is disabled, begin your response directly after the {_THINK_END} prefix. "
+        "When thinking is adaptive, decide on your own whether to think for the current turn.\n"
+        f"{mode_text}</thinking_instructions>"
+    )
+
+
+def _element_value(element: ET.Element) -> Any:
+    children = list(element)
+    if not children:
+        text = element.text or ""
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError:
+            return text
+    if all(child.tag == "item" for child in children):
+        return [_element_value(child) for child in children]
+    return {child.tag: _element_value(child) for child in children}
+
+
+def _parse_tool_block(
+    raw: str, raw_text: str
+) -> tuple[list[ToolCall], list[UnparsedToolCall]]:
+    try:
+        root = ET.fromstring(f"<root>{raw.replace(_NS, '')}</root>")
+    except ET.ParseError as exc:
+        return [], [UnparsedToolCall(raw_text=raw_text, error=str(exc))]
+    calls: list[ToolCall] = []
+    for invoke in root.findall("invoke"):
+        name = invoke.attrib.get("name")
+        if not name:
+            continue
+        arguments = {child.tag: _element_value(child) for child in invoke}
+        calls.append(
+            ToolCall(
+                function=ToolCall.FunctionBody(
+                    name=name,
+                    arguments=json.dumps(arguments, ensure_ascii=False),
+                )
+            )
+        )
+    if calls:
+        return calls, []
+    return [], [UnparsedToolCall(raw_text=raw_text, error="No <invoke> element found")]
+
+
+class MiniMaxM3Renderer(Renderer):
+    def __init__(
+        self, tokenizer: Tokenizer, thinking_mode: ThinkingMode = "adaptive"
+    ) -> None:
+        super().__init__(tokenizer)
+        if thinking_mode not in {"enabled", "disabled", "adaptive"}:
+            raise ValueError(f"Unsupported MiniMax M3 thinking mode: {thinking_mode!r}")
+        self.thinking_mode = thinking_mode
+        self._pending_tools: list[ToolSpec | Mapping[str, Any]] | None = None
+
+    @property
+    def has_extension_property(self) -> bool:
+        return True
+
+    @property
+    def _bos_tokens(self) -> list[int]:
+        # M3 has separate BOD (conversation start) and BOS (role prefix)
+        # tokens. ``tokenizer.bos_token_id`` is the latter, so encode BOD here.
+        return list(self.tokenizer.encode(_BOD, add_special_tokens=False))
+
+    @property
+    def _end_message_token(self) -> int:
+        eos_token_id = getattr(self.tokenizer, "eos_token_id", None)
+        if eos_token_id is not None:
+            return int(eos_token_id)
+        tokens = self.tokenizer.encode(_EOS, add_special_tokens=False)
+        if len(tokens) != 1:
+            raise RuntimeError(
+                f"Expected {_EOS!r} to encode as one token, got {tokens}"
+            )
+        return int(tokens[0])
+
+    def get_stop_sequences(self) -> list[int]:
+        return [self._end_message_token]
+
+    @staticmethod
+    def _group_tool_messages(messages: list[Message]) -> list[Message]:
+        grouped: list[Message] = []
+        index = 0
+        while index < len(messages):
+            message = messages[index]
+            if message["role"] != "tool":
+                grouped.append(message)
+                index += 1
+                continue
+            outputs: list[dict[str, str]] = []
+            tool_messages: list[Message] = []
+            while index < len(messages) and messages[index]["role"] == "tool":
+                tool_message = messages[index]
+                tool_messages.append(tool_message)
+                outputs.append({"output": _visible_text(tool_message["content"])})
+                index += 1
+            grouped_tool = Message(role="tool", content=outputs)
+            if any("trainable" in tool_message for tool_message in tool_messages):
+                grouped_tool["trainable"] = any(
+                    bool(tool_message.get("trainable", False))
+                    for tool_message in tool_messages
+                )
+            grouped.append(grouped_tool)
+        return grouped
+
+    def _preprocess_messages(self, messages: list[Message]) -> list[Message]:
+        remaining = list(messages)
+        uses_customized_weights = any("trainable" in message for message in remaining)
+        root_message = Message(role="root", content=_DEFAULT_ROOT_SENTINEL)
+        developer_message = Message(
+            role="developer",
+            content=_DEFAULT_DEVELOPER_SENTINEL,
+        )
+        if remaining and remaining[0]["role"] == "root":
+            source = remaining.pop(0)
+            root_message["content"] = source["content"]
+            if "trainable" in source:
+                root_message["trainable"] = source["trainable"]
+            if remaining and remaining[0]["role"] in {"system", "developer"}:
+                source = remaining.pop(0)
+                developer_message["content"] = source["content"]
+                if "trainable" in source:
+                    developer_message["trainable"] = source["trainable"]
+        elif remaining and remaining[0]["role"] in {"system", "developer"}:
+            source = remaining.pop(0)
+            developer_message["content"] = source["content"]
+            if "trainable" in source:
+                developer_message["trainable"] = source["trainable"]
+        if uses_customized_weights:
+            root_message.setdefault("trainable", False)
+            developer_message.setdefault("trainable", False)
+        prefix = [root_message, developer_message]
+        return prefix + self._group_tool_messages(remaining)
+
+    def _encode_chunk(self, text: str) -> tinker.types.EncodedTextChunk | None:
+        tokens = list(self.tokenizer.encode(text, add_special_tokens=False))
+        return tinker.types.EncodedTextChunk(tokens=tokens) if tokens else None
+
+    def render_message(self, message: Message, ctx: RenderContext) -> RenderedMessage:
+        del ctx
+        role = message["role"]
+        if role == "root":
+            content = message["content"]
+            body = (
+                _DEFAULT_SYSTEM
+                if content == _DEFAULT_ROOT_SENTINEL or not _visible_text(content)
+                else _visible_text(content)
+            )
+            header_text = f"{_BOS}system\n"
+            output_text = (
+                body + _thinking_instructions(self.thinking_mode) + f"{_EOS}\n"
+            )
+        elif role == "developer":
+            content = message["content"]
+            body = (
+                _DEFAULT_DEVELOPER
+                if content == _DEFAULT_DEVELOPER_SENTINEL or not _visible_text(content)
+                else _visible_text(content)
+            )
+            if self._pending_tools:
+                body += _format_tools(self._pending_tools)
+                self._pending_tools = None
+            header_text = f"{_BOS}developer\n"
+            output_text = body + f"{_EOS}\n"
+        elif role == "assistant":
+            reasoning, visible = _assistant_parts(message["content"])
+            body = f"{_THINK_BEGIN}{reasoning}{_THINK_END}" if reasoning else _THINK_END
+            body += visible
+            if message.get("tool_calls"):
+                body += _format_tool_calls(message["tool_calls"])
+            header_text = f"{_BOS}ai\n"
+            output_text = body + f"{_EOS}\n"
+        elif role == "user":
+            header_text = f"{_BOS}user\n"
+            output_text = _visible_text(message["content"]) + f"{_EOS}\n"
+        elif role == "tool":
+            header_text = f"{_BOS}tool"
+            content = message["content"]
+            entries = (
+                content
+                if isinstance(content, list)
+                else [{"output": _visible_text(content)}]
+            )
+            responses = "".join(
+                f"\n<response>{_visible_text(entry.get('output') if isinstance(entry, Mapping) else entry)}</response>"
+                for entry in entries
+            )
+            output_text = responses + f"{_EOS}\n"
+        else:
+            raise ValueError(f"Unsupported MiniMax M3 role: {role!r}")
+
+        output = self._encode_chunk(output_text)
+        return RenderedMessage(
+            header=self._encode_chunk(header_text),
+            output=[output] if output is not None else [],
+        )
+
+    def _get_generation_suffix(self, role: Role, ctx: RenderContext) -> list[int]:
+        del ctx
+        rendered_role = "ai" if role == "assistant" else role
+        suffix = f"{_BOS}{rendered_role}\n"
+        if rendered_role == "ai":
+            if self.thinking_mode == "enabled":
+                suffix += _THINK_BEGIN
+            elif self.thinking_mode == "disabled":
+                suffix += _THINK_END
+        return list(self.tokenizer.encode(suffix, add_special_tokens=False))
+
+    def build_generation_prompt(
+        self,
+        messages: list[Message],
+        role: Role = "assistant",
+        prefill: str | None = None,
+    ) -> tinker.ModelInput:
+        return super().build_generation_prompt(
+            self._preprocess_messages(messages),
+            role=role,
+            prefill=prefill,
+        )
+
+    def build_supervised_example(
+        self,
+        messages: list[Message],
+        train_on_what: TrainOnWhat = TrainOnWhat.LAST_ASSISTANT_MESSAGE,
+    ) -> tuple[tinker.ModelInput, torch.Tensor]:
+        return super().build_supervised_example(
+            self._preprocess_messages(messages),
+            train_on_what=train_on_what,
+        )
+
+    def create_conversation_prefix_with_tools(
+        self,
+        tools: list[ToolSpec],
+        system_prompt: str = "",
+    ) -> list[Message]:
+        self._pending_tools = list(tools)
+        return [
+            Message(
+                role="system",
+                content=system_prompt or _DEFAULT_DEVELOPER_SENTINEL,
+            )
+        ]
+
+    def _normalize_response_tokens(self, response: list[int]) -> list[int]:
+        if self.thinking_mode == "enabled":
+            return (
+                list(self.tokenizer.encode(_THINK_BEGIN, add_special_tokens=False))
+                + response
+            )
+        if self.thinking_mode == "disabled":
+            return (
+                list(self.tokenizer.encode(_THINK_END, add_special_tokens=False))
+                + response
+            )
+        return response
+
+    def parse_response(self, response: list[int]) -> tuple[Message, ParseTermination]:
+        response = self._normalize_response_tokens(response)
+        message, termination = parse_response_for_stop_token(
+            response=response,
+            tokenizer=self.tokenizer,
+            stop_token=self._end_message_token,
+        )
+        if termination == ParseTermination.MALFORMED:
+            return message, termination
+        assert isinstance(message["content"], str)
+        raw_content = message["content"]
+        tool_calls: list[ToolCall] = []
+        unparsed: list[UnparsedToolCall] = []
+        clean_parts: list[str] = []
+        offset = 0
+        for match in _TOOL_CALL_RE.finditer(raw_content):
+            clean_parts.append(raw_content[offset : match.start()])
+            parsed, failed = _parse_tool_block(match.group(1), match.group(0))
+            tool_calls.extend(parsed)
+            unparsed.extend(failed)
+            offset = match.end()
+        clean_parts.append(raw_content[offset:])
+        clean = "".join(clean_parts)
+        reasoning, visible = _assistant_parts(clean)
+        content: list[dict[str, str]] = []
+        if reasoning:
+            content.append({"type": "thinking", "thinking": reasoning})
+        if visible:
+            content.append({"type": "text", "text": visible})
+        message["content"] = content if content else visible
+        if tool_calls:
+            message["tool_calls"] = tool_calls
+        if unparsed:
+            message["unparsed_tool_calls"] = unparsed
+        return message, termination
+
+    def to_openai_message(self, message: Message) -> dict[str, Any]:
+        result: dict[str, Any] = {"role": message["role"]}
+        reasoning, visible = _assistant_parts(message["content"])
+        result["content"] = visible
+        if reasoning:
+            result["reasoning_content"] = reasoning
+        if message.get("tool_calls"):
+            result["tool_calls"] = [
+                {
+                    "type": "function",
+                    "id": tool_call.id,
+                    "function": {
+                        "name": tool_call.function.name,
+                        "arguments": _tool_arguments(tool_call),
+                    },
+                }
+                for tool_call in message["tool_calls"]
+            ]
+        return result
+
+
+def _factory(tokenizer: Tokenizer, image_processor=None) -> MiniMaxM3Renderer:
+    del image_processor
+    return MiniMaxM3Renderer(tokenizer)
+
+
+register_renderer("minimax_m3", _factory)

--- a/training/tests/unit/test_minimax_m3_renderer.py
+++ b/training/tests/unit/test_minimax_m3_renderer.py
@@ -1,0 +1,282 @@
+"""Parity tests for the MiniMax M3 renderer and official HF template."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+import transformers
+from tinker_cookbook.renderers.base import ParseTermination, ToolCall, TrainOnWhat
+from tinker_cookbook.supervised.common import datum_from_model_input_weights
+
+from training.renderer.minimax_m3 import MiniMaxM3Renderer
+
+_LOCAL_PATH = "/shared/MiniMax-M3"
+_HF_REPO = "MiniMaxAI/MiniMax-M3"
+TOKENIZER_MODEL = _LOCAL_PATH if Path(_LOCAL_PATH).exists() else _HF_REPO
+
+
+@pytest.fixture(scope="module")
+def tokenizer() -> transformers.PreTrainedTokenizerBase:
+    return transformers.AutoTokenizer.from_pretrained(TOKENIZER_MODEL)
+
+
+def _hf_tokens(
+    tokenizer: transformers.PreTrainedTokenizerBase,
+    messages: list[dict[str, Any]],
+    *,
+    thinking_mode: str,
+    add_generation_prompt: bool,
+    tools: list[dict[str, Any]] | None = None,
+) -> list[int]:
+    result = tokenizer.apply_chat_template(
+        messages,
+        tools=tools,
+        tokenize=True,
+        add_generation_prompt=add_generation_prompt,
+        thinking_mode=thinking_mode,
+    )
+    return list(result.input_ids if hasattr(result, "input_ids") else result)
+
+
+def _tool_call(name: str, arguments: dict[str, Any]) -> ToolCall:
+    return ToolCall(
+        function=ToolCall.FunctionBody(
+            name=name,
+            arguments=json.dumps(arguments),
+        )
+    )
+
+
+def _find_unique_token_span(tokens: list[int], subsequence: list[int]) -> slice:
+    starts = [
+        index
+        for index in range(len(tokens) - len(subsequence) + 1)
+        if tokens[index : index + len(subsequence)] == subsequence
+    ]
+    assert len(starts) == 1
+    return slice(starts[0], starts[0] + len(subsequence))
+
+
+@pytest.mark.parametrize("thinking_mode", ["enabled", "disabled", "adaptive"])
+def test_generation_prompt_matches_hf(
+    tokenizer: transformers.PreTrainedTokenizerBase,
+    thinking_mode: str,
+) -> None:
+    messages = [{"role": "user", "content": "Hello"}]
+    expected = _hf_tokens(
+        tokenizer,
+        messages,
+        thinking_mode=thinking_mode,
+        add_generation_prompt=True,
+    )
+    actual = list(
+        MiniMaxM3Renderer(tokenizer, thinking_mode)
+        .build_generation_prompt(messages)
+        .to_ints()
+    )
+    assert actual == expected
+
+
+def test_root_developer_and_all_turn_thinking_match_hf(
+    tokenizer: transformers.PreTrainedTokenizerBase,
+) -> None:
+    hf_messages = [
+        {"role": "root", "content": "Root policy"},
+        {"role": "developer", "content": "Be concise"},
+        {"role": "user", "content": "u1"},
+        {"role": "assistant", "reasoning_content": "r1", "content": "a1"},
+        {"role": "user", "content": "u2"},
+        {"role": "assistant", "content": "<mm:think>r2</mm:think>a2"},
+    ]
+    messages = [
+        {"role": "root", "content": "Root policy"},
+        {"role": "developer", "content": "Be concise"},
+        {"role": "user", "content": "u1"},
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "thinking", "thinking": "r1"},
+                {"type": "text", "text": "a1"},
+            ],
+        },
+        {"role": "user", "content": "u2"},
+        {"role": "assistant", "content": "<mm:think>r2</mm:think>a2"},
+    ]
+    expected = _hf_tokens(
+        tokenizer,
+        hf_messages,
+        thinking_mode="enabled",
+        add_generation_prompt=False,
+    )
+    actual = list(
+        MiniMaxM3Renderer(tokenizer, "enabled")
+        .build_supervised_example(
+            messages, train_on_what=TrainOnWhat.ALL_ASSISTANT_MESSAGES
+        )[0]
+        .to_ints()
+    )
+    assert actual == expected
+
+
+@pytest.mark.parametrize("thinking_mode", ["enabled", "disabled", "adaptive"])
+def test_supervised_mask_trains_selected_thinking_and_answer(
+    tokenizer: transformers.PreTrainedTokenizerBase,
+    thinking_mode: str,
+) -> None:
+    messages = [
+        {"role": "user", "content": "u1"},
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "thinking", "thinking": "r1"},
+                {"type": "text", "text": "a1"},
+            ],
+        },
+        {"role": "user", "content": "u2"},
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "thinking", "thinking": "r2"},
+                {"type": "text", "text": "a2"},
+            ],
+        },
+    ]
+    renderer = MiniMaxM3Renderer(tokenizer, thinking_mode)
+
+    model_input, weights = renderer.build_supervised_example(
+        messages,
+        train_on_what=TrainOnWhat.LAST_ASSISTANT_MESSAGE,
+    )
+    tokens = list(model_input.to_ints())
+    weight_values = weights.tolist()
+    first_assistant = _find_unique_token_span(
+        tokens,
+        list(
+            tokenizer.encode(
+                "<mm:think>r1</mm:think>a1[e~[\n",
+                add_special_tokens=False,
+            )
+        ),
+    )
+    last_assistant = _find_unique_token_span(
+        tokens,
+        list(
+            tokenizer.encode(
+                "<mm:think>r2</mm:think>a2[e~[\n",
+                add_special_tokens=False,
+            )
+        ),
+    )
+
+    expected_last_only = [0.0] * len(tokens)
+    expected_last_only[last_assistant] = [1.0] * len(expected_last_only[last_assistant])
+    assert weight_values == expected_last_only
+
+    all_input, all_weights = renderer.build_supervised_example(
+        messages,
+        train_on_what=TrainOnWhat.ALL_ASSISTANT_MESSAGES,
+    )
+    assert list(all_input.to_ints()) == tokens
+    expected_all_assistant = list(expected_last_only)
+    expected_all_assistant[first_assistant] = [1.0] * len(
+        expected_all_assistant[first_assistant]
+    )
+    assert all_weights.tolist() == expected_all_assistant
+
+    datum = datum_from_model_input_weights(model_input, weights)
+    assert datum.loss_fn_inputs["target_tokens"].data == tokens[1:]
+    assert datum.loss_fn_inputs["weights"].data == weight_values[1:]
+
+    customized_messages = [
+        {**message, "trainable": message is messages[-1]} for message in messages
+    ]
+    customized_input, customized_weights = renderer.build_supervised_example(
+        customized_messages,
+        train_on_what=TrainOnWhat.CUSTOMIZED,
+    )
+    assert list(customized_input.to_ints()) == tokens
+    assert customized_weights.tolist() == expected_last_only
+
+
+def test_nested_tool_arguments_match_hf(
+    tokenizer: transformers.PreTrainedTokenizerBase,
+) -> None:
+    function = {
+        "name": "create_event",
+        "description": "Create event",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "title": {"type": "string"},
+                "meta": {"type": "object"},
+            },
+        },
+    }
+    arguments = {
+        "title": "Sync",
+        "attendees": ["a", "b"],
+        "meta": {"room": "1", "optional": None},
+    }
+    hf_messages = [
+        {"role": "system", "content": "Be useful"},
+        {"role": "user", "content": "book"},
+        {
+            "role": "assistant",
+            "reasoning_content": "plan",
+            "content": "Doing it",
+            "tool_calls": [
+                {
+                    "type": "function",
+                    "function": {"name": "create_event", "arguments": arguments},
+                }
+            ],
+        },
+        {"role": "tool", "content": "ok"},
+    ]
+    expected = _hf_tokens(
+        tokenizer,
+        hf_messages,
+        thinking_mode="disabled",
+        add_generation_prompt=True,
+        tools=[{"type": "function", "function": function}],
+    )
+
+    renderer = MiniMaxM3Renderer(tokenizer, "disabled")
+    messages = renderer.create_conversation_prefix_with_tools(
+        [function], "Be useful"
+    ) + [
+        {"role": "user", "content": "book"},
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "thinking", "thinking": "plan"},
+                {"type": "text", "text": "Doing it"},
+            ],
+            "tool_calls": [_tool_call("create_event", arguments)],
+        },
+        {"role": "tool", "content": "ok"},
+    ]
+    assert list(renderer.build_generation_prompt(messages).to_ints()) == expected
+
+
+def test_parse_nested_tool_call_roundtrip(
+    tokenizer: transformers.PreTrainedTokenizerBase,
+) -> None:
+    renderer = MiniMaxM3Renderer(tokenizer, "adaptive")
+    arguments = {"items": [{"name": "a", "enabled": True}], "count": 1}
+    rendered = renderer.render_message(
+        {
+            "role": "assistant",
+            "content": [{"type": "thinking", "thinking": "plan"}],
+            "tool_calls": [_tool_call("batch", arguments)],
+        },
+        ctx=None,  # type: ignore[arg-type]
+    )
+    response = [token for chunk in rendered.output for token in chunk.tokens]
+    parsed, termination = renderer.parse_response(response)
+    assert termination == ParseTermination.STOP_SEQUENCE
+    assert parsed["tool_calls"][0].function.name == "batch"
+    assert json.loads(parsed["tool_calls"][0].function.arguments) == arguments

--- a/training/tests/unit/test_supervised_rendering.py
+++ b/training/tests/unit/test_supervised_rendering.py
@@ -978,9 +978,9 @@ def test_resolve_renderer_name_prefers_minimax_m2() -> None:
     assert resolve_renderer_name("MiniMaxAI/MiniMax-M2") == "minimax_m2"
 
 
-def test_resolve_renderer_name_minimax_m3_reuses_minimax_m2() -> None:
-    """MiniMax-M3 keeps M2's chat template; it reuses the minimax_m2 renderer."""
-    assert resolve_renderer_name("MiniMaxAI/MiniMax-M3") == "minimax_m2"
+def test_resolve_renderer_name_prefers_minimax_m3() -> None:
+    """Released MiniMax-M3 tokenizers use the dedicated M3 renderer."""
+    assert resolve_renderer_name("MiniMaxAI/MiniMax-M3") == "minimax_m3"
 
 
 def test_resolve_renderer_name_prefers_upstream_nemotron3() -> None:

--- a/training/utils/supervised.py
+++ b/training/utils/supervised.py
@@ -33,6 +33,7 @@ from tinker_cookbook.renderers import (
 from tinker_cookbook.image_processing_utils import get_image_processor
 from tinker_cookbook.supervised.common import datum_from_model_input_weights
 import training.renderer.minimax_m2 as _minimax_m2_renderer  # noqa: F401 — triggers register_renderer
+import training.renderer.minimax_m3 as _minimax_m3_renderer  # noqa: F401 — triggers register_renderer
 import training.renderer.gemma4 as _gemma4_renderer  # noqa: F401 — triggers register_renderer
 import training.renderer._gemma4_split as _gemma4_split_renderer  # noqa: F401 — split override
 import training.renderer.deepseek_v4 as _deepseek_v4_renderer  # noqa: F401 — triggers register_renderer
@@ -73,7 +74,9 @@ def _tool_prefix_builder(renderer: Renderer):
     prefix_builder = getattr(renderer, "create_conversation_prefix_with_tools", None)
     if prefix_builder is None:
         return None
-    class_builder = getattr(type(renderer), "create_conversation_prefix_with_tools", None)
+    class_builder = getattr(
+        type(renderer), "create_conversation_prefix_with_tools", None
+    )
     if class_builder is Renderer.create_conversation_prefix_with_tools:
         return None
     return prefix_builder
@@ -171,11 +174,10 @@ def resolve_renderer_name(
         return "nemotron3"
     if "minimax-m2" in normalized_model_name or "minimax_m2" in normalized_model_name:
         return "minimax_m2"
-    # MiniMax-M3 keeps M2's chat template / tool format (the shape CI passes
-    # renderer_name=minimax_m2 for it); reuse the minimax_m2 renderer -- same
-    # alias pattern as kimi-k2.5 -> Kimi-K2.6 above.
+    # The released MiniMax-M3 tokenizer uses its own BOD/BOS role protocol,
+    # thinking tags, and XML tool-call format; it is not M2-compatible.
     if "minimax-m3" in normalized_model_name or "minimax_m3" in normalized_model_name:
-        return "minimax_m2"
+        return "minimax_m3"
     if "qwen3-vl" in normalized_model_name:
         return "qwen3_vl_instruct"
     # Qwen3.6 reuses Qwen3.5's vocab + special tokens; the chat template only
@@ -534,7 +536,9 @@ def normalize_messages(
         reasoning = message.get("reasoning")
         if thinking is None and reasoning is not None:
             if not isinstance(reasoning, str):
-                raise TypeError(f"Unsupported reasoning value type: {type(reasoning)!r}")
+                raise TypeError(
+                    f"Unsupported reasoning value type: {type(reasoning)!r}"
+                )
             if reasoning:
                 normalized_message["content"] = [
                     {"type": "thinking", "thinking": reasoning},
@@ -956,9 +960,8 @@ def _equivalent_single_example_train_on_what(
     the false-positive warning while preserving true warnings for non-equivalent
     conversations.
     """
-    if (
-        train_on_what != TrainOnWhat.ALL_ASSISTANT_MESSAGES
-        or getattr(renderer, "has_extension_property", False)
+    if train_on_what != TrainOnWhat.ALL_ASSISTANT_MESSAGES or getattr(
+        renderer, "has_extension_property", False
     ):
         return train_on_what
 


### PR DESCRIPTION
## Summary
- add a dedicated `minimax_m3` renderer matching the released `MiniMaxAI/MiniMax-M3` chat template
- route MiniMax M3 tokenizers to it instead of the M2 renderer
- preserve supervised masks across thinking modes, per-message weights, and tool-call round trips

## Why
The cookbook currently aliases MiniMax M3 to `minimax_m2`, based on an earlier shape assumption. The released tokenizer uses a different BOD/BOS role protocol, `<mm:think>` controls, and namespaced XML tool format. Reusing M2 therefore mis-tokenizes training data and can misalign inference and training prompts.

## Impact
MiniMax M3 SFT now uses tokens aligned with the official Hugging Face template. Default loss masking trains only the selected assistant thinking and visible answer tokens while masking prompts and history; `CUSTOMIZED` per-message weights remain honored.

## Validation
- `uv run --project training --extra dev python -m pytest tests/unit/test_minimax_m3_renderer.py tests/unit/test_supervised_rendering.py -v` — 61 passed
- `uvx ruff check ...` — passed
- `uvx ruff format --check ...` — passed
- local real-tokenizer parity against `/shared/xiaoyifan/MiniMax-M3` / `MiniMaxAI/MiniMax-M3`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which tokens MiniMax M3 SFT and inference use (fixing prior M2 mis-tokenization); risk is mitigated by HF parity tests but any renderer bug would directly affect training data alignment.
> 
> **Overview**
> **MiniMax M3** no longer reuses the M2 renderer. This PR adds a registered `minimax_m3` renderer and points `MiniMaxAI/MiniMax-M3` (and related names) at it in `resolve_renderer_name` and supervised imports.
> 
> The new renderer implements the released M3 chat protocol: separate BOD/BOS role framing, `root`/`developer`/`ai` roles, `<mm:think>` handling with **enabled/disabled/adaptive** modes, namespaced XML tool calls (including nested args), grouped tool results, and response parsing with thinking normalization. It opts into extension-property behavior so multi-turn `ALL_ASSISTANT_MESSAGES` / `CUSTOMIZED` masking works without split-render warnings.
> 
> Unit tests assert **byte-level parity** with the official Hugging Face `apply_chat_template` for generation prompts, multi-turn supervised examples, tool-heavy conversations, loss masks, and tool-call parse round-trips.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59da57ad48855b2a180589acc8b97aaaaa7d6e91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->