### PR TITLE
fix(training): clean up dedicated recipe trainers on close

### DIFF
--- a/training/recipes/embedding_loop.py
+++ b/training/recipes/embedding_loop.py
@@ -338,6 +338,7 @@ def main(config: Config):
             max_context_length=max_context_length,
             learning_rate=cfg.learning_rate,
             trainer=cfg.trainer,
+            cleanup_trainer_on_close=True,
         )
         stack.callback(service.close)
         training_client = service.create_training_client(cfg.base_model, lora_rank=cfg.lora_rank)

--- a/training/recipes/orpo_loop.py
+++ b/training/recipes/orpo_loop.py
@@ -312,6 +312,7 @@ def main(
             max_context_length=cfg.max_seq_len,
             learning_rate=cfg.learning_rate,
             trainer=cfg.trainer,
+            cleanup_trainer_on_close=True,
         )
         stack.callback(service.close)
         training_client = service.create_training_client(cfg.base_model, lora_rank=cfg.lora_rank)

--- a/training/recipes/sft_loop.py
+++ b/training/recipes/sft_loop.py
@@ -835,6 +835,7 @@ def main(
                 max_context_length=cfg.max_seq_len,
                 learning_rate=cfg.learning_rate,
                 trainer=cfg.trainer,
+                cleanup_trainer_on_close=True,
             )
             stack.callback(service.close)
             training_client = service.create_training_client(

--- a/training/tests/unit/test_embedding_loop.py
+++ b/training/tests/unit/test_embedding_loop.py
@@ -6,6 +6,10 @@ import torch
 import training.recipes.embedding_loop as module
 
 
+class _StopAfterProvisioning(RuntimeError):
+    pass
+
+
 def _make_trailing_special_tokenizer():
     """A tiny self-contained fast tokenizer that appends one trailing special.
 
@@ -141,6 +145,30 @@ def test_main_rejects_small_batch_size(monkeypatch, tmp_path):
     )
     with pytest.raises(ValueError, match="batch_size must be >= 2"):
         module.main(cfg)
+
+
+def test_main_requests_cleanup_for_sdk_created_trainer(monkeypatch, tmp_path):
+    calls = []
+    monkeypatch.setenv("FIREWORKS_API_KEY", "test-key")
+    monkeypatch.setattr(module, "setup_wandb", lambda *args, **kwargs: None)
+    monkeypatch.setattr(module, "validate_config", lambda *args, **kwargs: None)
+
+    def fake_build_service_client(**kwargs):
+        calls.append(kwargs)
+        raise _StopAfterProvisioning
+
+    monkeypatch.setattr(module, "build_service_client", fake_build_service_client)
+    cfg = module.Config(
+        log_path=str(tmp_path),
+        dataset="/tmp/pairs.jsonl",
+        tokenizer_model="Qwen/Qwen3-Embedding-8B",
+    )
+
+    with pytest.raises(_StopAfterProvisioning):
+        module.main(cfg)
+
+    assert len(calls) == 1
+    assert calls[0]["cleanup_trainer_on_close"] is True
 
 
 def test_infonce_recall_is_perfect_for_aligned_pairs():

--- a/training/tests/unit/test_orpo_loop.py
+++ b/training/tests/unit/test_orpo_loop.py
@@ -42,6 +42,18 @@ def test_config_uses_shared_default_weight_decay():
     assert cfg.weight_decay == pytest.approx(module.DEFAULT_ADAM["weight_decay"])
 
 
+def test_main_requests_cleanup_for_sdk_created_trainer(monkeypatch, tmp_path):
+    cfg = module.Config(
+        log_path=str(tmp_path),
+        dataset="/tmp/preferences.jsonl",
+        tokenizer_model="Qwen/Qwen3.5-9B",
+    )
+
+    kwargs = _build_service_kwargs(monkeypatch, cfg)
+
+    assert kwargs["cleanup_trainer_on_close"] is True
+
+
 def test_main_rejects_invalid_base_model(monkeypatch):
     monkeypatch.setattr(module, "setup_wandb", lambda *args, **kwargs: None)
     cfg = module.Config(log_path="/tmp/orpo_test_logs", base_model="qwen3-4b", dataset="/tmp/pairs.jsonl", tokenizer_model="Qwen/Qwen3-4B")

--- a/training/tests/unit/test_sft_loop.py
+++ b/training/tests/unit/test_sft_loop.py
@@ -11,6 +11,10 @@ from training.utils import supervised as supervised_utils
 from training.utils.checkpoints import TrainingCheckpoints
 
 
+class _StopAfterProvisioning(RuntimeError):
+    pass
+
+
 def _patch_resume(monkeypatch, resume_info):
     """Replace TrainingCheckpoints.resume on the class for unit tests.
 
@@ -376,6 +380,41 @@ def test_main_requires_tokenizer_model(tmp_path, monkeypatch):
 
     with pytest.raises(ValueError, match="tokenizer_model"):
         module.main(cfg)
+
+
+def test_main_requests_cleanup_for_sdk_created_trainer(tmp_path, monkeypatch):
+    calls = []
+    monkeypatch.setenv("FIREWORKS_API_KEY", "test-key")
+    monkeypatch.setattr(module, "setup_wandb", lambda *args, **kwargs: None)
+    monkeypatch.setattr(module, "validate_config", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        module,
+        "validate_warm_start_config",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        module,
+        "_resolved_renderer_name",
+        lambda **kwargs: "qwen3",
+    )
+
+    def fake_build_service_client(**kwargs):
+        calls.append(kwargs)
+        raise _StopAfterProvisioning
+
+    monkeypatch.setattr(module, "build_service_client", fake_build_service_client)
+    cfg = module.Config(
+        log_path=str(tmp_path),
+        dataset="/tmp/sft.jsonl",
+        tokenizer_model="Qwen/Qwen3-8B",
+        max_seq_len=32,
+    )
+
+    with pytest.raises(_StopAfterProvisioning):
+        module.main(cfg)
+
+    assert len(calls) == 1
+    assert calls[0]["cleanup_trainer_on_close"] is True
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- enable `cleanup_trainer_on_close` for dedicated SFT, ORPO, and embedding recipes
- retain the existing `ExitStack` lifecycle so cleanup runs on normal completion and exceptions
- add call-site regression tests for all three changed recipes
- verify DPO continues to request the same cleanup policy

## Why

These recipes registered `service.close()` but inherited `build_service_client(..., cleanup_trainer_on_close=False)`. Closing therefore left SDK-created trainers running until inactivity cleanup, even though the recipes previously cleaned up newly created trainers and the cleanup documentation requires this flag.

The SDK applies trainer cleanup only when it created the trainer, so reattached trainers remain preserved.

## Testing

- explicit cleanup-policy assertions for SFT, DPO, ORPO, and embedding: **4 passed**
- `uvx ruff check` on all changed files
- full SFT, ORPO, and embedding unit modules: **50 passed**
- complete `training/tests/unit` run: **2,987 passed, 358 skipped, 75 xfailed, 26 failed**; the failures are unrelated environment/version mismatches (Tinker 0.22.2 vs tests requiring 0.23.0, stale SDK schema, and existing DeepSeek renderer expectations)