### PR TITLE
Clarify async RL rollout trajectory cardinality

### DIFF
--- a/skills/fireworks-training/references/async-rl-metrics.md
+++ b/skills/fireworks-training/references/async-rl-metrics.md
@@ -27,9 +27,12 @@ in every metric record. Read these first:
 - `max_head_offpolicy_versions` (`O`)
 - `max_concurrency_rollout_sample` (`C`, optional)
 
-One optimizer batch contains `B = P × G` samples. When `C` is unset there is no
-concurrency gate, and `producer/concurrency_capacity_samples` is intentionally
-absent. Do not interpret a missing concurrency-capacity series as zero.
+One optimizer batch requests `B = P × G` logical rollout results. Producer
+metrics call these scheduler slots `samples`; they are rollout calls and GRPO
+group members, not the trainer trajectories inside each result. When `C` is
+unset there is no concurrency gate, and
+`producer/concurrency_capacity_samples` is intentionally absent. Do not
+interpret a missing concurrency-capacity series as zero.
 
 ## Read complete histories
 
@@ -83,10 +86,17 @@ The optimizer record exposes exactly five rollout-quality metrics:
 | Metric | Meaning |
 |---|---|
 | `rollout/raw_reward` | Mean reward before `dynamic_filter_fn` |
-| `rollout/filtered_reward` | Mean reward on samples sent to forward/backward |
-| `rollout/raw_samples` | Successfully assembled samples before filtering |
-| `rollout/filtered_samples` | Samples sent to forward/backward |
+| `rollout/filtered_reward` | Mean reward on logical rollout results retained after filtering |
+| `rollout/raw_samples` | Successfully assembled logical rollout results before filtering |
+| `rollout/filtered_samples` | Logical rollout results retained after filtering |
 | `rollout/filter_ratio` | `1 - filtered_samples / raw_samples` |
+
+These counts follow `RolloutRun` rewards, so a run containing multiple
+`RolloutSample` trajectories still contributes one sample. Trainer-facing
+sequence metrics count the contained trajectories instead. In particular,
+`train/local_input_sequences:sum`, when reported, may exceed
+`rollout/filtered_samples`; that is expected and does not mean the GRPO group
+was expanded or its advantage recomputed.
 
 Raw inference-logprob drift metrics are optional: when the sampler does not
 return the distinct raw model-logprob field, the coverage and drift series are
@@ -123,7 +133,7 @@ rows     = Δ producer/completion_refill_rows_submitted_total
 rate     = attempts / Δ producer/elapsed_time_s
 ```
 
-- `attempts > 0` proves completed rollouts triggered admission retries.
+- `attempts > 0` proves completed rollout calls triggered admission retries.
 - `rows > 0` proves those retries admitted new complete prompt rows.
 - `attempts > 0` and `rows = 0` is valid when the staleness gate is full. A
   completion converts reserved samples to accepted samples but does not create

--- a/skills/fireworks-training/references/rl-agentic.md
+++ b/skills/fireworks-training/references/rl-agentic.md
@@ -1,9 +1,9 @@
 # RL: agentic rollout design
 
 Use this reference when one logical rollout contains multiple policy calls,
-tool calls, environment steps, retries, subagents, or context rewrites. Read
-[`rl-async.md`](rl-async.md) separately for scheduler, batching, off-policy,
-optimizer, and publication behavior.
+tool calls, environment steps, retries, subagents, context rewrites, or
+trainer-ready trajectories. Read [`rl-async.md`](rl-async.md) separately for
+scheduler, batching, off-policy, optimizer, and publication behavior.
 
 ## Sections
 
@@ -28,8 +28,10 @@ async def rollout_fn(sample_prompt: dict) -> RolloutRun | None:
     ...
 ```
 
-One call is one logical environment trajectory and one GRPO completion. It may
-return multiple physical `RolloutSample` segments. Preserve these invariants:
+One successful call produces one logical rollout and GRPO group member. It may
+return one or more trainer-ready trajectories as `RolloutSample`s in
+`RolloutRun.segments`. In this reference, *trajectory* means one such trainer
+input; it is not another group member. Preserve these invariants:
 
 1. Record the exact prompt and output token IDs observed at inference. Do not
    reconstruct generated tokens from text when exact IDs are available.
@@ -37,8 +39,9 @@ return multiple physical `RolloutSample` segments. Preserve these invariants:
    raw log probability and Router Replay payload.
 3. Set loss only on policy-generated tokens. Mask prompts, system text, user
    messages, tool results, environment observations, and repaired context.
-4. Give every physical segment from the same logical run the same reward. The
-   run remains one group member and receives one advantage.
+4. Give every trajectory from the same logical run the same reward. The run
+   remains one group member, receives one advantage, and broadcasts that
+   advantage to all of its trajectories.
 5. Make every non-append, truncation, repair, and drop decision explicit and
    observable. Never silently zip, trim, or pad malformed generated data.
 
@@ -96,14 +99,15 @@ declared parent. Select one policy deliberately:
 
 ### Split
 
-Flush the prior exact-ancestry segment and start another segment from the new
-prompt. Preserve both sampled outputs, reward, logical run, group membership,
-and advantage. This is the general policy implemented by
+Flush the prior exact-ancestry trajectory and start another trajectory from the
+new prompt. Return both under the same `RolloutRun`, preserving sampled
+outputs, reward, group membership, and advantage. This is the general policy
+implemented by
 `training.utils.rl.agent.merge_turn_segments` and used by the Harbor/OpenCode
 example.
 
-Splitting is lossless and easy to audit. It can increase physical trainer
-sequences, and a new segment cannot reuse a prior generated suffix as trainable
+Splitting is lossless and easy to audit. It increases trainer trajectory
+count, and a new trajectory cannot reuse a prior generated suffix as trainable
 ancestry.
 
 ### Realign
@@ -113,9 +117,9 @@ later prompt's representation, mask the replacement, and continue. Fork or
 reject anything outside the validated repair window. This is similar to
 Slime's bounded repair policy.
 
-Realignment reduces segmentation but changes which earlier sampled tokens carry
-loss. Require replay tests proving that the mismatch is rendering drift rather
-than a semantic history rewrite.
+Realignment reduces trajectory splitting but changes which earlier sampled
+tokens carry loss. Require replay tests proving that the mismatch is rendering
+drift rather than a semantic history rewrite.
 
 ### Reject or retry
 
@@ -138,13 +142,13 @@ message normalization, tool-call identity, subagent parent selection, retries,
 and context-management semantics. A generic token tree should only receive the
 chosen parent and exact turn snapshot.
 
-When one logical run branches:
+When one logical rollout branches:
 
-- materialize the selected root-to-leaf paths;
+- materialize the selected root-to-leaf paths as trainer trajectories;
 - train each shared generated node on only one selected path;
 - include shared tokens as masked context on later paths;
-- keep all physical segments in one `RolloutRun`;
-- retain one environment reward and one prompt-group completion.
+- keep all trajectories in one `RolloutRun`;
+- retain one environment reward, one group member, and one advantage.
 
 Do not call every non-append history "compaction." Dynamic system fields,
 subagent roots, retries, tool rewrites, renderer changes, and genuine context
@@ -228,8 +232,8 @@ Before a paid training run:
    renderer and assembler.
 4. Assert token/logprob/loss-mask lengths and optional R3 alignment at the
    rollout gate.
-5. Confirm multiple physical segments remain one logical completion in reward,
-   advantage, and rollout metrics.
+5. Confirm multiple returned trajectories remain one logical rollout in
+   reward, advantage, grouping, and rollout metrics.
 6. Measure mismatch, split/realign/reject, retry, drop, zero-turn, and rollout
    length distributions.
 7. Confirm a broken trace is dropped, while a legitimate terminal environment
@@ -246,7 +250,8 @@ Before a paid training run:
 - a local policy server records exact sampler responses;
 - example-local code resolves structured history and retries;
 - shared agent utilities own sampler affinity and token ancestry;
-- any exact-token non-append boundary starts another physical segment.
+- any exact-token non-append boundary starts another `RolloutSample`
+  trajectory within the same logical run.
 
 Fork only the pieces that match the target harness. Harbor is environment
 support, OpenCode is one agent, and strict split-on-mismatch is one valid policy;

--- a/skills/fireworks-training/references/rl-async.md
+++ b/skills/fireworks-training/references/rl-async.md
@@ -28,7 +28,8 @@ Users provide:
 
 - dataset rows through `Config.dataset` or `rows=`;
 - `rollout_fn_factory(setup) -> rollout_fn`;
-- environment interaction, scoring, and trainer-ready rollout segments;
+- environment interaction, scoring, and one or more trainer-ready trajectories
+  per successful rollout call;
 - algorithm and scheduling config;
 - optional `dynamic_filter_fn` and `evaluation_fn` callbacks.
 
@@ -42,7 +43,7 @@ trainer lifecycle state in the rollout.
 
 ## Rollout API
 
-The factory runs once. Each rollout call produces one trajectory:
+The factory runs once. Each rollout call produces one logical rollout result:
 
 ```python
 def make_rollout_fn(setup: RolloutSetup) -> RolloutFn:
@@ -53,8 +54,10 @@ def make_rollout_fn(setup: RolloutSetup) -> RolloutFn:
 ```
 
 The recipe invokes `rollout_fn` `completions_per_prompt` times for each dataset
-row. Return `None` to drop one trajectory draw. Return a `RolloutRun` with one
-or more `RolloutSample` segments on success:
+row. Return `None` to drop that rollout draw. On success, return a `RolloutRun`
+containing one or more trainer-ready `RolloutSample` trajectories. The API
+field is named `segments` because these trajectories may be branches or
+disjoint token spans from one environment interaction:
 
 ```python
 @dataclass
@@ -69,13 +72,20 @@ class RolloutSample:
     reward: float
 ```
 
-For every segment:
+For every returned trajectory:
 
 - `tokens`, `logprobs`, and `loss_mask` must have equal lengths;
 - `loss_mask=1` marks tokens trained on; prompt, user, tool, and environment
   tokens stay `0`;
 - non-generated positions should use `0.0` logprobs;
-- all segments in one run must share the same scalar reward.
+- all trajectories in one run must share the same scalar reward.
+
+`RolloutRun` is the reward, advantage, and GRPO group-member boundary; it is
+not restricted to one trainer trajectory. Group assembly computes one
+advantage per surviving run and broadcasts it to every trajectory in that
+run. Each trajectory is then packed as a separate trainer datum. Thus a group
+with `R` surviving runs has `R` rewards and advantages, while its trainer datum
+count is `sum(len(run.segments) for run in runs)` and may exceed `R`.
 
 `RolloutSetup` contains the tokenizer, tokenizer ID, sampling kwargs, inference
 base URL, API key, deployment model, group size, and caller-provided `extras`.
@@ -124,11 +134,11 @@ Use these symbols when reasoning about capacity:
 
 | Config field | Symbol | Unit | Meaning |
 |---|---:|---|---|
-| `completions_per_prompt` | `G` | samples per row | GRPO trajectories for one dataset row; must be at least 2 |
+| `completions_per_prompt` | `G` | rollout calls per row | Logical GRPO group members requested for one dataset row |
 | `prompt_groups_per_step` | `P` | rows | Complete prompt groups in one optimizer batch |
 | `pipeline_chunks_per_step` | `K` | chunks | Requested forward/backward chunks per optimizer batch |
 | `max_head_offpolicy_versions` | `O` | published versions | Admission headroom beyond the current policy version; `0` is fully on-policy |
-| `max_concurrency_rollout_sample` | `C` | samples | Optional hard cap on in-flight rollout calls |
+| `max_concurrency_rollout_sample` | `C` | rollout calls | Optional hard cap on in-flight rollout calls |
 
 Router Replay (R3) is a numerics-alignment setting, not a scheduling knob.
 Both RL recipes default `router_replay=True` and
@@ -136,9 +146,11 @@ Both RL recipes default `router_replay=True` and
 tokens without the serving cost of `echo=True`. Use full-sequence replay only
 when the extra alignment is worth that throughput cost.
 
-One optimizer batch contains `B = P × G` samples. The scheduler creates
-`min(P, K)` non-empty, balanced chunk targets before production begins. For
-example, `P=10, K=4` creates targets `(3, 3, 2, 2)`.
+One optimizer batch requests `B = P × G` logical rollout results. The number of
+trainer trajectories can be larger when a result contains multiple
+`RolloutSample`s. The scheduler balances its `min(P, K)` non-empty chunk
+targets by prompt rows, not by the eventual trajectory count. For example,
+`P=10, K=4` creates targets `(3, 3, 2, 2)`.
 
 Chunking changes when forward/backward work can start; it does not change the
 optimizer batch. Exactly one optimizer mutation, one sampler hotload, and one
@@ -146,8 +158,9 @@ version publication follow all chunks in a batch.
 
 ## Row-atomic admission gate
 
-Admission bookkeeping uses samples, the same unit as rollout concurrency. A
-row is submitted only when both budgets can fit all `G` rollout calls:
+Admission bookkeeping uses rollout-call slots, exposed as `*_samples` in the
+producer metrics. It does not reserve capacity per returned trajectory. A row
+is submitted only when both budgets can fit all `G` rollout calls:
 
 ```text
 B = prompt_groups_per_step * completions_per_prompt
@@ -217,11 +230,12 @@ batch rather than silently dropping accepted prompt groups.
 
 ## Failure policy
 
-One flaky rollout does not immediately abort a long run:
+One flaky rollout call does not immediately abort a long run:
 
-- `None` is an explicit dropped draw;
+- `None` explicitly drops that call and contributes no trajectories;
 - explicit drops increment `producer/trajectory_drops_total` but are neutral to
-  the infrastructure circuit breaker;
+  the infrastructure circuit breaker; despite its name, this metric counts
+  dropped rollout calls;
 - timeouts, connection failures, HTTP 408/429/5xx, explicitly marked
   `RecoverableRolloutError`s, and known client transport errors are recoverable;
 - recoverable errors drop that draw and continue if the row still satisfies
@@ -240,11 +254,12 @@ Agentic adapters may own a broader trajectory boundary than generic rollouts.
 Keep that policy in the adapter and follow [`rl-agentic.md`](rl-agentic.md);
 malformed R3 data is still discarded at async admission before group assembly.
 
-Incomplete-group retries are bounded. After that budget is exhausted, the row
-is rejected and the producer advances. If every row is rejected, the loop can
-finish with zero optimizer steps; use the returned step count together with
-`producer/trajectory_drops_total` and `producer/rows_rejected_total` as the
-experiment-level success criterion.
+Incomplete-group retries are bounded and `min_group_size` counts surviving
+`RolloutRun`s, not their contained trajectories. After that budget is
+exhausted, the row is rejected and the producer advances. If every row is
+rejected, the loop can finish with zero optimizer steps; use the returned step
+count together with `producer/trajectory_drops_total` and
+`producer/rows_rejected_total` as the experiment-level success criterion.
 
 If a producer failure affects the active optimizer batch, training stops before
 its optimizer mutation. If it affects only a future batch, the recipe finishes


### PR DESCRIPTION
## Summary

- define a successful rollout call as one logical GRPO group member that may contain one or more trainer-ready trajectories
- document how reward and advantage stay at the `RolloutRun` boundary while each `RolloutSample` becomes a trainer datum
- align async scheduling, admission, failure, agentic splitting, and metrics terminology with that contract

## Scope

Documentation only. No runtime behavior or backward-compatibility layer is changed.

## Validation

- `python skills/validate_skills.py`
- skill structure validation
- `git diff --check`