### PR TITLE
Allow trainer-first rollout provisioning and MTP on older SDKs

### DIFF
--- a/skills/fireworks-training/references/rl-hotload.md
+++ b/skills/fireworks-training/references/rl-hotload.md
@@ -30,6 +30,8 @@ DeployConfig(weight_sync_scope=WeightSyncScope.PER_TRAINER, ...)
 
 Bucket path: `gs://.../rl-checkpoints/{account}/trainer-{trainer_id}/`. Good when one trainer feeds multiple deployments, or for clean per-run isolation.
 
+The managed SDK path overlaps trainer readiness with deployment creation. Set `DeployConfig.wait_for_trainer_before_deployment=True` to wait for trainer capacity before allocating rollout GPUs (requires an SDK that honors the flag). `draft_model` / `draft_token_count` / `enable_session_affinity` are create-time speculation and affinity knobs; they are forwarded when the SDK declares them.
+
 ### PER_DEPLOYMENT
 
 ```python

--- a/training/tests/unit/test_sdk_compat.py
+++ b/training/tests/unit/test_sdk_compat.py
@@ -133,3 +133,21 @@ def test_to_deployment_config_leaves_hot_load_transition_type_unset_by_default()
     )
 
     assert deployment_config.hot_load_transition_type is None
+
+
+def test_to_deployment_config_preserves_fields_missing_from_sdk():
+    deploy_cfg = config_module.DeployConfig(
+        deployment_id="dep-123",
+        draft_model="mtp",
+        draft_token_count=3,
+        enable_session_affinity=False,
+    )
+
+    deployment_config = deploy_cfg.to_deployment_config(
+        "accounts/test/models/qwen3-35b",
+        config_module.InfraConfig(),
+    )
+
+    assert deployment_config.draft_model == "mtp"
+    assert deployment_config.draft_token_count == 3
+    assert deployment_config.enable_session_affinity is False

--- a/training/tests/unit/test_service.py
+++ b/training/tests/unit/test_service.py
@@ -7,8 +7,10 @@ import inspect
 
 import pytest
 
+from types import SimpleNamespace
+
 from training.utils import service
-from training.utils.config import DeployConfig, TrainerConfig
+from training.utils.config import DeployConfig, TrainerConfig, WeightSyncScope
 from training.utils.service import build_service_client, resolve_router_replay_enabled
 
 
@@ -458,6 +460,90 @@ def test_trainer_config_rejects_removed_accelerator_fields(field_name, value):
         ),
     ):
         TrainerConfig(**{field_name: value})
+
+
+def test_build_service_client_rejects_trainer_wait_without_per_trainer():
+    with pytest.raises(ValueError, match="wait_for_trainer_before_deployment"):
+        build_service_client(
+            api_key="k",
+            base_url="https://api",
+            additional_headers=None,
+            base_model="accounts/acct/models/base",
+            tokenizer_model=None,
+            max_lora_rank=None,
+            max_context_length=None,
+            learning_rate=1e-5,
+            trainer=TrainerConfig(training_shape_id="ts-x"),
+            deployment=DeployConfig(
+                deployment_id="dep-1",
+                wait_for_trainer_before_deployment=True,
+                weight_sync_scope=WeightSyncScope.PER_DEPLOYMENT,
+            ),
+        )
+
+
+def test_build_service_client_forwards_trainer_wait_when_sdk_declares_it(monkeypatch):
+    calls: list[dict] = []
+
+    def fake_from_firetitan_config(**kwargs):
+        calls.append(kwargs)
+        return "service-sentinel"
+
+    class FakeServiceClient:
+        from_firetitan_config = staticmethod(fake_from_firetitan_config)
+
+    monkeypatch.setattr(service, "FiretitanServiceClient", FakeServiceClient)
+    monkeypatch.setattr(
+        service,
+        "fields",
+        lambda _cls: (
+            SimpleNamespace(name="wait_for_trainer_before_deployment"),
+            SimpleNamespace(name="draft_model"),
+            SimpleNamespace(name="draft_token_count"),
+            SimpleNamespace(name="enable_session_affinity"),
+        ),
+    )
+
+    build_service_client(
+        api_key="k",
+        base_url="https://api",
+        additional_headers=None,
+        base_model="accounts/acct/models/base",
+        tokenizer_model=None,
+        max_lora_rank=None,
+        max_context_length=None,
+        learning_rate=1e-5,
+        trainer=TrainerConfig(training_shape_id="ts-x"),
+        deployment=DeployConfig(
+            deployment_id="dep-1",
+            wait_for_trainer_before_deployment=True,
+            draft_model="mtp",
+            draft_token_count=3,
+            enable_session_affinity=False,
+        ),
+    )
+
+    assert calls[0]["wait_for_trainer_before_deployment"] is True
+    assert calls[0]["draft_model"] == "mtp"
+    assert calls[0]["draft_token_count"] == 3
+    assert calls[0]["enable_session_affinity"] is False
+
+
+def test_build_service_client_errors_when_mtp_requested_on_old_sdk(monkeypatch):
+    monkeypatch.setattr(service, "fields", lambda _cls: ())
+    with pytest.raises(RuntimeError, match="draft_model"):
+        build_service_client(
+            api_key="k",
+            base_url="https://api",
+            additional_headers=None,
+            base_model="accounts/acct/models/base",
+            tokenizer_model=None,
+            max_lora_rank=None,
+            max_context_length=None,
+            learning_rate=1e-5,
+            trainer=TrainerConfig(training_shape_id="ts-x"),
+            deployment=DeployConfig(deployment_id="dep-1", draft_model="mtp"),
+        )
 
 
 def test_trainer_config_does_not_advertise_removed_accelerator_fields():

--- a/training/utils/config.py
+++ b/training/utils/config.py
@@ -298,6 +298,15 @@ class DeployConfig:
     Increase for R3 + long completions where responses can be very large."""
     disable_speculative_decoding: bool = False
     """When true, disable the base model's default draft/EAGLE speculation."""
+    wait_for_trainer_before_deployment: bool = False
+    """For ``PER_TRAINER``, wait for trainer capacity before rollout allocation.
+    Avoids idle rollout GPUs while queued, but serializes trainer/deployment boot."""
+    draft_model: str | None = None
+    """Speculative-decoding draft model at deploy create (e.g. ``\"mtp\"``)."""
+    draft_token_count: int | None = None
+    """Tokens drafted per step (paired with ``draft_model``)."""
+    enable_session_affinity: bool | None = None
+    """If set, configure session affinity at deploy create time."""
     replica_count: int | None = None
     """If set, pin the deployment to a fixed replica count."""
     extra_values: dict[str, str] | None = None
@@ -314,24 +323,39 @@ class DeployConfig:
         skip_validation = False
         accel = None if self.deployment_shape else self.deployment_accelerator_type
         replica_count = 1 if self.replica_count is None else self.replica_count
-        return DeploymentConfig(
-            deployment_id=self.deployment_id,
-            base_model=base_model,
-            region=infra.region,
-            deployment_shape=self.deployment_shape,
-            hot_load_bucket_type=self.hot_load_bucket_type if self.enable_hot_load else None,
-            hot_load_trainer_job=self.hot_load_trainer_job if self.enable_hot_load else None,
-            hot_load_transition_type=self.hot_load_transition_type if self.enable_hot_load else None,
-            enable_hot_load=self.enable_hot_load,
-            skip_shape_validation=skip_validation,
-            extra_args=self.deployment_extra_args,
-            min_replica_count=replica_count,
-            max_replica_count=replica_count,
-            accelerator_type=accel,
-            disable_speculative_decoding=self.disable_speculative_decoding,
-            extra_values=self.extra_values,
-            preemptible=self.preemptible or getattr(infra, "preemptible", False),
-        )
+        kwargs = {
+            "deployment_id": self.deployment_id,
+            "base_model": base_model,
+            "region": infra.region,
+            "deployment_shape": self.deployment_shape,
+            "hot_load_bucket_type": self.hot_load_bucket_type if self.enable_hot_load else None,
+            "hot_load_trainer_job": self.hot_load_trainer_job if self.enable_hot_load else None,
+            "hot_load_transition_type": self.hot_load_transition_type if self.enable_hot_load else None,
+            "enable_hot_load": self.enable_hot_load,
+            "skip_shape_validation": skip_validation,
+            "extra_args": self.deployment_extra_args,
+            "min_replica_count": replica_count,
+            "max_replica_count": replica_count,
+            "accelerator_type": accel,
+            "disable_speculative_decoding": self.disable_speculative_decoding,
+            "draft_model": self.draft_model,
+            "draft_token_count": self.draft_token_count,
+            "enable_session_affinity": self.enable_session_affinity,
+            "extra_values": self.extra_values,
+            "preemptible": self.preemptible or getattr(infra, "preemptible", False),
+        }
+        supported = getattr(DeploymentConfig, "__dataclass_fields__", {})
+        passthrough = {"draft_model", "draft_token_count", "enable_session_affinity"}
+        lost = {
+            key: value for key, value in kwargs.items()
+            if key not in supported and key not in passthrough and value is not None
+        }
+        if lost:
+            raise TypeError(f"SDK DeploymentConfig cannot express settings: {lost}")
+        config = DeploymentConfig(**{key: value for key, value in kwargs.items() if key in supported})
+        for key in passthrough - supported.keys():
+            setattr(config, key, kwargs[key])
+        return config
 
 
 @dataclass

--- a/training/utils/service.py
+++ b/training/utils/service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import fields
 from typing import Any
 
 from fireworks.training.sdk import (
@@ -9,8 +10,9 @@ from fireworks.training.sdk import (
     FireworksClient,
     FiretitanServiceClient,
 )
+from fireworks.training.sdk.managed import FiretitanProvisioningConfig
 
-from training.utils.config import DeployConfig, TrainerConfig
+from training.utils.config import DeployConfig, TrainerConfig, WeightSyncScope
 
 
 def resolve_router_replay_enabled(
@@ -110,6 +112,33 @@ def _firetitan_service_kwargs(
             "hot_load_transition_type": deployment.hot_load_transition_type,
         }
     )
+    if (
+        deployment.wait_for_trainer_before_deployment
+        and deployment.weight_sync_scope != WeightSyncScope.PER_TRAINER
+    ):
+        raise ValueError(
+            "wait_for_trainer_before_deployment requires PER_TRAINER weight sync"
+        )
+    supported = {f.name for f in fields(FiretitanProvisioningConfig)}
+    optional_deploy = {
+        "wait_for_trainer_before_deployment": deployment.wait_for_trainer_before_deployment,
+        "draft_model": deployment.draft_model,
+        "draft_token_count": deployment.draft_token_count,
+        "enable_session_affinity": deployment.enable_session_affinity,
+    }
+    for name, value in optional_deploy.items():
+        if name in supported:
+            if name == "wait_for_trainer_before_deployment" and not value:
+                continue
+            service_kwargs[name] = value
+            continue
+        requested = value if name == "wait_for_trainer_before_deployment" else value is not None
+        if requested:
+            raise RuntimeError(
+                f"{name}={value!r} was requested, but the installed fireworks-ai "
+                f"SDK's FiretitanProvisioningConfig has no {name!r} field. "
+                "Upgrade the SDK or drop the option."
+            )
     return service_kwargs
 
 


### PR DESCRIPTION
Superseded by the authoritative staging PR: https://github.com/fw-ai/fireworks/pull/47925

The official cookbook is generated from `fw-ai/fireworks/public-repos/cookbook`; direct public-repository PRs cannot pass the promotion-source gate.