### PR TITLE
Fix DeepSeek V4 multi-turn SFT rendering

### DIFF
--- a/training/renderer/deepseek_v4.py
+++ b/training/renderer/deepseek_v4.py
@@ -87,6 +87,8 @@ from tinker_cookbook.renderers.base import (
 )
 from tinker_cookbook.tokenizer_utils import Tokenizer
 
+from training.renderer._disaggregate_mixin import DisaggregateMultiTurnMixin
+
 # ── Special tokens (must match encoding_dsv4.py exactly) ────────────────────
 # NOTE: ``｜`` is U+FF5C FULLWIDTH VERTICAL LINE (not ASCII ``|``).
 #       ``▁`` is U+2581 LOWER ONE EIGHTH BLOCK (not ASCII ``_``).
@@ -424,8 +426,15 @@ def _drop_thinking_from_history(messages: list[Message]) -> list[Message]:
 ThinkingMode = Literal["chat", "thinking"]
 
 
-class DeepseekV4Renderer(Renderer):
-    """Renderer for ``deepseek-ai/DeepSeek-V4-Flash`` instruct models."""
+class DeepseekV4Renderer(DisaggregateMultiTurnMixin, Renderer):
+    """Renderer for ``deepseek-ai/DeepSeek-V4-Flash`` instruct models.
+
+    The default thinking mode strips reasoning from historical assistant
+    turns and therefore does not satisfy the sequence extension property.
+    ``DisaggregateMultiTurnMixin`` renders each user-turn prefix as an
+    independent supervised example so multi-turn ``ALL_ASSISTANT_MESSAGES``
+    training stays aligned with inference-time history rendering.
+    """
 
     def __init__(
         self,

--- a/training/tests/unit/test_deepseek_v4_renderer.py
+++ b/training/tests/unit/test_deepseek_v4_renderer.py
@@ -37,8 +37,9 @@ from training.renderer.deepseek_v4 import (
     _DSML,
 )
 from training.tests import _encoding_dsv4_oracle as oracle
+from training.utils.supervised import render_messages_to_datums
 from tinker_cookbook.renderers import get_renderer
-from tinker_cookbook.renderers.base import ToolCall, TrainOnWhat
+from tinker_cookbook.renderers.base import Renderer, ToolCall, TrainOnWhat
 
 # Public HF tokenizer. Local mirror probed first so internal CI works without
 # the Hub; falls through to public if absent.
@@ -47,21 +48,27 @@ _PUBLIC_TOKENIZER = "deepseek-ai/DeepSeek-V4-Flash"
 
 
 def _load_tokenizer() -> transformers.PreTrainedTokenizerBase | None:
+    candidates: list[str] = []
     if Path(_LOCAL_TOKENIZER).exists():
+        candidates.append(_LOCAL_TOKENIZER)
+    candidates.append(_PUBLIC_TOKENIZER)
+
+    for model_id in candidates:
         try:
             return transformers.AutoTokenizer.from_pretrained(
-                _LOCAL_TOKENIZER,
+                model_id,
                 trust_remote_code=True,
             )
         except Exception:  # noqa: BLE001
-            pass
-    try:
-        return transformers.AutoTokenizer.from_pretrained(
-            _PUBLIC_TOKENIZER,
-            trust_remote_code=True,
-        )
-    except Exception:  # noqa: BLE001
-        return None
+            # DeepSeek V4's tokenizer is a standard tokenizer.json, but
+            # AutoTokenizer first loads the unregistered deepseek_v4 model
+            # config on some Transformers versions. Bypass model config so
+            # this suite cannot silently skip otherwise valid coverage.
+            try:
+                return transformers.PreTrainedTokenizerFast.from_pretrained(model_id)
+            except Exception:  # noqa: BLE001
+                continue
+    return None
 
 
 @pytest.fixture(scope="module")
@@ -184,6 +191,7 @@ def test_registered_factory_returns_thinking_strip(tokenizer):
     assert r.thinking_mode == "thinking"
     assert r.strip_thinking_from_history is True
     assert r.has_extension_property is False
+    assert type(r).build_supervised_examples is not Renderer.build_supervised_examples
 
 
 def test_keep_thinking_renderer_has_extension_property(renderer_thinking_keep):
@@ -1069,11 +1077,13 @@ def test_multi_turn_keeps_history_reasoning_in_keep_mode(
         {"role": "user", "content": "q2"},
         {"role": "assistant", "reasoning_content": "R2", "content": "A2"},
     ]
-    sup, weights = _renderer_supervised(
-        renderer_thinking_keep,
+    examples = renderer_thinking_keep.build_supervised_examples(
         _renderer_messages_from(msgs),
         train_on_what=TrainOnWhat.ALL_ASSISTANT_MESSAGES,
     )
+    assert len(examples) == 1
+    sup = list(examples[0][0].to_ints())
+    weights = [int(weight) for weight in examples[0][1].tolist()]
     trained = _trained_text(tokenizer, sup, weights)
     # Both turns' reasoning + content trained; user content not trained.
     assert "R1" in trained
@@ -1082,6 +1092,142 @@ def test_multi_turn_keeps_history_reasoning_in_keep_mode(
     assert "A2" in trained
     assert "q1" not in trained
     assert "q2" not in trained
+
+
+def test_default_renderer_disaggregates_multi_turn_all_assistant_messages(
+    tokenizer,
+    renderer_thinking_strip,
+):
+    """The production default must split and preserve each turn's target."""
+    messages = _renderer_messages_from(
+        [
+            {"role": "user", "content": "QUESTION_TURN_1"},
+            {
+                "role": "assistant",
+                "reasoning_content": "REASON_TURN_1",
+                "content": "ANSWER_TURN_1",
+            },
+            {"role": "user", "content": "QUESTION_TURN_2"},
+            {
+                "role": "assistant",
+                "reasoning_content": "REASON_TURN_2",
+                "content": "ANSWER_TURN_2",
+            },
+        ]
+    )
+    examples = renderer_thinking_strip.build_supervised_examples(
+        messages,
+        train_on_what=TrainOnWhat.ALL_ASSISTANT_MESSAGES,
+    )
+    assert len(examples) == 2
+
+    trained = [
+        _trained_text(
+            tokenizer,
+            list(model_input.to_ints()),
+            [int(weight) for weight in weights.tolist()],
+        )
+        for model_input, weights in examples
+    ]
+    assert "REASON_TURN_1" in trained[0]
+    assert "ANSWER_TURN_1" in trained[0]
+    assert "REASON_TURN_2" in trained[1]
+    assert "ANSWER_TURN_2" in trained[1]
+    assert "ANSWER_TURN_1" not in trained[1]
+
+
+@pytest.mark.parametrize(
+    ("renderer_fixture", "thinking_mode", "oracle_kwargs", "prefix_lengths"),
+    [
+        ("renderer_thinking_strip", "thinking", {}, [2, 4]),
+        (
+            "renderer_thinking_keep",
+            "thinking",
+            {"drop_thinking": False},
+            [4],
+        ),
+        ("renderer_chat", "chat", {}, [4]),
+    ],
+    ids=["thinking-interleaved", "thinking-preserved", "non-thinking"],
+)
+def test_production_sft_path_matches_upstream_tokens_for_each_mode(
+    request,
+    tokenizer,
+    renderer_fixture,
+    thinking_mode,
+    oracle_kwargs,
+    prefix_lengths,
+):
+    """Production dispatch is token-identical to every upstream SFT prefix.
+
+    The default interleaved renderer emits one datum per user turn, so compare
+    each split independently with ``encoding_dsv4.encode_messages``. Preserved
+    thinking and non-thinking chat mode satisfy the extension property and
+    therefore render the full conversation as one datum.
+    """
+    messages = [
+        {"role": "user", "content": "QUESTION_TURN_1"},
+        {
+            "role": "assistant",
+            "reasoning_content": "REASON_TURN_1",
+            "content": "ANSWER_TURN_1",
+        },
+        {"role": "user", "content": "QUESTION_TURN_2"},
+        {
+            "role": "assistant",
+            "reasoning_content": "REASON_TURN_2",
+            "content": "ANSWER_TURN_2",
+        },
+    ]
+    renderer = request.getfixturevalue(renderer_fixture)
+
+    datums = render_messages_to_datums(
+        messages,
+        renderer=renderer,
+        train_on_what=TrainOnWhat.ALL_ASSISTANT_MESSAGES,
+    )
+
+    assert len(datums) == len(prefix_lengths)
+    for datum, prefix_length in zip(datums, prefix_lengths, strict=True):
+        prefix = messages[:prefix_length]
+        expected_ids = _oracle_ids(
+            tokenizer,
+            prefix,
+            thinking_mode=thinking_mode,
+            **oracle_kwargs,
+        )
+        assert datum.token_ids == expected_ids
+
+        expected_weights = [0.0] * len(expected_ids)
+        assistant_indexes = [
+            index
+            for index, message in enumerate(prefix)
+            if message["role"] == "assistant"
+        ]
+        if renderer_fixture == "renderer_thinking_strip":
+            assistant_indexes = assistant_indexes[-1:]
+
+        for assistant_index in assistant_indexes:
+            generation_prompt_ids = _oracle_ids(
+                tokenizer,
+                prefix[:assistant_index],
+                thinking_mode=thinking_mode,
+                **oracle_kwargs,
+            )
+            through_assistant_ids = _oracle_ids(
+                tokenizer,
+                prefix[: assistant_index + 1],
+                thinking_mode=thinking_mode,
+                **oracle_kwargs,
+            )
+            assert expected_ids[: len(through_assistant_ids)] == through_assistant_ids
+            expected_weights[
+                len(generation_prompt_ids) : len(through_assistant_ids)
+            ] = [1.0] * (
+                len(through_assistant_ids) - len(generation_prompt_ids)
+            )
+
+        assert datum.token_weights == expected_weights
 
 
 def test_strip_history_drops_first_turn_reasoning(

--- a/training/tests/unit/test_disaggregate_overrides.py
+++ b/training/tests/unit/test_disaggregate_overrides.py
@@ -74,6 +74,11 @@ _PARITY_CASES = [
         "DeepSeekV3ThinkingSplitRenderer",
     ),
     (
+        "deepseek_v4",
+        "deepseek-ai/DeepSeek-V4-Flash",
+        "DeepseekV4Renderer",
+    ),
+    (
         "nemotron3",
         "nvidia/NVIDIA-Nemotron-Nano-9B-v2",
         "Nemotron3SplitRenderer",
@@ -136,7 +141,15 @@ def _load_tokenizer(model_id: str):
     except _TokenizerLoadTimeout:
         return None
     except Exception:  # noqa: BLE001 — network / gated repo / config drift
-        return None
+        if model_id != "deepseek-ai/DeepSeek-V4-Flash":
+            return None
+        try:
+            with _tokenizer_load_timeout():
+                return transformers.PreTrainedTokenizerFast.from_pretrained(model_id)
+        except _TokenizerLoadTimeout:
+            return None
+        except Exception:  # noqa: BLE001 — network / tokenizer file drift
+            return None
 
 
 def _decoded(tok, token_ids: list[int]) -> str:


### PR DESCRIPTION
## Summary

- make `DeepseekV4Renderer` use the shared multi-turn disaggregation path
- split `ALL_ASSISTANT_MESSAGES` rows into one supervised datum per user turn when historical thinking is stripped
- keep non-training modes on the existing single-datum fast path
- add production-path token and loss-mask parity coverage against DeepSeek's official `encoding_dsv4.py`
- prevent the DeepSeek V4 tokenizer suite from silently skipping when `AutoTokenizer` cannot load the unregistered `deepseek_v4` model config

## Root cause

The default DeepSeek V4 renderer strips thinking from historical assistant turns, so it does not have the sequence extension property. Multi-turn SFT therefore needs `build_supervised_examples` to render each user-turn prefix independently.

The renderer previously inherited the base implementation, which raised `NotImplementedError` when production attempted to render a multi-turn `ALL_ASSISTANT_MESSAGES` row.

## Behavior

For a two-turn conversation, training now produces:

- datum 1: first assistant reasoning/answer is the target
- datum 2: the first assistant is masked history and the second assistant reasoning/answer is the target

For each datum, the test independently derives:

1. expected token IDs from the official DeepSeek V4 encoder plus HF tokenizer
2. expected mask boundaries from the official generation prompt versus full supervised sequence

Both token IDs and masks must match the production `render_messages_to_datums` output exactly.

## Validation

- `94 passed` — DeepSeek V4 renderer suite
- `110 passed` — shared disaggregation matrix
- `67 passed` — production supervised rendering suite
- `1892 passed, 82 skipped, 78 xfailed` — renderer property suite
- `ruff check`
- `git diff --check`

A managed GPU training canary is still required after the branch/image is deployed; the existing scheduled training smoke currently covers Qwen rather than DeepSeek V4.