### PR TITLE
skills(training): preserve depth from docs revamp

### DIFF
--- a/skills/fireworks-training/SKILL.md
+++ b/skills/fireworks-training/SKILL.md
@@ -168,10 +168,11 @@ serverless, or dedicated workflows.
 Live docs:
 
 - Training overview: <https://docs.fireworks.ai/fine-tuning/finetuning-intro.md>
+- Agent Skills: <https://docs.fireworks.ai/fine-tuning/agent/use-with-coding-agents.md>
 - Managed training: <https://docs.fireworks.ai/fine-tuning/managed-finetuning-intro.md>
 - Training API: <https://docs.fireworks.ai/fine-tuning/training-api/introduction.md>
 - Serverless training: <https://docs.fireworks.ai/fine-tuning/training-api/serverless.md>
-- Dedicated training lifecycle: <https://docs.fireworks.ai/fine-tuning/training-api/training-and-sampling.md>
+- Dedicated training: <https://docs.fireworks.ai/fine-tuning/training-api/dedicated.md>
 
 ## Mandatory final-plan confirmation
 
@@ -252,7 +253,7 @@ This handoff is identical across Claude Code, Cursor, and Codex.
 | Managed SFT | `firectl sftj` | Not applicable | `references/choose-method.md` |
 | Managed DPO | `firectl dpo-job create --loss-method DPO` | Not applicable | `references/choose-method.md` |
 | Managed ORPO | `firectl dpo-job create --loss-method ORPO` | Not applicable | `references/choose-method.md` |
-| Managed RFT | `firectl rftj create --evaluator <resource>` | Not applicable | `references/preference-data-and-evaluators.md`, `references/training-api.md` |
+| Managed RFT | `firectl rftj create --evaluator <resource>` | Not applicable | `references/managed-rft-operations.md`, `references/preference-data-and-evaluators.md` |
 | Training API SFT | Not applicable | [`training/recipes/sft_loop.py`](https://github.com/fw-ai/cookbook/blob/main/training/recipes/sft_loop.py) | `references/sdk-recipes.md` |
 | Training API DPO | Not applicable | [`training/recipes/dpo_loop.py`](https://github.com/fw-ai/cookbook/blob/main/training/recipes/dpo_loop.py) | `references/sdk-recipes.md` |
 | Training API ORPO | Not applicable | [`training/recipes/orpo_loop.py`](https://github.com/fw-ai/cookbook/blob/main/training/recipes/orpo_loop.py) | `references/sdk-recipes.md` |
@@ -412,6 +413,10 @@ Read only what the task requires:
 | Method choice, schemas, classification, LoRA/full parameter | `references/choose-method.md` |
 | Preference generation and evaluator authoring | `references/preference-data-and-evaluators.md` |
 | Managed versus Training API RFT | `references/training-api.md` |
+| Managed RFT launch, monitoring, and validation | `references/managed-rft-operations.md` |
+| Managed RFT remote tracing | `references/rft-agent-tracing.md` |
+| Secure training operations | `references/secure-training-operations.md` |
+| Training API losses and datum contracts | `references/training-api-losses.md` |
 | Models, contexts, shapes, and costs | `references/models-shapes-and-cost.md` |
 | Deployment, evaluation, and teardown | `references/deploy-and-troubleshoot.md` |
 | Failure classification and escalation | `references/error-reference.md` |

--- a/skills/fireworks-training/references/choose-method.md
+++ b/skills/fireworks-training/references/choose-method.md
@@ -44,7 +44,7 @@ JSONL, one object per line; OpenAI-style `messages`. **Min 3, max 3M** (aim for 
 {"messages":[{"role":"system","content":"You are a helpful assistant."},{"role":"user","content":"Capital of France?"},{"role":"assistant","content":"Paris."}]}
 ```
 
-Docs: https://docs.fireworks.ai/fine-tuning/fine-tuning-models · [weighted training](https://docs.fireworks.ai/fine-tuning/weighted-training)
+Docs: https://docs.fireworks.ai/fine-tuning/fine-tuning-models.md. For managed RFT weighting and launch controls, read `managed-rft-operations.md` and the installed CLI help.
 
 ## DPO format
 
@@ -59,7 +59,7 @@ If the user has prompts but no preference pairs, do not reject the task or silen
 
 ## RFT — reinforcement fine-tuning
 
-Provide three things (not necessarily labeled outputs): a **dataset** of prompts; an **evaluator or inline reward** that scores an output 0.0→1.0; and the **agent** being trained. Managed RFT uses a registered evaluator. Training API RFT uses reward code and may read `ground_truth` or any other field declared by that reward. Start with **200–500 diverse prompts**. Docs: https://docs.fireworks.ai/fine-tuning/how-rft-works · [evaluators](https://docs.fireworks.ai/fine-tuning/evaluators)
+Provide three things (not necessarily labeled outputs): a **dataset** of prompts; an **evaluator or inline reward** that scores an output 0.0→1.0; and the **agent** being trained. Managed RFT uses a registered evaluator. Training API RFT uses reward code and may read `ground_truth` or any other field declared by that reward. Start with **200–500 diverse prompts**. Docs: https://docs.fireworks.ai/fine-tuning/reinforcement-fine-tuning-models.md. Evaluator authoring: `preference-data-and-evaluators.md`.
 
 ## Classification (a common SFT task)
 
@@ -77,7 +77,7 @@ For anything past a smoke run, don't hand-pick one config: run the small grid be
 
 ## LoRA vs full-parameter
 
-**Pick LoRA first** — small adapter, cheaper/faster, fewer GPUs, deployable on the base model. **LoRA rank** default 8 (range 4–32); raise for complex reasoning, keep low for style/format. Go **full-parameter** only when LoRA plateaus and you have GPU budget. Docs: https://docs.fireworks.ai/fine-tuning/parameter-tuning
+**Pick LoRA first** — small adapter, cheaper/faster, fewer GPUs, deployable on the base model. Resolve the current default and range from live docs, the selected training shape, and CLI or recipe configuration. Go **full-parameter** only when LoRA plateaus and you have GPU budget. Docs: https://docs.fireworks.ai/fine-tuning/reinforcement-fine-tuning-models.md.
 
 ## Data quality (the main driver of SFT quality)
 

--- a/skills/fireworks-training/references/getting-started.md
+++ b/skills/fireworks-training/references/getting-started.md
@@ -91,4 +91,4 @@ firectl quota list      # GPU quotas, rate limits, spend limit, usage
 - [ ] New fine-tuned LoRA in `firectl model list`.
 - [ ] Deploy it on-demand and get a sensible completion → `references/deploy-and-troubleshoot.md`.
 
-> Wrong text learned / assistant turn ignored? Use Render Samples / [Debug SFT tokenization](https://docs.fireworks.ai/fine-tuning/debug-sft-tokenization.md).
+> Wrong text learned or assistant turn ignored? Use Render Samples and `renderer-verification.md`.

--- a/skills/fireworks-training/references/managed-rft-operations.md
+++ b/skills/fireworks-training/references/managed-rft-operations.md
@@ -1,0 +1,122 @@
+# Managed RFT: launch, monitor, and validate
+
+*Source of truth: live [RFT overview](https://docs.fireworks.ai/fine-tuning/reinforcement-fine-tuning-models.md), [Models matrix](https://docs.fireworks.ai/fine-tuning/models.md), [RFT parameters](https://docs.fireworks.ai/fine-tuning/rft-parameters-reference.md), and [Eval Protocol](https://evalprotocol.io/introduction). Defer flags and defaults to installed CLI `--help`.*
+
+Use this reference for managed RFT preflight, launch, job states, monitoring, and recovery. Training API or cookbook RL belongs in `references/training-api.md` and `references/rl-async.md`.
+
+## Preflight
+
+Before any upload or create:
+
+- Confirm the base model is RFT-compatible in the live Models matrix.
+- Validate JSONL locally. Each row needs a `messages` array; evaluator-specific fields must match the reviewed evaluator contract.
+- Probe the evaluator on at least five rows and require non-identical scores.
+- Check authentication, account, billing readiness, and `firectl quota list`.
+- Use full resource names such as `accounts/fireworks/models/<id>`.
+- Run `firectl rftj create --help` and resolve every user-set or defaulted value before the confirmation gate in `SKILL.md`.
+
+## Launch surfaces
+
+| Surface | When | Entry |
+|---|---|---|
+| Eval Protocol | Reproducible evaluator and dataset workflow | `eval-protocol create rft ...` |
+| `firectl` | Direct managed API and advanced flags | `firectl rftj create ...` |
+| Dashboard | Human-guided exploratory launch | Fine-Tuning, then Reinforcement |
+
+### Eval Protocol workflow
+
+```bash
+pip install eval-protocol
+export FIREWORKS_API_KEY=...
+
+cd evaluator_directory
+ep local-test
+
+eval-protocol create rft \
+  --base-model accounts/fireworks/models/qwen3-4b \
+  --output-model my-rft-output
+```
+
+The create command uploads changed evaluator and dataset artifacts, creates the job, and prints dashboard links. Treat upload and create as protected work under the confirmation gate.
+
+### `firectl` alternative
+
+```bash
+firectl rftj create \
+  --base-model accounts/fireworks/models/qwen3-4b \
+  --dataset accounts/<acct>/datasets/<id> \
+  --evaluator accounts/<acct>/evaluators/<id> \
+  --output-model accounts/<acct>/models/<out>
+```
+
+Run `firectl rftj create --help` for the authoritative checkpoint, rollout, W&B, and sampling flags.
+
+### Warm start
+
+Continue from a promoted or uploaded LoRA without also passing `--base-model`:
+
+```bash
+eval-protocol create rft \
+  --warm-start-from accounts/<acct>/models/<sft-model-id> \
+  --output-model <rft-model-id>
+```
+
+If the API reports that an `HF_PEFT_ADDON` is not a base model, remove `--base-model`.
+
+## Parameter policy
+
+Do not freeze volatile defaults in this skill. Resolve them from `--help`, the dry-run output, and live docs. The important relationships are:
+
+- `epochs`, learning rate, and LoRA rank control optimization.
+- Batch size is a token budget, while chunk size controls prompts per GRPO step.
+- GRPO accepts a KL coefficient; DAPO and GSPO-token use different clipping and reject GRPO-only settings.
+- Candidate count and temperature control rollout diversity.
+- Maximum concurrent rollouts controls throughput, not the objective.
+- Remote server URL selects a remote evaluator or environment.
+
+Method semantics and starting points live in `references/choose-method.md`; exact parameter fields live in the RFT parameter reference.
+
+## Job states and progress
+
+Poll with:
+
+```bash
+firectl rftj get <job-id> -o json
+```
+
+| State | Meaning | Agent action |
+|---|---|---|
+| `PENDING` | Waiting for resources | Continue bounded monitoring |
+| `VALIDATING` | Dataset and evaluator checks | Wait for validation result |
+| `RUNNING` | Active work | Require rollout, step, reward, or W&B movement |
+| `COMPLETED` | Successful run | Evaluate, then separately confirm promotion and deployment |
+| `FAILED` | Hard failure | Classify with `references/error-reference.md` |
+| `CANCELLED` | User stopped the run | Report final state and partial artifacts |
+| `EARLY_STOPPED` | No useful improvement | Inspect evaluator and data signal |
+
+State alone is not progress. Use the approved no-progress timeout and the evidence contract in `references/run-state-and-reporting.md`.
+
+Use the dashboard for rollout inspection, reward curves, logs, job comparison, and human diagnosis. Keep automation on stable resource IDs and `firectl ... get`.
+
+## Secrets in evaluators
+
+Create secrets through the Fireworks secret-management surface and reference them by environment-variable name in evaluator code. Never paste secret values into a manifest, dataset, or chat. For remote environments, also read `references/rft-agent-tracing.md`.
+
+## Common failures
+
+| Symptom | Next action |
+|---|---|
+| Invalid JSON on line N | Fix that JSONL row locally |
+| Missing `messages` | Add the required conversation array |
+| Evaluator not found | Register or select the reviewed evaluator |
+| Flat reward across probes | Fix evaluator saturation before launch |
+| HTTP 429 | Check quota and back off; do not create replacement IDs |
+| `HF_PEFT_ADDON` rejected as base model | Remove `--base-model` when warm-starting |
+
+## Related
+
+- Evaluator authoring: `references/preference-data-and-evaluators.md`
+- Remote tracing: `references/rft-agent-tracing.md`
+- Failure triage: `references/error-reference.md`
+- Run manifest and reporting: `references/run-state-and-reporting.md`
+- Cost formulas: [multi-turn cost comparison](https://docs.fireworks.ai/fine-tuning/multi-turn-cost-comparison.md)

--- a/skills/fireworks-training/references/models-shapes-and-cost.md
+++ b/skills/fireworks-training/references/models-shapes-and-cost.md
@@ -1,6 +1,6 @@
 # Models, training shapes & cost
 
-*Source of truth: [Training shapes catalog](https://docs.fireworks.ai/fine-tuning/training-api/training-shapes.md) · [pricing](https://fireworks.ai/pricing) — these are generated live; always defer to them over anything written here.*
+*Source of truth: [Models and method support](https://docs.fireworks.ai/fine-tuning/models.md), [Training shapes](https://docs.fireworks.ai/fine-tuning/training-api/training-shapes.md), and [pricing](https://fireworks.ai/pricing). These are generated live; always defer to them over anything written here.*
 
 How to choose a base model + training shape, and reason about cost. **Always confirm against the live catalog and pricing page — model lists and prices change.**
 
@@ -10,7 +10,7 @@ A **training shape** is a pre-configured GPU + model profile bundled into one re
 
 Locked by the shape (not user-overridable): `acceleratorType`, `acceleratorCount`, `nodeCount`, `maxSupportedContextLength`, trainer image, linked deployment shape. You still set: `base_model`, `lora_rank`, `lora_alpha`, `learning_rate`, `display_name`, replica counts.
 
-**Pick one:** find your base model in the catalog → pick the shape matching your method (SFT/DPO/RFT) and approach (LoRA vs full-param); the per-model **Training method support** matrix shows combinations + total GPU + surfaces. Pass the full path, e.g. `accounts/fireworks/trainingShapes/qwen3p5-9b-256k`. Catalog (live): https://docs.fireworks.ai/fine-tuning/training-api/training-shapes.md
+**Pick one:** find your base model in the catalog, confirm the supported method and surface, then pick the compatible shape for LoRA or full-parameter work. Pass the full path, for example `accounts/fireworks/trainingShapes/qwen3p5-9b-256k`. Live catalog: https://docs.fireworks.ai/fine-tuning/models.md
 
 ```python
 service = FiretitanServiceClient.from_firetitan_config(
@@ -24,7 +24,7 @@ service = FiretitanServiceClient.from_firetitan_config(
 
 ## Supported base models
 
-Most major open families — **DeepSeek, Qwen, Kimi, GLM, Gemma, Llama, Nemotron, MiniMax** and more. Eligibility is specific to method, tuning mode, and training shape. Confirm SFT, DPO, ORPO, or RFT support in the live Training Shapes matrix before launch. The set is generated from the live registry — **don't hardcode it**. Live: [tunable text](https://app.fireworks.ai/models?filter=LLM&tunable=true) · [vision](https://app.fireworks.ai/models?filter=vision&tunable=true) · [method-support matrix](https://docs.fireworks.ai/fine-tuning/training-api/training-shapes.md)
+Eligibility is specific to model, method, tuning mode, surface, and training shape. Confirm support in the live Models matrix before launch. The set is generated from the registry; do not hardcode a family list. Live: [tunable text](https://app.fireworks.ai/models?filter=LLM&tunable=true) · [vision](https://app.fireworks.ai/models?filter=vision&tunable=true) · [method-support matrix](https://docs.fireworks.ai/fine-tuning/models.md)
 
 ## Context length & LoRA configuration
 
@@ -42,7 +42,7 @@ The platform maps GPU class + count to the model — **let it**. Larger/MoE → 
 
 **Per training token** — managed SFT and DPO where listed. **Read current rates from the live [pricing page](https://fireworks.ai/pricing)** rather than trusting a hardcoded table.
 
-**Runtime-priced resources** — managed RFT may be free for eligible small models (confirm on the live pricing page; do not assume a fixed size threshold). Other managed RFT and dedicated Training API resources follow current pricing. Dedicated trainers and deployments use GPU-hour rates, including priced classes such as B300 and GB300, and are metered by runtime.
+**Runtime-priced resources** — managed RFT and dedicated Training API resources follow current pricing. Dedicated trainers and deployments use GPU-hour rates and are metered by runtime. Never claim a free RFT tier unless the live pricing page explicitly shows one.
 
 **Inference:** serverless per-token; dedicated per GPU-hour.
 

--- a/skills/fireworks-training/references/preference-data-and-evaluators.md
+++ b/skills/fireworks-training/references/preference-data-and-evaluators.md
@@ -89,7 +89,7 @@ Show the spec to the user and resolve ambiguity before implementing the evaluato
 
 ### Managed RFT evaluator
 
-Managed RFT uses a registered eval3 evaluator with an `entry_point`. Use Eval Protocol's current code-first flow and defer exact APIs to the live [evaluator docs](https://docs.fireworks.ai/fine-tuning/evaluators.md).
+Managed RFT uses a registered evaluator with a reviewed entry point. Use Eval Protocol's current code-first flow, read `managed-rft-operations.md`, and defer exact APIs to the live [RFT overview](https://docs.fireworks.ai/fine-tuning/reinforcement-fine-tuning-models.md).
 
 1. Write the Eval Protocol reward in the workspace.
 2. Add deterministic unit examples for full credit, partial credit, zero, malformed output, and edge cases.

--- a/skills/fireworks-training/references/rft-agent-tracing.md
+++ b/skills/fireworks-training/references/rft-agent-tracing.md
@@ -1,0 +1,94 @@
+# Managed RFT remote tracing
+
+*Source of truth: live [Remote Environment Setup](https://docs.fireworks.ai/fine-tuning/connect-environments.md) and [Eval Protocol](https://evalprotocol.io/introduction).*
+
+Use this reference when implementing a managed RFT remote environment, wiring Fireworks tracing, or debugging a reward-to-rollout join. For custom Training API agent trajectories, use `references/rl-agentic.md`.
+
+## Why tracing matters
+
+Agent training needs the complete trajectory, including model calls, tools, environment state, and terminal reward. Tracing supports credit assignment, replay, and diagnosis without forcing the evaluator to infer hidden steps from the final answer.
+
+## Correlation metadata
+
+Carry the identifiers provided by the `/init` request through every log and trace:
+
+- `invocation_id`
+- `experiment_id`
+- `rollout_id`
+- `run_id`
+- `row_id`
+
+Do not invent replacements or drop them when spawning a child process.
+
+## Required pieces
+
+1. Use the supplied `model_base_url` unchanged for model calls. It contains the routing and correlation context required by the trainer.
+2. Attach `FireworksTracingHttpHandler` and `RolloutIdFilter`, or propagate `EP_ROLLOUT_ID` to child processes.
+3. Emit a structured terminal status with `Status.rollout_finished()` or `Status.rollout_error(message)`.
+
+The trainer polls by `rollout_id`, joins status and trace data, and then computes or records the reward.
+
+## Minimal server pattern
+
+```python
+import logging
+
+from eval_protocol import (
+    FireworksTracingHttpHandler,
+    InitRequest,
+    RolloutIdFilter,
+    Status,
+)
+
+logging.getLogger().addHandler(FireworksTracingHttpHandler())
+
+
+@app.post("/init")
+def init(request: InitRequest):
+    logger = logging.getLogger(f"eval.{request.metadata.rollout_id}")
+    logger.addFilter(RolloutIdFilter(request.metadata.rollout_id))
+    try:
+        # Use request.model_base_url and request.api_key for policy calls.
+        # Run the environment and compute the reviewed reward.
+        logger.info("done", extra={"status": Status.rollout_finished()})
+    except Exception as exc:
+        logger.error(
+            "failed",
+            extra={"status": Status.rollout_error(str(exc))},
+        )
+```
+
+Treat exception text as potentially sensitive. Redact credentials, signed URLs, raw customer data, and private environment values before logging.
+
+## Capture
+
+- Input identifiers, deterministic seeds, and retrieval-context summaries
+- Model messages, parameters, token counts, and response identifiers
+- Tool input and output summaries without credentials
+- Per-step and terminal rewards with documented weights
+- Errors, timeouts, and artifacts required for verification
+
+## Operational rules
+
+- Keep stable field names for automated filters.
+- Emit heartbeats for long rollouts.
+- Always finalize success or failure.
+- Normalize rewards to the reviewed range.
+- Pin code and dependency versions when reproducibility matters.
+- Never substitute a reconstructed base URL for `model_base_url`.
+
+## Join failures
+
+When a rollout is missing from reward or trace views:
+
+1. Confirm the same `rollout_id` appears in `/init`, logger filters, child processes, and terminal status.
+2. Confirm the policy client used the supplied `model_base_url`.
+3. Confirm a terminal status was emitted exactly once.
+4. Check for process exits before buffered logs were flushed.
+5. Inspect redacted traces before retrying; do not convert a missing trace into reward zero.
+
+## Related
+
+- Managed RFT launch and monitoring: `managed-rft-operations.md`
+- Evaluator authoring: `preference-data-and-evaluators.md`
+- Custom Training API agent trajectories: `rl-agentic.md`

--- a/skills/fireworks-training/references/rl-hotload.md
+++ b/skills/fireworks-training/references/rl-hotload.md
@@ -9,7 +9,7 @@ is controlled by `max_head_offpolicy_versions`, not by delaying weight sync.
 `weight_sync_timeout` controls the hotload timeout; the *scope* (who owns the
 GCS bucket) is set on `DeployConfig.weight_sync_scope`.
 
-For current user-facing checkpoint and sampling flows, see [Training and Sampling](https://docs.fireworks.ai/fine-tuning/training-api/training-and-sampling.md) and [Saving and Loading](https://docs.fireworks.ai/fine-tuning/training-api/saving-and-loading.md). This file is the deep scope-mismatch and recovery reference.
+For the current user-facing lifecycle, see [Dedicated Training](https://docs.fireworks.ai/fine-tuning/training-api/dedicated.md). This file is the deep scope-mismatch and recovery reference.
 
 ## Weight sync scope: PER_TRAINER vs PER_DEPLOYMENT
 
@@ -105,7 +105,7 @@ Note that neither mode re-prefills: `ASYNC` reuses the old-weight KV and `SYNC`
 avoids the overlap entirely. Fireworks has no mode that discards the prefix KV
 and recomputes it under the new weights mid-generation.
 
-## Base vs delta chain
+## Incremental snapshots ARC2
 
 For full-parameter training, the first sampler save is `base` (full weights, ~16 GB for 8B). Subsequent saves are `delta` (XOR diff, ~10× smaller). The SDK-managed sampler backend records this chain automatically — users don't pick per-step.
 
@@ -245,8 +245,8 @@ Agents sometimes copy old cookbook snippets that reference `hot_load_deployment_
 
 ## See also
 
-- [Training and Sampling](https://docs.fireworks.ai/fine-tuning/training-api/training-and-sampling.md) — current user-facing lifecycle
-- [Saving and Loading](https://docs.fireworks.ai/fine-tuning/training-api/saving-and-loading.md) — checkpoint and sampler behavior
+- [Dedicated Training](https://docs.fireworks.ai/fine-tuning/training-api/dedicated.md) — user-facing lifecycle
+- [`sdk-checkpoints.md`](sdk-checkpoints.md) — checkpoint and resume behavior
 - Low-level `WeightSyncer` lifecycle: `fireworks.training.sdk.weight_syncer.WeightSyncer` (installed under `src/fireworks/training/sdk/weight_syncer.py`). Recipes use SDK-managed service hotload directly.
 - `save_weights_for_sampler_ext`, `save_state`, `list_checkpoints`: `fireworks.training.sdk.client.FiretitanTrainingClient`.
 - Trainer + deployment managers this flow depends on: `fireworks.training.sdk.trainer.TrainerJobManager` and `fireworks.training.sdk.deployment.DeploymentManager`.

--- a/skills/fireworks-training/references/sdk-tools.md
+++ b/skills/fireworks-training/references/sdk-tools.md
@@ -37,7 +37,7 @@ python training/examples/tools/promote_checkpoint.py \
     --hot-load-deployment-id <deployment-id>
 ```
 
-Source: `training/examples/tools/promote_checkpoint.py`. Hands the row's 4-segment `name` (`accounts/<a>/rlorTrainerJobs/<j>/checkpoints/<c>`) verbatim to `TrainerJobManager.promote_checkpoint(name=...)` — the modern promote API. See the public docs at [`/fine-tuning/training-api/saving-and-loading`](https://docs.fireworks.ai/fine-tuning/training-api/saving-and-loading) for the full contract. The `--hot-load-deployment-id` flag is only needed for deployments that predate the stored-bucket-URL migration; passing it emits a `DeprecationWarning`.
+Source: `training/examples/tools/promote_checkpoint.py`. Hands the row's 4-segment `name` (`accounts/<a>/rlorTrainerJobs/<j>/checkpoints/<c>`) verbatim to `TrainerJobManager.promote_checkpoint(name=...)`, the modern promote API. See [Dedicated Training](https://docs.fireworks.ai/fine-tuning/training-api/dedicated.md) and `sdk-checkpoints.md` for the full contract. The `--hot-load-deployment-id` flag is only needed for deployments that predate the stored-bucket-URL migration; passing it emits a `DeprecationWarning`.
 
 `output_model_id` is validated server-side at 63 chars — validate client-side too:
 

--- a/skills/fireworks-training/references/secure-training-operations.md
+++ b/skills/fireworks-training/references/secure-training-operations.md
@@ -1,0 +1,80 @@
+# Secure training operations
+
+*Source of truth: live [Training overview](https://docs.fireworks.ai/fine-tuning/finetuning-intro.md), [Data handling](https://docs.fireworks.ai/guides/security_compliance/data_handling.md), and [Data security](https://docs.fireworks.ai/guides/security_compliance/data_security.md). Public policy, retention, and current product support stay in those docs.*
+
+Use this reference for agent-assisted BYOB and CMEK setup. Always confirm the current cloud, method, and resource support in live docs before preparing commands.
+
+## Bring your own bucket
+
+BYOB lets Fireworks read a training dataset from customer-managed object storage. Use least-privilege access scoped to the required bucket and prefix, and revoke access after the approved workflow completes.
+
+```bash
+firectl dataset create <dataset-id> \
+  --external-url gs://<bucket>/<prefix>/data.jsonl
+```
+
+Use the equivalent `s3://` or Azure URL only when the live docs confirm support for the selected workflow. Dataset registration is protected work and requires the final-plan confirmation in `SKILL.md`.
+
+### GCS
+
+Use the exact service-account identities supplied during onboarding. Grant only the documented bucket-policy read and object-view permissions required by the current flow. Do not copy service-account emails from another account or an old run.
+
+### AWS S3
+
+- Prefer OIDC federation to long-lived access keys.
+- Restrict the trust policy by issuer, subject, and audience exactly as current onboarding specifies.
+- Grant only `s3:GetObject` and the required `s3:ListBucket` prefix.
+- Pass the reviewed IAM role only on commands that support it according to `--help`.
+
+### Azure Blob
+
+Prefer workload identity federation. If a supported workflow requires a Fireworks secret resource, reference its resource name without exposing the credential value.
+
+## Customer-managed encryption keys
+
+CMEK uses the customer's cloud KMS key to wrap Fireworks-managed data-encryption keys. Keep these concerns separate:
+
+- BYOB controls where the source dataset lives.
+- CMEK controls encryption of supported Fireworks-managed artifacts at rest.
+- Neither substitutes for in-memory training isolation or inference data-handling policy.
+
+Before setup:
+
+1. Confirm the selected cloud and training method are supported in the live Training security section.
+2. Confirm the exact issuer, subject, audience, and permissions for the user's account.
+3. Show the role and key resource names without secret material.
+4. Run the installed `firectl ... --help` for the current registration command.
+5. Obtain confirmation before registering a key or starting a job.
+
+Do not publish or automate a draft CLI contract from memory.
+
+## Rotation and revocation
+
+- Treat key disablement or IAM removal as a potentially disruptive action.
+- Explain which active and stored artifacts depend on the key before asking for confirmation.
+- Verify access after rotation with a read-only listing or status check.
+- Use the cloud provider's audit log for KMS operations.
+
+## Secure RFT
+
+For proprietary prompts or rewards:
+
+1. Keep dataset access least-privileged through BYOB when supported.
+2. Keep evaluator or environment credentials in the secret-management surface.
+3. Use a managed remote environment or Training API path appropriate to the reviewed workflow.
+4. Follow `references/rft-agent-tracing.md` for redacted managed tracing or `references/rl-agentic.md` for custom Training API trajectories.
+5. Revoke temporary storage access and tear down billable resources after the run.
+
+## Non-negotiables
+
+- Never place cloud credentials, signed URLs, raw IAM policy output, or customer data in a run report.
+- Never reuse another account's onboarding identities or OIDC audience.
+- Never claim a method or cloud is CMEK-supported without checking live docs.
+- Keep human-readable policy in public docs; this reference only governs operational execution.
+
+## Related
+
+- Managed RFT: `managed-rft-operations.md`
+- Managed remote tracing: `rft-agent-tracing.md`
+- Training API agent trajectories: `rl-agentic.md`
+- Failure handling: `error-reference.md`

--- a/skills/fireworks-training/references/training-api-losses.md
+++ b/skills/fireworks-training/references/training-api-losses.md
@@ -1,0 +1,89 @@
+# Training API losses and datums
+
+*Source of truth: live [Dedicated Training](https://docs.fireworks.ai/fine-tuning/training-api/dedicated.md), [service client reference](https://docs.fireworks.ai/fine-tuning/training-api/reference/service-client.md), and the maintained cookbook recipes. Defer signatures to the installed SDK and pinned cookbook checkout.*
+
+Use this reference when selecting a loss path, constructing datums, or forking a recipe. Checkpoint behavior belongs in `sdk-checkpoints.md`; hotload recovery belongs in `rl-hotload.md`.
+
+## Choose the loss path
+
+| Need | API pattern | Start from |
+|---|---|---|
+| Standard SFT | Recipe-owned weighted token loss | `training/recipes/sft_loop.py` |
+| DPO or ORPO | Pairwise recipe objective | `dpo_loop.py` or `orpo_loop.py` |
+| Standard synchronous RL | Cookbook GRPO path | `rl_loop.py` |
+| Standard asynchronous RL | Cookbook async objective and scheduler | `async_rl_loop.py` |
+| New research objective | Fork the closest maintained recipe | `rl-custom-loss.md` |
+| Direct built-in loss | `forward_backward(...)` | Installed SDK contract |
+| Direct client closure | `forward_backward_custom(...)` | Closest recipe implementation |
+
+Prefer a maintained recipe over a blank loop. A direct SDK call is appropriate only when the reviewed task needs a contract the recipes do not expose.
+
+## Datum invariants
+
+- Preserve exact token IDs produced by the selected renderer.
+- Apply loss only to intended policy or target tokens.
+- Keep prompt, system, user, tool-result, and repaired-context tokens masked.
+- Keep per-token weights aligned with tokens and log probabilities.
+- Validate every row locally before upload or trainer creation.
+- For multimodal datums, follow the public docs and renderer reference rather than inventing an image schema in the skill.
+
+Read `renderer.md` and `renderer-verification.md` before changing tokenization or masks.
+
+## Built-in and custom calls
+
+`forward_backward` uses a trainer-supported objective and the datum fields that objective requires. `forward_backward_custom` returns local differentiable log probabilities to a reviewed closure that produces one scalar loss and metrics.
+
+```python
+loss, metrics = loss_fn(data, logprobs_list)
+```
+
+The closure must:
+
+1. Return a scalar differentiable loss.
+2. Preserve token alignment.
+3. Normalize by the reviewed unit, such as loss tokens or sequences.
+4. Report enough metrics to detect empty masks, zero variance, NaNs, and clipping saturation.
+
+Do not assume that a weighted SFT datum satisfies a built-in cross-entropy contract. Use the recipe path or inspect the installed SDK's required datum fields.
+
+## Gradient accumulation
+
+Accumulate by calling forward/backward multiple times before one optimizer step. Do not configure removed trainer-launch accumulation fields.
+
+Normalization must be explicit when microbatches have different token or sequence counts. Read `rl-gradient-accumulation.md` for supported normalization modes and failure checks.
+
+## DPO, ORPO, and RL
+
+- DPO and ORPO use the pairwise schema and recipe implementation in `sdk-recipes.md`.
+- GRPO and related objectives require grouped samples, aligned behavior log probabilities, and reviewed advantage normalization.
+- Custom agent trajectories must satisfy `rl-agentic.md`.
+- Async scheduling and off-policy admission belong in `rl-async.md`, not in the loss closure.
+
+## Checkpoints are a separate contract
+
+Do not conflate:
+
+1. Sampler snapshots for weight sync.
+2. DCP state for exact resume.
+3. Promotable checkpoints for creating a Fireworks model.
+
+Read `sdk-checkpoints.md` for save, resume, and promote behavior and `rl-hotload.md` for deployment synchronization.
+
+## Preflight checklist
+
+- Pin the cookbook commit and compatible SDK version.
+- Select the closest maintained recipe.
+- Validate datum schema and renderer output on a small local sample.
+- Verify non-empty masks and finite loss.
+- Record the normalization unit and gradient-accumulation behavior.
+- Resolve checkpoint, resume, deployment, and teardown configuration.
+- Include all resolved values in the final-plan confirmation.
+
+## Related
+
+- Recipe catalog: `sdk-recipes.md`
+- Custom RL objectives: `rl-custom-loss.md`, `rl-loss-paths.md`
+- Gradient accumulation: `rl-gradient-accumulation.md`
+- Checkpoints: `sdk-checkpoints.md`
+- Hotload: `rl-hotload.md`
+- Renderer correctness: `renderer-verification.md`

--- a/skills/fireworks-training/references/training-api.md
+++ b/skills/fireworks-training/references/training-api.md
@@ -23,7 +23,7 @@ Use **managed training** for standard SFT/DPO/ORPO/RFT jobs. Reach for the **Tra
 | **Serverless** | Supported-model LoRA SFT or RL, shared pool, per-token billing, no provisioning | `training/examples/serverless_rl/` |
 | **Dedicated** | Full-parameter, DPO, broader model/method support, sustained runs, explicit trainer/deployment/checkpoint control | `training/recipes/` |
 
-Read the live [serverless](https://docs.fireworks.ai/fine-tuning/training-api/serverless.md) and [dedicated lifecycle](https://docs.fireworks.ai/fine-tuning/training-api/training-and-sampling.md) pages before choosing.
+Read the live [serverless](https://docs.fireworks.ai/fine-tuning/training-api/serverless.md) and [dedicated](https://docs.fireworks.ai/fine-tuning/training-api/dedicated.md) pages before choosing.
 
 ## Two agent-drivable ways to run RFT/RL
 
@@ -84,7 +84,7 @@ Recipes cover SFT, DPO/ORPO, and RL (GRPO, DAPO, GSPO, CISPO).
 - `optim_step(...)` — optimizer update after gradient accumulation.
 - `save_weights_for_sampler()` + `create_sampling_client()` — export a checkpoint + stand up a sampler (weight sync for eval/rollouts).
 
-Loss docs: https://docs.fireworks.ai/fine-tuning/training-api/loss-functions
+Loss and datum routing: `training-api-losses.md`.
 
 ```python
 def loss_fn(data, logprobs_list):   # logprobs_list: per-token, requires_grad

--- a/skills/validate_skills.py
+++ b/skills/validate_skills.py
@@ -167,7 +167,7 @@ def check_training_contract(
         "must never configure",
         "https://docs.fireworks.ai/llms.txt",
         "https://docs.fireworks.ai/fine-tuning/training-api/serverless.md",
-        "https://docs.fireworks.ai/fine-tuning/training-api/training-and-sampling.md",
+        "https://docs.fireworks.ai/fine-tuning/training-api/dedicated.md",
         "git rev-parse HEAD",
         "training/pyproject.toml",
         "training/recipes/sft_loop.py",


### PR DESCRIPTION
## Summary

- add focused managed RFT, remote tracing, secure training, and Training API loss references
- route removed docs topics through the canonical `fireworks-training` skill without duplicating executable cookbook behavior
- replace links to pages removed by [fw-ai/docs#1184](https://github.com/fw-ai/docs/pull/1184) and update skill validation for the surviving Dedicated Training page

## Ownership

This follows the Terry/Sinan docs decisions from July 14 and August 3: public docs stay concise and human-facing, cookbook code owns executable recipes, and the skill owns agent routing, safety, and operational recovery.

This PR should merge before docs PR #1184 because that docs branch links directly to the four new references.

## Test plan

- [x] `python3 skills/validate_skills.py`
- [x] `python3 -m py_compile skills/validate_skills.py`
- [x] `git diff --check`
- [x] verify all changed `docs.fireworks.ai` URLs return HTTP 200
- [x] confirm removed training page URLs no longer appear in `skills/fireworks-training`

Made with [Cursor](https://cursor.com)