### PR TITLE
nl2repo: Add mixed partial-success Nemotron Ultra SFT ablation

### DIFF
--- a/training/README.md
+++ b/training/README.md
@@ -216,6 +216,7 @@ recipes/                                Training loop scripts (fork these)
 recipes/experiment/                     Experimental recipe variants, including async serverless RL
 utils/                                  Shared config, data loading, loss functions, metrics
 examples/sft/                           Worked example: SFT getting started
+examples/sft/nl2repo_mixed/             Nemotron Ultra mixed NL2Repo SFT ablation
 examples/embedding/                     Worked example: embedding (retrieval) fine-tuning
 examples/dpo/                           Worked example: DPO
 examples/orpo/ifeval/                   Worked example: IFEval with ORPO

--- a/training/examples/sft/nl2repo_mixed/README.md
+++ b/training/examples/sft/nl2repo_mixed/README.md
@@ -1,0 +1,126 @@
+# Nemotron Ultra mixed NL2Repo SFT ablation
+
+This example reproduces a one-epoch LoRA ablation that mixes fully successful
+PRD-to-Repo trajectories with trajectories whose verifier tests pass at least
+80%. It consumes prepared artifacts from the provenance-bound workflow in
+[fw-ai/upheaval#148](https://github.com/fw-ai/upheaval/pull/148); it does not
+duplicate raw-trajectory curation or semantic rubric judging.
+
+This is a recorded **negative ablation**, not a recommended checkpoint. The
+completed run was numerically stable but regressed on DeepSWE, so this launcher
+always saves an unpromoted checkpoint and does not expose an output-model
+promotion option.
+
+## Data contract
+
+Set `RUN_DIR` to one curation output directory containing:
+
+- `report.json` with schema `upheaval-prd-to-repo-curation-v1`;
+- `renderer-report.json` with schema
+  `upheaval-prd-to-repo-render-validation-v1`; and
+- `train.jsonl`, `val.jsonl`, `test.jsonl`, and the row-level
+  `manifest.jsonl`.
+
+Before a run, `train.py` rechecks the curation and renderer-report hashes,
+target model and tokenizer revision, exact `nemotron3_ultra` renderer, 262,144
+token limit, 80% partial-success threshold, mixed quality labels, split hashes,
+physical JSONL row counts, reviewed curator/validator source hashes, exact
+renderer source hashes, and every fail-closed renderer check. In particular,
+the report must match the reviewed aggregate think-boundary counts, including
+zero trainable prefilled `<think>` tokens and a trainable generated `</think>`
+token in every rendered datum. The four training/provenance files must also
+match the canonical byte hashes recorded in `RESULTS.json`; a self-consistent
+but drifted or synthetic report is rejected.
+
+The frozen Wentao-v1 input contained 692 trajectories from 268 tasks:
+
+- 260 full successes and 432 partial successes;
+- Claude Code 2.1.231 and 2.1.237 source captures;
+- 10,528 windows: 10,215 train, 168 validation, and 145 test; and
+- 6,524 partial-success train windows (63.9% of train windows).
+
+Raw Harbor trials, capture bundles, repositories, prepared JSONL, credentials,
+and evaluation outputs are intentionally not committed here.
+
+## Environment
+
+From the repository root:
+
+```bash
+cd training
+uv venv --python 3.12 .venv
+uv pip install --python .venv/bin/python --pre -e ".[dev]"
+```
+
+The API key used for a paid run must belong to an account that can use the
+configured Nemotron Ultra LoRA training shape. Do not commit `.env` files or
+keys.
+
+## Resolve without creating resources
+
+Dry-run is the default:
+
+```bash
+RUN_DIR=/path/to/wentao-v1-curation-output \
+  training/examples/sft/nl2repo_mixed/run.sh
+```
+
+Review
+`$RUN_DIR/training/ultra-mixed-partial80/resolved_config.json`. It binds the
+dataset reports and split hashes, renderer implementation hashes, model
+settings, optimization settings, and Fireworks session ID.
+
+## Launch the paid ablation
+
+Only after reviewing the resolved config:
+
+```bash
+RUN_DIR=/path/to/wentao-v1-curation-output \
+DRY_RUN=0 \
+CONFIRM_FIREWORKS_TRAINING=YES \
+FIREWORKS_API_KEY=... \
+WANDB_ENTITY=... \
+WANDB_PROJECT=nl2repo-ultra-sft \
+  training/examples/sft/nl2repo_mixed/run.sh
+```
+
+The reviewed defaults are Nemotron 3 Ultra BF16, `nemotron3_ultra`, 262K
+context, one epoch, batch size 1, LoRA rank/alpha 16/32, peak learning rate
+`3e-7`, 3% warmup, cosine decay to `3e-8`, seed `20260828`, and no reservation.
+This launcher saves a final checkpoint but does not promote or deploy it. The
+historical checkpoint was later promoted and deployed through a separate,
+explicit evaluation-only workflow; those resource IDs in `RESULTS.json` are
+evidence of the measured ablation, not an endorsement for production use.
+
+## Completed result
+
+[`RESULTS.json`](RESULTS.json) records the training job, evaluated model and
+deployment, benchmark run IDs, exact metrics, renderer hashes, and SHA-256
+commitments for the retained source artifacts.
+
+The freshly materialized #148 output matched the historically validated
+dataset's semantic row-hash multiset exactly in all three splits (10,528 of
+10,528 rows, with no rows present on only one side). This binds the canonical
+byte hashes accepted by the launcher to the full renderer report used by the
+completed run.
+
+The completed 10,215-step run had finite, contiguous metrics:
+
+- first/last 100-step mean cross entropy: 0.4497 / 0.3775;
+- final validation cross entropy: 0.3507;
+- no overlength or zero-loss datums; and
+- corrected think-boundary masks throughout.
+
+Lower training and validation loss did not transfer to agent performance:
+
+- DeepSWE Pass@1: Base 5/113 (4.42%), Mixed SFT 2/113 (1.77%);
+- infrastructure errors: Base 4, Mixed SFT 20;
+- on 91 paired-valid tasks: 2 gains, 5 regressions, and 84 unchanged failures;
+- fail-to-pass coverage fell 6.67 percentage points; and
+- partial reward fell 2.87 percentage points.
+
+The most likely causes are objective and task-distribution mismatch, a
+validation split covering only four canonical tasks, and correlated
+partial-success windows receiving the same token loss weight as full
+successes. The corrected renderer means the previous think-boundary masking
+bug does not explain this run's remaining regression.

--- a/training/examples/sft/nl2repo_mixed/RESULTS.json
+++ b/training/examples/sft/nl2repo_mixed/RESULTS.json
@@ -1,0 +1,108 @@
+{
+  "schema": "nl2repo-mixed-sft-result/v1",
+  "status": "negative_ablation_do_not_promote",
+  "dataset": {
+    "profile": "wentao-v1",
+    "selected_tasks": 268,
+    "selected_trajectories": 692,
+    "split_rows": {
+      "train": 10215,
+      "val": 168,
+      "test": 145
+    },
+    "trial_quality_labels": {
+      "full_success": 260,
+      "partial_success": 432
+    },
+    "partial_train_window_share": 0.6386686245717083,
+    "canonical_semantic_equivalence_to_historical_rendered_set": true,
+    "historical_training_manifest_sha256": "5b60c966103dc0fff247857f675a9f60f5faf1fdff76167c57727538293a36d7",
+    "canonical_curation_artifact_sha256": {
+      "train.jsonl": "4940da51f3a8dbe756993468cec1a4bf6aa1c18a729fb63e6e36c4e5b8f4a299",
+      "val.jsonl": "92ea8bd38474df14b92dd798888e3c1f9d9b3d2b3a7db90ba765f0d7e3cd8d8c",
+      "test.jsonl": "929aa7dec19483019dcb5305d825593058f2dcb0398b0e686c0d582f3faaa1b5",
+      "manifest.jsonl": "97e698e019fb8d1c251f7340df3d97d682628436f57ae387f6875e4be8ce7729"
+    }
+  },
+  "training": {
+    "job_id": "training-api-service-1c9623db",
+    "base_model": "accounts/fireworks/models/nemotron-3-ultra-bf16",
+    "result_model": "accounts/valkyrie/models/nl2repo-nemotron-ultra-mixed-partial80-lr3e7-20260828",
+    "result_model_usage": "separately promoted for evaluation only; not recommended for production",
+    "cookbook_base_commit": "76821fa1ded720d903029381b37d3c3ea7ce9ddd",
+    "steps": 10215,
+    "first_100_mean_ce": 0.44971343787959744,
+    "last_100_mean_ce": 0.37753814880952347,
+    "final_eval_ce": 0.35066258428313607,
+    "final_eval_ppl": 1.4200081120145234,
+    "renderer_source_sha256": {
+      "_think_prefill.py": "c33d8d11b7a896f3f895ec3dce7e82c184ecfd235258d0b80cadf25fa2912c10",
+      "_qwen3_split.py": "1ef9c7b4332c33031fe7903bd5ef107e84989fc3f51895f3261b164a15b550b4",
+      "_nemotron3_split.py": "f1390ba1870d66a20308bde146102e63c6be21a6cf9b2e0ab1fb6dc92e0e01dc"
+    }
+  },
+  "evaluation": {
+    "benchmark": {
+      "name": "DeepSWE v1.1",
+      "tasks": 113,
+      "agent": "mini-swe-agent 2.4.6",
+      "temperature": 0.0,
+      "seed": 0,
+      "max_output_tokens": 32768
+    },
+    "base": {
+      "run_id": "4a3fc34a-ef57-4ef0-beb5-490647278a3f",
+      "model": "accounts/fireworks/models/nemotron-3-ultra-bf16",
+      "passes": 5,
+      "errors": 4,
+      "f2p": 0.49317846093321027,
+      "p2p": 0.9443573426801666,
+      "partial": 0.8086101566854218
+    },
+    "mixed_sft": {
+      "run_id": "c8610655-5c6a-4753-adf4-82e947049feb",
+      "model": "accounts/valkyrie/models/nl2repo-nemotron-ultra-mixed-partial80-lr3e7-20260828",
+      "deployment": "accounts/valkyrie/deployments/nl2repo-ultra-mixed-partial80-deepswe-20260828",
+      "started_at": "2026-08-28T20:53:16.184122",
+      "finished_at": "2026-08-29T23:51:59.150249",
+      "passes": 2,
+      "errors": 20,
+      "error_types": {
+        "AgentTimeoutError": 13,
+        "NonZeroAgentExitCodeError": 7
+      },
+      "f2p": 0.4264511190545348,
+      "p2p": 0.9432188177748073,
+      "partial": 0.7799453304214861
+    },
+    "paired_valid": {
+      "tasks": 91,
+      "base_passes": 5,
+      "mixed_sft_passes": 2,
+      "transitions": {
+        "0_to_0": 84,
+        "0_to_1": 2,
+        "1_to_0": 5
+      }
+    }
+  },
+  "evidence_sha256": {
+    "training_pipeline_log": "872898cf8cb75ba867f5e3220335bcf540cdcb3e6148e0e576d2a1af75041046",
+    "resolved_training_config": "ab92643f5f60c71cee5c6c0f987fec487e057907b8a6c05fb287f52a6bbc36f8",
+    "renderer_validation_report": "93f149a8728d594239b4afcb999581daace4ec6dcf0362c07b406e46b8584cd1",
+    "training_metrics_analysis": "2a5b6af7668f68b0678a7ea85794d2671088c1c2c30fb3764c15cd73d6fcafdc",
+    "base_deepswe_result": "f23e1d28fd49f6cbd896d804ead74e78ac62b17dc9604b445f6e25ef7ce8b23a",
+    "mixed_sft_deepswe_result": "a9a4e9363316b56f4d61fd6a74338dcbda1898d97e910d6e12154c1dc5e3c6da",
+    "paired_analysis": "55693917860ef238cfc2648f3088a05efc6366f516427c82dc0fafe5a0de1044",
+    "paired_analysis_script": "a1a674c52bff3302a778d99af61f01950d9fdbd63cece224d40e85beaa12348a",
+    "canonical_profile_audit": "70b97d3dd47429ac6a40e8b2cb29cf6bb03b663437c5d4df2132317bff93194a",
+    "canonical_materializer": "d3b6a9474437ee7172edba471eb4b32d80cce17d05e9fddd783c66673615e4e9",
+    "canonical_semantic_comparison": "8733da24668945c4f68457dd93aeee151676edd6b57c58646388238191d88714",
+    "canonical_semantic_comparison_script": "324dcad499bb8d0fa708ff3149acdbcc3905573a49d5271d5bfd9ce01b502aa5"
+  },
+  "limitations": [
+    "Evidence hashes bind retained internal artifacts; the full training and evaluation logs are not committed.",
+    "DeepSWE had 4 Base and 20 Mixed SFT infrastructure errors, so paired-valid results are reported separately.",
+    "The four-task validation split was adequate for numerical checks but not for predicting repository-task transfer."
+  ]
+}

--- a/training/examples/sft/nl2repo_mixed/__init__.py
+++ b/training/examples/sft/nl2repo_mixed/__init__.py
@@ -1,0 +1,1 @@
+"""Nemotron Ultra mixed partial-success NL2Repo SFT example."""

--- a/training/examples/sft/nl2repo_mixed/run.sh
+++ b/training/examples/sft/nl2repo_mixed/run.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Reproduce the reviewed mixed partial-success SFT configuration.
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TRAINING_ROOT="$(cd "$HERE/../../.." && pwd)"
+REPO_ROOT="$(cd "$TRAINING_ROOT/.." && pwd)"
+PYTHON="${PYTHON:-$TRAINING_ROOT/.venv/bin/python}"
+
+: "${RUN_DIR:?Set RUN_DIR to a validated upheaval PR #148 curation output}"
+DRY_RUN="${DRY_RUN:-1}"
+RUN_NAME="${RUN_NAME:-ultra-mixed-partial80}"
+TRAINING_SHAPE="${TRAINING_SHAPE:-accounts/fireworks/trainingShapes/nemotron-3-ultra-550b-a55b-bf16-lora}"
+WANDB_ENTITY="${WANDB_ENTITY:-}"
+WANDB_PROJECT="${WANDB_PROJECT:-}"
+WANDB_RUN_NAME="${WANDB_RUN_NAME:-$RUN_NAME}"
+
+if [[ ! -x "$PYTHON" ]]; then
+  echo "Python environment not found at $PYTHON; install training/.[dev] first" >&2
+  exit 1
+fi
+if [[ "$DRY_RUN" != "1" && -z "${FIREWORKS_API_KEY:-}" ]]; then
+  echo "FIREWORKS_API_KEY is required when DRY_RUN is not 1" >&2
+  exit 1
+fi
+if [[ -n "$WANDB_ENTITY" && -z "$WANDB_PROJECT" ]] || \
+   [[ -z "$WANDB_ENTITY" && -n "$WANDB_PROJECT" ]]; then
+  echo "WANDB_ENTITY and WANDB_PROJECT must be set together" >&2
+  exit 1
+fi
+
+args=(
+  --run-dir "$RUN_DIR"
+  --run-name "$RUN_NAME"
+  --training-shape "$TRAINING_SHAPE"
+  --epochs 1
+  --batch-size 1
+  --learning-rate 3e-7
+  --lora-rank 16
+  --lora-alpha 32
+  --trainer-replicas 1
+  --no-use-reservation
+  --seed 20260828
+  --pipeline-depth 4
+  --checkpoint-interval 200
+  --grad-clip-norm 1.0
+  --warmup-ratio 0.03
+  --min-lr-ratio 0.1
+  --weight-decay 0
+  --max-eval-seqs 200
+)
+if [[ -n "$WANDB_ENTITY" ]]; then
+  args+=(
+    --wandb-entity "$WANDB_ENTITY"
+    --wandb-project "$WANDB_PROJECT"
+    --wandb-run-name "$WANDB_RUN_NAME"
+  )
+fi
+if [[ "$DRY_RUN" == "1" ]]; then
+  args+=(--dry-run)
+fi
+
+cd "$REPO_ROOT"
+export PYTHONPATH="$REPO_ROOT${PYTHONPATH:+:$PYTHONPATH}"
+exec "$PYTHON" -m training.examples.sft.nl2repo_mixed.train "${args[@]}"

--- a/training/examples/sft/nl2repo_mixed/train.py
+++ b/training/examples/sft/nl2repo_mixed/train.py
@@ -1,0 +1,569 @@
+#!/usr/bin/env python3
+"""Train Nemotron Ultra on a validated mixed partial-success NL2Repo bundle.
+
+The input contract is the fail-closed output of fw-ai/upheaval PR #148:
+``report.json``, ``renderer-report.json``, and split JSONL files in one
+directory. The launcher rechecks their hashes and rendering invariants before
+it can create paid Fireworks resources.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.metadata
+import json
+import math
+import os
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import training.recipes.sft_loop as sft_loop
+import training.renderer  # noqa: F401  (register local renderers)
+from training.utils import TrainerConfig, WandBConfig
+
+CURATION_SCHEMA = "upheaval-prd-to-repo-curation-v1"
+RENDER_REPORT_SCHEMA = "upheaval-prd-to-repo-render-validation-v1"
+EXPECTED_PROFILE = "wentao-v1"
+BASE_MODEL = "accounts/fireworks/models/nemotron-3-ultra-bf16"
+TOKENIZER_MODEL = "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16"
+TOKENIZER_REVISION = "624ba927cfbef0427354998700de3d51173c8c04"
+RENDERER_NAME = "nemotron3_ultra"
+MAX_SEQ_LEN = 262_144
+LORA_SHAPE = "accounts/fireworks/trainingShapes/nemotron-3-ultra-550b-a55b-bf16-lora"
+MASK_FIX_PROMOTION_COMMIT = "e11f1ba4260b5321e542377be2bc77f8a3123e7f"
+MASK_FIX_SOURCE_PR = "https://github.com/fw-ai/fireworks/pull/44496"
+CURATION_SOURCE_PR = "https://github.com/fw-ai/upheaval/pull/148"
+SKILL_CLIENT_SOURCE = "fireworks-training-skill/2.0.0"
+EXPECTED_TRIAL_QUALITY = {"full_success": 260, "partial_success": 432}
+EXPECTED_VERSION_COUNTS = {"2.1.231": 448, "2.1.237": 244}
+EXPECTED_SPLIT_ROWS = {"train": 10_215, "val": 168, "test": 145}
+EXPECTED_ARTIFACT_SHA256 = {
+    "train.jsonl": ("4940da51f3a8dbe756993468cec1a4bf6aa1c18a729fb63e6e36c4e5b8f4a299"),
+    "val.jsonl": ("92ea8bd38474df14b92dd798888e3c1f9d9b3d2b3a7db90ba765f0d7e3cd8d8c"),
+    "test.jsonl": ("929aa7dec19483019dcb5305d825593058f2dcb0398b0e686c0d582f3faaa1b5"),
+    "manifest.jsonl": (
+        "97e698e019fb8d1c251f7340df3d97d682628436f57ae387f6875e4be8ce7729"
+    ),
+}
+EXPECTED_CURATOR_SHA256 = (
+    "a3f47437c53a781dece2f5992611daea02f3609a9e7c4daed1093a865ed2fdec"
+)
+EXPECTED_RENDER_VALIDATOR_SHA256 = (
+    "4fe62fd08cbd93662bf6cca8e63bce1bf6ee6aea5f9cf97c114a575461237c4c"
+)
+EXPECTED_RENDER_CHECKS = {
+    "all_rows_rendered",
+    "one_datum_per_row",
+    "all_rows_within_context",
+    "all_datums_have_loss",
+    "prefilled_think_open_masked",
+    "generated_think_close_weighted",
+    "no_errors",
+}
+EXPECTED_TINKER_COOKBOOK_VERSION = "0.4.3"
+EXPECTED_RENDERING_SOURCE_SHA256 = {
+    "renderer/_think_prefill.py": (
+        "c33d8d11b7a896f3f895ec3dce7e82c184ecfd235258d0b80cadf25fa2912c10"
+    ),
+    "renderer/_qwen3_split.py": (
+        "1ef9c7b4332c33031fe7903bd5ef107e84989fc3f51895f3261b164a15b550b4"
+    ),
+    "renderer/_nemotron3_split.py": (
+        "f1390ba1870d66a20308bde146102e63c6be21a6cf9b2e0ab1fb6dc92e0e01dc"
+    ),
+    "renderer/_disaggregate_mixin.py": (
+        "5bae7e3225ba7d31d656fb32e4a69a0e46c1d4e903ca59d8cf47ad41dc9dad44"
+    ),
+    "renderer/message_weights.py": (
+        "a69f32322fec39fcbd21d66d9c775dce7ccbd52e197f19f93abb300d4814fb9a"
+    ),
+    "renderer/__init__.py": (
+        "8e7f44c014dfd77b3cd7e3c0db6a0dba8b5ded5d5d138962c50e7f58e651c3ad"
+    ),
+    "utils/supervised.py": (
+        "f92fcd36a3cd40d97ebfca427eb7fed58c5f1ef58d27a2a0fa2d1b6da0671c06"
+    ),
+    "utils/tokenizers.py": (
+        "76bf305c0788b108e994de707ccd0ea8d83a971a3f78387d9cd9e8072e962f99"
+    ),
+}
+EXPECTED_THINK_BOUNDARY_COUNTS = {
+    "weighted_open_count": 0,
+    "masked_open_count": 607_144,
+    "weighted_close_count": 81_763,
+    "masked_close_count": 525_561,
+    "datums_without_weighted_close_count": 0,
+}
+
+
+@dataclass(frozen=True)
+class DatasetBundle:
+    """Validated local inputs and their provenance."""
+
+    root: Path
+    curation_report: dict[str, Any]
+    renderer_report: dict[str, Any]
+    train_path: Path
+    val_path: Path
+    manifest_path: Path
+    train_sha256: str
+    val_sha256: str
+    manifest_sha256: str
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _sha256_and_rows(path: Path) -> tuple[str, int]:
+    digest = hashlib.sha256()
+    rows = 0
+    with path.open("rb") as handle:
+        for line_number, line in enumerate(handle, 1):
+            digest.update(line)
+            if not line.strip():
+                raise ValueError(f"{path}:{line_number}: blank JSONL line")
+            rows += 1
+    return digest.hexdigest(), rows
+
+
+def _rendering_source_hashes() -> dict[str, str]:
+    root = Path(__file__).parents[3]
+    return {
+        relative_path: sha256_file(root / relative_path)
+        for relative_path in EXPECTED_RENDERING_SOURCE_SHA256
+    }
+
+
+def _require_reviewed_rendering_runtime() -> dict[str, str]:
+    actual = _rendering_source_hashes()
+    if actual != EXPECTED_RENDERING_SOURCE_SHA256:
+        raise ValueError("rendering sources differ from the reviewed implementation")
+    try:
+        tinker_version = importlib.metadata.version("tinker-cookbook")
+    except importlib.metadata.PackageNotFoundError as error:
+        raise ValueError("tinker-cookbook is not installed") from error
+    if tinker_version != EXPECTED_TINKER_COOKBOOK_VERSION:
+        raise ValueError("tinker-cookbook differs from the reviewed version")
+    return actual
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as error:
+        raise FileNotFoundError(f"missing required artifact: {path}") from error
+    except json.JSONDecodeError as error:
+        raise ValueError(f"{path}: invalid JSON: {error}") from error
+    if not isinstance(value, dict):
+        raise ValueError(f"{path}: expected a JSON object")
+    return value
+
+
+def _curation_artifact(
+    root: Path,
+    curation_report: dict[str, Any],
+    filename: str,
+) -> tuple[Path, str, int]:
+    path = root / filename
+    if not path.is_file():
+        raise FileNotFoundError(f"missing required artifact: {path}")
+    digest, rows = _sha256_and_rows(path)
+    artifact = (curation_report.get("artifacts") or {}).get(filename) or {}
+    if artifact.get("sha256") != digest:
+        raise ValueError(f"{filename}: hash differs from curation report")
+    if EXPECTED_ARTIFACT_SHA256.get(filename) != digest:
+        raise ValueError(f"{filename}: hash differs from the canonical dataset")
+    reported_path = artifact.get("path")
+    if not isinstance(reported_path, str) or Path(reported_path).name != filename:
+        raise ValueError(f"{filename}: malformed artifact path in curation report")
+    return path, digest, rows
+
+
+def _rendered_artifact(
+    root: Path,
+    curation_report: dict[str, Any],
+    renderer_report: dict[str, Any],
+    filename: str,
+) -> tuple[Path, str, int]:
+    path, digest, rows = _curation_artifact(root, curation_report, filename)
+    if (renderer_report.get("input_artifacts") or {}).get(filename) != digest:
+        raise ValueError(f"{filename}: hash differs from renderer report")
+    return path, digest, rows
+
+
+def load_dataset_bundle(run_dir: Path) -> DatasetBundle:
+    """Load and fail closed on stale, non-mixed, or unsafe inputs."""
+
+    _require_reviewed_rendering_runtime()
+    root = run_dir.resolve()
+    curation_path = root / "report.json"
+    renderer_path = root / "renderer-report.json"
+    curation = _load_json(curation_path)
+    renderer = _load_json(renderer_path)
+
+    if curation.get("schema") != CURATION_SCHEMA:
+        raise ValueError("unsupported curation report schema")
+    if curation.get("profile") != EXPECTED_PROFILE:
+        raise ValueError(f"dataset must use the frozen {EXPECTED_PROFILE!r} profile")
+    curation_implementation = curation.get("implementation") or {}
+    if (
+        curation_implementation.get("module")
+        != "experiments.nemotron_ultra_prd_to_repo.data.curation"
+        or curation_implementation.get("script_sha256") != EXPECTED_CURATOR_SHA256
+    ):
+        raise ValueError("curation report was not produced by the reviewed curator")
+    if renderer.get("schema") != RENDER_REPORT_SCHEMA:
+        raise ValueError("unsupported renderer report schema")
+    renderer_implementation = renderer.get("implementation") or {}
+    if (
+        renderer_implementation.get("module")
+        != "experiments.nemotron_ultra_prd_to_repo.data.render_validate"
+        or renderer_implementation.get("script_sha256")
+        != EXPECTED_RENDER_VALIDATOR_SHA256
+    ):
+        raise ValueError("renderer report was not produced by the reviewed validator")
+    if renderer.get("source_report_sha256") != sha256_file(curation_path):
+        raise ValueError("renderer report is not bound to the current curation report")
+    if not renderer.get("ready_for_training"):
+        raise ValueError("renderer report is not ready for training")
+    if renderer.get("errors"):
+        raise ValueError("renderer report contains rendering errors")
+    checks = renderer.get("checks")
+    if (
+        not isinstance(checks, dict)
+        or set(checks) != EXPECTED_RENDER_CHECKS
+        or not all(value is True for value in checks.values())
+    ):
+        raise ValueError("renderer report has failed or missing checks")
+
+    target = curation.get("target")
+    expected_target = {
+        "model": BASE_MODEL,
+        "renderer": RENDERER_NAME,
+        "tokenizer_model": TOKENIZER_MODEL,
+        "tokenizer_revision": TOKENIZER_REVISION,
+        "max_seq_len": MAX_SEQ_LEN,
+    }
+    if target != expected_target:
+        raise ValueError("curation target differs from the reviewed training target")
+
+    renderer_target = renderer.get("renderer") or {}
+    for curation_key, renderer_key in (
+        ("renderer", "renderer_name"),
+        ("tokenizer_model", "tokenizer_model"),
+        ("tokenizer_revision", "tokenizer_revision"),
+        ("max_seq_len", "max_seq_len"),
+    ):
+        if renderer_target.get(renderer_key) != expected_target[curation_key]:
+            raise ValueError(
+                f"renderer report {renderer_key} differs from curation target"
+            )
+    if renderer_target.get("oversize_count") != 0:
+        raise ValueError("renderer report contains overlength datums")
+    if renderer_target.get("empty_loss_count") != 0:
+        raise ValueError("renderer report contains zero-loss datums")
+    expected_rows = sum(EXPECTED_SPLIT_ROWS.values())
+    if renderer_target.get("rows_rendered") != expected_rows:
+        raise ValueError("renderer report has an unexpected rendered row count")
+    if renderer_target.get("datums_rendered") != expected_rows:
+        raise ValueError("renderer report has an unexpected rendered datum count")
+    think_weights = renderer_target.get("think_boundary_weights") or {}
+    actual_think_counts = {
+        key: think_weights.get(key) for key in EXPECTED_THINK_BOUNDARY_COUNTS
+    }
+    if actual_think_counts != EXPECTED_THINK_BOUNDARY_COUNTS:
+        raise ValueError("think-boundary counts differ from the reviewed render")
+
+    selection = curation.get("selection") or {}
+    if selection.get("min_test_pass_rate") != 0.8:
+        raise ValueError("mixed dataset must use the reviewed 80% verifier threshold")
+    quality_counts = curation.get("trial_quality_labels") or {}
+    if quality_counts != EXPECTED_TRIAL_QUALITY:
+        raise ValueError("trial quality counts differ from the frozen profile")
+    if curation.get("trial_claude_code_versions") != EXPECTED_VERSION_COUNTS:
+        raise ValueError("Claude Code version counts differ from the frozen profile")
+    if curation.get("selected_trials") != sum(EXPECTED_TRIAL_QUALITY.values()):
+        raise ValueError("selected trial count differs from the frozen profile")
+    if curation.get("selected_tasks") != 268:
+        raise ValueError("selected task count differs from the frozen profile")
+
+    train_path, train_sha, train_rows = _rendered_artifact(
+        root, curation, renderer, "train.jsonl"
+    )
+    val_path, val_sha, val_rows = _rendered_artifact(
+        root, curation, renderer, "val.jsonl"
+    )
+    _, _, test_rows = _rendered_artifact(root, curation, renderer, "test.jsonl")
+    manifest_path, manifest_sha, manifest_rows = _curation_artifact(
+        root, curation, "manifest.jsonl"
+    )
+    rows = renderer.get("rows") or {}
+    if rows != EXPECTED_SPLIT_ROWS:
+        raise ValueError("renderer split rows differ from the frozen profile")
+    if {"train": train_rows, "val": val_rows, "test": test_rows} != (
+        EXPECTED_SPLIT_ROWS
+    ):
+        raise ValueError("physical split rows differ from the frozen profile")
+    if manifest_rows != expected_rows:
+        raise ValueError("physical manifest rows differ from the frozen profile")
+
+    return DatasetBundle(
+        root=root,
+        curation_report=curation,
+        renderer_report=renderer,
+        train_path=train_path,
+        val_path=val_path,
+        manifest_path=manifest_path,
+        train_sha256=train_sha,
+        val_sha256=val_sha,
+        manifest_sha256=manifest_sha,
+    )
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--run-dir", required=True, type=Path)
+    parser.add_argument("--run-name", default="ultra-mixed-partial80")
+    parser.add_argument("--training-shape", default=LORA_SHAPE)
+    parser.add_argument("--epochs", type=int, default=1)
+    parser.add_argument("--batch-size", type=int, default=1)
+    parser.add_argument("--learning-rate", type=float, default=3e-7)
+    parser.add_argument("--lora-rank", type=int, default=16)
+    parser.add_argument("--lora-alpha", type=int, default=32)
+    parser.add_argument("--trainer-replicas", type=int, default=1)
+    parser.add_argument(
+        "--use-reservation",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+    )
+    parser.add_argument("--seed", type=int, default=20260828)
+    parser.add_argument("--pipeline-depth", type=int, default=4)
+    parser.add_argument("--checkpoint-interval", type=int, default=200)
+    parser.add_argument("--grad-clip-norm", type=float, default=1.0)
+    parser.add_argument("--warmup-ratio", type=float, default=0.03)
+    parser.add_argument("--min-lr-ratio", type=float, default=0.1)
+    parser.add_argument("--weight-decay", type=float, default=0.0)
+    parser.add_argument("--max-eval-seqs", type=int, default=200)
+    parser.add_argument("--wandb-entity", default="")
+    parser.add_argument("--wandb-project", default="")
+    parser.add_argument("--wandb-run-name", default="")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Resolve and write config without creating Fireworks resources.",
+    )
+    return parser.parse_args(argv)
+
+
+def _validate_training_args(args: argparse.Namespace) -> None:
+    if (
+        not args.run_name
+        or Path(args.run_name).name != args.run_name
+        or args.run_name in {".", ".."}
+    ):
+        raise ValueError("--run-name must be one non-empty path segment")
+    if not args.training_shape:
+        raise ValueError("--training-shape must not be empty")
+    positive = {
+        "--epochs": args.epochs,
+        "--batch-size": args.batch_size,
+        "--learning-rate": args.learning_rate,
+        "--lora-rank": args.lora_rank,
+        "--lora-alpha": args.lora_alpha,
+        "--trainer-replicas": args.trainer_replicas,
+        "--pipeline-depth": args.pipeline_depth,
+        "--checkpoint-interval": args.checkpoint_interval,
+        "--grad-clip-norm": args.grad_clip_norm,
+        "--max-eval-seqs": args.max_eval_seqs,
+    }
+    for name, value in positive.items():
+        if isinstance(value, float) and not math.isfinite(value):
+            raise ValueError(f"{name} must be finite")
+        if value <= 0:
+            raise ValueError(f"{name} must be positive")
+    if args.seed < 0:
+        raise ValueError("--seed must be non-negative")
+    if not 0 <= args.warmup_ratio < 1:
+        raise ValueError("--warmup-ratio must be in [0, 1)")
+    if not 0 <= args.min_lr_ratio <= 1:
+        raise ValueError("--min-lr-ratio must be in [0, 1]")
+    if args.weight_decay < 0:
+        raise ValueError("--weight-decay must be non-negative")
+    if bool(args.wandb_entity) != bool(args.wandb_project):
+        raise ValueError("--wandb-entity and --wandb-project must be set together")
+
+
+def _resolved_config(
+    args: argparse.Namespace,
+    bundle: DatasetBundle,
+    session_id: str,
+) -> dict[str, Any]:
+    rows = bundle.renderer_report["rows"]
+    quality = bundle.curation_report["trial_quality_labels"]
+    return {
+        "method": "Training API dedicated SFT",
+        "experiment": "mixed full-success and >=80% verifier partial-success",
+        "risk": "negative ablation; checkpoint promotion is intentionally unsupported",
+        "run_name": args.run_name,
+        "model": {
+            "base_model": BASE_MODEL,
+            "tokenizer_model": TOKENIZER_MODEL,
+            "tokenizer_revision": TOKENIZER_REVISION,
+            "renderer_name": RENDERER_NAME,
+            "max_seq_len": MAX_SEQ_LEN,
+        },
+        "renderer_fix": {
+            "source_pr": MASK_FIX_SOURCE_PR,
+            "public_promotion_commit": MASK_FIX_PROMOTION_COMMIT,
+            "policy": "mask_prefilled_open_train_generated_close",
+            "source_sha256": _require_reviewed_rendering_runtime(),
+            "tinker_cookbook_version": EXPECTED_TINKER_COOKBOOK_VERSION,
+        },
+        "dataset": {
+            "curation_source_pr": CURATION_SOURCE_PR,
+            "profile": bundle.curation_report["profile"],
+            "curation_report": str(bundle.root / "report.json"),
+            "curation_report_sha256": sha256_file(bundle.root / "report.json"),
+            "renderer_report": str(bundle.root / "renderer-report.json"),
+            "renderer_report_sha256": sha256_file(bundle.root / "renderer-report.json"),
+            "provenance": {
+                "path": str(bundle.manifest_path),
+                "sha256": bundle.manifest_sha256,
+            },
+            "train": {
+                "path": str(bundle.train_path),
+                "sha256": bundle.train_sha256,
+                "rows": rows["train"],
+            },
+            "validation": {
+                "path": str(bundle.val_path),
+                "sha256": bundle.val_sha256,
+                "rows": rows["val"],
+            },
+            "trial_quality_labels": quality,
+        },
+        "training": {
+            "training_shape": args.training_shape,
+            "epochs": args.epochs,
+            "batch_size": args.batch_size,
+            "learning_rate": args.learning_rate,
+            "lora_rank": args.lora_rank,
+            "lora_alpha": args.lora_alpha,
+            "trainer_replicas": args.trainer_replicas,
+            "use_reservation": args.use_reservation,
+            "seed": args.seed,
+            "pipeline_depth": args.pipeline_depth,
+            "checkpoint_interval": args.checkpoint_interval,
+            "grad_clip_norm": args.grad_clip_norm,
+            "lr_scheduler": {
+                "type": "cosine",
+                "warmup_ratio": args.warmup_ratio,
+                "min_lr_ratio": args.min_lr_ratio,
+            },
+            "weight_decay": args.weight_decay,
+            "max_eval_seqs": args.max_eval_seqs,
+            "save_final_checkpoint": True,
+            "output_model_id": None,
+        },
+        "wandb": {
+            "entity": args.wandb_entity or None,
+            "project": args.wandb_project or None,
+            "run_name": args.wandb_run_name or None,
+        },
+        "client": {
+            "session_id": session_id,
+            "source": SKILL_CLIENT_SOURCE,
+        },
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    _validate_training_args(args)
+    bundle = load_dataset_bundle(args.run_dir)
+    session_id = os.environ.setdefault("FIREWORKS_SESSION_ID", str(uuid.uuid4()))
+    os.environ.setdefault("FIREWORKS_CLIENT_SOURCE", SKILL_CLIENT_SOURCE)
+
+    log_path = bundle.root / "training" / args.run_name
+    log_path.mkdir(parents=True, exist_ok=True)
+    resolved = _resolved_config(args, bundle, session_id)
+    resolved_path = log_path / "resolved_config.json"
+    resolved_path.write_text(
+        json.dumps(resolved, allow_nan=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    print(json.dumps(resolved, allow_nan=False, indent=2, sort_keys=True))
+    print(f"Resolved config: {resolved_path}")
+
+    if args.dry_run:
+        return 0
+    if os.environ.get("CONFIRM_FIREWORKS_TRAINING") != "YES":
+        raise RuntimeError(
+            "Refusing to create paid resources. Review resolved_config.json, "
+            "then set CONFIRM_FIREWORKS_TRAINING=YES."
+        )
+    if not os.environ.get("FIREWORKS_API_KEY"):
+        raise RuntimeError("FIREWORKS_API_KEY is required for paid training")
+
+    config = sft_loop.Config(
+        log_path=str(log_path),
+        render_samples_file=str(log_path / "render_samples.jsonl"),
+        render_samples_limit=100,
+        base_model=BASE_MODEL,
+        dataset=str(bundle.train_path),
+        evaluation_dataset=str(bundle.val_path),
+        eval_auto_carveout=False,
+        max_eval_seqs=args.max_eval_seqs,
+        tokenizer_model=TOKENIZER_MODEL,
+        tokenizer_revision=TOKENIZER_REVISION,
+        tokenizer_trust_remote_code=True,
+        renderer_name=RENDERER_NAME,
+        train_on_what="all_assistant_messages",
+        learning_rate=args.learning_rate,
+        lr_scheduler={
+            "type": "cosine",
+            "warmup_ratio": args.warmup_ratio,
+            "min_lr_ratio": args.min_lr_ratio,
+        },
+        epochs=args.epochs,
+        batch_size=args.batch_size,
+        max_seq_len=MAX_SEQ_LEN,
+        lora_rank=args.lora_rank,
+        lora_alpha=args.lora_alpha,
+        output_model_id=None,
+        save_final_checkpoint=True,
+        dcp_save_interval=args.checkpoint_interval,
+        grad_clip_norm=args.grad_clip_norm,
+        weight_decay=args.weight_decay,
+        warmup_steps=0,
+        seed=args.seed,
+        group_by_length=True,
+        pipeline_depth=args.pipeline_depth,
+        trainer=TrainerConfig(
+            training_shape_id=args.training_shape,
+            replica_count=args.trainer_replicas,
+            use_reservation=args.use_reservation,
+        ),
+        wandb=WandBConfig(
+            entity=args.wandb_entity or None,
+            project=args.wandb_project or None,
+            run_name=args.wandb_run_name or None,
+        ),
+    )
+    metrics = sft_loop.main(config)
+    print(
+        json.dumps({"final_metrics": metrics}, allow_nan=False, indent=2, default=str)
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/training/renderer/_nemotron3_split.py
+++ b/training/renderer/_nemotron3_split.py
@@ -26,8 +26,8 @@ Nemotron-3 inherits Qwen3.5's assistant split, which puts the prefilled
 ``<think>`` in the trainable span and the model-generated ``</think>`` in the
 masked header. Every thinking-enabled variant therefore mixes in
 :class:`training.renderer._think_prefill.ThinkPrefillWeightsMixin`.
-``nemotron3_disable_thinking`` does not: its generation suffix prefills the
-whole ``<think></think>`` wrapper, so masking both markers is already right.
+Disable-thinking variants do not: their generation suffix prefills the whole
+``<think></think>`` wrapper, so masking both markers is already correct.
 """
 
 from __future__ import annotations
@@ -38,6 +38,9 @@ from tinker_cookbook.renderers.nemotron3 import (
     Nemotron3DisableThinkingRenderer,
     Nemotron3LowThinkingRenderer,
     Nemotron3Renderer,
+    Nemotron3UltraDisableThinkingRenderer,
+    Nemotron3UltraMediumThinkingRenderer,
+    Nemotron3UltraRenderer,
 )
 
 from training.renderer._disaggregate_mixin import DisaggregateMultiTurnMixin
@@ -76,6 +79,32 @@ class Nemotron3DisableThinkingSplitRenderer(
     Nemotron3DisableThinkingRenderer,
 ):
     pass
+
+
+class Nemotron3UltraSplitRenderer(
+    ThinkPrefillWeightsMixin,
+    DisaggregateMultiTurnMixin,
+    _UntrainedSynthesizedSystemMixin,
+    Nemotron3UltraRenderer,
+):
+    """Ultra full reasoning with Ultra-specific think-block separators."""
+
+
+class Nemotron3UltraMediumThinkingSplitRenderer(
+    ThinkPrefillWeightsMixin,
+    DisaggregateMultiTurnMixin,
+    _UntrainedSynthesizedSystemMixin,
+    Nemotron3UltraMediumThinkingRenderer,
+):
+    """Ultra medium-effort reasoning with corrected think-boundary weights."""
+
+
+class Nemotron3UltraDisableThinkingSplitRenderer(
+    DisaggregateMultiTurnMixin,
+    _UntrainedSynthesizedSystemMixin,
+    Nemotron3UltraDisableThinkingRenderer,
+):
+    """Ultra non-thinking mode; the complete empty wrapper stays masked."""
 
 
 class _Nemotron3PreserveThinkingMixin:
@@ -137,6 +166,18 @@ register_renderer(
 register_renderer(
     "nemotron3_disable_thinking",
     lambda tok, ip=None: Nemotron3DisableThinkingSplitRenderer(tok),
+)
+register_renderer(
+    "nemotron3_ultra",
+    lambda tok, ip=None: Nemotron3UltraSplitRenderer(tok),
+)
+register_renderer(
+    "nemotron3_ultra_medium_thinking",
+    lambda tok, ip=None: Nemotron3UltraMediumThinkingSplitRenderer(tok),
+)
+register_renderer(
+    "nemotron3_ultra_disable_thinking",
+    lambda tok, ip=None: Nemotron3UltraDisableThinkingSplitRenderer(tok),
 )
 register_renderer(
     "nemotron3_preserve_thinking",

--- a/training/tests/test_smoke_imports.py
+++ b/training/tests/test_smoke_imports.py
@@ -86,6 +86,7 @@ EXAMPLE_MODULES_WITH_ENV = [
 
 EXAMPLE_MODULES = [
     "training.examples.rl.deepmath.prepare_data",
+    "training.examples.sft.nl2repo_mixed.train",
     "training.examples.rl.single_turn_token_in.rollout",
     "training.examples.rl.multi_turn_message_in.rollout",
     "training.examples.tools.promote_checkpoint",

--- a/training/tests/unit/test_nl2repo_mixed_sft.py
+++ b/training/tests/unit/test_nl2repo_mixed_sft.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from training.examples.sft.nl2repo_mixed import train
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _write_json(path: Path, value: dict) -> None:
+    path.write_text(json.dumps(value, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _make_bundle(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    for split, rows in train.EXPECTED_SPLIT_ROWS.items():
+        line = json.dumps({"messages": [{"role": "user", "content": split}]}) + "\n"
+        (tmp_path / f"{split}.jsonl").write_text(
+            line * rows,
+            encoding="utf-8",
+        )
+    manifest_line = json.dumps({"split": "train", "row_index": 0}) + "\n"
+    (tmp_path / "manifest.jsonl").write_text(
+        manifest_line * sum(train.EXPECTED_SPLIT_ROWS.values()),
+        encoding="utf-8",
+    )
+
+    target = {
+        "model": train.BASE_MODEL,
+        "renderer": train.RENDERER_NAME,
+        "tokenizer_model": train.TOKENIZER_MODEL,
+        "tokenizer_revision": train.TOKENIZER_REVISION,
+        "max_seq_len": train.MAX_SEQ_LEN,
+    }
+    curation = {
+        "schema": train.CURATION_SCHEMA,
+        "profile": train.EXPECTED_PROFILE,
+        "target": target,
+        "selection": {"min_test_pass_rate": 0.8},
+        "trial_quality_labels": train.EXPECTED_TRIAL_QUALITY,
+        "trial_claude_code_versions": train.EXPECTED_VERSION_COUNTS,
+        "selected_trials": 692,
+        "selected_tasks": 268,
+        "implementation": {
+            "module": "experiments.nemotron_ultra_prd_to_repo.data.curation",
+            "script_sha256": train.EXPECTED_CURATOR_SHA256,
+        },
+        "artifacts": {
+            filename: {
+                "path": str(tmp_path / filename),
+                "sha256": _sha256(tmp_path / filename),
+            }
+            for filename in (
+                "train.jsonl",
+                "val.jsonl",
+                "test.jsonl",
+                "manifest.jsonl",
+            )
+        },
+    }
+    curation_path = tmp_path / "report.json"
+    _write_json(curation_path, curation)
+
+    renderer = {
+        "schema": train.RENDER_REPORT_SCHEMA,
+        "source_report_sha256": _sha256(curation_path),
+        "implementation": {
+            "module": ("experiments.nemotron_ultra_prd_to_repo.data.render_validate"),
+            "script_sha256": train.EXPECTED_RENDER_VALIDATOR_SHA256,
+        },
+        "input_artifacts": {
+            f"{split}.jsonl": _sha256(tmp_path / f"{split}.jsonl")
+            for split in ("train", "val", "test")
+        },
+        "rows": train.EXPECTED_SPLIT_ROWS,
+        "renderer": {
+            "renderer_name": train.RENDERER_NAME,
+            "tokenizer_model": train.TOKENIZER_MODEL,
+            "tokenizer_revision": train.TOKENIZER_REVISION,
+            "max_seq_len": train.MAX_SEQ_LEN,
+            "rows_rendered": sum(train.EXPECTED_SPLIT_ROWS.values()),
+            "datums_rendered": sum(train.EXPECTED_SPLIT_ROWS.values()),
+            "oversize_count": 0,
+            "empty_loss_count": 0,
+            "think_boundary_weights": train.EXPECTED_THINK_BOUNDARY_COUNTS,
+        },
+        "checks": {
+            "all_rows_rendered": True,
+            "one_datum_per_row": True,
+            "all_rows_within_context": True,
+            "all_datums_have_loss": True,
+            "prefilled_think_open_masked": True,
+            "generated_think_close_weighted": True,
+            "no_errors": True,
+        },
+        "errors": [],
+        "ready_for_training": True,
+    }
+    _write_json(tmp_path / "renderer-report.json", renderer)
+    monkeypatch.setattr(
+        train,
+        "EXPECTED_ARTIFACT_SHA256",
+        {
+            filename: _sha256(tmp_path / filename)
+            for filename in (
+                "train.jsonl",
+                "val.jsonl",
+                "test.jsonl",
+                "manifest.jsonl",
+            )
+        },
+    )
+    return tmp_path
+
+
+def test_load_dataset_bundle_accepts_bound_mixed_inputs(tmp_path, monkeypatch):
+    run_dir = _make_bundle(tmp_path, monkeypatch)
+
+    bundle = train.load_dataset_bundle(run_dir)
+
+    assert bundle.train_path == run_dir / "train.jsonl"
+    assert bundle.val_path == run_dir / "val.jsonl"
+    assert bundle.manifest_path == run_dir / "manifest.jsonl"
+    assert bundle.train_sha256 == _sha256(bundle.train_path)
+
+
+def test_load_dataset_bundle_rejects_self_consistent_noncanonical_inputs(
+    tmp_path, monkeypatch
+):
+    canonical_hashes = dict(train.EXPECTED_ARTIFACT_SHA256)
+    run_dir = _make_bundle(tmp_path, monkeypatch)
+    monkeypatch.setattr(train, "EXPECTED_ARTIFACT_SHA256", canonical_hashes)
+
+    with pytest.raises(ValueError, match="canonical dataset"):
+        train.load_dataset_bundle(run_dir)
+
+
+def test_load_dataset_bundle_rejects_split_hash_drift(tmp_path, monkeypatch):
+    run_dir = _make_bundle(tmp_path, monkeypatch)
+    (run_dir / "train.jsonl").write_text("{}\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="hash differs from curation report"):
+        train.load_dataset_bundle(run_dir)
+
+
+def test_load_dataset_bundle_counts_physical_rows_after_rehash(tmp_path, monkeypatch):
+    run_dir = _make_bundle(tmp_path, monkeypatch)
+    train_path = run_dir / "train.jsonl"
+    lines = train_path.read_text(encoding="utf-8").splitlines(keepends=True)
+    train_path.write_text("".join(lines[:-1]), encoding="utf-8")
+
+    curation_path = run_dir / "report.json"
+    curation = json.loads(curation_path.read_text(encoding="utf-8"))
+    curation["artifacts"]["train.jsonl"]["sha256"] = _sha256(train_path)
+    _write_json(curation_path, curation)
+
+    renderer_path = run_dir / "renderer-report.json"
+    renderer = json.loads(renderer_path.read_text(encoding="utf-8"))
+    renderer["source_report_sha256"] = _sha256(curation_path)
+    renderer["input_artifacts"]["train.jsonl"] = _sha256(train_path)
+    _write_json(renderer_path, renderer)
+    expected_hashes = dict(train.EXPECTED_ARTIFACT_SHA256)
+    expected_hashes["train.jsonl"] = _sha256(train_path)
+    monkeypatch.setattr(train, "EXPECTED_ARTIFACT_SHA256", expected_hashes)
+
+    with pytest.raises(ValueError, match="physical split rows"):
+        train.load_dataset_bundle(run_dir)
+
+
+def test_load_dataset_bundle_rejects_non_mixed_curation(tmp_path, monkeypatch):
+    run_dir = _make_bundle(tmp_path, monkeypatch)
+    curation_path = run_dir / "report.json"
+    curation = json.loads(curation_path.read_text(encoding="utf-8"))
+    curation["trial_quality_labels"]["partial_success"] = 0
+    _write_json(curation_path, curation)
+    renderer_path = run_dir / "renderer-report.json"
+    renderer = json.loads(renderer_path.read_text(encoding="utf-8"))
+    renderer["source_report_sha256"] = _sha256(curation_path)
+    _write_json(renderer_path, renderer)
+
+    with pytest.raises(ValueError, match="trial quality counts"):
+        train.load_dataset_bundle(run_dir)
+
+
+def test_load_dataset_bundle_rejects_weighted_think_open(tmp_path, monkeypatch):
+    run_dir = _make_bundle(tmp_path, monkeypatch)
+    renderer_path = run_dir / "renderer-report.json"
+    renderer = json.loads(renderer_path.read_text(encoding="utf-8"))
+    renderer["renderer"]["think_boundary_weights"]["weighted_open_count"] = 1
+    _write_json(renderer_path, renderer)
+
+    with pytest.raises(ValueError, match="think-boundary counts"):
+        train.load_dataset_bundle(run_dir)
+
+
+def test_load_dataset_bundle_rejects_unreviewed_validator(tmp_path, monkeypatch):
+    run_dir = _make_bundle(tmp_path, monkeypatch)
+    renderer_path = run_dir / "renderer-report.json"
+    renderer = json.loads(renderer_path.read_text(encoding="utf-8"))
+    renderer["implementation"]["script_sha256"] = "0" * 64
+    _write_json(renderer_path, renderer)
+
+    with pytest.raises(ValueError, match="reviewed validator"):
+        train.load_dataset_bundle(run_dir)
+
+
+def test_dry_run_writes_resolved_config_without_training(tmp_path, monkeypatch):
+    run_dir = _make_bundle(tmp_path, monkeypatch)
+    monkeypatch.setenv("FIREWORKS_SESSION_ID", "test-session")
+    monkeypatch.setattr(
+        train.sft_loop,
+        "main",
+        lambda config: pytest.fail("dry-run must not call sft_loop.main"),
+    )
+
+    result = train.main(
+        ["--run-dir", str(run_dir), "--run-name", "dry-run-test", "--dry-run"]
+    )
+
+    assert result == 0
+    resolved_path = run_dir / "training" / "dry-run-test" / "resolved_config.json"
+    resolved = json.loads(resolved_path.read_text(encoding="utf-8"))
+    assert resolved["model"]["renderer_name"] == "nemotron3_ultra"
+    assert resolved["dataset"]["trial_quality_labels"] == train.EXPECTED_TRIAL_QUALITY
+    assert resolved["training"]["output_model_id"] is None
+
+
+def test_paid_run_requires_explicit_confirmation(tmp_path, monkeypatch):
+    run_dir = _make_bundle(tmp_path, monkeypatch)
+    monkeypatch.delenv("CONFIRM_FIREWORKS_TRAINING", raising=False)
+    monkeypatch.setenv("FIREWORKS_API_KEY", "test-key")
+
+    with pytest.raises(RuntimeError, match="CONFIRM_FIREWORKS_TRAINING=YES"):
+        train.main(["--run-dir", str(run_dir)])
+
+
+def test_confirmed_run_calls_sft_with_reviewed_defaults(tmp_path, monkeypatch):
+    run_dir = _make_bundle(tmp_path, monkeypatch)
+    seen = {}
+    monkeypatch.setenv("CONFIRM_FIREWORKS_TRAINING", "YES")
+    monkeypatch.setenv("FIREWORKS_API_KEY", "test-key")
+
+    def fake_main(config):
+        seen["config"] = config
+        return {"loss": 0.5}
+
+    monkeypatch.setattr(train.sft_loop, "main", fake_main)
+
+    assert train.main(["--run-dir", str(run_dir)]) == 0
+    config = seen["config"]
+    assert config.dataset == str(run_dir / "train.jsonl")
+    assert config.evaluation_dataset == str(run_dir / "val.jsonl")
+    assert config.renderer_name == "nemotron3_ultra"
+    assert config.max_seq_len == 262_144
+    assert config.learning_rate == pytest.approx(3e-7)
+    assert config.lora_rank == 16
+    assert config.lora_alpha == 32
+    assert config.output_model_id is None

--- a/training/tests/unit/test_think_boundary_weights.py
+++ b/training/tests/unit/test_think_boundary_weights.py
@@ -16,6 +16,7 @@ import training.renderer  # noqa: F401  (registers local renderers)
 from training.utils.supervised import normalize_messages, render_messages_to_datums
 
 _NEMOTRON = "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16"
+_NEMOTRON_ULTRA = "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16"
 _RENDERERS = [
     ("qwen3_5", "Qwen/Qwen3.5-9B"),
     ("qwen3_5_interleaved", "Qwen/Qwen3.5-9B"),
@@ -30,6 +31,8 @@ _RENDERERS = [
     ("nemotron3_low_thinking", _NEMOTRON),
     ("nemotron3_preserve_thinking", _NEMOTRON),
     ("nemotron3_preserved", _NEMOTRON),
+    ("nemotron3_ultra", _NEMOTRON_ULTRA),
+    ("nemotron3_ultra_medium_thinking", _NEMOTRON_ULTRA),
 ]
 _PROMPT = [
     {"role": "system", "content": "Be brief."},
@@ -92,6 +95,7 @@ _DISABLE_THINKING = [
     ("qwen3_5_disable_thinking", "Qwen/Qwen3.5-9B"),
     ("qwen3_6_disable_thinking", "Qwen/Qwen3.6-27B"),
     ("nemotron3_disable_thinking", _NEMOTRON),
+    ("nemotron3_ultra_disable_thinking", _NEMOTRON_ULTRA),
 ]
 
 
@@ -134,6 +138,12 @@ _UPSTREAM_PARITY = [
         _NEMOTRON,
         "tinker_cookbook.renderers.nemotron3",
         "Nemotron3Renderer",
+    ),
+    (
+        "nemotron3_ultra",
+        _NEMOTRON_ULTRA,
+        "tinker_cookbook.renderers.nemotron3",
+        "Nemotron3UltraRenderer",
     ),
 ]
 
@@ -180,3 +190,88 @@ def test_preserved_multi_turn_reweights_every_assistant(
     tokenizer, datum = _render(renderer_name, tokenizer_model, messages)
     assert _weights_for(tokenizer, datum, "<think>") == [0.0, 0.0]
     assert _weights_for(tokenizer, datum, "</think>") == [1.0, 1.0]
+
+
+@pytest.mark.timeout(180)
+@pytest.mark.parametrize(
+    ("renderer_name", "tokenizer_model"),
+    [
+        ("qwen3_6", "Qwen/Qwen3.6-27B"),
+        ("nemotron3_ultra", _NEMOTRON_ULTRA),
+    ],
+)
+def test_supervised_prefix_matches_generation_prompt(renderer_name, tokenizer_model):
+    """The complete generation prefill is an identical zero-loss prefix."""
+    tokenizer = _load_tokenizer(tokenizer_model)
+    renderer = get_renderer(renderer_name, tokenizer)
+    prompt = list(
+        renderer.build_generation_prompt(
+            normalize_messages(_PROMPT), role="assistant"
+        ).to_ints()
+    )
+    model_input, weights = renderer.build_supervised_example(
+        normalize_messages(_WITH_REASONING),
+        train_on_what=TrainOnWhat.LAST_ASSISTANT_TURN,
+    )
+    tokens = list(model_input.to_ints())
+    weight_values = [float(weight) for weight in weights.tolist()]
+    assert tokens[: len(prompt)] == prompt
+    assert weight_values[: len(prompt)] == [0.0] * len(prompt)
+    [open_token] = tokenizer.encode("<think>", add_special_tokens=False)
+    [close_token] = tokenizer.encode("</think>", add_special_tokens=False)
+    assert open_token in prompt
+    assert close_token not in prompt
+    assert weight_values[tokens.index(close_token)] == 1.0
+
+
+@pytest.mark.timeout(180)
+@pytest.mark.parametrize(
+    ("renderer_name", "tokenizer_model"),
+    [
+        ("qwen3_6", "Qwen/Qwen3.6-27B"),
+        ("nemotron3_ultra", _NEMOTRON_ULTRA),
+    ],
+)
+def test_all_tokens_keeps_both_think_markers_trainable(renderer_name, tokenizer_model):
+    """ALL_TOKENS intentionally trains headers, including the prefilled opener."""
+    tokenizer = _load_tokenizer(tokenizer_model)
+    renderer = get_renderer(renderer_name, tokenizer)
+    [datum] = render_messages_to_datums(
+        _WITH_REASONING,
+        renderer=renderer,
+        train_on_what=TrainOnWhat.ALL_TOKENS,
+    )
+    assert _weights_for(tokenizer, datum, "<think>") == [1.0]
+    assert _weights_for(tokenizer, datum, "</think>") == [1.0]
+
+
+@pytest.mark.timeout(180)
+def test_ultra_tool_call_turn_uses_correct_think_boundary_weights():
+    """Thinking-only tool-call turns use the same prefill boundary."""
+    tokenizer = _load_tokenizer(_NEMOTRON_ULTRA)
+    renderer = get_renderer("nemotron3_ultra", tokenizer)
+    messages = [
+        *_PROMPT,
+        {
+            "role": "assistant",
+            "content": "",
+            "reasoning_content": "Inspect the repository before editing.",
+            "tool_calls": [
+                {
+                    "id": "call-1",
+                    "type": "function",
+                    "function": {
+                        "name": "Read",
+                        "arguments": '{"file_path": "README.md"}',
+                    },
+                }
+            ],
+        },
+    ]
+    [datum] = render_messages_to_datums(
+        messages,
+        renderer=renderer,
+        train_on_what=TrainOnWhat.ALL_ASSISTANT_MESSAGES,
+    )
+    assert _weights_for(tokenizer, datum, "<think>") == [0.0]
+    assert _weights_for(tokenizer, datum, "</think>") == [1.0]

--- a/training/tests/unit/test_weighted_row_invariants.py
+++ b/training/tests/unit/test_weighted_row_invariants.py
@@ -83,6 +83,13 @@ _EXTRA_TOKENIZERS = {
     "nemotron3_low_thinking": "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
     "nemotron3_preserve_thinking": "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
     "nemotron3_preserved": "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
+    "nemotron3_ultra": "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16",
+    "nemotron3_ultra_disable_thinking": (
+        "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16"
+    ),
+    "nemotron3_ultra_medium_thinking": (
+        "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16"
+    ),
     "gpt_oss_high_reasoning": "openai/gpt-oss-120b",
     "gpt_oss_no_sysprompt": "openai/gpt-oss-120b",
     "mistral": "mistralai/Ministral-3-3B-Instruct-2512",


### PR DESCRIPTION
## Summary

- Add a dry-run-first, fail-closed Training API example for the exact mixed full-success / >=80%-verifier PRD-to-Repo dataset produced by [fw-ai/upheaval#148](https://github.com/fw-ai/upheaval/pull/148).
- Register Nemotron 3 Ultra full, medium-thinking, and disable-thinking split renderers on top of the promoted Qwen/Nemotron think-prefill fix.
- Record the completed run and DeepSWE evidence as a negative ablation; the launcher saves an unpromoted checkpoint and deliberately exposes no promotion option.

## Dataset and safety

- Pin the canonical `train.jsonl`, `val.jsonl`, `test.jsonl`, and `manifest.jsonl` SHA-256 values from a fresh full Wentao-v1 materialization.
- Recheck physical row counts, curator and renderer-validator implementations, all material rendering/tokenization source hashes, `tinker-cookbook==0.4.3`, and exact think-boundary aggregates before training.
- Require `CONFIRM_FIREWORKS_TRAINING=YES` before any paid resource creation.
- Commit no raw trajectories, capture bundles, repositories, prepared JSONL, credentials, deployment automation, RL code, or evaluation orchestration.

## Completed ablation

- Dataset: 692 trajectories / 268 tasks / 10,528 windows; 260 full successes and 432 partial successes.
- Training: 10,215/10,215 steps; first/last-100 mean CE 0.4497/0.3775; final eval CE 0.3507.
- DeepSWE-113: Base 5 passes vs Mixed SFT 2; Base/Mixed infrastructure errors 4/20.
- On 91 paired-valid tasks: 2 gains, 5 regressions, 84 unchanged failures.
- Verdict: numerically stable but not promotable. The dominant risks are equal weighting of a 63.9% partial-success window majority, correlated windows, a four-task validation split, and task-distribution mismatch.

`RESULTS.json` binds the training job, evaluated model/deployment, benchmark run IDs, exact metrics, renderer hashes, and retained evidence hashes. A fresh #148 materialization matched all 10,528 semantic row hashes from the historically fully rendered dataset.

## Validation

- [x] `pytest -q training/tests/unit/test_nl2repo_mixed_sft.py` — 10 passed
- [x] `pytest -q training/tests/test_smoke_imports.py -k nl2repo_mixed` — 1 passed
- [x] `pytest -q training/tests/unit/test_think_boundary_weights.py` — 32 passed
- [x] `pytest -q training/tests/unit/test_weighted_row_invariants.py -k 'nemotron3_ultra or every_registered_renderer'` — 31 passed
- [x] Ruff, JSON syntax, Bash syntax, and whitespace checks passed
- [x] Fresh full canonical curation and per-split semantic comparison passed with zero unmatched rows

## Merge path

The public cookbook `main` branch only accepts generated promotion PRs from Fireworks staging. This PR is the human-review surface; after approval, the same commit must be mirrored through the staging promotion path.

Made with [Cursor](https://cursor.com)