### PR TITLE
Document metadata-only future retrieval behavior

### DIFF
--- a/skills/fireworks-training/SKILL.md
+++ b/skills/fireworks-training/SKILL.md
@@ -383,6 +383,11 @@ Read only what the task requires:
 - Let training shapes own infrastructure; do not hand-set shape-owned fields.
 - For RL, align trainer and inference numerics; use Router Replay for MoE when
   required.
+- Diagnose large-batch transport by direction: metadata-only future retrieval
+  backpressures large completed response downloads; it does not shrink request
+  uploads or repair sequence-arrival gaps. Keep the cookbook opt-out in place
+  until the trainer is compatible and Fireworks provides a supported opt-in;
+  read `references/rl-concurrency.md`.
 - Separate quota, billing, scheduler capacity, user configuration, and platform
   failures.
 - Never expose API keys, raw environment dumps, customer data, or private paths

--- a/skills/fireworks-training/references/rl-concurrency.md
+++ b/skills/fireworks-training/references/rl-concurrency.md
@@ -31,3 +31,32 @@ Recipe concurrency is only admission control. Deployment replicas and batch
 capacity still determine actual serving throughput. If the trainer repeatedly
 waits for rollout batches, increase rollout capacity or reduce the optimizer
 batch size after checking the async performance metrics.
+
+## Large batches and metadata-only future retrieval
+
+Separate the request-upload path from the future-result download path:
+
+- A large request uploads the input datums. The SDK may split one logical batch
+  into transport chunks, submit chunks `2..N` in parallel, and submit chunk
+  `1` last so the trainer runs the chunks together. Metadata-only retrieval
+  does not reduce these uploads and cannot prevent a sequence-arrival gap while
+  the request is still in flight.
+- A large completed future response downloads outputs such as per-token
+  logprobs. On a compatible trainer, metadata-only retrieval lets the trainer
+  report that the future is complete and state its response size before the
+  client fetches the full body. The client can then reserve download capacity
+  and avoid concurrent multi-megabyte response fan-out.
+
+For a large batch that produces large future results, prefer metadata-only
+retrieval after confirming that the selected trainer and client both support
+the protocol. Do not describe it as a generic large-batch or upload-timeout
+mode.
+
+The current public cookbook intentionally disables metadata-only retrieval
+while the trainer fleet is being upgraded. It is not a cookbook default, and
+the cookbook does not currently expose a supported public toggle. If Fireworks
+has approved the staged rollout for a compatible trainer/client pair, enable it
+manually using the rollout-specific instructions. Do not monkeypatch private
+`tinker` internals. Otherwise, keep the compatibility behavior until the
+backend rollout is complete and the cookbook publishes a supported opt-in or
+changes the default.


### PR DESCRIPTION
Closed because this repository is a generated promotion target, not the authoring source.

The change will be ported to the reviewed staging source under `fw-ai/fireworks/public-repos/cookbook` and published through the normal promotion workflow.