### PR TITLE
Archive standalone cookbook tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,8 @@ AI-agent safety guard is active.
 ## Repository Structure
 
 `training/` is the primary development surface. `eval/` contains reproducible
-evaluation packages, and `tools/` holds standalone customer-facing scripts
-(public `firectl` workflows). Legacy integrations, multimedia examples, and
-earlier cookbook content live under `archived/`.
+evaluation packages. Legacy integrations, standalone customer scripts,
+multimedia examples, and earlier cookbook content live under `archived/`.
 
 ```
 training/           Training API recipes, utilities, and examples
@@ -60,9 +59,9 @@ training/           Training API recipes, utilities, and examples
   renderer/         Local renderers and correctness verifier
   tests/            Unit and end-to-end tests
 eval/               Reproducible evaluation packages and benchmark adapters
-tools/              Standalone customer scripts (downloadable from GitHub)
 skills/             One Fireworks training skill and progressive references
 archived/           Legacy integrations, multimedia, and cookbook content
+  tools/            Archived standalone customer scripts
 ```
 
 ## Evaluations

--- a/archived/tools/README.md
+++ b/archived/tools/README.md
@@ -1,8 +1,8 @@
-# Cookbook Tools
+# Archived Cookbook Tools
 
-Standalone scripts for customer-operated Fireworks workflows. These use public
-`firectl` and Fireworks APIs only — no Fireworks-internal credentials or GCP
-access required.
+Legacy standalone scripts for customer-operated Fireworks workflows, retained
+as implementation references. These use public `firectl` and Fireworks APIs
+only — no Fireworks-internal credentials or GCP access required.
 
 ## Prerequisites
 
@@ -32,12 +32,12 @@ python3 list_low_token_deployments.py --account my-account-dev --server gateway-
 
 ```bash
 curl -fsSL -o list_low_token_deployments.py \
-  https://raw.githubusercontent.com/fw-ai/cookbook/main/tools/list_low_token_deployments.py
+  https://raw.githubusercontent.com/fw-ai/cookbook/main/archived/tools/list_low_token_deployments.py
 chmod +x list_low_token_deployments.py
 ```
 
 Or browse the directory on GitHub:
-https://github.com/fw-ai/cookbook/tree/main/tools
+https://github.com/fw-ai/cookbook/tree/main/archived/tools
 
 ## Scripts
 
@@ -122,4 +122,4 @@ model, and token totals.
 - Deployments with no metrics data in the window are treated as **0 tokens/day**.
 
 Related agent skill:
-[`skills/fireworks-training/SKILL.md`](../skills/fireworks-training/SKILL.md)
+[`skills/fireworks-training/SKILL.md`](../../skills/fireworks-training/SKILL.md)

--- a/archived/tools/list_low_token_deployments.py
+++ b/archived/tools/list_low_token_deployments.py
@@ -7,7 +7,7 @@ not billing usage (dedicated deployment billing reports GPU-seconds only).
 
 Download (no clone required):
     curl -fsSL -o list_low_token_deployments.py \\
-      https://raw.githubusercontent.com/fw-ai/cookbook/main/tools/list_low_token_deployments.py
+      https://raw.githubusercontent.com/fw-ai/cookbook/main/archived/tools/list_low_token_deployments.py
     chmod +x list_low_token_deployments.py
 
 Examples:


### PR DESCRIPTION
## What changed

- Move the top-level `tools/` directory to `archived/tools/`.
- Mark the standalone deployment-usage helper as a retained legacy reference.
- Update the cookbook structure overview, raw download URL, GitHub browse URL, script docstring, and relative skill link for the archived path.

## Why

The active cookbook surface is focused on training recipes, evaluations, and the canonical training skill. The standalone customer script should remain available for reference without appearing as an active top-level surface.

## Impact

The helper script's behavior is unchanged. Direct links now use `archived/tools/`; consumers of the old `tools/` URLs need to follow the new archived path.

## Validation

- `git diff --check`
- `python3 -m py_compile archived/tools/list_low_token_deployments.py`
- `python3 archived/tools/list_low_token_deployments.py --help`
- Searched the cookbook and docs repositories for stale references to the old top-level path
