### PR TITLE
RL: add lagged teacher on-policy distillation

### DIFF
--- a/training/recipes/async_rl_loop.py
+++ b/training/recipes/async_rl_loop.py
@@ -39,6 +39,7 @@ from dataclasses import dataclass, field
 from typing import Any, Awaitable, Callable, Literal
 
 import tinker
+from fireworks.training.sdk.deployment import DeploymentConfig
 from fireworks.training.sdk.training_spec import (
     LRSchedulerSpec,
     compute_lr,
@@ -202,6 +203,11 @@ class Config:
     """Save a resumable+promotable checkpoint at the end of training."""
     output_model_id: str | None = None
     """Promote the final checkpoint to this 4-segment model id on clean exit."""
+    opd_beta: float = 0.0
+    """Sampled reverse-KL weight for a privileged lagged teacher."""
+    opd_teacher_sync_every: int = 10
+    opd_teacher_deployment_id: str | None = None
+    opd_teacher_replica_count: int = 1
 
 
 @dataclass
@@ -230,6 +236,8 @@ class RolloutSetup:
     remain for compatibility with externally constructed setups and older
     rollout factories.
     """
+    teacher_sampler: Any | None = None
+    """Optional lagged teacher sampler used to score rollout token IDs."""
 
 
 RolloutFn = Callable[..., Awaitable[RolloutRun | None]]
@@ -385,6 +393,17 @@ def main(
     )
     if cfg.server_side_grpo and cfg.kl_beta != 0:
         raise ValueError("server_side_grpo requires kl_beta=0.")
+    if cfg.server_side_grpo and cfg.opd_beta > 0:
+        raise ValueError("server_side_grpo does not support OPD.")
+    if cfg.opd_beta < 0:
+        raise ValueError("opd_beta must be non-negative.")
+    if cfg.opd_beta > 0:
+        if not cfg.opd_teacher_deployment_id:
+            raise ValueError("opd_beta > 0 requires opd_teacher_deployment_id.")
+        if cfg.opd_teacher_sync_every <= 0:
+            raise ValueError("opd_teacher_sync_every must be positive.")
+        if cfg.opd_teacher_replica_count <= 0:
+            raise ValueError("opd_teacher_replica_count must be positive.")
     logger.warning(
         "async_rl_loop is EXPERIMENTAL and under active development; "
         "the Config / RolloutSetup API may change. See "
@@ -449,6 +468,8 @@ def main(
             "anchor_logp": cfg.anchor_logp,
             "lr": cfg.learning_rate,
             "lr_schedule": lr_scheduler.type,
+            "opd_beta": cfg.opd_beta,
+            "opd_teacher_sync_every": cfg.opd_teacher_sync_every,
         },
         metric_steps=ASYNC_RL_WANDB_METRIC_STEPS,
     )
@@ -499,6 +520,34 @@ def main(
         sampler = service.create_deployment_sampler(tokenizer=tokenizer)
         stack.callback(sampler.close)
         rollout_model = sampler.model
+        teacher_sampler = None
+        teacher_deploy_manager = None
+        if cfg.opd_beta > 0:
+            account_id = service._resolved_account_id()
+            if not account_id:
+                raise RuntimeError("Could not resolve OPD teacher trainer account.")
+            teacher_sampler = service.create_inference_deployment_sampler(
+                DeploymentConfig(
+                    deployment_id=cfg.opd_teacher_deployment_id,
+                    base_model=cfg.base_model,
+                    min_replica_count=cfg.opd_teacher_replica_count,
+                    max_replica_count=cfg.opd_teacher_replica_count,
+                    hot_load_trainer_job=(
+                        f"accounts/{account_id}/rlorTrainerJobs/{service.trainer_job_id}"
+                    ),
+                    enable_hot_load=True,
+                    disable_speculative_decoding=True,
+                    for_training=True,
+                ),
+                cleanup_on_close=(
+                    CLEANUP_DEPLOYMENT_ON_CLOSE_SCALE_TO_ZERO
+                    if cfg.cleanup_on_exit
+                    else None
+                ),
+                tokenizer=tokenizer,
+            )
+            stack.callback(teacher_sampler.close)
+            teacher_deploy_manager = service._managed_deployment_manager()
         log_metrics({"rollout/step": 0}, step=0)
 
         policy = ReconnectableClient.from_training_client(
@@ -548,6 +597,15 @@ def main(
                 checkpoint_type="base",
             )
             service.hotload_sampler_snapshot(saved.path)
+            if teacher_deploy_manager is not None:
+                ok = teacher_deploy_manager.hotload_and_wait(
+                    cfg.opd_teacher_deployment_id,
+                    cfg.base_model,
+                    saved.path,
+                    timeout_seconds=cfg.weight_sync_timeout,
+                )
+                if not ok:
+                    raise RuntimeError("Initial OPD teacher hotload failed.")
         logger.info(
             "[step %d] initial weight sync (%.1fs)",
             step_offset,
@@ -614,6 +672,7 @@ def main(
             completions_per_prompt=cfg.completions_per_prompt,
             extras=dict(rollout_extras or {}),
             sampler=sampler,
+            teacher_sampler=teacher_sampler,
         )
         rollout_fn = rollout_fn_factory(rollout_setup)
         rollout_context_param_names = _rollout_fn_context_param_names(rollout_fn)
@@ -711,6 +770,7 @@ def main(
             prompt_lens,
             inf_lp,
             raw_inf_lp,
+            teacher_lp,
             old_policy_logprobs,
             precomputed_forward,
         ):
@@ -740,6 +800,8 @@ def main(
                     eps_clip_high=cfg.eps_clip_high,
                     tis_config=cfg.tis,
                     raw_inf_logprobs=raw_inf_lp,
+                    teacher_logprobs=teacher_lp,
+                    opd_beta=cfg.opd_beta,
                 ),
                 precomputed_forward=precomputed_forward,
             )
@@ -751,10 +813,13 @@ def main(
             with elapsed_timer("ref_forward"):
                 ref_forward(prompt_groups)
 
-            data, adv, ref_lp, prompt_lens, inf_lp, raw_inf_lp = combine_prompt_groups(
+            combined = combine_prompt_groups(
                 prompt_groups,
                 include_raw=True,
+                include_teacher=cfg.opd_beta > 0,
             )
+            data, adv, ref_lp, prompt_lens, inf_lp, raw_inf_lp = combined[:6]
+            teacher_lp = combined[6] if cfg.opd_beta > 0 else []
             precomputed_forward = None
             if cfg.anchor_logp == "old_policy":
                 with elapsed_timer("old_policy_forward"):
@@ -784,6 +849,7 @@ def main(
                     prompt_lens,
                     inf_lp,
                     raw_inf_lp,
+                    teacher_lp,
                     old_policy_logprobs,
                     precomputed_forward,
                 )
@@ -822,6 +888,20 @@ def main(
             with wall_timer() as span:
                 saved = policy.save_weights_for_sampler(f"step-{step}")
                 service.hotload_sampler_snapshot(saved.path)
+                if (
+                    teacher_deploy_manager is not None
+                    and step % cfg.opd_teacher_sync_every == 0
+                ):
+                    ok = teacher_deploy_manager.hotload_and_wait(
+                        cfg.opd_teacher_deployment_id,
+                        cfg.base_model,
+                        saved.path,
+                        timeout_seconds=cfg.weight_sync_timeout,
+                    )
+                    if not ok:
+                        raise RuntimeError(
+                            f"OPD teacher hotload failed at step {step}."
+                        )
             return span.elapsed
 
         async def run_training() -> tuple[int, dict[str, Any]]:

--- a/training/recipes/async_rl_loop.py
+++ b/training/recipes/async_rl_loop.py
@@ -530,6 +530,7 @@ def main(
                 DeploymentConfig(
                     deployment_id=cfg.opd_teacher_deployment_id,
                     base_model=cfg.base_model,
+                    region=cfg.trainer.region,
                     min_replica_count=cfg.opd_teacher_replica_count,
                     max_replica_count=cfg.opd_teacher_replica_count,
                     hot_load_trainer_job=(

--- a/training/recipes/async_rl_loop.py
+++ b/training/recipes/async_rl_loop.py
@@ -67,6 +67,7 @@ from training.utils import (
 )
 from training.utils.checkpoints import TrainingCheckpoints, validate_warm_start_config
 from training.utils.dataloader import CursorDataLoader
+from training.utils.distillation import build_rl_topk_forward_kl_datums
 from training.utils.logging import ASYNC_RL_WANDB_METRIC_STEPS
 from training.utils.rl import PromptGroup
 from training.utils.rl.async_rl import (
@@ -205,6 +206,8 @@ class Config:
     """Promote the final checkpoint to this 4-segment model id on clean exit."""
     opd_beta: float = 0.0
     """Sampled reverse-KL weight for a privileged lagged teacher."""
+    opd_top_k: int = 0
+    """Use sparse forward-KL over this many teacher candidates; 0 uses sampled KL."""
     opd_teacher_sync_every: int = 10
     opd_teacher_deployment_id: str | None = None
     opd_teacher_replica_count: int = 1
@@ -397,6 +400,10 @@ def main(
         raise ValueError("server_side_grpo does not support OPD.")
     if cfg.opd_beta < 0:
         raise ValueError("opd_beta must be non-negative.")
+    if not 0 <= cfg.opd_top_k <= 5:
+        raise ValueError("opd_top_k must be between 0 and 5.")
+    if cfg.opd_top_k > 0 and cfg.opd_beta <= 0:
+        raise ValueError("opd_top_k > 0 requires opd_beta > 0.")
     if cfg.opd_beta > 0:
         if not cfg.opd_teacher_deployment_id:
             raise ValueError("opd_beta > 0 requires opd_teacher_deployment_id.")
@@ -469,6 +476,7 @@ def main(
             "lr": cfg.learning_rate,
             "lr_schedule": lr_scheduler.type,
             "opd_beta": cfg.opd_beta,
+            "opd_top_k": cfg.opd_top_k,
             "opd_teacher_sync_every": cfg.opd_teacher_sync_every,
         },
         metric_steps=ASYNC_RL_WANDB_METRIC_STEPS,
@@ -772,6 +780,7 @@ def main(
             inf_lp,
             raw_inf_lp,
             teacher_lp,
+            teacher_topk,
             old_policy_logprobs,
             precomputed_forward,
         ):
@@ -788,8 +797,17 @@ def main(
                     config=cfg,
                 )
 
-            return policy.forward_backward_custom(
-                data,
+            train_data = data
+            topk_metrics = {}
+            if cfg.opd_top_k > 0:
+                train_data, topk_metrics = build_rl_topk_forward_kl_datums(
+                    data,
+                    teacher_topk,
+                    top_k=cfg.opd_top_k,
+                )
+                precomputed_forward = None
+            result = policy.forward_backward_custom(
+                train_data,
                 make_grpo_loss_fn(
                     advantages=adv,
                     ref_logprobs=ref_lp,
@@ -803,9 +821,12 @@ def main(
                     raw_inf_logprobs=raw_inf_lp,
                     teacher_logprobs=teacher_lp,
                     opd_beta=cfg.opd_beta,
+                    opd_top_k=cfg.opd_top_k,
                 ),
                 precomputed_forward=precomputed_forward,
             )
+            result.metrics.update(topk_metrics)
+            return result
 
         def train_chunk(chunk: TrainingChunk) -> dict[str, Any]:
             """Run the visible GRPO forward/backward phase for one chunk."""
@@ -817,10 +838,14 @@ def main(
             combined = combine_prompt_groups(
                 prompt_groups,
                 include_raw=True,
-                include_teacher=cfg.opd_beta > 0,
+                include_teacher=cfg.opd_beta > 0 and cfg.opd_top_k == 0,
+                include_teacher_topk=cfg.opd_top_k > 0,
             )
             data, adv, ref_lp, prompt_lens, inf_lp, raw_inf_lp = combined[:6]
-            teacher_lp = combined[6] if cfg.opd_beta > 0 else []
+            teacher_lp = (
+                combined[6] if cfg.opd_beta > 0 and cfg.opd_top_k == 0 else []
+            )
+            teacher_topk = combined[6] if cfg.opd_top_k > 0 else []
             precomputed_forward = None
             if cfg.anchor_logp == "old_policy":
                 with elapsed_timer("old_policy_forward"):
@@ -841,6 +866,8 @@ def main(
                         "anchor_logp='rollout' requires non-empty rollout_logprobs."
                     )
                 old_policy_logprobs = inf_lp
+            if cfg.opd_top_k > 0:
+                precomputed_forward = None
 
             with elapsed_timer("fwd_bwd"):
                 fwd_bwd_result = fwd_bwd_batch(
@@ -851,6 +878,7 @@ def main(
                     inf_lp,
                     raw_inf_lp,
                     teacher_lp,
+                    teacher_topk,
                     old_policy_logprobs,
                     precomputed_forward,
                 )

--- a/training/tests/unit/test_distillation.py
+++ b/training/tests/unit/test_distillation.py
@@ -68,6 +68,7 @@ from training.utils.distillation.sampling import (
     _extract_teacher_topk,
     _extract_scored_token_logprobs,
     _score_teacher_topk,
+    _score_teacher_topk_with_logprobs,
     _slice_response_logprobs,
     _teacher_messages_for_row,
     _tokenize_teacher_prompt,
@@ -677,6 +678,31 @@ def test_score_teacher_topk_requests_top_logprobs_and_aligns_response_window() -
         TopKDist(token_ids=[30, 31], logprobs=[-0.3, -1.3]),
     ]
     assert sampler.calls[0][1]["top_logprobs"] == 2
+
+
+def test_score_teacher_topk_returns_token_scores_from_one_echo() -> None:
+    sampler = _FakeScoringSampler(
+        response_logprobs_by_token={2: -0.4, 3: -0.7},
+        top_logprobs_by_token={
+            2: [{"token_id": 20, "logprob": -0.2}, {"token_id": 21, "logprob": -1.2}],
+            3: [{"token_id": 30, "logprob": -0.3}, {"token_id": 31, "logprob": -1.3}],
+        },
+    )
+    scored = asyncio.run(
+        _score_teacher_topk_with_logprobs(
+            sampler,
+            [1, 2, 3],
+            prompt_len=1,
+            response_len=2,
+            top_logprobs=2,
+            http_timeout=30,
+        )
+    )
+    assert scored is not None
+    token_logprobs, topk_by_pos = scored
+    assert token_logprobs == [-0.4, -0.7]
+    assert topk_by_pos[0].token_ids == [20, 21]
+    assert len(sampler.calls) == 1
 
 
 def test_score_teacher_topk_fails_when_inference_returns_too_few_candidates() -> None:

--- a/training/tests/unit/test_opd.py
+++ b/training/tests/unit/test_opd.py
@@ -1,0 +1,70 @@
+import pytest
+import tinker
+import torch
+
+from training.utils.rl.grpo import make_grpo_loss_fn
+from training.utils.rl.gspo import make_gspo_loss_fn
+from training.utils.rl.rollout import Rollout, RolloutRun, RolloutSample
+from training.utils.rl.rollout.types import rollout_to_prompt_group
+
+
+def _datum():
+    return tinker.Datum(
+        model_input=tinker.ModelInput.from_ints([1, 2]),
+        loss_fn_inputs={
+            "target_tokens": tinker.TensorData(data=[2, 3], dtype="int64", shape=[2]),
+            "weights": tinker.TensorData(data=[1, 1], dtype="int64", shape=[2]),
+        },
+    )
+
+
+def test_rollout_packs_teacher_logprobs():
+    sample = RolloutSample(
+        tokens=[1, 2, 3],
+        logprobs=[0.0, -2.0, -2.0],
+        teacher_logprobs=[0.0, -1.0, -1.0],
+        loss_mask=[0, 1, 1],
+        reward=1.0,
+    )
+    group = rollout_to_prompt_group(
+        Rollout(runs=[RolloutRun(segments=[sample])]),
+        advantage_fn=lambda rewards: rewards,
+    )
+    assert group is not None
+    assert group.teacher_logprobs == [[-1.0, -1.0]]
+
+
+@pytest.mark.parametrize("loss_builder", [make_grpo_loss_fn, make_gspo_loss_fn])
+def test_opd_gradient_raises_mass_when_teacher_is_higher(loss_builder):
+    student = torch.tensor([-2.0, -2.0], requires_grad=True)
+    kwargs = {
+        "advantages": [0.0],
+        "ref_logprobs": [],
+        "inf_logprobs": [[-2.0, -2.0]],
+        "prompt_len": [1],
+        "old_policy_logprobs": [[-2.0, -2.0]],
+        "teacher_logprobs": [[-1.0, -1.0]],
+        "opd_beta": 0.05,
+    }
+    if loss_builder is make_grpo_loss_fn:
+        kwargs["kl_beta"] = 0.0
+    loss, metrics = loss_builder(**kwargs)([_datum()], [student])
+    loss.backward()
+    assert student.grad is not None
+    assert torch.all(student.grad < 0)
+    assert metrics["opd_kl_mean"] == pytest.approx(-1.0)
+
+
+def test_opd_requires_aligned_teacher_logprobs():
+    loss_fn = make_grpo_loss_fn(
+        advantages=[0.0],
+        ref_logprobs=[],
+        inf_logprobs=[[-2.0, -2.0]],
+        prompt_len=[1],
+        old_policy_logprobs=[[-2.0, -2.0]],
+        teacher_logprobs=[[-1.0]],
+        opd_beta=0.05,
+        kl_beta=0.0,
+    )
+    with pytest.raises(ValueError, match="must align with target tokens"):
+        loss_fn([_datum()], [torch.tensor([-2.0, -2.0], requires_grad=True)])

--- a/training/tests/unit/test_opd.py
+++ b/training/tests/unit/test_opd.py
@@ -59,6 +59,26 @@ def test_rollout_packs_teacher_topk_and_preserves_mask():
     assert metrics["sdft_active_positions"] == 2
 
 
+def test_rl_topk_builder_honors_weights_mask():
+    dist = TopKDist(token_ids=[7, 8], logprobs=[-0.2, -1.8])
+    datum = tinker.Datum(
+        model_input=tinker.ModelInput.from_ints([1, 2]),
+        loss_fn_inputs={
+            "target_tokens": tinker.TensorData(
+                data=[2, 3], dtype="int64", shape=[2]
+            ),
+            "weights": tinker.TensorData(
+                data=[0, 1], dtype="int64", shape=[2]
+            ),
+        },
+    )
+    datums, metrics = build_rl_topk_forward_kl_datums(
+        [datum], [[None, dist]], top_k=2
+    )
+    assert datums[0].loss_fn_inputs["weights"].data[:3] == [0.0, 0.0, 0.0]
+    assert metrics["sdft_active_positions"] == 1
+
+
 @pytest.mark.parametrize("loss_builder", [make_grpo_loss_fn, make_gspo_loss_fn])
 def test_opd_gradient_raises_mass_when_teacher_is_higher(loss_builder):
     student = torch.tensor([-2.0, -2.0], requires_grad=True)

--- a/training/tests/unit/test_opd.py
+++ b/training/tests/unit/test_opd.py
@@ -2,6 +2,8 @@ import pytest
 import tinker
 import torch
 
+from training.utils.distillation import build_rl_topk_forward_kl_datums
+from training.utils.distillation.sampling import TopKDist
 from training.utils.rl.grpo import make_grpo_loss_fn
 from training.utils.rl.gspo import make_gspo_loss_fn
 from training.utils.rl.rollout import Rollout, RolloutRun, RolloutSample
@@ -34,6 +36,29 @@ def test_rollout_packs_teacher_logprobs():
     assert group.teacher_logprobs == [[-1.0, -1.0]]
 
 
+def test_rollout_packs_teacher_topk_and_preserves_mask():
+    dist = TopKDist(token_ids=[7, 8], logprobs=[-0.2, -1.8])
+    sample = RolloutSample(
+        tokens=[1, 2, 3],
+        logprobs=[0.0, -2.0, -2.0],
+        teacher_topk=[None, dist, dist],
+        loss_mask=[0, 1, 1],
+        reward=1.0,
+    )
+    group = rollout_to_prompt_group(
+        Rollout(runs=[RolloutRun(segments=[sample])]),
+        advantage_fn=lambda rewards: rewards,
+    )
+    assert group is not None
+    assert group.teacher_topk == [[dist, dist]]
+    datums, metrics = build_rl_topk_forward_kl_datums(
+        group.data, group.teacher_topk, top_k=2
+    )
+    assert datums[0].loss_fn_inputs["target_tokens"].shape == [2, 3]
+    assert datums[0].loss_fn_inputs["weights"].shape == [2, 3]
+    assert metrics["sdft_active_positions"] == 2
+
+
 @pytest.mark.parametrize("loss_builder", [make_grpo_loss_fn, make_gspo_loss_fn])
 def test_opd_gradient_raises_mass_when_teacher_is_higher(loss_builder):
     student = torch.tensor([-2.0, -2.0], requires_grad=True)
@@ -53,6 +78,38 @@ def test_opd_gradient_raises_mass_when_teacher_is_higher(loss_builder):
     assert student.grad is not None
     assert torch.all(student.grad < 0)
     assert metrics["opd_kl_mean"] == pytest.approx(-1.0)
+
+
+@pytest.mark.parametrize("loss_builder", [make_grpo_loss_fn, make_gspo_loss_fn])
+def test_topk_opd_gradient_raises_teacher_candidate_mass(loss_builder):
+    dist = TopKDist(
+        token_ids=[7, 8],
+        logprobs=[torch.log(torch.tensor(0.8)).item(), torch.log(torch.tensor(0.2)).item()],
+    )
+    datums, _ = build_rl_topk_forward_kl_datums(
+        [_datum()], [[dist, dist]], top_k=2
+    )
+    student = torch.tensor(
+        [[-2.0, -0.3, -2.0], [-2.0, -0.3, -2.0]],
+        requires_grad=True,
+    )
+    kwargs = {
+        "advantages": [0.0],
+        "ref_logprobs": [],
+        "inf_logprobs": [[-2.0, -2.0]],
+        "prompt_len": [1],
+        "old_policy_logprobs": [[-2.0, -2.0]],
+        "opd_beta": 0.05,
+        "opd_top_k": 2,
+    }
+    if loss_builder is make_grpo_loss_fn:
+        kwargs["kl_beta"] = 0.0
+    loss, metrics = loss_builder(**kwargs)(datums, [student])
+    loss.backward()
+    assert student.grad is not None
+    assert torch.allclose(student.grad[:, 0], torch.zeros(2))
+    assert torch.all(student.grad[:, 1:] < 0)
+    assert metrics["opd_forward_kl_mean"] > 0
 
 
 def test_opd_requires_aligned_teacher_logprobs():

--- a/training/utils/distillation/__init__.py
+++ b/training/utils/distillation/__init__.py
@@ -598,6 +598,87 @@ class _TopKForwardKLMetrics:
         }
 
 
+def build_rl_topk_forward_kl_datums(
+    student_data: Sequence[tinker.Datum],
+    teacher_topk: Sequence[Sequence[TopKDist | None]],
+    *,
+    top_k: int,
+) -> tuple[list[tinker.Datum], dict[str, float]]:
+    """Augment RL targets with sparse teacher candidates for one custom loss."""
+    if top_k <= 0:
+        raise ValueError("top_k must be positive.")
+    teacher_values = _require_lengths_match(
+        "teacher_topk", teacher_topk, len(student_data)
+    )
+    datums: list[tinker.Datum] = []
+    metrics = _TopKForwardKLMetrics()
+    for datum_idx, (datum, topk_by_pos) in enumerate(
+        zip(student_data, teacher_values, strict=True)
+    ):
+        target = datum.loss_fn_inputs.get("target_tokens")
+        if target is None:
+            raise ValueError(
+                f"Datum {datum_idx} is missing loss_fn_inputs['target_tokens']."
+            )
+        target_tokens = [int(value) for value in target.data]
+        target_len = len(target_tokens)
+        mask = _loss_mask_for_datum(datum, target_len)
+        positions = list(topk_by_pos)
+        if len(positions) != target_len:
+            raise ValueError(
+                f"Datum {datum_idx}: teacher_topk has {len(positions)} positions, "
+                f"expected {target_len}."
+            )
+
+        target_rows: list[list[int]] = []
+        weight_rows: list[list[float]] = []
+        for pos, (sampled_token, active, dist) in enumerate(
+            zip(target_tokens, mask, positions, strict=True)
+        ):
+            candidate_ids = [0] * top_k
+            candidate_probs = [0.0] * top_k
+            if active > 0:
+                if dist is None or len(dist.token_ids) < top_k:
+                    count = 0 if dist is None else len(dist.token_ids)
+                    raise ValueError(
+                        f"Datum {datum_idx}, active position {pos}: teacher top-K "
+                        f"returned {count} candidates, expected {top_k}."
+                    )
+                ranked = sorted(
+                    zip(dist.token_ids, dist.logprobs, strict=True),
+                    key=lambda item: item[1],
+                    reverse=True,
+                )[:top_k]
+                limited = TopKDist(
+                    token_ids=[token_id for token_id, _ in ranked],
+                    logprobs=[logprob for _, logprob in ranked],
+                )
+                candidate_ids, candidate_probs = _renormalize_topk(limited)
+                metrics.add_position(limited.logprobs, candidate_probs)
+            target_rows.append([sampled_token, *candidate_ids])
+            weight_rows.append([float(active), *candidate_probs])
+
+        width = top_k + 1
+        datums.append(
+            tinker.Datum(
+                model_input=datum.model_input,
+                loss_fn_inputs={
+                    "target_tokens": tinker.TensorData(
+                        data=[value for row in target_rows for value in row],
+                        dtype="int64",
+                        shape=[target_len, width],
+                    ),
+                    "weights": tinker.TensorData(
+                        data=[value for row in weight_rows for value in row],
+                        dtype="float32",
+                        shape=[target_len, width],
+                    ),
+                },
+            )
+        )
+    return datums, metrics.as_dict(top_k=top_k)
+
+
 def build_topk_forward_kl_datums(
     student_data: Sequence[tinker.Datum],
     teacher_topk: Sequence[Sequence[TopKDist]],

--- a/training/utils/distillation/__init__.py
+++ b/training/utils/distillation/__init__.py
@@ -97,7 +97,9 @@ def _pad_or_trim(values: Sequence[float], length: int) -> list[float]:
 
 
 def _loss_mask_for_datum(datum: tinker.Datum, length: int) -> list[float]:
-    mask = datum.loss_fn_inputs.get("loss_mask")
+    mask = datum.loss_fn_inputs.get("weights") or datum.loss_fn_inputs.get(
+        "loss_mask"
+    )
     if mask is None:
         return [1.0] * length
     return _pad_or_trim(mask.data, length)

--- a/training/utils/distillation/sampling.py
+++ b/training/utils/distillation/sampling.py
@@ -341,6 +341,29 @@ async def _score_teacher_topk(
     tokenizer: Any | None = None,
 ) -> list[TopKDist] | None:
     """Return teacher candidates from inference ``top_logprobs``."""
+    scored = await _score_teacher_topk_with_logprobs(
+        sampler,
+        token_ids,
+        prompt_len=prompt_len,
+        response_len=response_len,
+        top_logprobs=top_logprobs,
+        http_timeout=http_timeout,
+        tokenizer=tokenizer,
+    )
+    return scored[1] if scored is not None else None
+
+
+async def _score_teacher_topk_with_logprobs(
+    sampler: DeploymentSampler,
+    token_ids: list[int],
+    *,
+    prompt_len: int,
+    response_len: int,
+    top_logprobs: int,
+    http_timeout: int,
+    tokenizer: Any | None = None,
+) -> tuple[list[float], list[TopKDist]] | None:
+    """Return sampled-token and top-K scores from one teacher echo."""
     target_len = max(0, len(token_ids) - 1)
     if target_len == 0 or response_len <= 0:
         return None
@@ -354,6 +377,16 @@ async def _score_teacher_topk(
     if response is None:
         return None
 
+    token_logprobs = _extract_scored_token_logprobs(response, target_len=target_len)
+    response_logprobs = (
+        _slice_response_logprobs(
+            token_logprobs,
+            prompt_len=prompt_len,
+            response_len=response_len,
+        )
+        if token_logprobs is not None
+        else None
+    )
     topk_by_pos = _extract_teacher_topk(
         response,
         prompt_len=prompt_len,
@@ -361,10 +394,10 @@ async def _score_teacher_topk(
         target_len=target_len,
         tokenizer=tokenizer,
     )
-    if topk_by_pos is None:
+    if response_logprobs is None or topk_by_pos is None:
         raise ValueError(
-            "Teacher inference response did not include usable top_logprobs "
-            "for every response token."
+            "Teacher inference response did not include usable token and "
+            "top_logprobs scores for every response token."
         )
     for pos, dist in enumerate(topk_by_pos):
         if len(dist.token_ids) < top_logprobs:
@@ -372,4 +405,4 @@ async def _score_teacher_topk(
                 "Teacher inference top_logprobs returned fewer candidates than requested "
                 f"at response position {pos}: got {len(dist.token_ids)}, requested {top_logprobs}."
             )
-    return topk_by_pos
+    return response_logprobs, topk_by_pos

--- a/training/utils/rl/common.py
+++ b/training/utils/rl/common.py
@@ -42,7 +42,17 @@ def _get_loss_mask(
         "loss_mask"
     )
     if mask_td is not None:
-        mask_vals = mask_td.data[response_start : response_start + resp_len]
+        shape = list(getattr(mask_td, "shape", []))
+        if len(shape) == 2:
+            rows, width = shape
+            mask_vals = [
+                mask_td.data[row * width]
+                for row in range(
+                    response_start, min(response_start + resp_len, rows)
+                )
+            ]
+        else:
+            mask_vals = mask_td.data[response_start : response_start + resp_len]
         if len(mask_vals) < resp_len:
             mask_vals = list(mask_vals) + [0.0] * (resp_len - len(mask_vals))
         return torch.tensor(mask_vals, dtype=dtype, device=device)
@@ -218,6 +228,10 @@ class SampleContext:
     """TIS importance weight per token."""
     resp_teacher: torch.Tensor | None = None
     """Privileged-teacher logprobs for response tokens, when configured."""
+    resp_teacher_topk_probs: torch.Tensor | None = None
+    """Renormalized privileged-teacher probabilities with shape [N, K]."""
+    resp_student_topk_logprobs: torch.Tensor | None = None
+    """Current student logprobs at teacher-selected tokens, shape [N, K]."""
 
 
 @dataclass
@@ -254,6 +268,7 @@ def run_loss_loop(
     policy_loss: str,
     policy_fn: PolicyFn,
     teacher_logprobs: List[List[float]] | None = None,
+    teacher_top_k: int = 0,
 ) -> LossLoopResult:
     """Shared loss loop: tensor setup, TIS weight, loss metrics, KL.
 
@@ -271,14 +286,42 @@ def run_loss_loop(
     tis_metrics_agg: Dict[str, float] = {}
     extra_sums: Dict[str, float] = {}
 
-    for i, pi_logprobs in enumerate(logprobs_list):
+    for i, raw_pi_logprobs in enumerate(logprobs_list):
+        teacher_probs = None
+        student_topk_logprobs = None
+        pi_logprobs = raw_pi_logprobs
+        if teacher_top_k > 0:
+            if raw_pi_logprobs.ndim != 2 or raw_pi_logprobs.shape[1] != teacher_top_k + 1:
+                raise ValueError(
+                    f"{policy_loss} expected [N, {teacher_top_k + 1}] logprobs "
+                    f"for top-K OPD, got {tuple(raw_pi_logprobs.shape)}."
+                )
+            pi_logprobs = raw_pi_logprobs[:, 0]
+            student_topk_logprobs = raw_pi_logprobs[:, 1:]
         response_start = max(0, prompt_lens[i] - 1)
         resp_pi = pi_logprobs[response_start:]
         resp_len = len(resp_pi)
         if resp_len == 0:
             continue
 
-        if i < len(data):
+        if teacher_top_k > 0 and i < len(data):
+            weights = data[i].loss_fn_inputs.get("weights")
+            expected_shape = [len(pi_logprobs), teacher_top_k + 1]
+            if weights is None or list(weights.shape) != expected_shape:
+                actual = None if weights is None else list(weights.shape)
+                raise ValueError(
+                    f"{policy_loss} expected top-K OPD weights shape "
+                    f"{expected_shape}, got {actual}."
+                )
+            weight_matrix = torch.tensor(
+                weights.data,
+                dtype=resp_pi.dtype,
+                device=resp_pi.device,
+            ).reshape(expected_shape)
+            resp_mask = weight_matrix[response_start:, 0]
+            teacher_probs = weight_matrix[response_start:, 1:]
+            student_topk_logprobs = student_topk_logprobs[response_start:]
+        elif i < len(data):
             resp_mask = _get_loss_mask(
                 data[i],
                 response_start,
@@ -398,6 +441,8 @@ def run_loss_loop(
             adv=adv_t,
             tis_weight=tis_weight,
             resp_teacher=resp_teacher,
+            resp_teacher_topk_probs=teacher_probs,
+            resp_student_topk_logprobs=student_topk_logprobs,
         )
         per_token_loss, extra = policy_fn(ctx)
 

--- a/training/utils/rl/common.py
+++ b/training/utils/rl/common.py
@@ -38,7 +38,9 @@ def _get_loss_mask(
     ``{"target_tokens", "weights"}`` for ``forward_backward_custom``, so
     new producers MUST write the per-token mask under ``"weights"``.
     """
-    mask_td = datum.loss_fn_inputs.get("weights") or datum.loss_fn_inputs.get("loss_mask")
+    mask_td = datum.loss_fn_inputs.get("weights") or datum.loss_fn_inputs.get(
+        "loss_mask"
+    )
     if mask_td is not None:
         mask_vals = mask_td.data[response_start : response_start + resp_len]
         if len(mask_vals) < resp_len:
@@ -68,7 +70,9 @@ def _coerce_logprobs_to_float(
             f"expected {expected_len} {coordinates} logprobs."
         )
     if any(value is None for value in values):
-        raise RuntimeError(f"{source} for sample {sample_idx} has null {coordinates} logprob.")
+        raise RuntimeError(
+            f"{source} for sample {sample_idx} has null {coordinates} logprob."
+        )
     return [float(value) for value in values]
 
 
@@ -212,6 +216,8 @@ class SampleContext:
     """Scalar advantage value (as a 0-d tensor)."""
     tis_weight: torch.Tensor
     """TIS importance weight per token."""
+    resp_teacher: torch.Tensor | None = None
+    """Privileged-teacher logprobs for response tokens, when configured."""
 
 
 @dataclass
@@ -247,6 +253,7 @@ def run_loss_loop(
     logprobs_list: List[torch.Tensor],
     policy_loss: str,
     policy_fn: PolicyFn,
+    teacher_logprobs: List[List[float]] | None = None,
 ) -> LossLoopResult:
     """Shared loss loop: tensor setup, TIS weight, loss metrics, KL.
 
@@ -289,7 +296,12 @@ def run_loss_loop(
         ref_lp = ref_logprobs[i] if ref_logprobs else []
         resp_ref = (
             torch.tensor(
-                [ref_lp[response_start + j] if (response_start + j) < len(ref_lp) else 0.0 for j in range(resp_len)],
+                [
+                    ref_lp[response_start + j]
+                    if (response_start + j) < len(ref_lp)
+                    else 0.0
+                    for j in range(resp_len)
+                ],
                 dtype=resp_pi.dtype,
                 device=resp_pi.device,
             )
@@ -320,7 +332,12 @@ def run_loss_loop(
         )
         old_policy_lp = old_policy_logprobs[i]
         resp_old_policy = torch.tensor(
-            [old_policy_lp[response_start + j] if (response_start + j) < len(old_policy_lp) else 0.0 for j in range(resp_len)],
+            [
+                old_policy_lp[response_start + j]
+                if (response_start + j) < len(old_policy_lp)
+                else 0.0
+                for j in range(resp_len)
+            ],
             dtype=resp_pi.dtype,
             device=resp_pi.device,
         )
@@ -340,7 +357,9 @@ def run_loss_loop(
             ref_num_samples += 1
         behavior_num_samples += 1
 
-        tis_weight_active, bm = compute_tis_weight(active_old_policy, active_inf, tis_config)
+        tis_weight_active, bm = compute_tis_weight(
+            active_old_policy, active_inf, tis_config
+        )
         # Identity (1.0) at masked positions: zeroes under ``resp_mask`` for
         # masked-multiplied losses, no-op weight for ``dro``.
         tis_weight = torch.ones(resp_len, dtype=resp_pi.dtype, device=resp_pi.device)
@@ -348,7 +367,26 @@ def run_loss_loop(
         for k, v in bm.items():
             tis_metrics_agg[k] = tis_metrics_agg.get(k, 0.0) + v
 
-        adv_t = torch.as_tensor(advantages[i], dtype=resp_pi.dtype, device=resp_pi.device)
+        adv_t = torch.as_tensor(
+            advantages[i], dtype=resp_pi.dtype, device=resp_pi.device
+        )
+        resp_teacher = None
+        if teacher_logprobs is not None:
+            if i >= len(teacher_logprobs):
+                raise ValueError(
+                    f"{policy_loss} requires teacher logprobs for sample {i}."
+                )
+            teacher_lp = teacher_logprobs[i]
+            if len(teacher_lp) != len(pi_logprobs):
+                raise ValueError(
+                    f"{policy_loss} teacher logprobs for sample {i} must align "
+                    f"with target tokens ({len(teacher_lp)} != {len(pi_logprobs)})."
+                )
+            resp_teacher = torch.tensor(
+                teacher_lp[response_start : response_start + resp_len],
+                dtype=resp_pi.dtype,
+                device=resp_pi.device,
+            )
 
         ctx = SampleContext(
             resp_pi=resp_pi,
@@ -359,6 +397,7 @@ def run_loss_loop(
             resp_mask=resp_mask,
             adv=adv_t,
             tis_weight=tis_weight,
+            resp_teacher=resp_teacher,
         )
         per_token_loss, extra = policy_fn(ctx)
 

--- a/training/utils/rl/grpo.py
+++ b/training/utils/rl/grpo.py
@@ -16,6 +16,7 @@ import tinker
 
 from training.utils.rl.common import _normalize_prompt_lens, run_loss_loop
 from training.utils.rl.observability import compute_inference_observability_metrics
+from training.utils.rl.opd import add_opd_metrics, add_sampled_reverse_kl
 from training.utils.rl.tis import SAFETY_CLAMP, TISConfig
 
 
@@ -44,8 +45,7 @@ def validate_grpo_config(
         raise ValueError("eps_clip and eps_clip_high must be non-negative.")
     if anchor_logp is not None and anchor_logp not in {"old_policy", "rollout"}:
         raise ValueError(
-            "anchor_logp must be 'old_policy' or 'rollout', got "
-            f"{anchor_logp!r}."
+            f"anchor_logp must be 'old_policy' or 'rollout', got {anchor_logp!r}."
         )
 
 
@@ -60,6 +60,8 @@ def make_grpo_loss_fn(
     eps_clip_high: float | None = None,
     tis_config: TISConfig | None = None,
     raw_inf_logprobs: List[List[float]] | None = None,
+    teacher_logprobs: List[List[float]] | None = None,
+    opd_beta: float = 0.0,
 ) -> ...:
     """GRPO loss with PPO-clipped ratio and behavioral TIS weight.
 
@@ -79,7 +81,9 @@ def make_grpo_loss_fn(
     _eps_high = eps_clip if eps_clip_high is None else eps_clip_high
 
     def policy_fn(ctx):
-        log_ratio = torch.clamp(ctx.resp_pi - ctx.resp_old_policy, min=-SAFETY_CLAMP, max=SAFETY_CLAMP)
+        log_ratio = torch.clamp(
+            ctx.resp_pi - ctx.resp_old_policy, min=-SAFETY_CLAMP, max=SAFETY_CLAMP
+        )
         ratio = torch.exp(log_ratio)
         clipped_ratio = torch.clamp(ratio, min=1.0 - eps_clip, max=1.0 + _eps_high)
 
@@ -121,6 +125,10 @@ def make_grpo_loss_fn(
             per_token_loss = per_token_loss + kl_penalty
             extra["kl_term"] = (kl_penalty * ctx.resp_mask).sum().item()
 
+        per_token_loss, opd_metrics = add_sampled_reverse_kl(
+            per_token_loss, ctx, opd_beta
+        )
+        extra.update(opd_metrics)
         return per_token_loss * ctx.resp_mask, extra
 
     def loss_fn(
@@ -128,8 +136,17 @@ def make_grpo_loss_fn(
         logprobs_list: List[torch.Tensor],
     ) -> Tuple[torch.Tensor, Dict[str, float]]:
         result = run_loss_loop(
-            advantages, ref_logprobs, inf_logprobs, prompt_lens,
-            old_policy_logprobs, tis_config, data, logprobs_list, "grpo", policy_fn,
+            advantages,
+            ref_logprobs,
+            inf_logprobs,
+            prompt_lens,
+            old_policy_logprobs,
+            tis_config,
+            data,
+            logprobs_list,
+            "grpo",
+            policy_fn,
+            teacher_logprobs=teacher_logprobs if opd_beta > 0 else None,
         )
         ns = result.n_samples
         nt = result.num_tokens
@@ -138,10 +155,13 @@ def make_grpo_loss_fn(
         metrics = dict(result.base_metrics)
         metrics["ppo_clip_frac"] = result.extra_sums.get("clip_frac", 0.0) / ns
         metrics["ppo_ratio_mean"] = result.extra_sums.get("ratio_mean", 0.0) / ns
+        add_opd_metrics(metrics, result.extra_sums)
         metrics["active_tokens"] = nt
         metrics["total_resp_tokens"] = total_resp
         metrics["mask_ratio"] = nt / total_resp if total_resp > 0 else 0.0
-        metrics["mean_adv_loss"] = result.extra_sums.get("adv_term", 0.0) / nt if nt > 0 else 0.0
+        metrics["mean_adv_loss"] = (
+            result.extra_sums.get("adv_term", 0.0) / nt if nt > 0 else 0.0
+        )
         if "kl_term" in result.extra_sums:
             metrics["mean_kl_penalty"] = (
                 result.extra_sums["kl_term"] / nt if nt > 0 else 0.0

--- a/training/utils/rl/grpo.py
+++ b/training/utils/rl/grpo.py
@@ -62,6 +62,7 @@ def make_grpo_loss_fn(
     raw_inf_logprobs: List[List[float]] | None = None,
     teacher_logprobs: List[List[float]] | None = None,
     opd_beta: float = 0.0,
+    opd_top_k: int = 0,
 ) -> ...:
     """GRPO loss with PPO-clipped ratio and behavioral TIS weight.
 
@@ -126,7 +127,7 @@ def make_grpo_loss_fn(
             extra["kl_term"] = (kl_penalty * ctx.resp_mask).sum().item()
 
         per_token_loss, opd_metrics = add_sampled_reverse_kl(
-            per_token_loss, ctx, opd_beta
+            per_token_loss, ctx, opd_beta, top_k=opd_top_k
         )
         extra.update(opd_metrics)
         return per_token_loss * ctx.resp_mask, extra
@@ -146,7 +147,10 @@ def make_grpo_loss_fn(
             logprobs_list,
             "grpo",
             policy_fn,
-            teacher_logprobs=teacher_logprobs if opd_beta > 0 else None,
+            teacher_logprobs=(
+                teacher_logprobs if opd_beta > 0 and opd_top_k == 0 else None
+            ),
+            teacher_top_k=opd_top_k if opd_beta > 0 else 0,
         )
         ns = result.n_samples
         nt = result.num_tokens
@@ -185,10 +189,15 @@ def make_grpo_loss_fn(
             )
             metrics["policy_gradient/sample_count"] = pg_count
         if raw_inf_logprobs is not None:
+            observed_logprobs = (
+                [values[:, 0] for values in logprobs_list]
+                if opd_top_k > 0
+                else logprobs_list
+            )
             metrics.update(
                 compute_inference_observability_metrics(
                     data,
-                    logprobs_list,
+                    observed_logprobs,
                     raw_inf_logprobs,
                     prompt_lens,
                     "grpo",

--- a/training/utils/rl/gspo.py
+++ b/training/utils/rl/gspo.py
@@ -56,6 +56,7 @@ def make_gspo_loss_fn(
     tis_config: TISConfig | None = None,
     teacher_logprobs: List[List[float]] | None = None,
     opd_beta: float = 0.0,
+    opd_top_k: int = 0,
 ) -> ...:
     """Build a GSPO loss closure with sequence-level PPO ratio and behavioral TIS weight."""
     if gspo_config is None:
@@ -84,7 +85,7 @@ def make_gspo_loss_fn(
         surr2 = -clipped_seq_ratio * ctx.adv
         per_token_loss = torch.maximum(surr1, surr2) * ctx.tis_weight * ctx.resp_mask
         per_token_loss, opd_metrics = add_sampled_reverse_kl(
-            per_token_loss, ctx, opd_beta
+            per_token_loss, ctx, opd_beta, top_k=opd_top_k
         )
         return per_token_loss, {
             "clip_frac": clip_frac,
@@ -107,7 +108,10 @@ def make_gspo_loss_fn(
             logprobs_list,
             "gspo",
             policy_fn,
-            teacher_logprobs=teacher_logprobs if opd_beta > 0 else None,
+            teacher_logprobs=(
+                teacher_logprobs if opd_beta > 0 and opd_top_k == 0 else None
+            ),
+            teacher_top_k=opd_top_k if opd_beta > 0 else 0,
         )
         metrics = dict(result.base_metrics)
         ns = result.n_samples

--- a/training/utils/rl/gspo.py
+++ b/training/utils/rl/gspo.py
@@ -19,6 +19,7 @@ import torch
 import tinker
 
 from training.utils.rl.common import _normalize_prompt_lens, run_loss_loop
+from training.utils.rl.opd import add_opd_metrics, add_sampled_reverse_kl
 from training.utils.rl.tis import TISConfig
 
 
@@ -53,6 +54,8 @@ def make_gspo_loss_fn(
     old_policy_logprobs: List[List[float]],
     gspo_config: GSPOConfig | None = None,
     tis_config: TISConfig | None = None,
+    teacher_logprobs: List[List[float]] | None = None,
+    opd_beta: float = 0.0,
 ) -> ...:
     """Build a GSPO loss closure with sequence-level PPO ratio and behavioral TIS weight."""
     if gspo_config is None:
@@ -71,27 +74,46 @@ def make_gspo_loss_fn(
         log_seq_ratio = torch.clamp(log_seq_ratio, max=gspo_config.seq_ratio_log_cap)
         seq_ratio = torch.exp(log_seq_ratio)
 
-        clipped_seq_ratio = torch.clamp(seq_ratio, min=1.0 - clip_low, max=1.0 + clip_high)
+        clipped_seq_ratio = torch.clamp(
+            seq_ratio, min=1.0 - clip_low, max=1.0 + clip_high
+        )
         clip_frac = (clipped_seq_ratio != seq_ratio).float().mean().item()
         ratio_mean = seq_ratio.detach().mean().item()
 
         surr1 = -seq_ratio * ctx.adv
         surr2 = -clipped_seq_ratio * ctx.adv
         per_token_loss = torch.maximum(surr1, surr2) * ctx.tis_weight * ctx.resp_mask
-        return per_token_loss, {"clip_frac": clip_frac, "ratio_mean": ratio_mean}
+        per_token_loss, opd_metrics = add_sampled_reverse_kl(
+            per_token_loss, ctx, opd_beta
+        )
+        return per_token_loss, {
+            "clip_frac": clip_frac,
+            "ratio_mean": ratio_mean,
+            **opd_metrics,
+        }
 
     def loss_fn(
         data: List[tinker.Datum],
         logprobs_list: List[torch.Tensor],
     ) -> Tuple[torch.Tensor, Dict[str, float]]:
         result = run_loss_loop(
-            advantages, ref_logprobs, inf_logprobs, prompt_lens,
-            old_policy_logprobs, tis_config, data, logprobs_list, "gspo", policy_fn,
+            advantages,
+            ref_logprobs,
+            inf_logprobs,
+            prompt_lens,
+            old_policy_logprobs,
+            tis_config,
+            data,
+            logprobs_list,
+            "gspo",
+            policy_fn,
+            teacher_logprobs=teacher_logprobs if opd_beta > 0 else None,
         )
         metrics = dict(result.base_metrics)
         ns = result.n_samples
         metrics["gspo_clip_frac"] = result.extra_sums.get("clip_frac", 0.0) / ns
         metrics["ppo_ratio_mean"] = result.extra_sums.get("ratio_mean", 0.0) / ns
+        add_opd_metrics(metrics, result.extra_sums)
         return result.total_loss, metrics
 
     return loss_fn

--- a/training/utils/rl/losses.py
+++ b/training/utils/rl/losses.py
@@ -7,7 +7,7 @@ forks that intentionally switch to the trainer's built-in PPO kernel can use
 
 from __future__ import annotations
 
-from typing import List
+from typing import Any, List
 from dataclasses import field, dataclass
 
 import tinker
@@ -46,6 +46,8 @@ class PromptGroup:
     """
     teacher_logprobs: List[List[float]] = field(default_factory=list)
     """Privileged-teacher logprobs aligned to ``target_tokens``."""
+    teacher_topk: List[List[Any]] = field(default_factory=list)
+    """Privileged-teacher sparse distributions aligned to ``target_tokens``."""
     completion_lens: List[int] = field(default_factory=list)
     """Per-sample completion lengths in tokens."""
     truncated: List[bool] = field(default_factory=list)
@@ -77,6 +79,7 @@ def combine_prompt_groups(
     *,
     include_raw: bool = False,
     include_teacher: bool = False,
+    include_teacher_topk: bool = False,
 ):
     """Flatten a list of PromptGroups into combined arrays for a fwd_bwd call.
 
@@ -91,6 +94,7 @@ def combine_prompt_groups(
     inf_logprobs: List[List[float]] = []
     raw_inf_logprobs: List[List[float]] = []
     teacher_logprobs: List[List[float]] = []
+    teacher_topk: List[List[Any]] = []
 
     for pg in groups:
         data.extend(pg.data)
@@ -112,12 +116,19 @@ def combine_prompt_groups(
                 teacher_logprobs.extend(pg.teacher_logprobs)
             else:
                 teacher_logprobs.extend([[] for _ in pg.data])
+        if include_teacher_topk:
+            if pg.teacher_topk:
+                teacher_topk.extend(pg.teacher_topk)
+            else:
+                teacher_topk.extend([[] for _ in pg.data])
 
     result = (data, advantages, ref_logprobs, prompt_lens, inf_logprobs)
     if include_raw:
         result += (raw_inf_logprobs,)
     if include_teacher:
         result += (teacher_logprobs,)
+    if include_teacher_topk:
+        result += (teacher_topk,)
     return result
 
 

--- a/training/utils/rl/losses.py
+++ b/training/utils/rl/losses.py
@@ -44,6 +44,8 @@ class PromptGroup:
     The direct client GRPO builder uses them only for drift metrics. They must
     never replace behavior logprobs in TIS.
     """
+    teacher_logprobs: List[List[float]] = field(default_factory=list)
+    """Privileged-teacher logprobs aligned to ``target_tokens``."""
     completion_lens: List[int] = field(default_factory=list)
     """Per-sample completion lengths in tokens."""
     truncated: List[bool] = field(default_factory=list)
@@ -74,6 +76,7 @@ def combine_prompt_groups(
     groups: List[PromptGroup],
     *,
     include_raw: bool = False,
+    include_teacher: bool = False,
 ):
     """Flatten a list of PromptGroups into combined arrays for a fwd_bwd call.
 
@@ -87,6 +90,7 @@ def combine_prompt_groups(
     prompt_lens: List[int] = []
     inf_logprobs: List[List[float]] = []
     raw_inf_logprobs: List[List[float]] = []
+    teacher_logprobs: List[List[float]] = []
 
     for pg in groups:
         data.extend(pg.data)
@@ -103,17 +107,18 @@ def combine_prompt_groups(
                 raw_inf_logprobs.extend(pg.raw_inf_logprobs)
             else:
                 raw_inf_logprobs.extend([[] for _ in pg.data])
+        if include_teacher:
+            if pg.teacher_logprobs:
+                teacher_logprobs.extend(pg.teacher_logprobs)
+            else:
+                teacher_logprobs.extend([[] for _ in pg.data])
 
+    result = (data, advantages, ref_logprobs, prompt_lens, inf_logprobs)
     if include_raw:
-        return (
-            data,
-            advantages,
-            ref_logprobs,
-            prompt_lens,
-            inf_logprobs,
-            raw_inf_logprobs,
-        )
-    return data, advantages, ref_logprobs, prompt_lens, inf_logprobs
+        result += (raw_inf_logprobs,)
+    if include_teacher:
+        result += (teacher_logprobs,)
+    return result
 
 
 def build_grpo_datums(
@@ -230,7 +235,9 @@ def build_grpo_datums(
         # Bulk extraction avoids per-token tensor calls while retaining Python-float arithmetic.
         per_token_adv.extend(
             float(advantage * weight * mask)
-            for weight, mask in zip(tis_weight.tolist(), loss_mask.tolist(), strict=True)
+            for weight, mask in zip(
+                tis_weight.tolist(), loss_mask.tolist(), strict=True
+            )
         )
 
         new_datum = tinker.Datum(

--- a/training/utils/rl/opd.py
+++ b/training/utils/rl/opd.py
@@ -1,0 +1,32 @@
+"""Sampled reverse-KL term for on-policy distillation."""
+
+from __future__ import annotations
+
+import torch
+
+from training.utils.rl.common import SampleContext
+
+
+def add_sampled_reverse_kl(
+    per_token_loss: torch.Tensor,
+    ctx: SampleContext,
+    beta: float,
+) -> tuple[torch.Tensor, dict[str, float]]:
+    """Add the stop-gradient reverse-KL estimator on active response tokens."""
+    if beta <= 0:
+        return per_token_loss, {}
+    if ctx.resp_teacher is None:
+        raise ValueError("opd_beta > 0 requires teacher_logprobs.")
+
+    sampled_kl = ctx.pi_detached - ctx.resp_teacher
+    opd_loss = beta * sampled_kl * ctx.resp_pi * ctx.tis_weight * ctx.resp_mask
+    return per_token_loss + opd_loss, {
+        "opd_kl_sum": (sampled_kl * ctx.resp_mask).sum().item(),
+        "opd_tokens": ctx.resp_mask.sum().item(),
+    }
+
+
+def add_opd_metrics(metrics: dict[str, float], extra_sums: dict[str, float]) -> None:
+    tokens = extra_sums.get("opd_tokens", 0.0)
+    if tokens > 0:
+        metrics["opd_kl_mean"] = extra_sums.get("opd_kl_sum", 0.0) / tokens

--- a/training/utils/rl/opd.py
+++ b/training/utils/rl/opd.py
@@ -11,10 +11,35 @@ def add_sampled_reverse_kl(
     per_token_loss: torch.Tensor,
     ctx: SampleContext,
     beta: float,
+    *,
+    top_k: int = 0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
-    """Add the stop-gradient reverse-KL estimator on active response tokens."""
+    """Add sampled reverse-KL or sparse forward-KL on active response tokens."""
     if beta <= 0:
         return per_token_loss, {}
+    if top_k > 0:
+        if (
+            ctx.resp_teacher_topk_probs is None
+            or ctx.resp_student_topk_logprobs is None
+        ):
+            raise ValueError("top-K OPD requires sparse teacher targets.")
+        teacher_probs = ctx.resp_teacher_topk_probs
+        cross_entropy = -(
+            teacher_probs * ctx.resp_student_topk_logprobs
+        ).sum(dim=-1)
+        teacher_entropy = -(
+            teacher_probs
+            * torch.log(torch.clamp(teacher_probs, min=1e-12))
+        ).sum(dim=-1)
+        forward_kl = cross_entropy - teacher_entropy
+        opd_loss = beta * cross_entropy * ctx.tis_weight * ctx.resp_mask
+        return per_token_loss + opd_loss, {
+            "opd_forward_kl_sum": (forward_kl * ctx.resp_mask).sum().item(),
+            "opd_cross_entropy_sum": (
+                cross_entropy * ctx.resp_mask
+            ).sum().item(),
+            "opd_tokens": ctx.resp_mask.sum().item(),
+        }
     if ctx.resp_teacher is None:
         raise ValueError("opd_beta > 0 requires teacher_logprobs.")
 
@@ -29,4 +54,13 @@ def add_sampled_reverse_kl(
 def add_opd_metrics(metrics: dict[str, float], extra_sums: dict[str, float]) -> None:
     tokens = extra_sums.get("opd_tokens", 0.0)
     if tokens > 0:
-        metrics["opd_kl_mean"] = extra_sums.get("opd_kl_sum", 0.0) / tokens
+        if "opd_forward_kl_sum" in extra_sums:
+            metrics["opd_forward_kl_mean"] = (
+                extra_sums["opd_forward_kl_sum"] / tokens
+            )
+            metrics["opd_cross_entropy_mean"] = (
+                extra_sums.get("opd_cross_entropy_sum", 0.0) / tokens
+            )
+            metrics["opd_kl_mean"] = metrics["opd_forward_kl_mean"]
+        else:
+            metrics["opd_kl_mean"] = extra_sums.get("opd_kl_sum", 0.0) / tokens

--- a/training/utils/rl/rollout/types.py
+++ b/training/utils/rl/rollout/types.py
@@ -93,6 +93,8 @@ class RolloutSample:
     ``PromptGroup.raw_inf_logprobs`` for optional train/inference drift metrics.
     It never replaces behavior logprobs in the loss or TIS.
     """
+    teacher_logprobs: List[float] | None = None
+    """Optional privileged-teacher logprobs aligned with ``tokens``."""
 
 
 @dataclass
@@ -182,6 +184,12 @@ def _completion_logprobs_from_sample(sample: RolloutSample) -> List[float]:
     return [float(lp) for lp, m in zip(sample.logprobs, sample.loss_mask) if m > 0]
 
 
+def _completion_logprobs_from_values(
+    values: List[float], loss_mask: List[int]
+) -> List[float]:
+    return [float(lp) for lp, m in zip(values, loss_mask) if m > 0]
+
+
 def _completion_raw_logprobs_from_sample(sample: RolloutSample) -> List[float] | None:
     """Return per-completion raw logprobs when present."""
     if sample.raw_logprobs is None:
@@ -243,12 +251,14 @@ def _validate_segment(
     segment_index: int,
     segment: RolloutSample,
 ) -> None:
-    def _validate_optional_logprobs(values: List[float] | None, *, n: int) -> None:
+    def _validate_optional_logprobs(
+        values: List[float] | None, *, n: int, source: str
+    ) -> None:
         if values is not None and len(values) != n:
             raise ValueError(
                 f"Run {run_index} segment {segment_index}: "
-                "raw_logprobs length mismatch "
-                f"({len(values)} / {n}). When set, raw_logprobs must align "
+                f"{source} length mismatch "
+                f"({len(values)} / {n}). When set, {source} must align "
                 "with tokens."
             )
 
@@ -260,7 +270,10 @@ def _validate_segment(
                 "tokens/logprobs/loss_mask mismatch "
                 f"({n} / {len(segment.logprobs)} / {len(segment.loss_mask)})."
             )
-        _validate_optional_logprobs(segment.raw_logprobs, n=n)
+        _validate_optional_logprobs(segment.raw_logprobs, n=n, source="raw_logprobs")
+        _validate_optional_logprobs(
+            segment.teacher_logprobs, n=n, source="teacher_logprobs"
+        )
         if n < 2:
             raise ValueError(
                 f"Run {run_index} segment {segment_index}: tokens must have "
@@ -286,7 +299,10 @@ def _validate_segment(
             f"({n} / {len(segment.logprobs)} / {len(segment.loss_mask)}). "
             "All three lists must be the same length.",
         )
-    _validate_optional_logprobs(segment.raw_logprobs, n=n)
+    _validate_optional_logprobs(segment.raw_logprobs, n=n, source="raw_logprobs")
+    _validate_optional_logprobs(
+        segment.teacher_logprobs, n=n, source="teacher_logprobs"
+    )
     if n < 2:
         raise ValueError(
             f"Run {run_index} segment {segment_index}: tokens must have length >= 2.",
@@ -358,6 +374,7 @@ def rollout_to_prompt_group(
     reference_data: List[tinker.Datum] = []
     inf_logprobs_aligned: List[List[float]] = []
     raw_inf_logprobs_aligned: List[List[float]] = []
+    teacher_logprobs_aligned: List[List[float]] = []
     completion_lens: List[int] = []
     truncated: List[bool] = []
     per_sample_prompt_lens: List[int] = []
@@ -396,6 +413,16 @@ def rollout_to_prompt_group(
                 target_raw_logprobs = (
                     _align_multimodal_inf_logprobs(completion_raw_logprobs, target_mask)
                     if completion_raw_logprobs is not None
+                    else []
+                )
+                target_teacher_logprobs = (
+                    _align_multimodal_inf_logprobs(
+                        _completion_logprobs_from_values(
+                            s.teacher_logprobs, s.loss_mask
+                        ),
+                        target_mask,
+                    )
+                    if s.teacher_logprobs is not None
                     else []
                 )
 
@@ -448,6 +475,7 @@ def rollout_to_prompt_group(
 
                 inf_logprobs_aligned.append(target_logprobs)
                 raw_inf_logprobs_aligned.append(target_raw_logprobs)
+                teacher_logprobs_aligned.append(target_teacher_logprobs)
                 completion_lens.append(sum(1 for w in target_mask if w > 0))
                 truncated.append(s.finish_reason == "length")
                 continue
@@ -460,6 +488,9 @@ def rollout_to_prompt_group(
             target_logprobs = s.logprobs[1:]
             target_raw_logprobs = (
                 s.raw_logprobs[1:] if s.raw_logprobs is not None else []
+            )
+            target_teacher_logprobs = (
+                s.teacher_logprobs[1:] if s.teacher_logprobs is not None else []
             )
 
             # Per-segment prompt boundary: index of the first assistant
@@ -523,6 +554,7 @@ def rollout_to_prompt_group(
 
             inf_logprobs_aligned.append(target_logprobs)
             raw_inf_logprobs_aligned.append(target_raw_logprobs)
+            teacher_logprobs_aligned.append(target_teacher_logprobs)
             completion_lens.append(sum(1 for m in s.loss_mask if m > 0))
             truncated.append(s.finish_reason == "length")
 
@@ -537,6 +569,7 @@ def rollout_to_prompt_group(
         rewards=rewards,
         inf_logprobs=inf_logprobs_aligned,
         raw_inf_logprobs=raw_inf_logprobs_aligned,
+        teacher_logprobs=teacher_logprobs_aligned,
         completion_lens=completion_lens,
         truncated=truncated,
         prompt=None,

--- a/training/utils/rl/rollout/types.py
+++ b/training/utils/rl/rollout/types.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 import logging
 import math
 from dataclasses import dataclass
-from typing import Callable, List
+from typing import Any, Callable, List
 
 import tinker
 
@@ -95,6 +95,8 @@ class RolloutSample:
     """
     teacher_logprobs: List[float] | None = None
     """Optional privileged-teacher logprobs aligned with ``tokens``."""
+    teacher_topk: List[Any] | None = None
+    """Optional sparse teacher distributions aligned with ``tokens``."""
 
 
 @dataclass
@@ -274,6 +276,8 @@ def _validate_segment(
         _validate_optional_logprobs(
             segment.teacher_logprobs, n=n, source="teacher_logprobs"
         )
+        if segment.teacher_topk is not None:
+            raise ValueError("teacher_topk is unsupported for multimodal segments.")
         if n < 2:
             raise ValueError(
                 f"Run {run_index} segment {segment_index}: tokens must have "
@@ -303,6 +307,11 @@ def _validate_segment(
     _validate_optional_logprobs(
         segment.teacher_logprobs, n=n, source="teacher_logprobs"
     )
+    if segment.teacher_topk is not None and len(segment.teacher_topk) != n:
+        raise ValueError(
+            f"Run {run_index} segment {segment_index}: teacher_topk length "
+            f"mismatch ({len(segment.teacher_topk)} / {n})."
+        )
     if n < 2:
         raise ValueError(
             f"Run {run_index} segment {segment_index}: tokens must have length >= 2.",
@@ -375,6 +384,7 @@ def rollout_to_prompt_group(
     inf_logprobs_aligned: List[List[float]] = []
     raw_inf_logprobs_aligned: List[List[float]] = []
     teacher_logprobs_aligned: List[List[float]] = []
+    teacher_topk_aligned: List[List[Any]] = []
     completion_lens: List[int] = []
     truncated: List[bool] = []
     per_sample_prompt_lens: List[int] = []
@@ -476,6 +486,7 @@ def rollout_to_prompt_group(
                 inf_logprobs_aligned.append(target_logprobs)
                 raw_inf_logprobs_aligned.append(target_raw_logprobs)
                 teacher_logprobs_aligned.append(target_teacher_logprobs)
+                teacher_topk_aligned.append([])
                 completion_lens.append(sum(1 for w in target_mask if w > 0))
                 truncated.append(s.finish_reason == "length")
                 continue
@@ -491,6 +502,9 @@ def rollout_to_prompt_group(
             )
             target_teacher_logprobs = (
                 s.teacher_logprobs[1:] if s.teacher_logprobs is not None else []
+            )
+            target_teacher_topk = (
+                s.teacher_topk[1:] if s.teacher_topk is not None else []
             )
 
             # Per-segment prompt boundary: index of the first assistant
@@ -555,6 +569,7 @@ def rollout_to_prompt_group(
             inf_logprobs_aligned.append(target_logprobs)
             raw_inf_logprobs_aligned.append(target_raw_logprobs)
             teacher_logprobs_aligned.append(target_teacher_logprobs)
+            teacher_topk_aligned.append(target_teacher_topk)
             completion_lens.append(sum(1 for m in s.loss_mask if m > 0))
             truncated.append(s.finish_reason == "length")
 
@@ -570,6 +585,7 @@ def rollout_to_prompt_group(
         inf_logprobs=inf_logprobs_aligned,
         raw_inf_logprobs=raw_inf_logprobs_aligned,
         teacher_logprobs=teacher_logprobs_aligned,
+        teacher_topk=teacher_topk_aligned,
         completion_lens=completion_lens,
         truncated=truncated,
         prompt=None,


### PR DESCRIPTION
## Summary
- add optional teacher logprobs to the rollout and prompt-group contracts
- add a masked sampled reverse-KL term to the client GRPO and GSPO losses
- let the async RL loop provision a same-base teacher deployment, initialize it from the policy, and refresh it on a configurable step interval

## Motivation
On-policy distillation gives a dense per-token signal alongside the sparse terminal reward. The teacher is the same base model as the student, so the recipe also works where no larger teacher exists: the teacher's advantage is privileged context supplied by the caller's prompt, not extra capacity.

## Interface
`Config.opd_beta` (default `0.0`) weights the distillation term, `Config.opd_teacher_deployment_id` names the teacher deployment, `Config.opd_teacher_sync_every` sets how many optimizer steps pass before the teacher is refreshed from the policy, and `Config.opd_teacher_replica_count` sizes it. The teacher sampler is handed to the rollout factory through `RolloutSetup.teacher_sampler`; the rollout function decides what privileged prefix to score against and returns `RolloutSample.teacher_logprobs`.

## Safety properties
- distillation scores the rollout's own token IDs; teacher-generated rewrites are never trained on
- the existing loss mask restricts the OPD term to trained response tokens
- teacher logprobs must align exactly with trainer target coordinates, otherwise the loss raises
- server-side GRPO rejects `opd_beta > 0` because the built-in kernel cannot express the extra term
- `opd_beta = 0` (default) leaves every existing code path unchanged

## Tests
- `PYTHONPATH=. pytest training/tests/unit/test_opd.py training/tests/unit/test_rollout_types.py training/tests/unit/test_grpo_loss.py training/tests/unit/test_async_rl_loop.py -q` — 62 passed
- `ruff check` and `ruff format --check` pass on the touched files
- the teacher deployment and per-trainer hotload path were exercised against live Fireworks infrastructure
