### PR TITLE
docs: add first-principles LLM systems primer (learning/)

### DIFF
--- a/learning/README.md
+++ b/learning/README.md
@@ -1,0 +1,54 @@
+# LLM systems from first principles
+
+An onboarding primer for the technology underneath the Fireworks Training API and
+this cookbook. It starts from "what is a token" and builds up to the exact loss
+functions and scheduling knobs implemented in `training/`.
+
+Nothing here is a substitute for the live [Fireworks docs](https://docs.fireworks.ai)
+or the skill references in [`skills/fireworks-training/`](../skills/fireworks-training/SKILL.md).
+Those are operational; this is conceptual. Where a concept lands in real code,
+the file path is cited so you can read the implementation next.
+
+## Reading order
+
+| # | File | What you learn |
+|---|---|---|
+| 1 | [transformers-and-attention.md](transformers-and-attention.md) | Tokens, embeddings, Q/K/V, softmax attention, multi-head, RoPE, MLP/SwiGLU, MoE, parameter and FLOP counting |
+| 2 | [inference.md](inference.md) | Prefill vs decode, KV cache math, continuous batching, speculative decoding, disaggregated serving, quantization |
+| 3 | [training.md](training.md) | Forward/backward/optimizer step, autodiff, AdamW, gradient accumulation, memory budgets, LoRA, SFT, DPO, ORPO, distillation |
+| 4 | [reinforcement-learning.md](reinforcement-learning.md) | Policy gradients, REINFORCE, PPO clipping, GRPO, KL estimators, on-policy vs off-policy, sync vs async RL, train–inference mismatch and TIS |
+| 5 | [gpus-and-systems.md](gpus-and-systems.md) | SMs, HBM, roofline, precision formats, collectives, FSDP/HSDP, TP/PP/EP, what a "training shape" hides |
+| 6 | [fireworks-stack-map.md](fireworks-stack-map.md) | How every concept above maps to the Tinker protocol, the SDK, and files in `training/` |
+
+Read 1 → 2 → 3 → 4 in order; each depends on the previous. Files 5 and 6 can be
+read at any point and are useful as references.
+
+## The one-paragraph version
+
+A transformer turns a sequence of tokens into a probability distribution over the
+next token, using attention (a learned, content-addressed lookup between
+positions) and MLPs, stacked in residual blocks. Serving it fast is a memory
+problem, not a math problem: you cache per-token key/value tensors so generation
+does not re-read history, batch many requests to amortize weight loads, and use
+tricks like speculative decoding to buy more tokens per pass. Training it is
+three primitives repeated: forward (compute a loss), backward (compute
+gradients), optimizer step (change the weights). Fine-tuning shrinks the cost by
+only training a low-rank correction (LoRA). Reinforcement learning replaces the
+fixed label with a reward you compute yourself, which forces you to run
+inference and training in the same loop — and that coupling is where most of the
+interesting systems work in this repo lives.
+
+## Notation used throughout
+
+| Symbol | Meaning |
+|---|---|
+| $t_1 \dots t_n$ | token IDs in a sequence |
+| $n$ | sequence length (context) |
+| $d$ or $d_\text{model}$ | model/residual-stream width |
+| $L$ | number of transformer layers |
+| $h$ | number of attention heads, $d_h = d/h$ the per-head width |
+| $V$ | vocabulary size |
+| $N$ | total parameter count |
+| $\pi_\theta$ | the policy (the model being trained), parameters $\theta$ |
+| $\pi_\text{ref}$ | frozen reference model |
+| $G$ | group size in GRPO (completions per prompt) |

--- a/learning/fireworks-stack-map.md
+++ b/learning/fireworks-stack-map.md
@@ -1,0 +1,191 @@
+# 6. The Fireworks stack map
+
+Where every concept from parts 1–5 lives in real code, plus the vocabulary you
+need to read the rest of the repo. Operational guidance lives in
+[`skills/fireworks-training/SKILL.md`](../skills/fireworks-training/SKILL.md) and
+its `references/`; this page is a translation table.
+
+## 6.1 Layers
+
+```
+your Python                 recipe (a training loop you fork and own)
+                            training/recipes/*.py
+        │
+        ▼
+cookbook utilities          config, client wrapper, data rendering, losses,
+                            checkpoints, async coordinator
+                            training/utils/**
+        │
+        ▼
+Fireworks Python SDK        FiretitanServiceClient, FiretitanTrainingClient,
+(fireworks.training.sdk)    DeploymentSampler, AdaptiveConcurrencyController
+        │
+        ▼
+Training API (Tinker-       forward / forward_backward / optim_step /
+compatible wire protocol)   save_state / save_weights_for_sampler
+        │
+        ▼
+Fireworks backend           RLOR trainer GPUs · inference deployment ·
+                            hot-load storage
+```
+
+The design decision worth noticing: **the loop stays on your machine.** You are
+not submitting a YAML job and waiting; you are making RPCs from a Python process
+you control, which is why arbitrary losses, custom reward functions, curricula,
+and multi-model schemes are ordinary code rather than platform features.
+
+## 6.2 Concept → code
+
+| Concept (part) | Where it lives |
+|---|---|
+| Cross-entropy SFT loss (§1.1, §3.6) | `loss_fn="cross_entropy"` in `training/recipes/sft_loop.py` |
+| Chat templates and tokenization parity (§1.10) | `training/renderer/`, verifiers in `training/renderer/verifier/` |
+| Loss masking / `weights` (§3.6) | `training/utils/supervised.py`, `train_on_what` config field |
+| MoE routing (§1.7) and R3 (§4.9) | `training/utils/rl/router_replay.py`, `router_replay=True` |
+| Speculative decoding (§2.4) | `DeployConfig.disable_speculative_decoding` |
+| Prefill queue / adaptive concurrency (§2.3) | `ConcurrencyConfig.prefill_queue_target`, SDK `AdaptiveConcurrencyController` |
+| KV reuse across turns (§2.2) | Session-affinity routing on dedicated deployments (`models-shapes-and-cost.md`) |
+| Forward / backward / optimizer (§3.1) | `training/utils/client.py` (`ReconnectableClient`) |
+| Gradient-accumulation normalization (§3.3) | `GradAccNormalization.NUM_SEQUENCES` / `NUM_LOSS_TOKENS` on `optim_step` |
+| LR schedule (§3.2) | `normalize_lr_scheduler_spec`, `compute_lr`, `LRSchedulerSpec` |
+| LoRA (§3.7) | `lora_rank` on every recipe config; `load_adapter` for warm start |
+| DPO (§3.8) | `training/recipes/dpo_loop.py` |
+| ORPO (§3.9) | `training/recipes/orpo_loop.py` |
+| Distillation, fwd vs reverse KL (§3.10) | `training/recipes/distillation_loop.py`, `DistillMode` |
+| GRPO / PPO clip / k3 KL (§4.4–4.6) | `training/utils/rl/grpo.py` |
+| DAPO / GSPO / CISPO / REINFORCE / DRO (§4.6) | `training/utils/rl/{dapo,gspo,cispo,reinforce,dro}.py` |
+| TIS, IcePop (§4.8) | `training/utils/rl/tis.py` |
+| Train–inference gap metrics (§4.8) | `training/utils/rl/observability.py` |
+| Sync RL loop (§4.10) | `training/recipes/rl_loop.py` |
+| Async RL, admission gate (§4.11) | `training/recipes/async_rl_loop.py`, `training/utils/rl/async_rl/` |
+| Weight sync / hot-load (§4.12) | `save_weights_for_sampler` + `service.hotload_sampler_snapshot`, `WeightSyncScope` |
+| HSDP replicas (§5.6) | `TrainerConfig.replica_count` |
+| Training shapes (§5.8) | `TrainerConfig.training_shape_id` |
+
+## 6.3 The Tinker protocol, one more time
+
+| Call | Compute on server | Gradient? | Used by |
+|---|---|---|---|
+| `forward(data, loss_fn)` | forward only | no | reference logprobs, old-policy anchor |
+| `forward_backward(data, "cross_entropy")` | built-in loss + backward | yes | SFT, SDFT distillation |
+| `forward_backward(data, "importance_sampling")` | built-in IS loss + backward | yes | serverless RL, sampled reverse-KL distillation |
+| `forward_backward_custom(data, loss_fn)` | forward → **your loss in Python** → backward | yes | DPO, ORPO, GRPO and every RL variant |
+| `forward_backward_contrastive(...)` | InfoNCE + backward | yes | embedding fine-tuning |
+| `optim_step(AdamParams, ...)` | AdamW update | mutates | all |
+| `save_state` / `load_state_with_optimizer` | DCP checkpoint | — | resume |
+| `save_weights_for_sampler` | inference-format snapshot | — | serving, hot-load |
+| `load_adapter(path)` | load LoRA weights | — | warm start |
+
+Calls return futures; the cookbook's `ReconnectableClient` resolves them with
+explicit timeouts and reconnect handling. Gradient accumulation is $k$
+`forward_backward` calls followed by one `optim_step` — client-side control flow,
+not a server setting.
+
+## 6.4 Serverless vs dedicated
+
+|  | Serverless | Dedicated |
+|---|---|---|
+| Provisioning | None — pooled trainer at `/training/v1/serverless` | Explicit trainer job (+ deployment for RL) |
+| Billing | Per training token | Per GPU-hour, metered by runtime |
+| LoRA | Required (`lora_rank > 0`) | LoRA or full-parameter |
+| Sampling for RL | `service.create_sampling_client(model_path=snapshot)` — no separate deployment | Rollout deployment + `hotload_sampler_snapshot` |
+| Good for | Fast LoRA SFT/RL iteration | DPO, sustained RL, full-parameter, explicit checkpoints |
+
+Entry points: `training/utils/serverless.py` (`create_lora_training_client`) vs
+`training/utils/service.py` (`build_service_client` →
+`FiretitanServiceClient.from_firetitan_config`).
+
+The dominant cost mistake is leaving a dedicated deployment up. GPU-hour billing
+does not care whether you are sending traffic.
+
+## 6.5 Two checkpoint axes, do not confuse them
+
+| | `save_state` (DCP) | `save_weights_for_sampler` |
+|---|---|---|
+| Contains | weights **+ optimizer moments** | inference-format weights only |
+| Purpose | resume training exactly | serve, hot-load, promote to a model ID |
+| Size | large | LoRA: MB. Full-param: `"base"` then `"delta"` (~10× smaller) |
+| Cannot | be served directly | be resumed from |
+
+Managed by `TrainingCheckpoints` (`training/utils/checkpoints.py`). The local
+dataloader cursor (`{log_path}/dataloader.json`) maps a checkpoint name to rows
+consumed, so a resume does not replay data it already trained on.
+
+## 6.6 A dedicated async RL step, end to end
+
+Every concept in this primer, in order, in one loop iteration:
+
+1. The **producer** admits a dataset row if the staleness and concurrency budgets
+   allow all $G$ of its samples (§4.11).
+2. `DeploymentSampler` sends the prompt to the **inference deployment**, which
+   prefills it (reusing cached prefix blocks where possible), decodes with
+   continuous batching and possibly speculation, and returns tokens plus
+   per-token logprobs — and routing matrices if the model is MoE (§2, §4.9).
+3. Your `reward_fn` scores each completion. Group $G$ samples per prompt,
+   z-score the rewards into advantages (§4.3).
+4. The **trainer** runs `forward` passes for the reference model (if
+   `kl_beta > 0`) and the old policy (if `anchor_logp="old_policy"`) (§4.5,
+   §4.8).
+5. `forward_backward_custom` runs GRPO in your Python: PPO clipped ratio × TIS
+   weight, plus k3 KL, masked to completion tokens (§4.6).
+6. Optionally repeated over $K$ chunks, accumulating gradients (§3.3).
+7. One `optim_step` — AdamW with the current scheduled LR and gradient clipping
+   (§3.2).
+8. `save_weights_for_sampler` + `hotload_sampler_snapshot` push the new weights
+   to the deployment in place (§4.12).
+9. `coordinator.publish(batch)` advances the policy version, which mints fresh
+   admission credit and wakes the producer (§4.11).
+
+Exactly one optimizer mutation, one hot-load, and one version publication per
+batch. That invariant is what keeps trainer and sampler versions from diverging.
+
+## 6.7 Metrics worth watching
+
+| Metric | Healthy | What it means when it is not |
+|---|---|---|
+| `mean_loss` / reward mean | trending the right way | flat → check reward variance per group |
+| `ppo_clip_frac` | 0.02–0.15 | high: LR too large or data too stale; ~0: steps too timid |
+| `ppo_ratio_mean` | ≈ 1.0 | drifting: policy moving fast relative to the anchor |
+| `tis/clip_frac`, `tis/weight_mean` | low, ≈ 1.0 | rising: trainer and inference engines diverging (§4.8) |
+| train–inference KL (`observability.py`) | small and stable | growing: quantization/routing/speculation mismatch |
+| `mask_ratio` | as designed | unexpected: loss masking or renderer bug |
+| `async/version_offset_*` | ≤ your $O$ | at the cap constantly: staleness-bound, not concurrency-bound |
+| grad norm | stable | spikes: clipping is saving you; investigate the data |
+
+## 6.8 Glossary
+
+**Adapter** — LoRA weights ($A$, $B$), servable on top of a base model.
+**Advantage** — reward minus baseline; in GRPO, the group z-score.
+**Base / delta checkpoint** — full vs incremental sampler snapshot for
+full-parameter runs.
+**DCP** — distributed checkpoint, weights + optimizer, for resume.
+**Datum** — one Tinker training example: `model_input` plus `loss_fn_inputs`.
+**Firetitan** — internal name of the training service; hence
+`FiretitanServiceClient`.
+**Hot-load** — swapping new weights into a running deployment without restart.
+**MFU** — model FLOPs utilization, achieved ÷ peak.
+**On-policy** — training data generated by the current policy.
+**Promote** — publish a sampler checkpoint as a durable model ID.
+**R3 / router replay** — replaying inference MoE routing in the trainer.
+**RFT** — reinforcement fine-tuning; the managed product surface for RL.
+**RLOR** — the backend trainer service RL jobs run on.
+**Rollout** — one sampled trajectory from the policy.
+**Serverless / dedicated** — pooled per-token vs provisioned per-GPU-hour.
+**Shape** — a pinned GPU/topology profile for training or serving.
+**TIS** — train–inference importance sampling (§4.8).
+**Tinker** — the training API protocol this SDK is compatible with.
+
+## 6.9 Where to go next
+
+Read in this order, with the primer sections as context:
+
+1. [`skills/fireworks-training/SKILL.md`](../skills/fireworks-training/SKILL.md) — routing between methods, lifecycle, confirmation gates.
+2. `training/recipes/sft_loop.py` — the simplest complete loop (parts 1 and 3).
+3. `training/utils/client.py` — the exact protocol surface (§3.11).
+4. `training/utils/config.py` — every infrastructure knob in one file (parts 2 and 5).
+5. `training/utils/rl/grpo.py` and `tis.py` — the RL math as code (part 4).
+6. `training/recipes/async_rl_loop.py` plus [`references/rl-async.md`](../skills/fireworks-training/references/rl-async.md) — scheduling (§4.11).
+7. [`references/rl-hotload.md`](../skills/fireworks-training/references/rl-hotload.md) — weight-sync semantics (§4.12).
+
+The best way to make it concrete is to run a small LoRA SFT job on the serverless
+path, then a small GRPO run, and watch the metrics in §6.7 move.

--- a/learning/gpus-and-systems.md
+++ b/learning/gpus-and-systems.md
@@ -1,0 +1,222 @@
+# 5. GPUs and distributed systems
+
+You do not need to write CUDA to work on this stack, but you do need a mental
+model of why some things are fast and others are not. Nearly every performance
+question reduces to one of two facts: *matrix multiplies are cheap, memory
+traffic is not*, and *communication is the tax on parallelism*.
+
+## 5.1 What a GPU is
+
+A CPU is optimized for latency on one thread. A GPU is optimized for throughput
+across tens of thousands.
+
+- **SM (streaming multiprocessor)** — the unit of scheduling. An H100 has 132.
+  Each runs many **warps** (groups of 32 threads executing in lockstep).
+- **CUDA cores** — general FP32/INT arithmetic.
+- **Tensor cores** — dedicated matrix-multiply-accumulate units. They are where
+  essentially all of a transformer's advertised FLOPs live; anything that is not
+  a matmul is running at a small fraction of peak.
+- **Memory hierarchy** — the important part:
+
+| Level | Size | Bandwidth | Latency |
+|---|---|---|---|
+| Registers | ~256 KB/SM | ~20 TB/s | ~1 cycle |
+| Shared memory / L1 | ~228 KB/SM | ~10 TB/s | ~30 cycles |
+| L2 | ~50 MB | ~5 TB/s | ~200 cycles |
+| HBM (global) | 80–192 GB | 3–8 TB/s | ~400–800 cycles |
+| Host RAM over PCIe | TB | ~64 GB/s | very slow |
+
+Two orders of magnitude separate registers from HBM. Kernel optimization is
+mostly the art of touching HBM as few times as possible — which is precisely
+what FlashAttention (§1.3) does, and what kernel *fusion* does in general:
+combining `x → norm → matmul → activation` into one kernel so intermediates never
+round-trip to HBM.
+
+## 5.2 The roofline model
+
+Everything above collapses into one picture. For a kernel doing $F$ FLOPs while
+moving $B$ bytes, arithmetic intensity is $I = F/B$. Achievable performance is
+
+$$\text{FLOP/s} = \min\big(\text{peak FLOP/s},\; I \times \text{bandwidth}\big)$$
+
+The crossover — machine balance — is $\text{peak} / \text{bandwidth}$. For an
+H100 that is roughly $990\,\text{TFLOP/s} \div 3.35\,\text{TB/s} \approx 300$
+FLOP/byte. Below that intensity you are memory-bound; above it, compute-bound.
+
+Where common operations land:
+
+| Operation | Intensity | Verdict |
+|---|---|---|
+| Large GEMM (prefill, training) | ~1000s | Compute-bound — good |
+| Decode at batch 1 | ~1 | Hopelessly memory-bound |
+| Decode at batch 256 | ~256 | Approaching balance |
+| RMSNorm, softmax, residual add | <10 | Memory-bound → must be fused |
+| All-reduce | 0 | Pure communication |
+
+This one table explains continuous batching, speculative decoding, kernel fusion,
+and disaggregation all at once. Reread §2.1 with it in mind.
+
+## 5.3 Precision formats
+
+| Format | Bits (E/M) | Range | Where used |
+|---|---|---|---|
+| FP32 | 8/23 | huge | Master weights, optimizer moments, reductions |
+| TF32 | 8/10 | FP32 range | Transparent tensor-core FP32 replacement |
+| **BF16** | 8/7 | FP32 range | The training default |
+| FP16 | 5/10 | narrow | Legacy; needs loss scaling |
+| FP8 E4M3 | 4/3 | small | Forward activations/weights on Hopper+ |
+| FP8 E5M2 | 5/2 | larger | Gradients (need range more than precision) |
+| FP4 (NVFP4/MXFP4) | — | tiny | Blackwell inference; relies on block scales |
+
+Rule of thumb: **tensor-core throughput roughly doubles each time you halve the
+bit width.** That is the entire economic argument for low precision, and it is
+also the source of the train–inference numerical gap in §4.8 — the inference
+engine takes the FP8/FP4 deal, the trainer usually does not.
+
+Two things stay in FP32 regardless: accumulation inside a matmul, and the
+optimizer state (§3.4).
+
+## 5.4 Accelerators you will see in this stack
+
+Approximate figures — always check the live catalog and pricing rather than
+trusting numbers written down anywhere, including here.
+
+| GPU | HBM | Bandwidth | Notes |
+|---|---|---|---|
+| A100 | 40/80 GB | ~2.0 TB/s | Ampere; no FP8 |
+| H100 | 80 GB | ~3.35 TB/s | Hopper; FP8; ~990 TFLOP/s BF16 dense |
+| H200 | 141 GB | ~4.8 TB/s | Same compute as H100, much more memory → bigger KV cache |
+| B200 | 192 GB | ~8 TB/s | Blackwell; FP4; roughly 2× H100 BF16 |
+| B300 | ~288 GB | higher | Blackwell Ultra |
+| GB300 | rack-scale | NVL72 domain | Grace CPU + Blackwell, 72 GPUs in one NVLink domain |
+
+The H100 → H200 jump is instructive: **identical compute, 76% more memory
+bandwidth and capacity.** For decode that is nearly a 1.4× throughput win purely
+from memory, and it enables much longer context at the same batch size. Memory,
+not FLOPs, is usually the binding constraint for serving.
+
+Interconnect matters as much as the chips:
+
+- **NVLink / NVSwitch** — intra-node GPU-to-GPU, ~900 GB/s per GPU on H100.
+- **InfiniBand / RoCE** — inter-node, ~400 Gb/s (50 GB/s) per NIC.
+
+That is an order of magnitude difference, and it dictates parallelism placement
+(§5.7): chatty parallelism strategies must stay inside a node.
+
+## 5.5 Collectives
+
+Distributed training is built on a few collective primitives: `all-reduce` (sum
+across ranks, everyone gets the result), `all-gather`, `reduce-scatter`,
+`all-to-all` (the MoE expert-routing pattern).
+
+Ring all-reduce of $S$ bytes over $P$ ranks moves
+
+$$2\,\frac{P-1}{P}\,S \ \text{bytes per rank} \;\approx\; 2S$$
+
+so its time is essentially $2S/\text{bandwidth}$, independent of $P$ — which is
+why data parallelism scales well. The practical trick is **overlap**: start
+reducing layer $\ell$'s gradients while layer $\ell-1$ is still computing its
+backward, hiding communication behind compute.
+
+## 5.6 Sharding the training state: ZeRO/FSDP
+
+From §3.5, full-parameter AdamW costs ~16 bytes per parameter. ZeRO shards it
+across $P$ data-parallel ranks in stages:
+
+| Stage | Sharded | Bytes/param/GPU |
+|---|---|---|
+| 0 (plain DDP) | nothing | 16 |
+| 1 | optimizer state | $4 + 12/P$ |
+| 2 | + gradients | $2 + 14/P$ |
+| **3 / FSDP** | + parameters | $16/P$ |
+
+Stage 3 (PyTorch's FSDP) keeps only a shard of each layer resident and
+`all-gather`s the full layer just before using it, then frees it. Memory becomes
+$O(1/P)$; the cost is an extra all-gather per layer per forward and per backward.
+
+**HSDP (hybrid sharded data parallel)** is the practical compromise: shard
+*within* a node (over fast NVLink) and *replicate* across nodes (so inter-node
+traffic is one all-reduce per step instead of per-layer all-gathers). This is
+what `TrainerConfig.replica_count` refers to in the cookbook — the number of
+data-parallel replicas of the sharded group.
+
+## 5.7 The parallelism zoo
+
+| Strategy | Splits | Communication | Placement |
+|---|---|---|---|
+| **Data (DP)** | the batch | all-reduce of gradients per step | Across nodes |
+| **Tensor (TP)** | individual matrices | all-reduce **twice per layer** | Inside a node only |
+| **Pipeline (PP)** | layer groups | point-to-point activations | Across nodes; needs micro-batches to fill the bubble |
+| **Expert (EP)** | MoE experts | all-to-all per MoE layer | Depends on expert count |
+| **Context/Sequence (CP/SP)** | the sequence | ring attention passes | Long-context training |
+
+Real jobs compose these ("4D parallelism"). The placement rule follows from
+§5.4: TP is the chattiest, so it goes on NVLink inside a node; PP and DP tolerate
+slower links and go across nodes.
+
+PP has a distinctive failure mode, the **bubble**: with $S$ stages and $M$
+micro-batches, the fraction of time stages sit idle is $(S-1)/(M+S-1)$. You need
+$M \gg S$ to amortize it, which is one reason pipeline parallelism interacts
+badly with small batches.
+
+## 5.8 Why "training shapes" exist
+
+Choosing accelerator type, count, node count, parallelism degrees, and context
+limits for a given model is expert work, and getting it wrong wastes money in
+ways that are hard to notice. Fireworks packages the answer as a **training
+shape** — one ID that pins the hardware and topology:
+
+```16:21:skills/fireworks-training/references/models-shapes-and-cost.md
+service = FiretitanServiceClient.from_firetitan_config(
+    api_key=api_key,
+    base_model="accounts/fireworks/models/qwen3p5-9b",
+    training_shape_id="accounts/fireworks/trainingShapes/qwen3p5-9b-256k",
+    lora_rank=0,   # 0 = full-parameter; positive int (16, 64…) = LoRA
+)
+```
+
+The shape owns `acceleratorType`, `acceleratorCount`, `nodeCount`,
+`maxSupportedContextLength`, the trainer image, and the linked deployment shape.
+You own `base_model`, `lora_rank`, `learning_rate`, and replica counts. The
+cookbook actively deprecates manual overrides:
+
+```154:157:training/utils/config.py
+    accelerator_type: str | None = None
+    """Deprecated and ignored. Trainer accelerator type is owned by the
+    training shape; setting this emits a ``DeprecationWarning``. Use
+    ``replica_count`` for data-parallel scaling."""
+```
+
+The same philosophy applies to region: leave it unset and let the backend place
+the trainer and its deployment together, rather than pinning a region and
+accidentally splitting a colocated pair across a network boundary
+([`CLAUDE.md`](../CLAUDE.md)).
+
+## 5.9 Back-of-envelope cost
+
+Two formulas cover most planning questions.
+
+**Training compute** (from §1.9):
+
+$$\text{GPU-hours} \approx \frac{6 N \cdot T_\text{tokens}}{\text{peak FLOP/s} \times \text{MFU} \times 3600}$$
+
+with MFU (model FLOPs utilization) realistically 0.3–0.5 for a well-tuned
+full-parameter run.
+
+**Serving throughput** (from §2.1–2.2):
+
+$$\text{tokens/s} \approx \frac{B}{\text{decode step time}}, \qquad \text{decode step time} \gtrsim \frac{\text{model bytes} + B \cdot \text{KV bytes read}}{\text{HBM bandwidth}}$$
+
+and $B$ itself is capped by KV cache capacity:
+$B_\text{max} \approx (\text{HBM} - \text{weights}) / (\text{KV bytes/token} \times n)$.
+
+The operational punchline from
+[`models-shapes-and-cost.md`](../skills/fireworks-training/references/models-shapes-and-cost.md):
+**for dedicated deployments the dominant cost is usually uptime, not tokens.** A
+small LoRA SFT job costs cents; a GPU left running for a week costs hundreds to
+thousands of dollars. Scale to zero, and tear down deployments you are not using.
+
+---
+
+**Next:** [6. The Fireworks stack map](fireworks-stack-map.md) — where all of this
+lives in the code.

--- a/learning/inference.md
+++ b/learning/inference.md
@@ -1,0 +1,272 @@
+# 2. Inference: KV caches, batching, speculation, disaggregation
+
+Serving an LLM is mostly a **memory-movement** problem. The math from part 1 is
+cheap; moving weights and cached state through the memory hierarchy is not. Every
+technique in this file exists to move fewer bytes, or to get more useful work out
+of the bytes you already moved.
+
+## 2.1 Two phases with opposite bottlenecks
+
+Generating a response has two distinct stages:
+
+**Prefill** — process the whole prompt ($n$ tokens) in one forward pass. All
+positions are known, so this is a batch of big matrix multiplies. It is
+**compute-bound**: you do $2N \cdot n$ FLOPs while reading the weights once.
+Latency here is **TTFT** (time to first token).
+
+**Decode** — generate tokens one at a time. Each step processes exactly one new
+token but must read *every weight in the model* to do it. It is
+**memory-bandwidth-bound**: one token of work for gigabytes of weight traffic.
+Latency here is **TPOT/ITL** (time per output token / inter-token latency).
+
+A single formula makes the asymmetry obvious. Define **arithmetic intensity** as
+FLOPs performed per byte read. For decode at batch size $B$ with an $N$-parameter
+model in 2-byte precision:
+
+$$\text{FLOPs} \approx 2NB, \qquad \text{bytes} \approx 2N \ (\text{weights, read once regardless of } B)$$
+$$\text{intensity} \approx B$$
+
+Modern accelerators need intensity in the hundreds to saturate their tensor
+cores. At $B = 1$ you are using well under 1% of the FLOPs. **This single fact
+motivates continuous batching, speculative decoding, and disaggregation.**
+
+Concretely: an 8B model in bf16 is 16 GB. An H200 has ~4.8 TB/s of HBM
+bandwidth, so the floor on one decode step is $16/4800 \approx 3.3$ ms → about
+300 tokens/s, *no matter how fast the GPU's math units are*. The only way to do
+better per GPU is to serve more sequences with those same weight reads, or to
+produce more than one token per weight read.
+
+## 2.2 The KV cache
+
+During decode at step $t$, attention for the new token needs $k_j$ and $v_j$ for
+all $j < t$. Because of causal masking, those tensors **do not change** when new
+tokens are appended — position 5's key is the same whether the sequence is 6 or
+6000 tokens long. So you compute them once and keep them.
+
+Without a cache, generating $n$ tokens re-runs the full prefix each step:
+$O(n^2)$ total work. With a cache, each step is $O(1)$ model work plus an
+$O(t)$ attention read. The KV cache is not an optimization detail; it is what
+makes autoregressive generation tractable.
+
+### How big is it?
+
+Per token, you store one key and one value vector per KV head per layer:
+
+$$\boxed{\text{bytes/token} = 2 \times L \times g \times d_h \times \text{bytes\_per\_element}}$$
+
+where $g$ is the number of **KV** heads (§1.5). Worked examples in bf16:
+
+| Model | $L$ | $g$ | $d_h$ | Bytes/token | 32k context | 32k × 64 concurrent |
+|---|---|---|---|---|---|---|
+| 8B-class (GQA) | 32 | 8 | 128 | 128 KB | 4.2 GB | 268 GB |
+| 70B-class (GQA) | 80 | 8 | 128 | 320 KB | 10.5 GB | 671 GB |
+| 70B with MHA (hypothetical) | 80 | 64 | 128 | 2.5 MB | 84 GB | — |
+
+Read that table again: at long context and real concurrency, **the KV cache is
+larger than the model weights**. It, not the parameter count, sets your maximum
+batch size, and maximum batch size sets your throughput and therefore your cost
+per token. Everything follows from here:
+
+- **GQA/MLA** (§1.5) shrink $g$ or replace it with a latent.
+- **KV quantization** to FP8 or INT8 halves it again, at some accuracy risk.
+- **Paged allocation** stops you wasting it.
+- **Prefix reuse** stops you rebuilding it.
+
+### PagedAttention
+
+Naively you reserve a contiguous buffer per request sized to `max_tokens`. Most
+requests finish early, so you waste most of it, and the leftover holes are
+unusable (external fragmentation). **PagedAttention** borrows virtual memory:
+split the cache into fixed-size blocks (e.g. 16 tokens), keep a per-sequence
+block table, and let a sequence's blocks live anywhere in HBM. Waste drops to
+under one block per sequence, and blocks become *shareable* — several beams or
+several requests with the same prefix can point at the same physical block with a
+reference count.
+
+### Prefix caching and session affinity
+
+If two requests share a prefix — a long system prompt, a few-shot preamble, or
+the earlier turns of a conversation — the KV blocks for that prefix are
+identical, and the second request can skip prefilling them entirely.
+
+This is a big deal for **multi-turn** workloads (agents, tool use, RL rollouts).
+Turn $k$ of a conversation contains all of turns $1..k-1$, so naive per-token
+billing re-prefills the whole history every turn: cost grows quadratically in the
+number of turns. Fireworks dedicated deployments use **session-affinity
+routing** — route a conversation's turns back to the replica that already holds
+its KV blocks — so the history is reused rather than recomputed. This is called
+out in
+[`skills/fireworks-training/references/models-shapes-and-cost.md`](../skills/fireworks-training/references/models-shapes-and-cost.md)
+as one of the main reasons dedicated GPU-hour pricing can beat per-token pricing
+for agentic workloads.
+
+## 2.3 Continuous batching
+
+Static batching — collect $B$ requests, run them together, wait for all to finish
+— wastes enormous capacity, because generation lengths vary by an order of
+magnitude and the whole batch runs until its slowest member is done.
+
+**Continuous batching** (a.k.a. iteration-level scheduling) makes the scheduling
+decision at every decode step instead: when a sequence emits its EOS token, evict
+it and admit a waiting request into that slot immediately. Combined with paged KV
+blocks, the batch composition is fluid and the GPU stays full.
+
+**Chunked prefill** completes the picture. A 20k-token prefill occupies the GPU
+long enough to stall every decode in flight, producing visible stutter. Split the
+prefill into chunks and interleave them with decode steps: TTFT for the new
+request degrades slightly, TPOT for everyone else stays smooth.
+
+The knob you will meet in this repo is on the *client* side of that queue.
+`ConcurrencyConfig.prefill_queue_target` (`training/utils/config.py`) drives an
+AIMD (additive-increase/multiplicative-decrease) controller —
+`AdaptiveConcurrencyController` in the SDK — that raises in-flight request count
+while the server's reported `prefill_queue_duration` stays under target and backs
+off when it does not. It is congestion control, TCP-style, for rollout traffic.
+
+## 2.4 Speculative decoding
+
+Decode is memory-bound (§2.1), so a forward pass over 1 token and a forward pass
+over 5 tokens cost *almost the same wall-clock time* — both read all the weights,
+and the extra math is nearly free. Speculative decoding converts that slack into
+tokens.
+
+**The algorithm.** Let $p$ be the target (real) model and $q$ a cheap **draft**.
+
+1. Draft $\gamma$ tokens autoregressively with $q$ (cheap: small model, or no
+   model at all).
+2. Run the target **once** over all $\gamma$ proposed positions in parallel,
+   obtaining $p(\cdot \mid \text{prefix} + \text{first } j \text{ drafts})$ for
+   every $j$.
+3. Accept or reject each draft token in order by rejection sampling.
+
+**Why it is exact.** For draft token $x$ drawn from $q$, accept it with
+probability
+
+$$\min\!\left(1, \frac{p(x)}{q(x)}\right)$$
+
+If rejected, stop and sample the replacement from the normalized residual
+distribution
+
+$$p'(x) = \frac{\max\big(0,\; p(x) - q(x)\big)}{\sum_{x'} \max\big(0,\; p(x') - q(x')\big)}$$
+
+The composition of these two steps is provably distributed exactly as $p$. So
+speculative decoding is a **pure latency optimization** — with a correct
+implementation the output distribution is unchanged, no matter how bad the draft
+model is. A bad draft just means low acceptance and little speedup.
+
+**How much it wins.** With per-token acceptance probability $\alpha$, the expected
+number of tokens produced per verification pass is
+
+$$\mathbb{E}[\text{tokens}] = \frac{1 - \alpha^{\gamma+1}}{1 - \alpha}$$
+
+At $\alpha = 0.8, \gamma = 4$: $\approx 3.4$ tokens per target pass — roughly a 2–3×
+latency win after draft overhead. Note the diminishing return in $\gamma$: each
+extra speculated token only pays off if all previous ones were accepted.
+
+**Flavors**, cheapest to most accurate:
+
+| Method | Draft source | Notes |
+|---|---|---|
+| Prompt lookup / n-gram | Copy from context | Free; excellent for summarization, code edits, RAG (lots of verbatim reuse) |
+| Draft model | A small model of the same family | Classic; needs a matched tokenizer |
+| Medusa | Extra heads on the target predicting $t+2, t+3, \dots$ | No separate model; tree-structured candidates |
+| EAGLE / EAGLE-2/3 | Autoregress on the target's *hidden features*, not tokens | Highest acceptance rates today; the usual default |
+
+**When to turn it off.** Speculation trades FLOPs for latency. If the server is
+already saturated — large batches, throughput-oriented offline workloads — those
+FLOPs are not free anymore, and rejected drafts are pure waste; throughput can go
+*down*. That is why this repo exposes it as a deployment flag rather than
+enabling it unconditionally:
+
+```250:251:training/utils/config.py
+    disable_speculative_decoding: bool = False
+    """When true, disable the base model's default draft/EAGLE speculation."""
+```
+
+For RL rollouts there is a second reason to care. Rollouts need per-token
+logprobs from the sampler, and different speculative implementations can report
+those slightly differently from a plain decode path. Any such discrepancy shows
+up downstream as train–inference mismatch, which part 4 handles explicitly with
+TIS (§4.8) and observability metrics that compare the trainer's logprobs against
+the raw inference logprobs (`training/utils/rl/observability.py`). If those
+metrics look pathological, toggling `disable_speculative_decoding` is a
+legitimate bisection step.
+
+## 2.5 Disaggregated prefill/decode
+
+Prefill and decode want opposite things from the hardware (§2.1) and, on a shared
+replica, they fight:
+
+- A long prefill monopolizes the SMs and stalls every in-flight decode → ugly
+  inter-token-latency spikes.
+- Decode's tiny batches leave the tensor cores idle → wasted compute.
+- They also want different parallelism: prefill likes tensor parallelism to cut
+  TTFT; decode often prefers less TP and more replicas, since it is bandwidth-
+  bound and TP adds all-reduce latency per step.
+
+**Disaggregation** ("disagg", also P/D disaggregation) runs them as separate
+pools of workers. A request is prefilled on a prefill worker, its KV cache is
+transferred over the interconnect (NVLink within a node, RDMA/InfiniBand across
+nodes) to a decode worker, and generation proceeds there.
+
+The trade:
+
+- **Win:** each pool is scheduled and scaled for one bottleneck; TTFT and TPOT
+  can be tuned independently and both SLOs met; no head-of-line blocking.
+- **Cost:** you must ship the whole KV cache for the prompt across the network —
+  tens to hundreds of MB per request (see the table in §2.2) — so it only pays
+  off with fast interconnect and reasonably long prompts. Below some prompt
+  length, chunked prefill on a colocated replica wins.
+
+Disaggregation is a serving-side architecture decision made by the platform, not
+a cookbook config. What surfaces to you is its *effect*: the
+`prefill_queue_duration` signal that the adaptive concurrency controller in §2.3
+reacts to.
+
+> Terminology warning: this repo also uses the word "disaggregate" for something
+> completely different. `training/renderer/_disaggregate_mixin.py` splits a
+> multi-turn conversation into one supervised example per assistant turn, so
+> thinking-model traces are trained with the right visibility. Same word,
+> unrelated concept.
+
+## 2.6 Quantization and why training cares
+
+Serving in lower precision reduces both weight bytes (→ faster decode, §2.1) and
+KV bytes (→ bigger batches, §2.2):
+
+| Format | Bits | Typical use |
+|---|---|---|
+| BF16 | 16 | Training default; the numerical reference point |
+| FP8 (E4M3) | 8 | Weights + activations on Hopper/Blackwell; near-lossless with per-tensor or per-block scales |
+| INT8 / INT4 | 8 / 4 | Weight-only quantization (AWQ, GPTQ); good for memory-bound decode |
+| FP4 (NVFP4/MXFP4) | 4 | Blackwell-class; block scaling factors do the heavy lifting |
+
+The key idea is **per-block scaling**: store a low-precision mantissa plus a
+higher-precision scale for each small group of values, so outliers do not destroy
+the whole tensor's dynamic range.
+
+For this repo, the important downstream consequence is that **the inference
+engine and the trainer are not numerically the same function.** They differ in
+precision, in kernels, in reduction order, in parallelism layout, possibly in
+MoE routing (§1.7), and possibly in speculation (§2.4). Feed the same tokens
+through both and you get different logprobs. During supervised training this is
+harmless. During RL it silently biases your gradient, which is exactly what TIS
+(§4.8) exists to correct.
+
+## 2.7 Serving metrics vocabulary
+
+| Metric | Meaning | Driven by |
+|---|---|---|
+| TTFT | Time to first token | Prefill compute, queueing, prefix cache hit rate |
+| TPOT / ITL | Time per output token | HBM bandwidth, batch size, TP degree |
+| Throughput | Total tokens/s across all requests | Batch size, therefore KV cache capacity |
+| Goodput | Throughput that actually met its SLO | Scheduling quality |
+| MFU | Model FLOPs utilization vs peak | High in prefill/training, low in decode |
+
+The recurring tension: batching raises throughput and lowers cost per token, but
+raises per-request latency. Speculation lowers latency but spends FLOPs.
+Disaggregation lets you stop making that trade globally and make it per phase.
+
+---
+
+**Next:** [3. Training](training.md) — forward, backward, optimizer step, and LoRA.

--- a/learning/reinforcement-learning.md
+++ b/learning/reinforcement-learning.md
@@ -1,0 +1,473 @@
+# 4. Reinforcement learning for LLMs
+
+SFT and DPO learn from data you already have. RL learns from an objective you can
+*evaluate* but not differentiate: did the unit test pass, did the agent finish the
+task, is the answer numerically correct. That single change — the label is
+replaced by a reward computed on the model's own output — forces inference and
+training into the same loop, and every hard part of this file follows from that
+coupling.
+
+## 4.1 The setup
+
+Frame generation as a sequential decision problem:
+
+| RL term | LLM meaning |
+|---|---|
+| State $s_t$ | prompt + tokens generated so far |
+| Action $a_t$ | the next token |
+| Policy $\pi_\theta(a_t \mid s_t)$ | the model's next-token distribution |
+| Trajectory / episode | one complete completion (or a full multi-turn agent run) |
+| Reward $R$ | a scalar from your `reward_fn`, usually only at the end |
+
+Objective: maximize expected reward.
+
+$$J(\theta) = \mathbb{E}_{x \sim \mathcal{D},\; y \sim \pi_\theta(\cdot|x)}\big[R(x,y)\big]$$
+
+Two structural features of the LLM case shape everything:
+
+- **Rewards are terminal and sparse.** You usually cannot score a partial
+  completion; credit for a 2000-token trajectory must be assigned from one final
+  number.
+- **The action space is enormous** ($V \approx 10^5$ per step) but the policy is
+  already very good, so exploration is a matter of sampling temperature rather
+  than of random search.
+
+## 4.2 The policy gradient
+
+$J$ is an expectation over samples *from the thing you are differentiating*, so
+you cannot just backprop through it. The log-derivative trick fixes that. Using
+$\nabla p = p \nabla \log p$:
+
+$$\nabla_\theta J = \nabla_\theta \sum_y \pi_\theta(y|x) R(y) = \sum_y \pi_\theta(y|x)\, \nabla_\theta \log \pi_\theta(y|x)\, R(y) = \mathbb{E}_{y\sim\pi_\theta}\big[R(y)\,\nabla_\theta \log \pi_\theta(y|x)\big]$$
+
+And since $\log \pi_\theta(y|x) = \sum_t \log \pi_\theta(a_t|s_t)$:
+
+$$\boxed{\ \nabla_\theta J = \mathbb{E}\left[\sum_{t} R \cdot \nabla_\theta \log \pi_\theta(a_t \mid s_t)\right]}$$
+
+This is **REINFORCE**, and it is remarkably simple: *increase the logprob of
+every token in a good trajectory, decrease it in a bad one, proportionally to how
+good.* No differentiable reward required — $R$ is just a number multiplying a
+gradient you already know how to compute.
+
+It is also very high variance. If every reward is between 8 and 10, REINFORCE
+pushes *up* on everything, and the useful signal (the differences) is buried in
+the common term.
+
+## 4.3 Baselines and advantages
+
+Subtract any function $b(x)$ that does not depend on the action. It leaves the
+gradient unbiased, because $\mathbb{E}[\nabla \log \pi] = 0$:
+
+$$\sum_y \pi_\theta \nabla \log \pi_\theta \cdot b = b \sum_y \nabla \pi_\theta = b\,\nabla \underbrace{\textstyle\sum_y \pi_\theta}_{=1} = 0$$
+
+Define the **advantage** $A = R - b$: "how much better than typical was this?"
+Choosing $b \approx \mathbb{E}[R]$ minimizes variance and gives you the right
+semantics — trajectories better than average get pushed up, worse than average
+get pushed down.
+
+Classic PPO learns $b$ with a **value network** (a second model of comparable
+size predicting expected return, trained with GAE). That doubles memory and adds
+its own training instability.
+
+### GRPO: the baseline is the group
+
+**Group Relative Policy Optimization** throws away the value network. Sample $G$
+completions for the *same* prompt and let them be each other's baseline:
+
+$$\boxed{\ A_i = \frac{r_i - \mathrm{mean}(r_1,\dots,r_G)}{\mathrm{std}(r_1,\dots,r_G)}\ }$$
+
+Why this works so well for LLMs: the value function's job is to say "how hard is
+this prompt," and $G$ samples from the same prompt answer that empirically for
+free. It also self-normalizes reward scale, so a hand-written `reward_fn`
+returning values in $[0,1]$ or $[0,100]$ behaves the same.
+
+Two consequences you meet immediately in practice:
+
+- **$G \ge 2$ is mandatory** — $\mathrm{std}$ of one sample is undefined. The
+  cookbook refuses to start otherwise, with an error message explaining the exact
+  failure mode it prevents:
+
+```299:307:training/recipes/async_rl_loop.py
+    if cfg.completions_per_prompt < 2:
+        raise ValueError(
+            "async_rl_loop requires cfg.completions_per_prompt >= 2: the "
+            "default GRPO-style advantage normalizer (z-score by "
+            "torch.std(rewards)) is undefined on length-1 reward tensors "
+            "and would drop every group, silently consuming the dataset "
+            "without ever training.  Set completions_per_prompt >= 2 (the "
+            f"default is 4); got {cfg.completions_per_prompt}."
+        )
+```
+
+- **Zero-variance groups teach nothing.** If all $G$ completions are correct (or
+  all wrong), every $A_i = 0$ and the group contributes no gradient while still
+  costing full rollout compute. Hence *dynamic filtering* (drop such groups, a
+  DAPO idea, exposed here as `dynamic_filter_fn`) and curriculum design that
+  keeps prompts near the model's current ability. A prompt set that is too easy
+  or too hard produces a beautifully stable run that learns nothing.
+
+## 4.4 Why you cannot just take one big step
+
+The policy gradient is valid *at* $\theta$. Take a large step and the data you
+collected no longer describes your policy, and the estimate becomes garbage —
+sometimes catastrophically, since a bad policy generates bad data which produces
+a worse policy.
+
+Classic answers: a trust region (TRPO's constrained optimization — correct but
+expensive). PPO's answer is a cheap first-order surrogate: define the
+probability ratio between the current policy and the one that generated the data,
+
+$$\rho_t(\theta) = \frac{\pi_\theta(a_t|s_t)}{\pi_{\theta_\text{old}}(a_t|s_t)} = \exp\big(\log \pi_\theta - \log \pi_{\theta_\text{old}}\big)$$
+
+and optimize the **clipped surrogate**:
+
+$$\boxed{\ \mathcal{L}^{\text{PPO}} = -\mathbb{E}\Big[\min\big(\rho_t A_t,\; \mathrm{clip}(\rho_t, 1-\epsilon, 1+\epsilon)\, A_t\big)\Big]}$$
+
+The `min` is the whole trick, and it is asymmetric on purpose:
+
+- $A_t > 0$ (good action): the objective is capped at $(1+\epsilon)A_t$. Once the
+  probability has risen enough, further increases earn nothing → no gradient →
+  no runaway.
+- $A_t < 0$ (bad action): capped at $(1-\epsilon)A_t$, so you cannot drive the
+  probability to zero in one step.
+- But if the ratio moves in the *wrong* direction, the unclipped term is worse
+  and `min` selects it, so the gradient still pulls you back. Clipping only
+  removes the incentive to over-shoot; it never removes the correction.
+
+Note ratios are computed in log space and exponentiated: logprobs are the natural
+output of the model, and subtracting before exponentiating avoids underflow.
+
+## 4.5 Staying near the reference: KL penalties
+
+Even with clipping, thousands of steps of reward maximization drift the model
+away from being a good language model — it discovers degenerate strategies that
+score well and read badly (**reward hacking**). Add a KL penalty to a frozen
+reference (usually the SFT starting point):
+
+$$\mathcal{L} = \mathcal{L}^{\text{PPO}} + \beta_{\text{KL}} \cdot \mathrm{KL}(\pi_\theta \,\|\, \pi_\text{ref})$$
+
+You cannot compute that KL exactly (it is a sum over the whole vocabulary at
+every position), so you estimate it from the sampled tokens. With
+$r = \log \pi_\text{ref} - \log \pi_\theta$ on a sample from $\pi_\theta$:
+
+| Estimator | Formula | Property |
+|---|---|---|
+| k1 | $-r$ | Unbiased, high variance, can be negative |
+| k2 | $r^2/2$ | Low variance, biased |
+| **k3** | $e^{r} - r - 1$ | **Unbiased, always $\ge 0$, low variance** |
+
+k3 is the standard choice, and it is what the cookbook uses:
+
+```95:98:training/utils/rl/grpo.py
+        ref_log_ratio = ctx.resp_ref - ctx.resp_pi
+        ref_kl = torch.exp(ref_log_ratio) - ref_log_ratio - 1.0
+        kl_penalty = kl_beta * ref_kl
+        per_token_loss = (torch.maximum(surr1, surr2) * ctx.tis_weight + kl_penalty) * ctx.resp_mask
+```
+
+(k3 is unbiased because $\mathbb{E}_{q}[e^{r}] = \sum q \cdot p/q = 1$, so
+$\mathbb{E}[e^r - r - 1] = \mathbb{E}[-r] = \mathrm{KL}$; and $e^r - r - 1 \ge 0$
+for all real $r$, so unlike k1 it never reports a negative divergence.)
+
+$\beta_\text{KL}$ is typically small — `kl_beta: float = 0.001` in the RL config —
+and setting it to 0 (no reference model at all) is common for verifiable-reward
+tasks like math and code, where the reward is hard to hack. The recipe validates
+that combination: configuring a reference trainer with `kl_beta = 0` is an error,
+because you would be paying for a model whose output is multiplied by zero.
+
+## 4.6 Putting the GRPO loss together
+
+Read the implementation directly — it is the clearest statement of everything
+above:
+
+```84:98:training/utils/rl/grpo.py
+    def policy_fn(ctx):
+        log_ratio = torch.clamp(ctx.resp_pi - ctx.resp_old_policy, min=-SAFETY_CLAMP, max=SAFETY_CLAMP)
+        ratio = torch.exp(log_ratio)
+        clipped_ratio = torch.clamp(ratio, min=1.0 - eps_clip, max=1.0 + _eps_high)
+
+        active = ctx.resp_mask > 0.5
+        clip_frac = (clipped_ratio[active] != ratio[active]).float().mean().item()
+        ratio_mean = ratio.detach()[active].mean().item()
+
+        surr1 = -ratio * ctx.adv
+        surr2 = -clipped_ratio * ctx.adv
+        ref_log_ratio = ctx.resp_ref - ctx.resp_pi
+        ref_kl = torch.exp(ref_log_ratio) - ref_log_ratio - 1.0
+        kl_penalty = kl_beta * ref_kl
+        per_token_loss = (torch.maximum(surr1, surr2) * ctx.tis_weight + kl_penalty) * ctx.resp_mask
+```
+
+Line by line:
+
+- `surr1`/`surr2` are negated because this is a **loss** to minimize;
+  `torch.maximum` of the two negatives is exactly $-\min(\rho A, \mathrm{clip}(\rho)A)$.
+- `resp_mask` zeroes prompt tokens and any masked spans (tool outputs,
+  environment text) — you only take gradient on tokens the policy actually chose.
+- `tis_weight` multiplies the **policy term only**, not the KL penalty. The KL is
+  a regularizer on the current policy, not an expectation over rollout data, so
+  it needs no importance correction.
+- `SAFETY_CLAMP = 20.0` on the log ratio prevents `exp` from producing `inf`
+  before the clip can act.
+- `clip_frac` is the single most useful RL health metric. Near 0 means your steps
+  are timid; persistently high (>0.2) means the policy is trying to move much
+  further than the trust region allows — usually LR too high, or data too stale.
+
+### Variants you will see in `training/utils/rl/`
+
+| Loss | Change | Why |
+|---|---|---|
+| **GRPO** | Token-level clipped ratio + group advantage | The default |
+| **DAPO** | Decoupled clip range (higher upper bound), dual clip, dynamic sampling, token-level normalization | Preserves entropy, prevents long-response collapse |
+| **GSPO** | Ratio computed at **sequence** level (geometric mean of token ratios) | Much more stable for MoE, where a single token's routing flip can blow up a token-level ratio |
+| **CISPO** | Clip the IS weight but **detach** it, keeping a REINFORCE-style $\hat\rho \cdot \log\pi \cdot A$ term | Every token keeps contributing gradient instead of being zeroed by clipping |
+| **REINFORCE / RLOO** | No ratio, leave-one-out baseline | Simplest baseline to compare against |
+| **DRO** | Direct reward optimization | Offline-friendly |
+
+There is deliberately **no runtime loss selector** in the canonical recipes — you
+fork the recipe and swap the call. That keeps the code path you are debugging
+identical to the code path you read.
+
+## 4.7 On-policy vs off-policy
+
+**On-policy**: the data being trained on was generated by the current policy.
+**Off-policy**: it was generated by some other policy $\mu$ — an older version,
+a different model, or a human.
+
+Off-policy data needs an **importance sampling** correction, from the identity
+
+$$\mathbb{E}_{x \sim p}[f(x)] = \mathbb{E}_{x \sim q}\!\left[\frac{p(x)}{q(x)} f(x)\right]$$
+
+which is unbiased for any $q$ with matching support. The catch is variance: it
+scales with the ratio, and for a sequence of $T$ tokens the sequence-level ratio
+is a product of $T$ per-token ratios, so it goes exponentially wrong with length.
+Every practical algorithm therefore *clips or caps* the ratio, trading a little
+bias for a lot of variance reduction. PPO's clip (§4.4), TIS's cap (§4.8), and
+CISPO's detached clip are all the same trade with different placement.
+
+The spectrum in practice:
+
+| Setting | Data source | Correction |
+|---|---|---|
+| Strictly on-policy | Sampled from $\pi_\theta$ right now | None needed |
+| PPO minibatching | $\pi_{\theta_\text{old}}$ from a few gradient steps ago | Clipped ratio |
+| Async RL | $\pi_{\theta - k}$, $k$ policy versions stale | Clipped ratio + staleness budget |
+| Replay buffer / offline | Arbitrary $\mu$ | Heavy IS, often fails |
+
+## 4.8 The train–inference gap and TIS
+
+Here is the subtlety that makes production LLM RL different from the textbook.
+
+Rollouts are generated by an **inference engine**: FP8 weights, fused kernels,
+continuous batching, a particular tensor-parallel layout, maybe speculative
+decoding, maybe different MoE routing. Training runs on a **trainer**: bf16,
+different kernels, different sharding, different reduction order.
+
+Send the same tokens through both and the logprobs differ. Therefore even data
+sampled *microseconds ago from the current weights* is off-policy with respect to
+the function the trainer is differentiating. Ignore it and you get a biased
+gradient, and in the worst case a run that quietly diverges after hundreds of
+steps.
+
+**TIS (train–inference importance sampling)** applies the §4.7 correction to
+exactly this gap:
+
+$$w_t = \mathrm{clamp}\Big(\exp\big(\log \pi_\text{trainer}(a_t) - \log \pi_\text{inference}(a_t)\big),\ \max = \text{cap}\Big)$$
+
+```63:73:training/utils/rl/tis.py
+    tis_log = torch.clamp(
+        resp_old_policy - resp_inf, min=-SAFETY_CLAMP, max=SAFETY_CLAMP
+    )
+
+    if config.level == "sequence":
+        tis_raw = torch.exp(tis_log.mean()).expand_as(tis_log)
+    else:
+        tis_raw = torch.exp(tis_log)
+
+    tis_weight = torch.clamp(tis_raw, min=0.0, max=config.cap)
+    clip_frac = (tis_weight != tis_raw).float().mean().item()
+```
+
+Configuration (`TISConfig` in `training/utils/rl/tis.py`):
+
+- `cap: float = 5.0` — upper bound on the weight. Uncapped IS weights are the
+  classic way to blow up a run on one pathological token.
+- `level: "token" | "sequence"` — per-token weights, or the geometric mean of the
+  token ratios broadcast across the sequence (lower variance, coarser).
+- `icepop_threshold` — instead of down-weighting extreme tokens, **zero them
+  out**: `threshold=2.0` keeps ratios in $[0.5, 2.0]$ and discards the rest. The
+  reasoning is that a token whose two engines disagree by more than 2× is
+  probably a numerical artifact, not signal, and a capped-but-nonzero weight
+  still injects that artifact into the gradient.
+
+There is a related choice, `anchor_logp`:
+
+- `"old_policy"` (default) — run an extra forward pass on the trainer to get
+  $\log \pi_{\theta_\text{old}}$, use it as the PPO anchor, and let TIS correct
+  old-policy against rollout logprobs. More forward compute, cleanest math.
+- `"rollout"` — skip that forward pass and anchor PPO directly on the rollout
+  logprobs. TIS then degenerates to the identity. Cheaper; correctness now rests
+  on the inference logprobs being close enough.
+
+And the observability to tell whether any of this is working:
+`training/utils/rl/observability.py` reports the mean absolute logprob difference
+and a k3-style KL between the trainer and the raw inference logprobs. Rising
+`tis/clip_frac` or a growing train–inference KL means the two engines are
+drifting apart — investigate before trusting the reward curve.
+
+## 4.9 MoE router replay (R3)
+
+A special case of §4.8 with an outsized effect. In an MoE model (§1.7) the router
+picks top-$k$ experts by a discrete `argmax`-like operation. A one-ULP numerical
+difference between the inference engine and the trainer can flip an expert
+choice, which changes the computation *completely* for that token — not by a
+rounding error but by an entirely different sub-network. The logprob difference is
+then large and structured, and no amount of capping fixes it cleanly.
+
+**Router Replay** makes the inference engine return its routing matrices
+(`include_routing_matrix: true`) and feeds them to the trainer in
+`loss_fn_inputs`, so the trainer reproduces inference's expert assignments
+exactly. Both RL recipes default `router_replay=True`, with
+`router_replay_completion_only=True` so only completion tokens carry routing data
+(sending it for prompt tokens would require `echo=True` and cost far more
+serving bandwidth). Implementation: `training/utils/rl/router_replay.py`.
+
+## 4.10 Sync RL
+
+The straightforward loop, `training/recipes/rl_loop.py`:
+
+```
+for step in range(steps):
+    1. sample G completions for each of P prompts   (inference deployment)
+    2. score them with reward_fn, compute advantages (your code)
+    3. forward: reference logprobs, old-policy logprobs (trainer)
+    4. forward_backward_custom(GRPO loss) + optim_step (trainer)
+    5. save_weights_for_sampler + hotload to the deployment
+```
+
+Simple, easy to reason about, and structurally wasteful. Steps 1 and 3–4 use
+different hardware pools, and each idles while the other runs. Worse, step 1's
+duration is set by the **longest** completion in the batch — and generation
+lengths in reasoning or agentic workloads vary by 10× or more, so most rollout
+workers sit idle waiting for stragglers while the trainer waits for all of them.
+Rollout generation commonly dominates wall-clock time in a sync loop.
+
+## 4.11 Async RL
+
+`training/recipes/async_rl_loop.py` overlaps the two phases: a **producer**
+continuously generates rollouts while the trainer consumes completed batches.
+The GPUs on both sides stay busy.
+
+The price is staleness. A rollout started under policy version $v$ may be trained
+on when the policy is at $v + k$ — genuinely off-policy data. Async RL is
+therefore a *scheduling* problem: how much staleness will you tolerate to keep
+the pipeline full?
+
+Five knobs (from
+[`skills/fireworks-training/references/rl-async.md`](../skills/fireworks-training/references/rl-async.md)):
+
+| Field | Symbol | Meaning |
+|---|---|---|
+| `completions_per_prompt` | $G$ | Samples per dataset row (the GRPO group) |
+| `prompt_groups_per_step` | $P$ | Rows per optimizer batch |
+| `pipeline_chunks_per_step` | $K$ | Forward/backward chunks per optimizer batch |
+| `max_head_offpolicy_versions` | $O$ | Staleness budget, in published policy versions |
+| `max_concurrency_rollout_sample` | $C$ | Cap on in-flight rollout calls |
+
+The **admission gate** is where the theory becomes arithmetic. With batch size
+$B = P \cdot G$:
+
+```text
+staleness_capacity =
+    (published_version + max_head_offpolicy_versions + 1) * B
+    - (accepted_samples_offset + accepted_samples + reserved_samples)
+
+concurrency_capacity =
+    max_concurrency_rollout_sample - in_flight_samples   # infinite when unset
+
+admit one row iff min(staleness_capacity, concurrency_capacity) >= G
+```
+
+Read it as a credit system: each published policy version mints one batch worth
+of rollout credit, and a row is admitted only if it can pay for all $G$ of its
+samples at once (row-atomic, so a GRPO group is never split across versions).
+
+$O = 0$ is **fully on-policy**: every optimizer batch trains only on rollouts
+sampled from its current published version. Note that this does *not* disable
+overlap — with $K > 1$ the trainer can start on an early chunk while the rest of
+the same batch is still generating. Overlap-within-a-batch and
+staleness-across-batches are independent axes.
+
+If you want to keep a concurrency window of $C$ full, you need enough staleness
+headroom to have that many samples outstanding:
+
+$$O \ge \left\lceil \frac{C}{B} \right\rceil - 1$$
+
+**Both loops hot-load after every optimizer step.** Async does not mean "sync
+weights less often"; it means "admit rollouts that were started under older
+weights." Those are different things and conflating them is a common source of
+confusion.
+
+Tuning intuition: start at $O = 0$ and confirm the run learns. Raise $O$ until
+throughput stops improving or `clip_frac` / `tis/clip_frac` starts climbing —
+that is off-policy bias showing up as the optimizer fighting its own trust
+region. `async/version_offset_*` metrics tell you the staleness you actually
+achieved, as opposed to the staleness you budgeted.
+
+## 4.12 Weight sync and hot-loading
+
+After every optimizer step the inference deployment is holding stale weights.
+Fixing that is the hot-load path:
+
+```647:651:training/recipes/async_rl_loop.py
+        def sync_weights(step: int) -> float:
+            with elapsed_timer("weight_sync") as sync_span:
+                saved = policy.save_weights_for_sampler(f"step-{step}")
+                service.hotload_sampler_snapshot(saved.path)
+            return sync_span.elapsed
+```
+
+The trainer writes an inference-format snapshot to shared storage and the
+deployment loads it in place — no pod restart, no re-provisioning, no dropped
+requests. The cost profile:
+
+- **LoRA:** only the adapter moves. Megabytes. Fast enough to do every step
+  without thinking about it.
+- **Full-parameter:** the first save is a `"base"` checkpoint and subsequent ones
+  are `"delta"` checkpoints (~10× smaller), because shipping a full 70B every
+  step would dominate the loop.
+
+`WeightSyncScope` (`training/utils/config.py`) controls where the bucket lives —
+`PER_TRAINER` (default; deployment reads the trainer's bucket) or
+`PER_DEPLOYMENT` (deployment owns a stable bucket, so a trainer restart does not
+force the serving pod to restart).
+
+## 4.13 Reward design, the part that actually decides your outcome
+
+The algorithm is rarely why an RL run fails. The reward is.
+
+- **Verifiable rewards** (unit tests, exact match, a parser that must succeed)
+  are strongly preferred: they cannot be talked out of. Most of the recent
+  progress in reasoning RL comes from tasks with verifiable rewards, not from
+  better policy-gradient math.
+- **Model-graded rewards** are hackable. The policy will find the phrasing that
+  the grader likes.
+- **Shaped rewards** (partial credit for format, length, intermediate steps)
+  speed up learning and add hacking surface. Every shaping term is a term the
+  policy will try to maximize in the dumbest available way.
+- **Length effects** are pervasive. Sum-over-tokens losses implicitly reward
+  longer outputs (more tokens, more gradient); length-normalized ones implicitly
+  penalize them. DAPO's token-level normalization exists specifically to stop
+  long-response degeneration.
+- **Watch the reward distribution, not just the mean.** If most groups have zero
+  variance, you are burning rollout compute for no gradient (§4.3).
+
+In the cookbook, managed **RFT** takes a registered evaluator resource
+(`firectl rftj create --evaluator <id>`), while the Training API RL recipes take
+an inline `reward_fn(completion, row) -> float` in your forked recipe. Same
+machinery underneath; different authoring surface.
+
+---
+
+**Next:** [5. GPUs and systems](gpus-and-systems.md) — the hardware all of this
+runs on.

--- a/learning/training.md
+++ b/learning/training.md
@@ -1,0 +1,379 @@
+# 3. Training: forward, backward, optimizer step, LoRA
+
+Training is three primitives in a loop. Everything else — SFT, DPO, ORPO,
+distillation, RL — is a choice of what to put in the loss and what data to feed
+it. The Fireworks Training API exposes exactly these primitives, which is why the
+API surface is small enough to fit on one screen (§3.11).
+
+## 3.1 The loop
+
+```python
+for batch in data:
+    loss = forward(model, batch)      # 1. compute a scalar
+    grads = backward(loss)            # 2. d(loss)/d(theta) for every parameter
+    theta = optimizer_step(theta, grads)  # 3. move the weights downhill
+```
+
+**Forward.** Run the network, produce a scalar loss $\mathcal{L}(\theta)$. Cost
+$\approx 2N$ FLOPs per token (§1.9). Along the way, every intermediate tensor
+needed by the backward pass is retained — the *activations*.
+
+**Backward.** Compute $\nabla_\theta \mathcal{L}$ by reverse-mode automatic
+differentiation. Start with $\partial \mathcal{L}/\partial \mathcal{L} = 1$ at the
+output and walk the graph backwards, applying the chain rule. For a layer
+$y = xW$:
+
+$$\frac{\partial \mathcal{L}}{\partial x} = \frac{\partial \mathcal{L}}{\partial y} W^{\top}, \qquad \frac{\partial \mathcal{L}}{\partial W} = x^{\top} \frac{\partial \mathcal{L}}{\partial y}$$
+
+Two matmuls per forward matmul — hence backward $\approx 4N$ and the total $6N$
+per token. Reverse mode is the right choice precisely because the output is a
+*scalar*: one backward pass yields the gradient with respect to all $N$
+parameters at once. (Forward-mode would need one pass per parameter.)
+
+Note what backward needs: $\partial\mathcal{L}/\partial x$ requires $W$, and
+$\partial\mathcal{L}/\partial W$ requires the saved input $x$. That is why
+activations dominate training memory, and it is why **freezing a layer does not
+let you skip its backward** — you still need $\partial\mathcal{L}/\partial x$ to
+reach the layers below it. Remember this when reasoning about LoRA speed (§3.7).
+
+**Optimizer step.** Apply the update rule. This is the only step that mutates
+weights. Everything before it is reversible bookkeeping.
+
+**Gradient checkpointing** (a.k.a. activation recomputation) trades compute for
+memory: keep only layer boundaries, and recompute the interior activations during
+backward. Cost rises from $6N$ to about $8N$ per token; activation memory drops
+from $O(L)$ to $O(\sqrt{L})$ or $O(1)$ per layer depending on the policy. Almost
+every long-context training run uses it.
+
+## 3.2 Gradient descent, then Adam
+
+Plain SGD: $\theta \leftarrow \theta - \eta \nabla_\theta \mathcal{L}$. It works
+badly for transformers because the loss surface is wildly anisotropic —
+embeddings, attention, and MLP parameters want very different step sizes, and a
+single global $\eta$ cannot serve all of them.
+
+**AdamW** fixes this with per-parameter adaptive step sizes built from two
+exponential moving averages. With $g_t = \nabla_\theta \mathcal{L}_t$:
+
+$$m_t = \beta_1 m_{t-1} + (1-\beta_1) g_t \qquad\text{(first moment: direction)}$$
+$$v_t = \beta_2 v_{t-1} + (1-\beta_2) g_t^2 \qquad\text{(second moment: scale)}$$
+$$\hat{m}_t = \frac{m_t}{1-\beta_1^t}, \quad \hat{v}_t = \frac{v_t}{1-\beta_2^t} \qquad\text{(bias correction)}$$
+$$\theta_t = \theta_{t-1} - \eta\left(\frac{\hat{m}_t}{\sqrt{\hat{v}_t}+\epsilon} + \lambda\,\theta_{t-1}\right)$$
+
+Reading it piece by piece:
+
+- $m_t$ is momentum: average away gradient noise, keep the consistent direction.
+- $v_t$ estimates each coordinate's gradient magnitude. Dividing by
+  $\sqrt{\hat v_t}$ makes the effective step roughly scale-invariant, so a
+  parameter with tiny gradients still moves.
+- Bias correction exists because $m_0 = v_0 = 0$ biases the early averages toward
+  zero; dividing by $1-\beta^t$ removes it. It matters for the first few hundred
+  steps.
+- The $\lambda\theta$ term is **decoupled** weight decay — the "W" in AdamW.
+  Classic L2 regularization would add $\lambda\theta$ to the gradient, where it
+  would then get divided by $\sqrt{\hat v}$ and effectively vanish for
+  high-gradient parameters. Applying it directly to the weights keeps the
+  regularization uniform.
+
+Typical values: $\beta_1 = 0.9$, $\beta_2 = 0.95$–$0.999$, $\epsilon = 10^{-8}$.
+In this repo these are `tinker.AdamParams(learning_rate=..., beta1=..., grad_clip_norm=...)`.
+
+**Gradient clipping.** Rare bad batches produce huge gradients that can destroy a
+run in one step. Clip by global norm: compute $\|g\|_2$ over *all* parameters,
+and if it exceeds a threshold $c$, rescale $g \leftarrow g \cdot c/\|g\|_2$. This
+preserves direction and only bounds magnitude. `grad_clip_norm` on `AdamParams`.
+
+**Learning-rate schedules.** Two nearly universal ingredients:
+
+- **Warmup** — ramp $\eta$ from ~0 over the first few hundred steps. Adam's
+  $\hat v$ estimate is based on almost no samples early on, so its adaptive steps
+  are unreliable; warmup prevents a large, badly scaled first move.
+- **Decay** — cosine or linear to a small final value, so the run finishes in a
+  flat minimum rather than bouncing around.
+
+This repo implements schedules client-side (`normalize_lr_scheduler_spec`,
+`compute_lr`, `LRSchedulerSpec`), computing $\eta$ per step and passing it into
+`AdamParams`. That is worth internalizing: **the learning rate is a property of
+the optimizer call, not of the trainer session.** You can change it mid-run.
+
+## 3.3 Batching and gradient accumulation
+
+You want a large batch for a low-variance gradient estimate, but the batch has to
+fit in memory. Solution: run several **micro-batches** of forward+backward,
+letting gradients accumulate in place, then take **one** optimizer step.
+
+In the Tinker protocol this is explicit client-side control flow — $k$ calls to
+`forward_backward` followed by one `optim_step` — rather than a server-side
+`gradient_accumulation_steps` setting:
+
+```python
+for micro in split(batch, k):
+    client.forward_backward(micro, loss_fn="cross_entropy")
+client.optim_step(adam_params)
+```
+
+This design is worth appreciating: gradient accumulation, curriculum, dynamic
+batch composition, and multi-loss training all become ordinary Python instead of
+config flags.
+
+### Normalization: per-sequence or per-token?
+
+Accumulated gradients must be divided by something. The choice is not cosmetic:
+
+$$\text{NUM\_SEQUENCES:}\quad \mathcal{L} = \frac{1}{B}\sum_{b=1}^{B}\sum_{i} \ell_{b,i} \qquad\qquad \text{NUM\_LOSS\_TOKENS:}\quad \mathcal{L} = \frac{\sum_{b}\sum_{i} \ell_{b,i}}{\sum_{b} n_b}$$
+
+- **Per sequence:** every example contributes equally, so a 2000-token example
+  contributes 20× more gradient *per token* than a 100-token one. Long examples
+  dominate.
+- **Per token:** every token contributes equally, so examples are weighted by
+  length.
+
+Neither is universally right — it depends on whether your unit of value is the
+example or the token — but mixing them across a run, or between your loss and
+your baseline, produces confusing results. The SDK makes it explicit via
+`GradAccNormalization.NUM_SEQUENCES` / `NUM_LOSS_TOKENS` passed to `optim_step`.
+The same question reappears in RL as token-level vs sequence-level loss
+normalization (§4.6).
+
+## 3.4 Precision in training
+
+Compute in **bf16** (or fp8 for some matmuls) but keep an **fp32 master copy** of
+the weights. Reason: an Adam update is often ~$10^{-6}$ relative to the weight,
+and bf16 has ~3 decimal digits of mantissa, so adding the update to a bf16 weight
+would round to a no-op. Small updates would silently disappear.
+
+bf16 beats fp16 for training because it has the same exponent range as fp32 (8
+bits) at the cost of mantissa precision. fp16's narrow range requires **loss
+scaling** — multiply the loss by a large constant so small gradients don't
+underflow, then divide it out before the update. With bf16 you can skip that
+machinery entirely.
+
+## 3.5 The training memory budget
+
+For full-parameter training with AdamW in mixed precision, per parameter:
+
+| Item | Bytes |
+|---|---|
+| bf16 weights | 2 |
+| bf16 gradients | 2 |
+| fp32 master weights | 4 |
+| Adam $m$ (fp32) | 4 |
+| Adam $v$ (fp32) | 4 |
+| **Total** | **~16 bytes/param** |
+
+An 8B model needs ~128 GB *before any activations* — more than one H100. A 70B
+needs ~1.1 TB. Two escape routes:
+
+1. **Shard the state across GPUs** — ZeRO / FSDP (§5.6). Divide that 16 bytes by
+   the number of data-parallel ranks.
+2. **Train fewer parameters** — LoRA (§3.7). If only 0.5% of parameters have
+   optimizer state, the 16-byte term nearly disappears.
+
+## 3.6 Supervised fine-tuning (SFT)
+
+Same cross-entropy as pretraining, with two changes:
+
+**Chat rendering.** Messages are serialized through the model's template
+(§1.10), producing tokens plus a **loss mask**.
+
+**Loss masking.** You only want to train the model to produce assistant
+turns, not to produce the user's questions. So the per-token weight is zero on
+prompt tokens:
+
+$$\mathcal{L} = -\frac{\sum_i w_i \log P(t_i \mid t_{<i})}{\sum_i w_i}, \qquad w_i = \mathbb{1}[t_i \in \text{supervised span}]$$
+
+In the SFT recipe this is `train_on_what: str = "all_assistant_messages"`
+(`training/recipes/sft_loop.py`), and the mask travels in the Tinker datum as
+`loss_fn_inputs["weights"]` alongside `target_tokens`
+(`training/utils/supervised.py`).
+
+The whole dedicated SFT step is then:
+
+```1006:1016:training/recipes/sft_loop.py
+            adam = tinker.AdamParams(learning_rate=_current_lr(step), **adam_kwargs)
+            t_submit = time.time()
+            in_flight.append(
+                (
+                    step,
+                    tokens,
+                    t_submit,
+                    client.submit_forward_backward(batch, loss_fn="cross_entropy"),
+                    client.submit_optim_step(adam),
+                )
+            )
+```
+
+Note `submit_*` and the `in_flight` list: the recipe pipelines several
+(forward_backward, optim_step) pairs so the client is never the bottleneck while
+the server coalesces work. That is `pipeline_depth` in the SFT config.
+
+## 3.7 LoRA from first principles
+
+Full fine-tuning updates $W \in \mathbb{R}^{d\times k}$ into $W + \Delta W$. The
+LoRA hypothesis is that for *adaptation* (as opposed to pretraining) the useful
+$\Delta W$ has low **intrinsic rank** — you are nudging behavior along a few
+directions, not rebuilding the function. So constrain it:
+
+$$\boxed{\ W' = W + \frac{\alpha}{r} B A, \qquad B \in \mathbb{R}^{d \times r},\ A \in \mathbb{R}^{r \times k},\ r \ll \min(d,k)\ }$$
+
+$W$ stays **frozen**; only $A$ and $B$ train.
+
+- **Initialization** matters: $A \sim \mathcal{N}(0, \sigma^2)$ and $B = 0$, so
+  $BA = 0$ at step zero and the fine-tune starts exactly at the base model. If
+  both were random you would corrupt the model before learning anything.
+- **The $\alpha/r$ scale** decouples the learning rate from the rank, so
+  changing $r$ does not silently change the effective step size.
+- **Parameter count**: $r(d+k)$ instead of $dk$. For $d = k = 4096$, $r = 16$:
+  131k instead of 16.7M — 0.8%.
+
+What you actually get:
+
+| Property | Effect |
+|---|---|
+| Optimizer memory | Collapses; $m$ and $v$ exist only for adapter weights |
+| Activation memory | Unchanged — you still backprop through the whole network |
+| Step time | Modestly faster (fewer weight-gradient matmuls), not 100× |
+| Checkpoint size | Megabytes instead of hundreds of gigabytes |
+| Serving | Adapters can be **merged** into the base, or served alongside it |
+| Catastrophic forgetting | Reduced — the base is literally unchanged |
+
+That "serving" row is why LoRA is a systems feature and not just a memory trick.
+Because $W' x = Wx + \frac{\alpha}{r}B(Ax)$, one replica holding the base weights
+can serve *many* adapters concurrently, batching requests for different adapters
+together and applying only the small $BA$ terms per request. This is
+**multi-LoRA serving**, and it is what makes per-token pricing for customized
+models possible at all.
+
+It is also why LoRA is so much cheaper in the RL loop (part 4): after every
+optimizer step you must ship new weights to the inference deployment. For LoRA
+that is a few MB of adapter; for full-parameter it is the whole model, which is
+why the SDK's full-parameter sampler saves use a `"base"` checkpoint first and
+`"delta"` checkpoints (~10× smaller) afterwards.
+
+**Choosing $r$.** Style, tone, format adherence, and narrow tasks: $r = 8$–$16$.
+Complex reasoning, large behavior changes, or lots of new domain knowledge:
+$r = 64$–$128$, or full-parameter. The signal that $r$ is too small is training
+loss plateauing well above where you expect. In the cookbook, `lora_rank = 0`
+means full-parameter and any positive integer means LoRA — a single field across
+every recipe.
+
+**Related variants.** QLoRA quantizes the frozen base to 4-bit and trains the
+adapter in bf16 (memory win, some quality cost). DoRA separately adapts weight
+magnitude and direction. rsLoRA changes the scaling to $\alpha/\sqrt{r}$ for
+better high-rank behavior.
+
+## 3.8 Preference optimization: DPO
+
+SFT teaches "produce this text." Often what you actually have is comparative:
+given a prompt $x$, humans preferred $y_w$ over $y_l$. Classic RLHF fits a reward
+model to those comparisons and then runs PPO against it. **DPO** shows you can
+skip the reward model entirely.
+
+Start with the Bradley–Terry model of preference:
+
+$$P(y_w \succ y_l \mid x) = \sigma\big(r(x,y_w) - r(x,y_l)\big)$$
+
+The RLHF objective is "maximize reward, stay close to the reference in KL," whose
+closed-form optimum is
+$\pi^*(y|x) \propto \pi_\text{ref}(y|x)\exp(r(x,y)/\beta)$. Invert that for $r$:
+
+$$r(x,y) = \beta \log \frac{\pi^*(y|x)}{\pi_\text{ref}(y|x)} + \beta \log Z(x)$$
+
+Substituting into Bradley–Terry, the intractable partition function $Z(x)$ cancels
+because it appears in both terms of the difference. What is left is a plain
+supervised loss on the policy:
+
+$$\boxed{\ \mathcal{L}_\text{DPO} = -\log \sigma\!\left(\beta\left[\log\frac{\pi_\theta(y_w|x)}{\pi_\text{ref}(y_w|x)} - \log\frac{\pi_\theta(y_l|x)}{\pi_\text{ref}(y_l|x)}\right]\right)}$$
+
+The model *is* the reward model. Interpretation: push up the chosen response's
+logprob and push down the rejected one's, but measured **relative to the
+reference**, so the model is not rewarded for changes it was already going to
+make. $\beta$ (typically 0.1) controls how far from the reference you will drift;
+small $\beta$ means a loose leash.
+
+Mechanically this needs two forward passes over each pair — one under $\pi_\theta$
+(with backward) and one under $\pi_\text{ref}$ (no backward, cacheable). That is
+exactly what `training/recipes/dpo_loop.py` does: a separate reference trainer
+computes and caches ref logprobs, then the policy runs
+`forward_backward_custom`; `release_reference_after_cache: bool = True` frees the
+reference resources once caching is done.
+
+## 3.9 ORPO: preference learning without a reference
+
+DPO's reference model costs memory and an extra forward pass. **ORPO** removes it
+by regularizing with an odds ratio on top of the ordinary SFT loss.
+
+Define the odds of a response under length-normalized sequence probability $p$:
+
+$$\text{odds}_\theta(y|x) = \frac{p_\theta(y|x)}{1 - p_\theta(y|x)}$$
+
+$$\mathcal{L}_\text{ORPO} = \mathcal{L}_\text{SFT}(y_w) + \lambda \cdot \underbrace{\left[-\log \sigma\left(\log\frac{\text{odds}_\theta(y_w|x)}{\text{odds}_\theta(y_l|x)}\right)\right]}_{\mathcal{L}_\text{OR}}$$
+
+The SFT term anchors the model to the chosen responses (playing the role DPO's
+reference plays), and the odds-ratio term separates chosen from rejected. Using
+odds rather than raw probabilities gives a gentler penalty on the rejected
+response: it discourages $y_l$ without driving its probability to zero, which
+would degrade the model's general fluency.
+
+One trainer, no reference, one pass — `training/recipes/orpo_loop.py`, with
+`orpo_lambda: float = 1.0`.
+
+## 3.10 Distillation
+
+Train a small **student** to mimic a large **teacher**. Two directions, and the
+choice determines the failure mode:
+
+**Forward KL** $\mathrm{KL}(p_\text{teacher} \| p_\text{student})$ — train on the
+teacher's distribution (in practice its top-$k$ logits) over a fixed dataset.
+Forward KL is **mode-covering**: it is infinitely penalized wherever the teacher
+has mass and the student has none, so the student spreads itself thin trying to
+cover everything the teacher might say.
+
+**Reverse KL** $\mathrm{KL}(p_\text{student} \| p_\text{teacher})$ — the student
+samples, the teacher scores those samples. Reverse KL is **mode-seeking**: the
+student concentrates on a subset of the teacher's behavior and does it well.
+This usually produces better task performance for a small student, at the cost of
+diversity. It also requires online generation, which makes it structurally an RL
+loop.
+
+`training/recipes/distillation_loop.py` implements both: `DistillMode.SAMPLED_REVERSE_KL`
+(using the server-side `"importance_sampling"` loss, since the student's samples
+are off-policy by the time they are trained on) and top-$k$ SDFT (`sdft_top_k: int = 5`,
+using `"cross_entropy"`).
+
+## 3.11 The Tinker protocol
+
+Fireworks' Training API is Tinker-compatible: the client sends primitives and
+gets futures back, and the training *loop* stays in your Python process. The
+cookbook wraps it in `ReconnectableClient` (`training/utils/client.py`):
+
+| Call | Purpose |
+|---|---|
+| `forward(data, loss_fn)` | Logprobs only, no gradient. Reference models, old-policy snapshots. |
+| `forward_backward(data, "cross_entropy")` | Server computes a built-in loss and backprops. SFT, distillation. |
+| `forward_backward_custom(data, loss_fn)` | **Server returns logprobs, your Python computes the loss, the server backprops through it.** DPO, ORPO, GRPO. |
+| `forward_backward_contrastive(...)` | Server-side InfoNCE for embedding models. |
+| `optim_step(AdamParams, grad_accumulation_normalization=...)` | The one mutating call. |
+| `save_state(name)` / `load_state_with_optimizer(path)` | Full checkpoint (weights **and** optimizer moments) for resume. |
+| `save_weights_for_sampler(name, checkpoint_type=...)` | Inference-shaped snapshot for serving or hot-load. |
+| `load_adapter(path)` | Warm-start from an existing LoRA adapter. |
+
+`forward_backward_custom` is the load-bearing one. It means an arbitrary loss —
+anything you can express in PyTorch over returned logprobs — runs without
+shipping code to the cluster or waiting for a platform feature. Every RL variant
+in `training/utils/rl/` (GRPO, DAPO, GSPO, CISPO, REINFORCE, DRO) is just a
+different function passed to this call.
+
+Note also the **two distinct checkpoint types**, a distinction people get wrong:
+
+- `save_state` → DCP checkpoint, includes optimizer state, used to *resume
+  training*. Large.
+- `save_weights_for_sampler` → inference-format weights, used to *serve or
+  hot-load*. No optimizer state; cannot resume from it.
+
+Both are managed by `TrainingCheckpoints` in `training/utils/checkpoints.py`.
+
+---
+
+**Next:** [4. Reinforcement learning](reinforcement-learning.md) — where training
+and inference become one system.

--- a/learning/transformers-and-attention.md
+++ b/learning/transformers-and-attention.md
@@ -1,0 +1,327 @@
+# 1. Transformers and attention
+
+## 1.1 The only task: predict the next token
+
+Everything a language model does reduces to one operation repeated: given a
+prefix of tokens, output a probability distribution over which token comes next.
+
+Text is first converted to integers by a **tokenizer**. Modern tokenizers use
+byte-pair encoding (BPE): start from raw bytes, then repeatedly merge the most
+frequent adjacent pair into a new symbol, until you have a vocabulary of
+$V \approx 32{,}000$ to $256{,}000$ symbols. A token is roughly 3–4 characters of
+English, less for code, much less for languages that do not use Latin script.
+Practical consequences: token counts (not word counts) drive both cost and
+context limits, and two tokenizers disagreeing about the same string is a real
+source of training bugs (see §1.10).
+
+A language model defines a joint probability over a sequence by factoring it with
+the chain rule:
+
+$$P(t_1,\dots,t_n) = \prod_{i=1}^{n} P(t_i \mid t_{<i})$$
+
+The model produces a **logit** vector $z \in \mathbb{R}^{V}$ at every position,
+and the distribution is the softmax:
+
+$$P(t_i = v \mid t_{<i}) = \frac{e^{z_v}}{\sum_{u=1}^{V} e^{z_u}} \qquad\text{often written}\qquad \mathrm{softmax}(z)_v$$
+
+Training maximizes the log-likelihood of real text, i.e. minimizes **cross
+entropy**:
+
+$$\mathcal{L} = -\frac{1}{n}\sum_{i=1}^{n} \log P(t_i \mid t_{<i})$$
+
+That single loss — averaged negative log probability of the correct next token —
+is what supervised fine-tuning still uses today. In this repo it is the
+server-side loss ID `"cross_entropy"` (`training/recipes/sft_loop.py`).
+
+Two derived quantities you will see constantly:
+
+- **Perplexity** $= e^{\mathcal{L}}$, interpretable as "effective number of
+  equally likely choices per token."
+- **Logprob** of a specific token, $\log P(t_i \mid t_{<i})$. RL and preference
+  methods manipulate logprobs directly, and almost every subtlety in part 4 is
+  about two systems disagreeing on the same logprob.
+
+## 1.2 From tokens to vectors
+
+Token IDs are looked up in an **embedding matrix** $E \in \mathbb{R}^{V \times d}$:
+
+$$x_i = E[t_i] \in \mathbb{R}^{d}$$
+
+The width $d$ (the "residual stream" or $d_\text{model}$) is 4096 for an 8B model,
+8192 for a 70B, and so on. The sequence becomes a matrix
+$X \in \mathbb{R}^{n \times d}$: one row per position.
+
+Every transformer layer reads $X$ and writes an updated $X$ of the same shape.
+At the very end, an output projection (the "unembedding" or LM head,
+$W_U \in \mathbb{R}^{d \times V}$, sometimes tied to $E$) turns each row into
+logits: $z_i = x_i W_U$.
+
+So the architecture question is only: *how should positions exchange
+information, and how should each position think on its own?* Attention answers
+the first; the MLP answers the second.
+
+## 1.3 Attention, derived
+
+Suppose position $i$ needs information stored at earlier positions. A hard lookup
+table would need exact keys. We want a **soft, learned, content-addressed
+lookup**.
+
+Give every position three vectors:
+
+- a **query** $q_i$ — "what am I looking for?"
+- a **key** $k_j$ — "what do I have on offer?"
+- a **value** $v_j$ — "what I will contribute if you pick me."
+
+Relevance of $j$ to $i$ is the dot product $q_i \cdot k_j$ (large when the vectors
+point the same way). Normalize the relevances into weights that sum to one, then
+take the weighted average of the values:
+
+$$\alpha_{ij} = \frac{\exp(q_i \cdot k_j / \sqrt{d_h})}{\sum_{j'} \exp(q_i \cdot k_{j'} / \sqrt{d_h})}, \qquad o_i = \sum_j \alpha_{ij}\, v_j$$
+
+That is attention. Three details justify themselves:
+
+**Why divide by $\sqrt{d_h}$.** If $q$ and $k$ have $d_h$ independent components
+with unit variance, their dot product has variance $d_h$. Without rescaling, the
+logits grow with head width, the softmax saturates into a near-one-hot
+distribution, and gradients vanish. Dividing by $\sqrt{d_h}$ keeps the score
+variance $\approx 1$ regardless of head size.
+
+**Why softmax.** It is the smooth, differentiable relaxation of "pick the
+argmax," and it guarantees weights are non-negative and sum to one, so the output
+stays in the convex hull of the values (a stable scale for the residual stream).
+
+**Why causal masking.** For next-token prediction, position $i$ must not see
+$j > i$, otherwise the model trivially cheats. Implement by adding a mask
+$M_{ij} = -\infty$ for $j > i$ before the softmax, which sends those weights to
+zero. This is why the whole sequence can be trained in parallel: the mask makes
+one forward pass compute the loss at every position simultaneously, as if you had
+run $n$ separate prefixes.
+
+### Q, K, V are linear projections — this is "KQV"
+
+The three vectors are not separate inputs; they are three learned views of the
+same residual stream:
+
+$$Q = X W_Q, \quad K = X W_K, \quad V = X W_V, \qquad W_Q, W_K, W_V \in \mathbb{R}^{d \times d_h}$$
+
+In matrix form, with mask $M$:
+
+$$\boxed{\ \mathrm{Attn}(Q,K,V) = \mathrm{softmax}\!\left(\frac{QK^{\top}}{\sqrt{d_h}} + M\right) V\ }$$
+
+$QK^\top$ is $n \times n$: every position scored against every position. That
+quadratic term is the source of both the expressive power and the entire cost
+problem of long context.
+
+The **Q/K circuit** decides *where* to read; the **V circuit** (with the output
+projection $W_O$) decides *what* gets written back. They are functionally
+different, which is why K/V can be shared across heads while Q is not (§1.5), and
+why only K and V need caching at inference time (§2.2).
+
+### Multi-head attention
+
+One attention operation can only compute one weighted average. Real reasoning
+needs several relations at once ("the subject of this verb", "the matching
+bracket", "the last mention of this variable"). So run $h$ attention operations
+in parallel with independent projections, each of width $d_h = d/h$, then
+concatenate and mix:
+
+$$\mathrm{MHA}(X) = \mathrm{Concat}(\mathrm{head}_1, \dots, \mathrm{head}_h)\, W_O, \qquad \mathrm{head}_i = \mathrm{Attn}(XW_Q^i, XW_K^i, XW_V^i)$$
+
+Total parameters stay $\approx 4d^2$ ($W_Q, W_K, W_V, W_O$), because the heads
+split the width rather than duplicating it. Splitting is nearly free and strictly
+more expressive than a single wide head, since a single head is forced to use one
+softmax distribution for everything.
+
+### Cost
+
+- Time: $O(n^2 d)$ for the scores and the value mixing, plus $O(n d^2)$ for the
+  projections. Short sequences are dominated by the $d^2$ projection term; long
+  sequences by the $n^2$ term.
+- Memory (naive): the $n \times n$ score matrix per head. At $n = 32{,}768$ and 32
+  heads in bf16 that is $32 \times 32768^2 \times 2 \approx 68$ GB — impossible.
+
+**FlashAttention** removes that memory cost. Instead of materializing the score
+matrix, it tiles the computation into blocks that fit in on-chip SRAM and uses an
+*online softmax*: keep a running max $m$ and running sum $\ell$, and rescale the
+accumulated output as each new block arrives, using
+$\mathrm{softmax}$'s shift-invariance ($\mathrm{softmax}(z) = \mathrm{softmax}(z-c)$).
+Memory becomes $O(n)$, and the kernel becomes compute-bound instead of
+bandwidth-bound. The backward pass recomputes the scores block by block rather
+than storing them. Every serious implementation uses this or a descendant; it is
+the reason 128k+ context is affordable at all.
+
+## 1.4 Position information: RoPE
+
+Attention as defined is permutation-equivariant — shuffle the tokens and the
+outputs shuffle with them. Nothing in $QK^\top$ knows about order. Position has
+to be injected.
+
+Older models added a learned or sinusoidal position vector to the embedding.
+Modern models use **RoPE** (rotary position embedding), which rotates $q$ and $k$
+by an angle proportional to their absolute position. Treat the $d_h$ components
+as $d_h/2$ 2-D pairs; pair $j$ at position $m$ is rotated by $m\theta_j$ with
+
+$$\theta_j = b^{-2j/d_h}, \qquad b = 10{,}000 \text{ (the "RoPE base")}$$
+
+$$R_m = \begin{pmatrix} \cos m\theta_j & -\sin m\theta_j \\ \sin m\theta_j & \cos m\theta_j \end{pmatrix} \text{ applied blockwise}$$
+
+The point is what happens to the score:
+
+$$\langle R_m q,\; R_n k \rangle = \langle q,\; R_{n-m} k \rangle$$
+
+The dot product depends only on the **relative** distance $n - m$, even though
+each vector was rotated by its absolute position. You get relative-position
+awareness for free, with no extra parameters, no additive bias term, and — the
+practical payoff — the ability to extend context after training by scaling the
+frequencies (linear interpolation, NTK-aware scaling, YaRN). "Context extension"
+almost always means "we changed the RoPE base or interpolation and did a bit of
+long-context fine-tuning."
+
+Note that RoPE is applied to $Q$ and $K$ only, not $V$: position should affect
+*where you look*, not *what gets copied*.
+
+## 1.5 MHA → MQA → GQA → MLA: shrinking the K/V footprint
+
+At inference, K and V for every past token must be kept around (§2.2). Their size
+is proportional to the number of **KV heads**. Since the Q/K matching circuit
+tolerates fewer distinct key spaces than you might expect, architectures share
+them:
+
+| Variant | KV heads | KV cache size | Notes |
+|---|---|---|---|
+| MHA (multi-head) | $h$ | $1\times$ | Original; largest cache |
+| MQA (multi-query) | 1 | $1/h$ | Cheapest, some quality loss |
+| GQA (grouped-query) | $g$, e.g. 8 | $g/h$ | Today's default; Q heads form $g$ groups sharing one K/V head |
+| MLA (multi-head latent) | — | small | DeepSeek: cache a low-rank latent, project up per head |
+
+A concrete example: Llama-3-70B has $L = 80$, 64 query heads, **8** KV heads,
+$d_h = 128$. With MHA the cache would be 8× larger. GQA is the single biggest
+reason long-context, high-batch serving is economical, and it is invisible in the
+math of §1.3 — only $W_K$ and $W_V$ get narrower and their outputs get broadcast
+across the query heads in each group.
+
+## 1.6 The rest of the block
+
+A transformer layer is two sublayers, each wrapped in a residual connection and
+preceded by a normalization (**pre-norm**, now universal because it makes deep
+stacks trainable without careful warmup):
+
+$$x \leftarrow x + \mathrm{Attn}(\mathrm{Norm}(x))$$
+$$x \leftarrow x + \mathrm{MLP}(\mathrm{Norm}(x))$$
+
+The residual stream is the backbone: every layer *adds* to it rather than
+replacing it, so gradients flow to layer 1 through an unbroken identity path.
+This is why depth works.
+
+**RMSNorm** replaced LayerNorm because the mean-subtraction term turns out to be
+unnecessary:
+
+$$\mathrm{RMSNorm}(x) = \frac{x}{\sqrt{\frac{1}{d}\sum_i x_i^2 + \epsilon}} \odot \gamma$$
+
+One fewer reduction, one fewer parameter vector, same quality.
+
+**The MLP** is where most parameters live and where "facts" are commonly
+localized. Modern models use **SwiGLU**, a gated variant:
+
+$$\mathrm{MLP}(x) = \big(\mathrm{silu}(x W_\text{gate}) \odot x W_\text{up}\big) W_\text{down}, \qquad \mathrm{silu}(z) = z\,\sigma(z)$$
+
+The elementwise product makes it multiplicative (a soft gate: one branch decides
+how much of the other passes), which empirically beats a plain
+$\mathrm{ReLU}(xW_1)W_2$ at equal parameter count. Because SwiGLU needs three
+matrices instead of two, implementations shrink $d_\text{ff}$ from $4d$ to about
+$\tfrac{8}{3}d$ to keep the parameter count the same.
+
+## 1.7 Mixture of Experts
+
+A dense model spends all $N$ parameters on every token. MoE decouples **total**
+parameters from **active** parameters: replace the single MLP with $E$ expert
+MLPs and a small **router** that picks the top-$k$ (typically 1, 2, or 8) per
+token:
+
+$$g = \mathrm{softmax}(x W_\text{router}) \in \mathbb{R}^{E}, \qquad y = \sum_{i \in \mathrm{TopK}(g)} \frac{g_i}{\sum_{j \in \mathrm{TopK}(g)} g_j} \, E_i(x)$$
+
+A model like Qwen3-235B-A22B has 235B total parameters but ~22B active per token:
+memory footprint of a 235B model, compute cost of a 22B one. MoE is how frontier
+open models get capacity without proportional serving cost.
+
+Three consequences that matter operationally:
+
+1. **Routing is discrete.** $\mathrm{TopK}$ is not differentiable and is
+   sensitive to tiny numerical differences. Two systems computing the same token
+   can pick *different experts* and therefore produce meaningfully different
+   logprobs. This is exactly why this repo has **Router Replay (R3)** — the
+   inference engine returns its routing matrices and the trainer replays them
+   (`training/utils/rl/router_replay.py`, `router_replay=True` by default in the
+   RL recipes). See §4.9.
+2. **Load balancing.** Left alone, the router collapses onto a few popular
+   experts. Training adds an auxiliary balancing loss (or bias-based
+   balancing) to spread tokens out.
+3. **Expert parallelism.** Experts are sharded across GPUs, so each token's
+   routing decision becomes a network all-to-all. MoE serving is a
+   communication problem as much as a compute one.
+
+## 1.8 Counting parameters
+
+Per layer, with GQA ($g$ KV heads out of $h$):
+
+| Component | Parameters |
+|---|---|
+| $W_Q$ | $d \times d$ |
+| $W_K, W_V$ | $2 \times d \times (g\,d_h)$ |
+| $W_O$ | $d \times d$ |
+| MLP (SwiGLU) | $3 \times d \times d_\text{ff}$ |
+
+With $d_\text{ff} \approx \tfrac{8}{3}d$ the MLP is $\approx 8d^2$ and attention
+is $\approx 2\text{–}4d^2$, so a layer is roughly $10\text{–}12 d^2$ and the whole
+model is
+
+$$N \approx 12 L d^2 + \underbrace{2Vd}_{\text{embed + unembed}}$$
+
+Sanity check for an 8B-class model: $L = 32$, $d = 4096$ →
+$12 \times 32 \times 4096^2 \approx 6.4$B, plus embeddings ≈ 7–8B. The formula
+works.
+
+## 1.9 Counting FLOPs — the numbers you actually plan with
+
+A matrix multiply of $(m \times k)$ by $(k \times n)$ costs $2mkn$ FLOPs (one
+multiply and one add per term). Every parameter is used in exactly one such
+multiply per token, so:
+
+$$\text{forward} \approx 2N \ \text{FLOPs/token}$$
+
+Backward computes two gradients per matmul (with respect to the input and with
+respect to the weight), so it costs about twice the forward:
+
+$$\text{backward} \approx 4N, \qquad \boxed{\text{training} \approx 6N \ \text{FLOPs/token}}$$
+
+Add roughly $2 \cdot 2 \cdot L \cdot n \cdot d$ for the attention score/value
+matmuls, which only matters once $n$ is comparable to $d$ — i.e. at long context.
+
+These two numbers ($2N$ inference, $6N$ training) let you estimate anything.
+Training an 8B model on 1B tokens: $6 \times 8\times10^9 \times 10^9 = 4.8\times10^{19}$
+FLOPs. On one H100 at ~400 TFLOP/s effective (about 40% of peak bf16, a realistic
+MFU), that is $\approx 1.2\times10^{5}$ s ≈ 33 GPU-hours. That estimate is usually
+within 2× of reality, and it tells you immediately whether an idea is a coffee
+break or a cluster booking.
+
+## 1.10 Chat templates: where the math meets reality
+
+Base models see raw text. Instruction models are trained on a **chat template**
+that serializes a message list into tokens with special role markers, e.g.
+`<|im_start|>user ... <|im_end|>`. Reasoning models add more structure (thinking
+blocks, tool-call syntax).
+
+If training renders a conversation differently than serving does — a stray space,
+a different end-of-turn token, thinking blocks kept in one and stripped in the
+other — the model is optimized for strings it will never see. Symptoms are
+maddening: fine-tuning "works" (loss goes down) and the deployed model is worse
+than the base.
+
+This is why this repo has a per-model renderer layer (`training/renderer/`, with
+`glm5.py`, `deepseek_v4.py`, `gemma4.py`, and friends) plus parity verifiers
+under `training/renderer/verifier/`. Treat renderer parity as a correctness
+requirement, not a detail.
+
+---
+
+**Next:** [2. Inference](inference.md) — what it costs to actually run this thing.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds `learning/`, a six-part onboarding primer that builds from "what is a token" up to the exact loss functions and scheduling knobs implemented in `training/`. Documentation only — no code paths touched, no config or protocol changes.

| File | Covers |
|---|---|
| `README.md` | Index, reading order, notation |
| `transformers-and-attention.md` | Tokenization, embeddings, Q/K/V derivation, softmax attention and the $\sqrt{d_h}$ scale, multi-head, FlashAttention, RoPE, MHA→GQA→MLA, RMSNorm/SwiGLU, MoE, parameter and FLOP counting ($2N$ / $6N$), chat-template parity |
| `inference.md` | Prefill vs decode and arithmetic intensity, KV cache sizing formula with worked examples, PagedAttention, prefix reuse/session affinity, continuous and chunked prefill batching, speculative decoding (rejection-sampling proof of exactness, acceptance math, EAGLE/Medusa/n-gram, when to disable), disaggregated prefill/decode, quantization |
| `training.md` | Forward/backward/optimizer as three primitives, reverse-mode autodiff, AdamW term by term, grad clipping, LR warmup/decay, gradient accumulation and `NUM_SEQUENCES` vs `NUM_LOSS_TOKENS`, mixed precision, the 16-bytes/param memory budget, LoRA derivation and multi-LoRA serving, SFT masking, DPO derivation (Bradley–Terry → $Z(x)$ cancels), ORPO, forward vs reverse KL distillation, the Tinker protocol table |
| `reinforcement-learning.md` | MDP framing, REINFORCE via the log-derivative trick, baselines and why they stay unbiased, GRPO group z-score advantages, PPO clipping asymmetry, k1/k2/k3 KL estimators, on-policy vs off-policy and importance sampling variance, sync loop and why it idles, async admission-gate arithmetic, TIS and the train–inference gap, IcePop, `anchor_logp`, MoE router replay, weight sync/hot-load, reward design |
| `gpus-and-systems.md` | SM/HBM hierarchy, roofline and machine balance, precision formats, accelerator table (H100/H200/B200/B300/GB300), collectives, ZeRO/FSDP/HSDP, TP/PP/EP/CP placement rules, what training shapes hide, cost back-of-envelope |
| `fireworks-stack-map.md` | Layer diagram, concept→file index, protocol table, serverless vs dedicated, the two checkpoint axes, an end-to-end async RL step, metrics to watch, glossary, reading order |

## Why

Every formula and knob is grounded in the implementation rather than written generically, so the math a reader learns is the math the recipes run. Code references point at `training/utils/rl/grpo.py`, `tis.py`, `config.py`, `recipes/sft_loop.py`, `recipes/async_rl_loop.py`, and the async admission-gate formula in `references/rl-async.md`.

Placement follows `CLAUDE.md`: `training/` is the product surface and `skills/` is agent-facing operational guidance, so this conceptual material lives in its own top-level directory rather than diluting either. It is self-contained — the root `README.md` is deliberately untouched to avoid conflicting with the staging→cookbook promotion flow. Happy to add a pointer there if maintainers prefer discoverability over promotion cleanliness.

## Notes for review

- Math is written in `$...$` / `$$...$$`, which GitHub renders natively.
- Line-numbered code citations were verified against the current `main` at time of writing; they will drift as those files change. They are illustrative, not load-bearing.
- Hardware figures are labeled approximate and defer to the live training-shape catalog and pricing page, consistent with `models-shapes-and-cost.md`.
- No protocol, payload, checkpoint, hot-load, or optimizer-step semantics changed, so no skill docs required updating under the `CLAUDE.md` protocol-change rule.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9d1f-d0d3-7acc-9f1e-2c2775cd88d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9d1f-d0d3-7acc-9f1e-2c2775cd88d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

