### PR TITLE
Remove deprecated trainer accelerator configuration

### DIFF
--- a/skills/fireworks-training/references/rl-custom-loss.md
+++ b/skills/fireworks-training/references/rl-custom-loss.md
@@ -134,8 +134,10 @@ All live on `rl_loop.Config`:
 | `router_replay`, `router_replay_completion_only` | `True`, `True` | Replay MoE routes for generated tokens by default. Set completion-only to `False` only when full-sequence replay is worth the serving cost of `echo=True`. |
 | `grad_accumulation_normalization` | `None` | No server-side normalization by default. Use `NUM_LOSS_TOKENS` for raw-sum losses. See [`rl-gradient-accumulation.md`](rl-gradient-accumulation.md). |
 
-Shape-owned fields (`accelerator_type`, `node_count`, and `custom_image_tag`)
-come from the training profile; never hand-set them.
+Trainer accelerator type and count are not cookbook config fields; select them
+indirectly with `training_shape_id`. Other shape-owned fields such as
+`node_count` and `custom_image_tag` come from the training profile; never
+hand-set them.
 
 ## Do not
 

--- a/skills/fireworks-training/references/sdk-migrate.md
+++ b/skills/fireworks-training/references/sdk-migrate.md
@@ -45,9 +45,11 @@ grep -rn -E 'InfraConfig|setup_infra|ResourceCleanup|make_reference_client|creat
 | `create_base_reference()` / `make_reference_client()` | `service.create_reference_client(...)` |
 | `with ResourceCleanup(...)` | `service.close()` / context-managed cleanup owned by the SDK service lifetime |
 
-`accelerator_type` / `accelerator_count` are deprecated and ignored by the SDK;
-the training shape owns accelerator selection. `node_count` and
-`custom_image_tag` remain advanced controls; prefer a training shape.
+`accelerator_type` / `accelerator_count` have been removed from cookbook
+trainer configuration. Passing either field now raises a clear error because
+clients cannot select trainer accelerators; set `training_shape_id` instead.
+`node_count` and `custom_image_tag` remain advanced controls; prefer a training
+shape.
 
 Trainer provisioning has two independent wait budgets. Set
 `TrainerConfig.pending_timeout_s` for capacity placement while the job is

--- a/skills/fireworks-training/references/sdk-recipes.md
+++ b/skills/fireworks-training/references/sdk-recipes.md
@@ -24,7 +24,7 @@ Always required on `Config` (with `trainer=TrainerConfig(...)`):
 - `dataset` — path to JSONL
 - `tokenizer_model` — HF model name
 - `log_path` — directory for `dataloader.json` and logs
-- `trainer.training_shape_id` — optional override; leave unset for auto-selection. Do not set manual `accelerator_type` / `node_count` (see [`sdk-shapes.md`](sdk-shapes.md))
+- `trainer.training_shape_id` — optional override; leave unset for auto-selection. `accelerator_type` and `accelerator_count` are unsupported; do not set manual `node_count` (see [`sdk-shapes.md`](sdk-shapes.md))
 
 RL-specific: for the primary `async_rl_loop.py`, you write a `rollout_fn` (typically a `rollout.py`) and a `train.py` that sets the `Config` (policy loss, reward wiring, deployment) and calls `main(cfg, rollout_fn_factory=..., rows=...)`; the recipe owns the loop. The simpler synchronous `rl_loop.py` takes a reward function, rollout batch sizes, and a deployment config directly. See [`rl-async.md`](rl-async.md).
 

--- a/skills/fireworks-training/references/sdk-shapes.md
+++ b/skills/fireworks-training/references/sdk-shapes.md
@@ -1,6 +1,10 @@
 # Training and deployment shapes — always use a profile
 
-Shapes are the required entry point for both trainer and deployment. Never hand-set `accelerator_type`, `accelerator_count`, `node_count`, or `custom_image_tag` when a shape is in use — the backend will reject or silently ignore them.
+Shapes are the required entry point for both trainer and deployment. Cookbook
+trainer config rejects `accelerator_type` and `accelerator_count`; clients
+cannot select trainer accelerators, so set `training_shape_id` instead.
+`node_count` and `custom_image_tag` remain advanced controls but should not be
+hand-set when a shape is in use.
 
 ## Training shape
 

--- a/training/provision/provision.py
+++ b/training/provision/provision.py
@@ -36,6 +36,7 @@ from training.utils import (
     load_deployment_tokenizer,
     read_api_extra_headers_env,
 )
+from training.utils.config import _reject_removed_accelerator_config
 from training.utils.rl.grpo import validate_grpo_config
 
 ProvisionMode = Literal["sft", "rl", "distillation", "dpo"]
@@ -1055,6 +1056,7 @@ def _resolve_named_section(doc: dict[str, Any], section: str, ref: Any) -> dict[
 
 
 def _make_dataclass_config(cls: type, values: dict[str, Any]) -> Any:
+    _reject_removed_accelerator_config(values, config_name=cls.__name__)
     allowed = {field.name for field in dataclasses.fields(cls)}
     type_hints = get_type_hints(cls)
     return cls(

--- a/training/provision/tests/test_provision.py
+++ b/training/provision/tests/test_provision.py
@@ -281,6 +281,88 @@ recipe:
     assert cfg.deployment.replica_count == 2
 
 
+@pytest.mark.parametrize(
+    ("field_name", "value"),
+    [
+        ("accelerator_type", "NVIDIA_B200"),
+        ("accelerator_count", 8),
+    ],
+)
+def test_load_yaml_provision_rejects_removed_trainer_accelerator_fields(
+    tmp_path: Path,
+    field_name: str,
+    value: object,
+) -> None:
+    config_path = tmp_path / "fireworks.yaml"
+    config_path.write_text(
+        f"""
+common:
+  base_model: accounts/test/models/base
+  tokenizer_model: Qwen/Test
+trainers:
+  policy:
+    training_shape_id: accounts/test/trainingShapes/policy
+    {field_name}: {value}
+recipe:
+  sft:
+    trainer: policy
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        TypeError,
+        match=(
+            rf"TrainerConfig no longer supports `{field_name}`.*"
+            r"select a training shape with `training_shape_id`"
+        ),
+    ):
+        module._load_yaml_provision(mode=None, recipe="sft", path=config_path)
+
+
+@pytest.mark.parametrize(
+    ("field_name", "value"),
+    [
+        ("accelerator_type", "NVIDIA_B200"),
+        ("accelerator_count", 8),
+    ],
+)
+def test_hydra_override_rejects_removed_trainer_accelerator_fields(
+    tmp_path: Path,
+    field_name: str,
+    value: object,
+) -> None:
+    config_path = tmp_path / "fireworks.yaml"
+    config_path.write_text(
+        """
+common:
+  base_model: accounts/test/models/base
+  tokenizer_model: Qwen/Test
+trainers:
+  policy:
+    training_shape_id: accounts/test/trainingShapes/policy
+recipe:
+  sft:
+    trainer: policy
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        TypeError,
+        match=(
+            rf"TrainerConfig no longer supports `{field_name}`.*"
+            r"select a training shape with `training_shape_id`"
+        ),
+    ):
+        module._load_yaml_provision(
+            mode=None,
+            recipe="sft",
+            path=config_path,
+            overrides=[f"+trainers.policy.{field_name}={value}"],
+        )
+
+
 def test_load_yaml_provision_applies_hydra_overrides(tmp_path: Path) -> None:
     if importlib.util.find_spec("hydra") is None:
         pytest.skip("hydra is not installed")

--- a/training/recipes/async_rl_loop.py
+++ b/training/recipes/async_rl_loop.py
@@ -377,13 +377,6 @@ def main(
         )
         sampler = service.create_deployment_sampler(tokenizer=tokenizer)
         rollout_model = sampler.model
-        training_profile = getattr(service, "training_profile", None)
-        accelerator_type = getattr(service, "accelerator_type", None)
-        if accelerator_type is None:
-            accelerator_type = getattr(training_profile, "accelerator_type", None)
-        accelerator_count = getattr(service, "accelerator_count", None)
-        if accelerator_count is None:
-            accelerator_count = getattr(training_profile, "accelerator_count", None)
         log_metrics({"rollout/step": 0}, step=0)
 
         policy = ReconnectableClient.from_training_client(
@@ -783,6 +776,4 @@ def main(
             "policy_job_id": service.trainer_job_id,
             "reference_job_id": service.reference_trainer_job_id,
             "deployment_id": service.deployment_id,
-            "accelerator_type": accelerator_type,
-            "accelerator_count": accelerator_count,
         }

--- a/training/recipes/rl_loop.py
+++ b/training/recipes/rl_loop.py
@@ -618,20 +618,11 @@ def main(
         )
         wandb_finish(metrics_file=os.environ.get("COOKBOOK_METRICS_FILE"))
 
-        training_profile = getattr(service, "training_profile", None)
-        accelerator_type = getattr(service, "accelerator_type", None)
-        if accelerator_type is None:
-            accelerator_type = getattr(training_profile, "accelerator_type", None)
-        accelerator_count = getattr(service, "accelerator_count", None)
-        if accelerator_count is None:
-            accelerator_count = getattr(training_profile, "accelerator_count", None)
         return {
             "steps": global_step,
             "policy_job_id": service.trainer_job_id,
             "reference_job_id": service.reference_trainer_job_id,
             "deployment_id": service.deployment_id,
-            "accelerator_type": accelerator_type,
-            "accelerator_count": accelerator_count,
         }
 
 

--- a/training/tests/e2e/conftest.py
+++ b/training/tests/e2e/conftest.py
@@ -28,7 +28,6 @@ DEFAULT_REFERENCE_TRAINING_SHAPE = (
     "accounts/fireworks/trainingShapes/qwen3p5-9b-256k-lora"
 )
 DEFAULT_LORA_TRAINING_SHAPE = "accounts/fireworks/trainingShapes/qwen3p5-9b-256k-lora"
-DEFAULT_TRAINING_ACCELERATOR = None
 DEFAULT_DEPLOYMENT_ACCELERATOR = "NVIDIA_B200_180GB"
 DEFAULT_DEPLOYMENT_SHAPE = "accounts/fireworks/deploymentShapes/rft-qwen3p5-9b-v2/versions/n864rzzy"
 
@@ -91,12 +90,6 @@ def e2e_model() -> str:
 def e2e_tokenizer_model() -> str:
     """HuggingFace model name for the tokenizer (client-side tokenization)."""
     return _get_env("FIREWORKS_E2E_TOKENIZER_MODEL", DEFAULT_TOKENIZER_MODEL)
-
-
-@pytest.fixture(scope="module")
-def e2e_training_accelerator() -> str | None:
-    """Accelerator for RLOR trainer jobs (None = server auto-configures)."""
-    return _get_env("FIREWORKS_E2E_TRAINING_ACCELERATOR", DEFAULT_TRAINING_ACCELERATOR)
 
 
 @pytest.fixture(scope="module")

--- a/training/tests/e2e/run_frozen_lake_b300.sh
+++ b/training/tests/e2e/run_frozen_lake_b300.sh
@@ -33,7 +33,6 @@ FIRECTL_BIN="${FIRECTL_BIN:-$REPO_ROOT/../fireworks/firectl/bin/firectl-admin}"
 FIRECTL_PROFILE="${FIRECTL_PROFILE:-dev-bennychen}"
 TRAINING_SHAPE="${TRAINING_SHAPE:-qwen3-4b-b300}"
 DEPLOYMENT_ID="${DEPLOYMENT_ID:-rl-qwen3-4b-b300-v10}"
-ACCELERATOR="${ACCELERATOR:-NVIDIA_B300_288GB}"
 JOB_WAIT_TIMEOUT="${JOB_WAIT_TIMEOUT:-80}"
 JOB_CREATE_RETRIES="${JOB_CREATE_RETRIES:-3}"
 
@@ -95,7 +94,6 @@ create_job() {
         output=$("$FIRECTL_BIN" -a "$FIRECTL_ACCOUNT" rlor create \
             --base-model "accounts/fireworks/models/qwen3-4b" \
             --training-shape "$TRAINING_SHAPE" \
-            --accelerator-type "$ACCELERATOR" --accelerator-count 8 \
             --display-name "frozen-lake-ci-$label" \
             --service-mode \
             "$@" \

--- a/training/tests/e2e/test_dpo_e2e.py
+++ b/training/tests/e2e/test_dpo_e2e.py
@@ -50,7 +50,6 @@ class TestDPOE2E:
         self,
         sdk_managers,
         e2e_model,
-        e2e_training_accelerator,
         custom_image_tag,
     ):
         rlor_mgr, deploy_mgr = sdk_managers
@@ -69,7 +68,6 @@ class TestDPOE2E:
                 epochs=2,
                 max_pairs=10,
                 trainer=TrainerConfig(
-                    accelerator_type=e2e_training_accelerator,
                     custom_image_tag=custom_image_tag,
                 ),
                 deployment=DeployConfig(),

--- a/training/tests/e2e/test_grpo_e2e.py
+++ b/training/tests/e2e/test_grpo_e2e.py
@@ -43,7 +43,6 @@ class TestGRPOE2E:
         sdk_managers,
         e2e_model,
         e2e_tokenizer_model,
-        e2e_training_accelerator,
         e2e_deployment_accelerator,
         e2e_deployment_shape,
         custom_image_tag,
@@ -66,7 +65,6 @@ class TestGRPOE2E:
             epochs=1,
             tis=TISConfig(cap=10.0),
             trainer=TrainerConfig(
-                accelerator_type=e2e_training_accelerator,
                 custom_image_tag=custom_image_tag,
             ),
             deployment=DeployConfig(

--- a/training/tests/e2e/test_sft_e2e.py
+++ b/training/tests/e2e/test_sft_e2e.py
@@ -42,7 +42,6 @@ class TestSFTE2E:
         self,
         sdk_managers,
         e2e_model,
-        e2e_training_accelerator,
         custom_image_tag,
     ):
         rlor_mgr, deploy_mgr = sdk_managers
@@ -61,7 +60,6 @@ class TestSFTE2E:
                 epochs=2,
                 max_examples=10,
                 trainer=TrainerConfig(
-                    accelerator_type=e2e_training_accelerator,
                     custom_image_tag=custom_image_tag,
                 ),
                 deployment=DeployConfig(),

--- a/training/tests/e2e/test_sft_resume_e2e.py
+++ b/training/tests/e2e/test_sft_resume_e2e.py
@@ -63,7 +63,6 @@ class TestSFTResumeE2E:
         self,
         sdk_managers,
         e2e_model,
-        e2e_training_accelerator,
         custom_image_tag,
     ):
         rlor_mgr, deploy_mgr = sdk_managers

--- a/training/tests/unit/test_rl_loop.py
+++ b/training/tests/unit/test_rl_loop.py
@@ -445,6 +445,8 @@ def test_main_collects_trains_and_hotloads_before_next_batch(monkeypatch) -> Non
     )
 
     assert result["steps"] == 2
+    assert "accelerator_type" not in result
+    assert "accelerator_count" not in result
     assert events.index("hotload:/step-0") < events.index("sample:0")
     assert events.index("sample:1") < events.index("optim")
     assert events.index("hotload:/step-1") < events.index("sample:2")

--- a/training/tests/unit/test_sdk_compat.py
+++ b/training/tests/unit/test_sdk_compat.py
@@ -1,7 +1,34 @@
 from __future__ import annotations
 
+import dataclasses
+
+import pytest
+
 import training.utils.config as config_module
 from fireworks.training.sdk.deployment import DeploymentConfig
+
+
+@pytest.mark.parametrize(
+    ("field_name", "value"),
+    [
+        ("accelerator_type", "NVIDIA_B200"),
+        ("accelerator_count", 8),
+    ],
+)
+def test_legacy_infra_config_rejects_removed_accelerator_fields(field_name, value):
+    with pytest.raises(
+        TypeError, match=rf"InfraConfig no longer supports `{field_name}`"
+    ):
+        config_module.InfraConfig(**{field_name: value})
+
+
+def test_legacy_infra_config_does_not_expose_removed_accelerator_fields():
+    field_names = {
+        field.name for field in dataclasses.fields(config_module.InfraConfig)
+    }
+
+    assert "accelerator_type" not in field_names
+    assert "accelerator_count" not in field_names
 
 
 def test_to_deployment_config_includes_extra_values():

--- a/training/tests/unit/test_service.py
+++ b/training/tests/unit/test_service.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import dataclasses
+import inspect
+
 import pytest
 
 from training.utils import service
@@ -18,8 +21,6 @@ def _trainer_config(**overrides) -> TrainerConfig:
         cleanup_reference_on_close=False,
         region="US_OHIO_1",
         node_count=2,
-        accelerator_type="NVIDIA_B200",
-        accelerator_count=8,
         custom_image_tag="0.0.0-dev",
         extra_args=["--foo"],
         replica_count=4,
@@ -148,8 +149,6 @@ def test_build_service_client_maps_cookbook_config_to_sdk_kwargs(monkeypatch):
             "learning_rate": 1e-5,
             "gradient_accumulation_steps": None,
             "node_count": 2,
-            "accelerator_type": "NVIDIA_B200",
-            "accelerator_count": 8,
             "custom_image_tag": "0.0.0-dev",
             "extra_args": ["--foo"],
             "trainer_replica_count": 4,
@@ -335,31 +334,36 @@ def test_trainer_region_becomes_sdk_region():
         lora_rank=0,
         max_context_length=None,
         learning_rate=1e-5,
-        trainer=_trainer_config(
-            region="US_OHIO_1",
-            accelerator_type=None,
-            accelerator_count=None,
-        ),
+        trainer=_trainer_config(region="US_OHIO_1"),
         deployment=_deployment_config(),
     )
 
     assert client._managed_config.region == "US_OHIO_1"
 
 
-def test_deprecated_trainer_accelerator_fields_warn_and_are_ignored():
-    with pytest.warns(DeprecationWarning):
-        client = build_service_client(
-            api_key="k",
-            base_url="https://api",
-            additional_headers=None,
-            base_model="accounts/acct/models/base",
-            tokenizer_model=None,
-            lora_rank=0,
-            max_context_length=None,
-            learning_rate=1e-5,
-            trainer=_trainer_config(),
-            deployment=_deployment_config(),
-        )
+@pytest.mark.parametrize(
+    ("field_name", "value"),
+    [
+        ("accelerator_type", "NVIDIA_B200"),
+        ("accelerator_count", 8),
+    ],
+)
+def test_trainer_config_rejects_removed_accelerator_fields(field_name, value):
+    with pytest.raises(
+        TypeError,
+        match=(
+            rf"TrainerConfig no longer supports `{field_name}`.*"
+            r"select a training shape with `training_shape_id`"
+        ),
+    ):
+        TrainerConfig(**{field_name: value})
 
-    assert client._managed_config.accelerator_type is None
-    assert client._managed_config.accelerator_count is None
+
+def test_trainer_config_does_not_advertise_removed_accelerator_fields():
+    field_names = {field.name for field in dataclasses.fields(TrainerConfig)}
+    parameters = inspect.signature(TrainerConfig).parameters
+
+    assert "accelerator_type" not in field_names
+    assert "accelerator_count" not in field_names
+    assert "accelerator_type" not in parameters
+    assert "accelerator_count" not in parameters

--- a/training/utils/config.py
+++ b/training/utils/config.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
+import functools
 import warnings
-from enum import Enum
-from typing import Dict, Callable
 from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Callable, Dict, Mapping
 
 from fireworks.training.sdk.client import FiretitanTrainingClient
 from fireworks.training.sdk.deployment import DeploymentConfig
@@ -20,6 +21,39 @@ EvalFn = Callable[[int, FiretitanTrainingClient], Dict[str, float]]
 
 StepCallback = Callable[[int, Dict[str, float]], None]
 """Called after each optimizer step: (global_step, step_metrics) -> None."""
+
+
+_REMOVED_ACCELERATOR_CONFIG_FIELDS = frozenset(
+    {"accelerator_type", "accelerator_count"}
+)
+
+
+def _reject_removed_accelerator_config(
+    values: Mapping[str, Any],
+    *,
+    config_name: str,
+) -> None:
+    removed = sorted(_REMOVED_ACCELERATOR_CONFIG_FIELDS.intersection(values))
+    if not removed:
+        return
+    names = " and ".join(f"`{name}`" for name in removed)
+    raise TypeError(
+        f"{config_name} no longer supports {names}. Cookbook clients cannot set "
+        "trainer accelerator type or count; select a training shape with "
+        "`training_shape_id` instead."
+    )
+
+
+def _reject_removed_accelerator_kwargs(cls):
+    original_init = cls.__init__
+
+    @functools.wraps(original_init)
+    def checked_init(self, *args, **kwargs):
+        _reject_removed_accelerator_config(kwargs, config_name=cls.__name__)
+        original_init(self, *args, **kwargs)
+
+    cls.__init__ = checked_init
+    return cls
 
 
 @dataclass
@@ -59,6 +93,7 @@ class ConcurrencyConfig:
     Remaining requests adjust at the step boundary; ``0`` adjusts only there."""
 
 
+@_reject_removed_accelerator_kwargs
 @dataclass
 class InfraConfig:
     """GPU and image settings.
@@ -76,8 +111,8 @@ class InfraConfig:
       shape-derived fields (accelerator, image tag, node count).
       Setting shape-owned infra overrides raises ``ValueError``; trainer
       replica count remains a run-level control.
-    * **Manual path** (``training_shape_id`` is ``None``): all fields
-      are sent as-is; the server skips shape validation.
+    * **Manual path** (``training_shape_id`` is ``None``): remaining advanced
+      fields are sent as-is; trainer accelerator type and count are unsupported.
     """
 
     training_shape_id: str | None = None
@@ -96,8 +131,6 @@ class InfraConfig:
     region: str | None = None
     """Optional explicit trainer region. Prefer leaving unset so the backend
     can place the trainer from the validated training shape."""
-    accelerator_type: str | None = None
-    accelerator_count: int | None = None
     node_count: int | None = None
     trainer_timeout_s: float = 3600
     extra_args: list[str] | None = None
@@ -123,6 +156,7 @@ class InfraConfig:
         )
 
 
+@_reject_removed_accelerator_kwargs
 @dataclass
 class TrainerConfig:
     """Training client launch settings."""
@@ -151,14 +185,6 @@ class TrainerConfig:
     region: str | None = None
     """Optional explicit trainer region. Prefer leaving unset so the backend
     can place the trainer from the validated training shape."""
-    accelerator_type: str | None = None
-    """Deprecated and ignored. Trainer accelerator type is owned by the
-    training shape; setting this emits a ``DeprecationWarning``. Use
-    ``replica_count`` for data-parallel scaling."""
-    accelerator_count: int | None = None
-    """Deprecated and ignored. Trainer accelerator count is owned by the
-    training shape; setting this emits a ``DeprecationWarning``. Use
-    ``replica_count`` for data-parallel scaling."""
     node_count: int | None = None
     timeout_s: float = 3600
     """Post-placement budget for the trainer to become healthy and ready."""
@@ -272,8 +298,6 @@ class DeployConfig:
         """Produce an SDK-level DeploymentConfig from cookbook settings."""
         skip_validation = False
         accel = None if self.deployment_shape else self.deployment_accelerator_type
-        if not accel and not self.deployment_shape:
-            accel = infra.accelerator_type
         replica_count = 1 if self.replica_count is None else self.replica_count
         return DeploymentConfig(
             deployment_id=self.deployment_id,

--- a/training/utils/service.py
+++ b/training/utils/service.py
@@ -70,8 +70,6 @@ def _firetitan_service_kwargs(
         # server-side knob unset.
         "gradient_accumulation_steps": None,
         "node_count": trainer.node_count,
-        "accelerator_type": trainer.accelerator_type,
-        "accelerator_count": trainer.accelerator_count,
         "custom_image_tag": trainer.custom_image_tag,
         "extra_args": trainer.extra_args,
         "trainer_replica_count": trainer.replica_count,


### PR DESCRIPTION
## Summary

- remove `accelerator_type` and `accelerator_count` from cookbook trainer configuration, including the legacy `InfraConfig` surface
- stop forwarding those fields through the cookbook-to-SDK service adapter and remove them from sync/async RL result payloads
- reject the removed fields with an actionable error from direct Python construction, YAML provisioning, and Hydra CLI overrides
- remove stale trainer accelerator flags/fixtures from cookbook E2E coverage and update the canonical training skill guidance

## Why

Trainer accelerator selection is shape-owned and cookbook clients can no longer set accelerator type or count. Keeping deprecated fields as ignored inputs made configurations look valid while doing nothing. This change intentionally drops compatibility: callers must remove those fields and use `training_shape_id` when they need an explicit trainer shape.

No SDK changes are included.

## User impact

Passing either removed field now fails immediately with:

> Cookbook clients cannot set trainer accelerator type or count; select a training shape with `training_shape_id` instead.

The fields are also absent from dataclass metadata and constructor signatures, so generated/config-driven clients no longer advertise them.

## Validation

- `uv run --project training pytest -q training/tests/unit training/provision/tests`
  - 3,191 passed, 217 skipped, 79 xfailed
- protected path regression suite:
  - `training/tests/unit/test_serverless.py`
  - `training/tests/unit/test_sft_loop.py`
  - `training/tests/unit/test_dpo_loop.py`
  - 79 passed
- `uv run --project training pytest -q training/tests/test_smoke_imports.py`
  - 68 passed
- `training/.venv/bin/python skills/validate_skills.py`
- Ruff lint on every changed Python file
- `git diff --check`
- `bash -n training/tests/e2e/run_frozen_lake_b300.sh`

Remote E2E jobs were not launched because they provision live/billable training resources.

## Retrospective / scope audit

Every change is needed for one of these contracts:

- **Config surface:** `TrainerConfig` and legacy `InfraConfig` must stop advertising the fields while still producing the required migration error.
- **Provisioning boundary:** the YAML/Hydra loader previously ignored unknown dataclass keys, so it needs an explicit rejection before filtering; the shared service adapter must stop passing the removed values to the SDK.
- **Recipe output:** sync and async RL carried newly-added accelerator result fields plus lookup code solely for those fields, so both are removed consistently.
- **Cookbook callers:** E2E fixtures and the FrozenLake smoke script still set trainer accelerators; removing them prevents the cookbook's own examples/tests from teaching or exercising an unsupported path.
- **Skill contract:** repository guidance requires compatibility changes to update the canonical training skill, so stale deprecated/ignored wording is replaced with the new hard-error contract.
- **Regression coverage:** direct construction, dataclass discovery, static YAML, Hydra CLI overrides, RL results, serverless SFT, and managed SFT/DPO are all covered.

Intentionally unchanged:

- the Fireworks SDK
- deployment-specific accelerator controls, which are a separate supported deployment contract
- server-resolved accelerator reads used by managed SFT/DPO runner metadata and provisioning progress; these are reporting/billing inputs, not client configuration
- the serverless SFT setup and `mark_serverless` billing path
