### PR TITLE
fix: align checkpoint guidance and flags

### DIFF
--- a/skills/fireworks-training/references/sdk-checkpoints.md
+++ b/skills/fireworks-training/references/sdk-checkpoints.md
@@ -98,9 +98,9 @@ Priority inside `TrainingCheckpoints.resume` (highest first):
 - `warm_start_from_adapter` and `init_from_checkpoint` are mutually exclusive.
 - Requires `lora_rank > 0`. Full-parameter continue-training uses `base_model` instead.
 
-Exposed by `sft_loop`, `dpo_loop`, `orpo_loop`, and `igpo_loop`. The generic
-GRPO recipes keep the smaller shared resume surface and use
-`init_from_checkpoint` instead.
+Exposed by `sft_loop`, `dpo_loop`, `orpo_loop`, `igpo_loop`,
+`distillation_loop`, and `async_rl_loop`. The synchronous `rl_loop` keeps the
+smaller resume surface and uses `init_from_checkpoint` instead.
 
 ## Cross-run resume
 

--- a/training/examples/sft/train_sft.py
+++ b/training/examples/sft/train_sft.py
@@ -48,8 +48,11 @@ def parse_args():
     parser.add_argument("--learning-rate", type=float, default=1e-5)
     parser.add_argument("--lora-rank", type=int, default=0)
     parser.add_argument("--renderer-name", default="")
-    parser.add_argument("--no-checkpoint", action="store_true",
-                        help="Skip final checkpoint save")
+    parser.add_argument(
+        "--no-checkpoint",
+        action="store_true",
+        help="Skip periodic and final checkpoint saves",
+    )
     parser.add_argument("--grad-clip-norm", type=float, default=0.0,
                         help="Max gradient norm for clipping (0 = no clipping)")
     parser.add_argument("--wandb-project", default="sft-tinker")
@@ -92,6 +95,7 @@ def main():
         output_model_id=args.output_model_id,
         grad_clip_norm=args.grad_clip_norm,
         dcp_save_interval=-1 if args.no_checkpoint else 0,
+        save_final_checkpoint=not args.no_checkpoint,
         trainer=TrainerConfig(
             training_shape_id=args.training_shape,
         ),

--- a/training/tests/e2e/test_sft_resume_e2e.py
+++ b/training/tests/e2e/test_sft_resume_e2e.py
@@ -80,7 +80,7 @@ class TestSFTResumeE2E:
 
             log_dir = tempfile.mkdtemp(prefix="sft_resume_")
 
-            # Phase 1: train, save DCP checkpoints to checkpoints.jsonl
+            # Phase 1: save DCP checkpoints and track cursor state in dataloader.json
             logger.info("PHASE 1: initial SFT training")
 
             phase1_config = Config(

--- a/training/tests/unit/test_text2sql_train_sft.py
+++ b/training/tests/unit/test_text2sql_train_sft.py
@@ -68,6 +68,28 @@ def test_parse_args_uses_bundled_text2sql_dataset_by_default(monkeypatch):
     assert os.path.basename(args.dataset_path) == "text2sql_dataset.jsonl"
 
 
+def test_no_checkpoint_disables_periodic_and_final_saves(monkeypatch):
+    module = _load_module(monkeypatch)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["train_sft.py", "--output-model-id", "out-model", "--no-checkpoint"],
+    )
+    monkeypatch.setattr(module.os.path, "exists", lambda path: True)
+    captured = {}
+
+    def fake_main(config):
+        captured["config"] = config
+        return {}
+
+    monkeypatch.setattr(module.sft_loop, "main", fake_main)
+
+    module.main()
+
+    assert captured["config"].dcp_save_interval == -1
+    assert captured["config"].save_final_checkpoint is False
+
+
 def test_main_raises_when_dataset_is_missing(monkeypatch):
     module = _load_module(monkeypatch)
     monkeypatch.setattr(sys, "argv", ["train_sft.py", "--dataset-path", "/tmp/missing.jsonl", "--output-model-id", "out"])


### PR DESCRIPTION
## Summary
- make `train_sft.py --no-checkpoint` disable both periodic and final checkpoint saves
- replace the stale `checkpoints.jsonl` E2E comment with the current `dataloader.json` cursor model
- align the checkpoint skill with the warm-start fields and tests currently exposed by `distillation_loop` and `async_rl_loop`

## Test plan
- [x] `uv run --project training --extra dev pytest training/tests/unit/test_text2sql_train_sft.py training/tests/unit/test_async_rl_loop.py -q`
- [x] `uvx ruff check training/examples/sft/train_sft.py training/tests/e2e/test_sft_resume_e2e.py training/tests/unit/test_text2sql_train_sft.py`
- [x] `git diff --check`

Made with [Cursor](https://cursor.com)