### PR TITLE
feat(training): support Gemma 4 reserved-token SFT

### DIFF
--- a/training/examples/sft/GEMMA4_RESERVED_TOKENS.md
+++ b/training/examples/sft/GEMMA4_RESERVED_TOKENS.md
@@ -1,0 +1,56 @@
+# Gemma 4 reserved-token SFT
+
+Gemma 4 already has thousands of `<unusedN>` vocabulary rows. Reusing those
+rows lets full-parameter SFT learn new control-token embeddings without
+resizing the model.
+
+## 1. Choose and persist the mapping
+
+Map each desired wire string to a different reserved slot:
+
+```bash
+python training/examples/sft/prepare_gemma4_tokenizer.py \
+  --source google/gemma-4-E2B-it \
+  --output /tmp/gemma4-tokenizer \
+  --token-map '{"<start_search>":"<unused123>","<end_search>":"<unused124>"}'
+```
+
+This changes the token strings attached to the selected IDs and registers them
+for atomic encoding. It asserts that the tokenizer length does not change.
+Keep the generated tokenizer files with the custom base model used for
+inference; promoted checkpoints inherit tokenizer metadata from that base.
+
+If the wire spelling `<unused123>` is acceptable, map it to itself. That only
+activates the existing string:
+
+```json
+{"<unused123>": "<unused123>"}
+```
+
+## 2. Train the selected rows
+
+Use the same mapping while rendering SFT data and run full-parameter training:
+
+```bash
+python training/examples/sft/train_sft.py \
+  --base-model accounts/YOUR_ACCOUNT/models/YOUR_GEMMA4_BASE \
+  --tokenizer-model /tmp/gemma4-tokenizer \
+  --renderer-name gemma4 \
+  --dataset-path /path/to/data.jsonl \
+  --output-model-id gemma4-reserved-token-sft \
+  --lora-rank 0 \
+  --gemma4-reserved-token-map \
+    '{"<start_search>":"<unused123>","<end_search>":"<unused124>"}'
+```
+
+The SFT recipe rejects this option with `lora_rank > 0`: LoRA does not update
+the base embedding rows. Include each new token in enough supervised examples
+to learn a useful embedding.
+
+If you custom-initialize the selected rows, edit the input embedding (and the
+untied output embedding, if present), save the model together with the
+generated tokenizer files, and upload that directory as the custom base before
+training.
+
+Inference must decode with `skip_special_tokens=False` when these strings are
+part of the model's output. Fireworks' text tokenizer uses that behavior.

--- a/training/examples/sft/prepare_gemma4_tokenizer.py
+++ b/training/examples/sft/prepare_gemma4_tokenizer.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Create a Gemma 4 tokenizer that maps aliases onto reserved vocabulary rows."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from training.utils.tokenizers import load_tokenizer
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Map customer token strings onto Gemma 4 <unusedN> IDs without "
+            "changing the tokenizer or embedding-matrix size."
+        )
+    )
+    parser.add_argument(
+        "--source",
+        default="google/gemma-4-E2B-it",
+        help="Hugging Face Gemma 4 tokenizer name or local directory",
+    )
+    parser.add_argument("--output", required=True, help="Output tokenizer directory")
+    parser.add_argument(
+        "--token-map",
+        type=json.loads,
+        required=True,
+        metavar="JSON",
+        help=(
+            "Token alias -> reserved slot, for example "
+            '\'{"<start_search>":"<unused123>"}\''
+        ),
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    tokenizer = load_tokenizer(
+        args.source,
+        gemma4_reserved_token_map=args.token_map,
+    )
+    output = Path(args.output)
+    output.mkdir(parents=True, exist_ok=True)
+    tokenizer.save_pretrained(output)
+
+    resolved = {
+        alias: tokenizer.encode(alias, add_special_tokens=False)[0]
+        for alias in args.token_map
+    }
+    print(f"Saved fixed-size tokenizer ({len(tokenizer)} tokens) to {output}")
+    print(json.dumps(resolved, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/training/examples/sft/train_sft.py
+++ b/training/examples/sft/train_sft.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import logging
 import os
 import signal
@@ -48,6 +49,16 @@ def parse_args():
     parser.add_argument("--learning-rate", type=float, default=1e-5)
     parser.add_argument("--lora-rank", type=int, default=0)
     parser.add_argument("--renderer-name", default="")
+    parser.add_argument(
+        "--gemma4-reserved-token-map",
+        type=json.loads,
+        default={},
+        metavar="JSON",
+        help=(
+            "Gemma 4 token alias -> existing <unusedN> slot, for example "
+            '\'{"<start_search>":"<unused123>"}\'. Requires --lora-rank=0.'
+        ),
+    )
     parser.add_argument("--no-checkpoint", action="store_true",
                         help="Skip final checkpoint save")
     parser.add_argument("--grad-clip-norm", type=float, default=1.0,
@@ -89,6 +100,7 @@ def main():
         batch_size=args.batch_size,
         max_examples=args.max_examples,
         lora_rank=args.lora_rank,
+        gemma4_reserved_token_map=args.gemma4_reserved_token_map,
         output_model_id=args.output_model_id,
         grad_clip_norm=args.grad_clip_norm,
         dcp_save_interval=-1 if args.no_checkpoint else 0,

--- a/training/recipes/sft_loop.py
+++ b/training/recipes/sft_loop.py
@@ -293,6 +293,7 @@ def _init_render_worker(
     tokenizer_revision: str = "",
     thinking_trace_history_mode: str = "",
     tokenizer_trust_remote_code: bool | None = None,
+    gemma4_reserved_token_map: dict[str, str] | None = None,
     render_samples_local_dir: str = "",
     render_samples_limit: int | None = 0,
     _worker_id: int | None = None,
@@ -311,6 +312,7 @@ def _init_render_worker(
         tokenizer_model=tokenizer_model,
         tokenizer_revision=tokenizer_revision,
         tokenizer_trust_remote_code=tokenizer_trust_remote_code,
+        gemma4_reserved_token_map=gemma4_reserved_token_map,
         renderer_name=resolved_renderer_name,
         max_seq_len=max_seq_len,
         thinking_trace_history_mode=thinking_trace_history_mode,
@@ -515,6 +517,13 @@ class Config:
     """Reviewed remote-code policy for a materialized tokenizer plan.
 
     ``None`` retains the legacy direct-cookbook behavior.
+    """
+    gemma4_reserved_token_map: dict[str, str] = field(default_factory=dict)
+    """Desired token string -> existing Gemma 4 ``<unusedN>`` slot.
+
+    This renames and activates fixed vocabulary rows without resizing the
+    embedding matrix. It is supported only for full-parameter SFT
+    (``lora_rank=0``).
     """
     renderer_name: str = ""
     renderer_name_is_resolved: bool = False
@@ -767,6 +776,11 @@ def main(
             "Config.tokenizer_model is required for chat template formatting. "
             "Set it to the HuggingFace model name (e.g. 'Qwen/Qwen3-1.7B')."
         )
+    if cfg.gemma4_reserved_token_map and cfg.lora_rank != 0:
+        raise ValueError(
+            "gemma4_reserved_token_map requires full-parameter SFT (lora_rank=0) "
+            "so the selected embedding rows are trainable"
+        )
     # Resolve a direct request or reuse the persisted concrete renderer before
     # a managed GPU trainer is provisioned. A persisted concrete name is
     # authoritative across retries and resumes.
@@ -881,6 +895,7 @@ def main(
             cfg.tokenizer_revision,
             cfg.thinking_trace_history_mode,
             cfg.tokenizer_trust_remote_code,
+            cfg.gemma4_reserved_token_map,
         )
         _init_render_worker(*base_init_args)
 

--- a/training/tests/unit/test_sft_loop.py
+++ b/training/tests/unit/test_sft_loop.py
@@ -87,16 +87,37 @@ def test_init_render_worker_forwards_materialized_tokenizer_plan(monkeypatch):
         "2755962",
         "interleaved",
         False,
+        {"<start_search>": "<unused123>"},
     )
 
     assert captured["state"] is module._worker_state
     assert captured["kwargs"]["tokenizer_model"] == "moonshotai/Kimi-K2.6"
     assert captured["kwargs"]["tokenizer_revision"] == "2755962"
     assert captured["kwargs"]["tokenizer_trust_remote_code"] is False
+    assert captured["kwargs"]["gemma4_reserved_token_map"] == {
+        "<start_search>": "<unused123>"
+    }
     assert captured["kwargs"]["renderer_name"] == "kimi_k25"
     assert captured["kwargs"]["max_seq_len"] == 4096
     assert captured["kwargs"]["thinking_trace_history_mode"] == "interleaved"
     assert captured["kwargs"]["renderer_name_is_resolved"] is True
+
+
+def test_gemma4_reserved_tokens_require_full_parameter_training(tmp_path, monkeypatch):
+    monkeypatch.setattr(module, "validate_config", lambda *args, **kwargs: None)
+    cfg = module.Config(
+        log_path=str(tmp_path / "logs"),
+        dataset=str(tmp_path / "data.jsonl"),
+        tokenizer_model="google/gemma-4-E2B-it",
+        gemma4_reserved_token_map={"<start_search>": "<unused123>"},
+        lora_rank=8,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=r"requires full-parameter SFT \(lora_rank=0\)",
+    ):
+        module.main(cfg)
 
 
 def test_init_render_worker_uses_exact_main_resolved_renderer(monkeypatch):

--- a/training/tests/unit/test_tokenizers.py
+++ b/training/tests/unit/test_tokenizers.py
@@ -8,12 +8,37 @@ from types import SimpleNamespace
 
 import httpx
 import pytest
+from tokenizers import Tokenizer, decoders, models, pre_tokenizers
+from transformers import PreTrainedTokenizerFast
 from huggingface_hub.errors import HfHubHTTPError
 from huggingface_hub.utils import hf_raise_for_status
 
 import training.utils.tokenizers as tokenizers
 import training.utils.runner as runner
 from training.utils.runner import RunnerConfig, RunnerIO
+
+
+def tiny_gemma4_tokenizer() -> PreTrainedTokenizerFast:
+    backend = Tokenizer(
+        models.BPE(
+            vocab={
+                "<pad>": 0,
+                "<unk>": 1,
+                "a": 2,
+                "<unused123>": 3,
+                "<unused124>": 4,
+            },
+            merges=[],
+            unk_token="<unk>",
+        )
+    )
+    backend.pre_tokenizer = pre_tokenizers.ByteLevel(add_prefix_space=False)
+    backend.decoder = decoders.ByteLevel()
+    return PreTrainedTokenizerFast(
+        tokenizer_object=backend,
+        unk_token="<unk>",
+        pad_token="<pad>",
+    )
 
 
 @contextmanager
@@ -93,6 +118,63 @@ def test_load_tokenizer_treats_empty_revision_as_unset(monkeypatch):
     tokenizers.load_tokenizer("Qwen/Qwen3-8B", "")
 
     assert captured["kwargs"]["revision"] is None
+
+
+def test_configure_gemma4_reserved_tokens_reuses_rows_without_resizing():
+    tokenizer = tiny_gemma4_tokenizer()
+    original_size = len(tokenizer)
+
+    resolved = tokenizers.configure_gemma4_reserved_tokens(
+        tokenizer,
+        {
+            "<start_search>": "<unused123>",
+            "<unused124>": "<unused124>",
+        },
+    )
+
+    assert resolved == {"<start_search>": 3, "<unused124>": 4}
+    assert len(tokenizer) == original_size
+    assert tokenizer.encode("<start_search>", add_special_tokens=False) == [3]
+    assert tokenizer.encode("<unused124>", add_special_tokens=False) == [4]
+    assert tokenizer.decode([3]) == "<start_search>"
+    assert tokenizer.init_kwargs[tokenizers.GEMMA4_RESERVED_TOKEN_MAP_CONFIG_KEY] == {
+        "<start_search>": "<unused123>",
+        "<unused124>": "<unused124>",
+    }
+
+
+def test_load_tokenizer_reapplies_saved_gemma4_mapping(tmp_path):
+    tokenizer = tiny_gemma4_tokenizer()
+    tokenizers.configure_gemma4_reserved_tokens(
+        tokenizer,
+        {"<start_search>": "<unused123>"},
+    )
+    tokenizer.save_pretrained(tmp_path)
+
+    reloaded = tokenizers.load_tokenizer(str(tmp_path), trust_remote_code=False)
+
+    assert len(reloaded) == 5
+    assert reloaded.encode("<start_search>", add_special_tokens=False) == [3]
+    assert reloaded.decode([3]) == "<start_search>"
+
+
+@pytest.mark.parametrize(
+    ("token_map", "message"),
+    [
+        ({"<new>": "<not-unused>"}, "exact '<unusedN>' spelling"),
+        (
+            {"<first>": "<unused123>", "<second>": "<unused123>"},
+            "only one alias",
+        ),
+        ({"a": "<unused123>"}, "already has vocabulary ID"),
+    ],
+)
+def test_configure_gemma4_reserved_tokens_rejects_unsafe_mappings(token_map, message):
+    with pytest.raises(ValueError, match=message):
+        tokenizers.configure_gemma4_reserved_tokens(
+            tiny_gemma4_tokenizer(),
+            token_map,
+        )
 
 
 def test_load_deployment_tokenizer_uses_generic_deploy_config_fields(monkeypatch):

--- a/training/utils/supervised.py
+++ b/training/utils/supervised.py
@@ -424,6 +424,7 @@ def populate_render_worker_state(
     tokenizer_model: str,
     tokenizer_revision: str | None = None,
     tokenizer_trust_remote_code: bool | None = None,
+    gemma4_reserved_token_map: Mapping[str, str] | None = None,
     renderer_name: str,
     max_seq_len: int,
     thinking_trace_history_mode: (
@@ -444,10 +445,18 @@ def populate_render_worker_state(
     ``extras`` (e.g. ``train_on_what`` for SFT). A ``None`` remote-code policy
     preserves the legacy permissive load; reviewed plans pass an explicit value.
     """
-    tokenizer = load_tokenizer(
+    tokenizer_args = [
         tokenizer_model,
         tokenizer_revision,
         tokenizer_trust_remote_code,
+    ]
+    tokenizer = (
+        load_tokenizer(
+            *tokenizer_args,
+            gemma4_reserved_token_map=gemma4_reserved_token_map,
+        )
+        if gemma4_reserved_token_map
+        else load_tokenizer(*tokenizer_args)
     )
     renderer = (
         build_renderer_from_resolved_name(

--- a/training/utils/tokenizers.py
+++ b/training/utils/tokenizers.py
@@ -2,15 +2,19 @@
 
 from __future__ import annotations
 
+import json
 import re
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from functools import wraps
 from typing import Any
 
+from tokenizers import Tokenizer
 import transformers
 
-
 _HTTP_STATUS_PATTERN = re.compile(r"\b([45]\d\d)\b")
+_GEMMA4_UNUSED_TOKEN_PATTERN = re.compile(r"^<unused\d+>$")
+# Cross-repo contract consumed by fireworks.text.tokenizer at inference startup.
+GEMMA4_RESERVED_TOKEN_MAP_CONFIG_KEY = "fireworks_gemma4_reserved_token_map"
 
 
 def _huggingface_http_status_code(exc: BaseException) -> int | None:
@@ -51,7 +55,10 @@ def _huggingface_http_status_code(exc: BaseException) -> int | None:
     return None
 
 
-_TokenizerLoader = Callable[[str | None, str | None, bool | None], Any]
+_TokenizerLoader = Callable[
+    [str | None, str | None, bool | None, Mapping[str, str] | None],
+    Any,
+]
 
 
 def _propagate_huggingface_http_status(loader: _TokenizerLoader) -> _TokenizerLoader:
@@ -62,9 +69,15 @@ def _propagate_huggingface_http_status(loader: _TokenizerLoader) -> _TokenizerLo
         tokenizer_model: str | None,
         tokenizer_revision: str | None = None,
         trust_remote_code: bool | None = None,
+        gemma4_reserved_token_map: Mapping[str, str] | None = None,
     ) -> Any:
         try:
-            return loader(tokenizer_model, tokenizer_revision, trust_remote_code)
+            return loader(
+                tokenizer_model,
+                tokenizer_revision,
+                trust_remote_code,
+                gemma4_reserved_token_map,
+            )
         except Exception as exc:
             status_code = _huggingface_http_status_code(exc)
             if status_code is None:
@@ -77,11 +90,145 @@ def _propagate_huggingface_http_status(loader: _TokenizerLoader) -> _TokenizerLo
     return wrapped
 
 
+def configure_gemma4_reserved_tokens(
+    tokenizer: Any,
+    token_map: Mapping[str, str],
+) -> dict[str, int]:
+    """Map customer token strings onto existing Gemma 4 ``<unusedN>`` rows.
+
+    The operation rewrites token *names*, not token IDs: every alias takes the
+    ID of its selected reserved slot and the tokenizer length must stay fixed.
+    The aliases are then registered as special ``AddedToken`` instances so
+    ordinary text encoding recognizes each complete string atomically.
+
+    ``token_map`` maps the desired wire string to a Gemma 4 reserved token, for
+    example ``{"<start_search>": "<unused123>"}``. Mapping a reserved token to
+    itself (``{"<unused123>": "<unused123>"}``) only activates the stock name.
+    """
+    if not isinstance(token_map, Mapping) or not token_map:
+        raise ValueError("gemma4_reserved_token_map must be a non-empty mapping")
+
+    normalized: dict[str, str] = {}
+    for alias, reserved_token in token_map.items():
+        if not isinstance(alias, str) or not alias:
+            raise ValueError("Gemma 4 reserved-token aliases must be non-empty strings")
+        if "\x00" in alias:
+            raise ValueError("Gemma 4 reserved-token aliases cannot contain null bytes")
+        if not isinstance(
+            reserved_token, str
+        ) or not _GEMMA4_UNUSED_TOKEN_PATTERN.fullmatch(reserved_token):
+            raise ValueError(
+                "Gemma 4 reserved-token targets must use the exact '<unusedN>' spelling; "
+                f"got {reserved_token!r} for alias {alias!r}"
+            )
+        if alias in normalized and normalized[alias] != reserved_token:
+            raise ValueError(f"Gemma 4 token alias {alias!r} is mapped more than once")
+        normalized[alias] = reserved_token
+
+    targets = list(normalized.values())
+    if len(set(targets)) != len(targets):
+        raise ValueError(
+            "Each Gemma 4 <unusedN> slot may be assigned to only one alias"
+        )
+
+    backend = getattr(tokenizer, "backend_tokenizer", None)
+    if backend is None or not hasattr(tokenizer, "_tokenizer"):
+        raise ValueError(
+            "Gemma 4 reserved-token mapping requires a fast Hugging Face tokenizer"
+        )
+
+    backend_config = json.loads(backend.to_str())
+    model_config = backend_config.get("model")
+    if not isinstance(model_config, dict) or model_config.get("type") != "BPE":
+        raise ValueError(
+            "Gemma 4 reserved-token mapping requires the Gemma 4 BPE tokenizer"
+        )
+    vocab = model_config.get("vocab")
+    if not isinstance(vocab, dict):
+        raise ValueError("Gemma 4 tokenizer JSON is missing model.vocab")
+
+    original_size = len(tokenizer)
+    resolved_ids: dict[str, int] = {}
+    needs_backend_rebuild = False
+    for alias, reserved_token in normalized.items():
+        reserved_id = vocab.get(reserved_token)
+        alias_id = vocab.get(alias)
+
+        if alias == reserved_token:
+            if reserved_id is None:
+                raise ValueError(
+                    f"{reserved_token!r} does not exist in this tokenizer vocabulary"
+                )
+            resolved_ids[alias] = int(reserved_id)
+            continue
+
+        if reserved_id is None:
+            # A tokenizer saved after this mapping has already replaced the
+            # reserved spelling with the alias. Treat an existing atomic alias
+            # as idempotently configured.
+            if alias_id is None:
+                raise ValueError(
+                    f"{reserved_token!r} does not exist in this tokenizer vocabulary"
+                )
+            resolved_ids[alias] = int(alias_id)
+            continue
+        if alias_id is not None:
+            raise ValueError(
+                f"Cannot map {alias!r}: that string already has vocabulary ID {alias_id}"
+            )
+
+        del vocab[reserved_token]
+        vocab[alias] = reserved_id
+        resolved_ids[alias] = int(reserved_id)
+        needs_backend_rebuild = True
+
+    if len(set(resolved_ids.values())) != len(resolved_ids):
+        raise ValueError(
+            "Each Gemma 4 reserved token mapping must resolve to a unique ID"
+        )
+
+    if needs_backend_rebuild:
+        tokenizer._tokenizer = Tokenizer.from_str(json.dumps(backend_config))
+
+    added_tokens = [
+        transformers.AddedToken(
+            alias,
+            normalized=False,
+            special=True,
+        )
+        for alias in normalized
+    ]
+    tokenizer.add_tokens(added_tokens, special_tokens=True)
+
+    if len(tokenizer) != original_size:
+        raise ValueError(
+            "Gemma 4 reserved-token mapping unexpectedly changed tokenizer size "
+            f"from {original_size} to {len(tokenizer)}; refusing to continue because "
+            "the model embedding matrix is fixed"
+        )
+
+    for alias, expected_id in resolved_ids.items():
+        actual_ids = tokenizer.encode(alias, add_special_tokens=False)
+        if actual_ids != [expected_id]:
+            raise ValueError(
+                f"Gemma 4 token alias {alias!r} did not become atomic: "
+                f"expected [{expected_id}], got {actual_ids}"
+            )
+
+    # Unknown tokenizer_config keys are retained in init_kwargs by HF and are
+    # written back by save_pretrained(). Fireworks inference consumes this same
+    # key, so a customized base carries the mapping across promotion.
+    if hasattr(tokenizer, "init_kwargs"):
+        tokenizer.init_kwargs[GEMMA4_RESERVED_TOKEN_MAP_CONFIG_KEY] = normalized
+    return resolved_ids
+
+
 @_propagate_huggingface_http_status
 def load_tokenizer(
     tokenizer_model: str | None,
     tokenizer_revision: str | None = None,
     trust_remote_code: bool | None = None,
+    gemma4_reserved_token_map: Mapping[str, str] | None = None,
 ) -> Any:
     """Load a tokenizer with cookbook defaults.
 
@@ -90,17 +237,29 @@ def load_tokenizer(
     the legacy remote-code policy (enabled), while a reviewed tokenizer plan
     can explicitly enable or disable it.
     """
-    return transformers.AutoTokenizer.from_pretrained(
+    tokenizer = transformers.AutoTokenizer.from_pretrained(
         tokenizer_model,
         revision=tokenizer_revision or None,
         trust_remote_code=True if trust_remote_code is None else trust_remote_code,
     )
+    configured_map = gemma4_reserved_token_map
+    if configured_map is None:
+        configured_map = getattr(tokenizer, "init_kwargs", {}).get(
+            GEMMA4_RESERVED_TOKEN_MAP_CONFIG_KEY
+        )
+    if configured_map:
+        configure_gemma4_reserved_tokens(tokenizer, configured_map)
+    return tokenizer
 
 
 def load_deployment_tokenizer(deployment: Any) -> Any:
     """Load the tokenizer configured on a deployment config-like object."""
-    return load_tokenizer(
+    args = [
         getattr(deployment, "tokenizer_model", None),
         getattr(deployment, "tokenizer_revision", None),
         getattr(deployment, "tokenizer_trust_remote_code", None),
-    )
+    ]
+    token_map = getattr(deployment, "gemma4_reserved_token_map", None)
+    if token_map:
+        return load_tokenizer(*args, gemma4_reserved_token_map=token_map)
+    return load_tokenizer(*args)


### PR DESCRIPTION
## Description

Enable full-parameter Gemma 4 SFT to train customer control tokens by reusing the model's existing `<unusedN>` vocabulary rows instead of resizing the tokenizer or embedding matrix.

- Adds the persisted `fireworks_gemma4_reserved_token_map` tokenizer contract.
- Renames/activates selected reserved rows while asserting fixed tokenizer size and atomic encoding.
- Applies the same mapping in the main renderer and every DataLoader worker.
- Rejects the mapping for LoRA training because LoRA does not update base embedding rows.
- Adds a preparation helper and an end-to-end customer guide, including custom initialization and decode caveats.

Companion inference PR: [fw-ai/fireworks#37406](https://github.com/fw-ai/fireworks/pull/37406).

## Reviewer Ask

**Manual repro:** Run `/home/tran_le/cookbook/.venv/bin/python -m pytest training/tests/unit/test_tokenizers.py training/tests/unit/test_sft_loop.py -q`; expected result is `45 passed`.

**Review focus:** Please review the fixed-vocabulary invariant, the `alias -> <unusedN>` config shape, and whether the tokenizer metadata persistence matches custom-base promotion expectations.

**Not asking for:** Model embedding resize support or LoRA embedding training; this deliberately reuses existing Gemma 4 rows and requires `lora_rank=0`.

## Architecture / Code Overview

```mermaid
flowchart LR
    Config["alias → Gemma 4 <unusedN> map"] --> Load["Tokenizer load"]
    Load --> Validate["Validate BPE row + fixed vocab size"]
    Validate --> Atomic["Register atomic alias at existing ID"]
    Atomic --> Workers["Main renderer + DataLoader workers"]
    Workers --> SFT["Full-parameter SFT"]
    SFT --> Embedding["Selected embedding/output rows learn"]
    Atomic --> Saved["tokenizer_config.json persists mapping"]
    Saved --> Inference["Companion inference loader"]
```

## Testing

- [x] Added/updated tests
- [x] Tested manually

- Unit tests: `45 passed`.
- Real Gemma 4 tokenizer: vocabulary stayed at `262144`; aliases resolved atomically to existing IDs `256035` and `256036`.
- Real Gemma 4 renderer: the aliased token appeared in the supervised assistant span with loss weight `1.0`.
- Formatting: focused Black check and `git diff --check`.

## Performance

The mapping is applied once per tokenizer/render-worker initialization. It adds no per-example work after startup and does not change GPU kernels, synchronization, or the training step.

## Surface Consistency

- [x] Training CLI, tokenizer persistence, renderer workers, docs, and companion inference support use the same config key and mapping semantics.

## Checklist

- [x] Agent-reviewed and self-reviewed the diff
- [x] Minimum necessary diff
- [x] Tests and documentation added
- [x] No secrets or credentials in the diff
- [x] Visual diagram included
