### PR TITLE
fix(training): retain compatibility with published SDK

### DIFF
--- a/training/tests/unit/test_service.py
+++ b/training/tests/unit/test_service.py
@@ -103,7 +103,6 @@ def test_build_service_client_maps_cookbook_config_to_sdk_kwargs(monkeypatch):
             "extra_args": ["--foo"],
             "trainer_replica_count": 4,
             "trainer_timeout_s": 1800,
-            "trainer_pending_timeout_s": 172800,
             "inactivity_timeout": "7200s",
             "disable_inactivity_cleanup": True,
             "purpose": "PURPOSE_UNSPECIFIED",

--- a/training/utils/service.py
+++ b/training/utils/service.py
@@ -56,7 +56,6 @@ def _firetitan_service_kwargs(
         "extra_args": trainer.extra_args,
         "trainer_replica_count": trainer.replica_count,
         "trainer_timeout_s": trainer.timeout_s,
-        "trainer_pending_timeout_s": trainer.pending_timeout_s,
         "inactivity_timeout": trainer.inactivity_timeout,
         "disable_inactivity_cleanup": trainer.disable_inactivity_cleanup,
         "purpose": trainer.purpose,


### PR DESCRIPTION
## Summary
- stop forwarding `trainer_pending_timeout_s` from cookbook config
- keep the service kwargs test aligned with the published SDK contract
- avoid `TypeError` with PyPI `fireworks-ai==1.2.0a89` until a newer SDK publishes support

## Code overview
```mermaid
flowchart LR
    A[Cookbook trainer config] --> B[_firetitan_service_kwargs]
    B -->|omit unsupported field| C[Published Python SDK]
```

## Testing
- `../.venv/bin/python -m pytest training/tests/unit/test_service.py` — 5 passed
- reproduced the original failure with PyPI `fireworks-ai==1.2.0a89`
- independently reviewed: PASS

## Reviewer ask
Please verify that temporarily omitting the pending timeout is the desired compatibility behavior. The focused unit test covers the mapping change; no broader manual run is required. Restoring the field after a compatible SDK release is outside this PR.

## Perf evidence
- [x] Not a perf-sensitive change

## Design quiz scores
| Participant | Score | Result |
|---|---:|---|
| Developer | 3/3 (100%) | PASS |
| Agent | 3/3 (100%) | PASS |

Made with [Cursor](https://cursor.com)